### PR TITLE
Add X-Forwarded-For header; also Travis and ebextensions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: java
+jdk:
+- oraclejdk8
+sudo: required
+before_deploy: mvn clean verify
+deploy:
+  skip_cleanup: true
+  provider: elasticbeanstalk
+  access_key_id: AKIAJ6YWVFOX3GHDXVRQ
+  secret_access_key: replace with secure key in parent fork
+  region: us-east-1
+  app: BridgeServer2-application
+  env: bridgeserver2-$TRAVIS_BRANCH
+  bucket_name: org-sagebridge-bridgeserver2-deployment-$TRAVIS_BRANCH
+  zip-file: target/BridgeServer2-2.0.war
+  on:
+    all_branches: true

--- a/ebextensions/tomcatlogs.config
+++ b/ebextensions/tomcatlogs.config
@@ -1,0 +1,30 @@
+###################################################################################################
+#### The configuration below sets the logs to be pushed, the Log Group name to push the logs to and
+#### the Log Stream name as the instance id. The following files are examples of logs that will be
+#### streamed to CloudWatch Logs in near real time:
+####
+#### /var/log/tomcat8/catalina.out
+####
+#### You can then access the CloudWatch Logs by accessing the AWS CloudWatch Console and clicking
+#### the "Logs" link on the left. The Log Group name will follow this format:
+####
+#### /aws/elasticbeanstalk/<environment name>/<full log name path>
+####
+#### Please note this configuration can be used additionally to the "Log Streaming" feature:
+#### http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.cloudwatchlogs.html
+###################################################################################################
+
+files:
+  "/etc/awslogs/config/tomcatlogs.conf" :
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      [/var/log/tomcat8/catalina.out]
+      log_group_name=`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/log/tomcat8/catalina.out"]]}`
+      log_stream_name={instance_id}
+      file=/var/log/tomcat8/catalina.out*
+
+commands:
+  "01_restart_awslogs":
+    command: service awslogs restart

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,19 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.2.2</version>
+                <configuration>
+                    <webResources>
+                        <resource>
+                            <directory>ebextensions</directory>
+                            <targetPath>.ebextensions</targetPath>
+                            <filtering>true</filtering>
+                        </resource>
+                    </webResources>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
                 <version>3.0.5</version>

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/PassthroughController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/PassthroughController.java
@@ -36,6 +36,7 @@ public class PassthroughController {
     private static final Logger LOG = LoggerFactory.getLogger(PassthroughController.class);
 
     static final String CONFIG_KEY_BRIDGE_PF_HOST = "bridge.pf.host";
+    static final String HEADER_IP_ADDRESS = "X-Forwarded-For";
     static final String HEADER_REQUEST_ID = "X-Request-Id";
 
     private String bridgePfHost;
@@ -55,7 +56,8 @@ public class PassthroughController {
         // URL. This includes query parameters. Spring provides them to use as a string, so we just append them to the
         // url like a string.
         String url = request.getRequestURI();
-        LOG.info("Received request " + request.getMethod() + " " + url);
+        String ipAddress = request.getRemoteAddr();
+        LOG.info("Received request " + request.getMethod() + " " + url + " from IP address " + ipAddress);
 
         String fullUrl = bridgePfHost + url;
         if (request.getQueryString() != null) {
@@ -82,6 +84,7 @@ public class PassthroughController {
 
         // Headers.
         Enumeration<String> headerNameEnum = request.getHeaderNames();
+        boolean hasIpAddress = false;
         String requestId = null;
         while (headerNameEnum.hasMoreElements()) {
             String headerName = headerNameEnum.nextElement();
@@ -94,9 +97,18 @@ public class PassthroughController {
             String headerValue = request.getHeader(headerName);
             pfRequest.addHeader(headerName, headerValue);
 
+            if (headerName.equalsIgnoreCase(HEADER_IP_ADDRESS)) {
+                hasIpAddress = true;
+            }
+
             if (headerName.equalsIgnoreCase(HEADER_REQUEST_ID)) {
                 requestId = headerValue;
             }
+        }
+
+        // Add IP Address header, if it doesn't exist.
+        if (!hasIpAddress) {
+            pfRequest.addHeader(HEADER_IP_ADDRESS, ipAddress);
         }
 
         // Add request ID header, if it doesn't exist.

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/PassthroughControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/PassthroughControllerTest.java
@@ -44,6 +44,8 @@ import org.sagebionetworks.bridge.config.Config;
 public class PassthroughControllerTest extends PowerMockTestCase {
     private static final String BRIDGE_PF_HOST = "http://example.com";
     private static final String DUMMY_BODY = "dummy body";
+    private static final String IP_ADDRESS = "my-ip-address";
+    private static final String OTHER_IP_ADDRESS = "other-ip-address";
     private static final String MIME_TYPE_TEXT_PLAIN = "text/plain";
     private static final String MIME_TYPE_TEXT_PLAIN_WITH_CHARSET = "text/plain;charset=utf-8";
     private static final String QUERY_PARAM_STRING = "key1=value1&key2=value2";
@@ -54,8 +56,10 @@ public class PassthroughControllerTest extends PowerMockTestCase {
     private static final String EXPECTED_FULL_URL = "http://example.com/v3/dummy/api";
     private static final String EXPECTED_FULL_URL_WITH_QUERY_PARAMS =
             "http://example.com/v3/dummy/api?key1=value1&key2=value2";
-    private static final Map<String, String> EXPECTED_HEADER_MAP_WITH_REQUEST_ID =
-            ImmutableMap.<String, String>builder().put(PassthroughController.HEADER_REQUEST_ID, REQUEST_ID).build();
+    private static final Map<String, String> EXPECTED_DEFAULT_HEADER_MAP = ImmutableMap.<String, String>builder()
+            .put(PassthroughController.HEADER_IP_ADDRESS, IP_ADDRESS)
+            .put(PassthroughController.HEADER_REQUEST_ID, REQUEST_ID)
+            .build();
 
     private PassthroughController controller;
 
@@ -80,6 +84,7 @@ public class PassthroughControllerTest extends PowerMockTestCase {
         when(mockRequest.getHeaderNames()).thenReturn(new Vector<String>().elements());
         when(mockRequest.getMethod()).thenReturn("GET");
         when(mockRequest.getQueryString()).thenReturn(QUERY_PARAM_STRING);
+        when(mockRequest.getRemoteAddr()).thenReturn(IP_ADDRESS);
         when(mockRequest.getRequestURI()).thenReturn(URL);
 
         // Mock HTTP client.
@@ -96,7 +101,7 @@ public class PassthroughControllerTest extends PowerMockTestCase {
         // Verify request.
         verifyStatic(Request.class);
         Request.Get(EXPECTED_FULL_URL_WITH_QUERY_PARAMS);
-        assertRequest(mockPfRequest, EXPECTED_HEADER_MAP_WITH_REQUEST_ID, null, null,
+        assertRequest(mockPfRequest, EXPECTED_DEFAULT_HEADER_MAP, null, null,
                 null);
     }
 
@@ -107,6 +112,7 @@ public class PassthroughControllerTest extends PowerMockTestCase {
         when(mockRequest.getContentType()).thenReturn(MIME_TYPE_TEXT_PLAIN);
         when(mockRequest.getHeaderNames()).thenReturn(new Vector<String>().elements());
         when(mockRequest.getMethod()).thenReturn("POST");
+        when(mockRequest.getRemoteAddr()).thenReturn(IP_ADDRESS);
         when(mockRequest.getRequestURI()).thenReturn(URL);
 
         // Mock HTTP client.
@@ -123,7 +129,7 @@ public class PassthroughControllerTest extends PowerMockTestCase {
         // Verify request.
         verifyStatic(Request.class);
         Request.Post(EXPECTED_FULL_URL);
-        assertRequest(mockPfRequest, EXPECTED_HEADER_MAP_WITH_REQUEST_ID, DUMMY_BODY, MIME_TYPE_TEXT_PLAIN,
+        assertRequest(mockPfRequest, EXPECTED_DEFAULT_HEADER_MAP, DUMMY_BODY, MIME_TYPE_TEXT_PLAIN,
                 null);
     }
 
@@ -134,6 +140,7 @@ public class PassthroughControllerTest extends PowerMockTestCase {
         when(mockRequest.getContentType()).thenReturn(MIME_TYPE_TEXT_PLAIN_WITH_CHARSET);
         when(mockRequest.getHeaderNames()).thenReturn(new Vector<String>().elements());
         when(mockRequest.getMethod()).thenReturn("POST");
+        when(mockRequest.getRemoteAddr()).thenReturn(IP_ADDRESS);
         when(mockRequest.getRequestURI()).thenReturn(URL);
 
         // Mock HTTP client.
@@ -150,7 +157,7 @@ public class PassthroughControllerTest extends PowerMockTestCase {
         // Verify request.
         verifyStatic(Request.class);
         Request.Post(EXPECTED_FULL_URL);
-        assertRequest(mockPfRequest, EXPECTED_HEADER_MAP_WITH_REQUEST_ID, DUMMY_BODY, MIME_TYPE_TEXT_PLAIN,
+        assertRequest(mockPfRequest, EXPECTED_DEFAULT_HEADER_MAP, DUMMY_BODY, MIME_TYPE_TEXT_PLAIN,
                 Charsets.UTF_8);
     }
 
@@ -160,6 +167,7 @@ public class PassthroughControllerTest extends PowerMockTestCase {
         HttpServletRequest mockRequest = mock(HttpServletRequest.class);
         when(mockRequest.getHeaderNames()).thenReturn(new Vector<String>().elements());
         when(mockRequest.getMethod()).thenReturn("DELETE");
+        when(mockRequest.getRemoteAddr()).thenReturn(IP_ADDRESS);
         when(mockRequest.getRequestURI()).thenReturn(URL);
 
         // Mock HTTP client.
@@ -176,7 +184,7 @@ public class PassthroughControllerTest extends PowerMockTestCase {
         // Verify request.
         verifyStatic(Request.class);
         Request.Delete(EXPECTED_FULL_URL);
-        assertRequest(mockPfRequest, EXPECTED_HEADER_MAP_WITH_REQUEST_ID, null, null,
+        assertRequest(mockPfRequest, EXPECTED_DEFAULT_HEADER_MAP, null, null,
                 null);
     }
 
@@ -221,6 +229,7 @@ public class PassthroughControllerTest extends PowerMockTestCase {
         Map<String, String> requestHeaderMap = ImmutableMap.<String, String>builder()
                 .put("Dummy-Header", "dummy header value")
                 .put("Content-Length", "10")
+                .put(PassthroughController.HEADER_IP_ADDRESS, OTHER_IP_ADDRESS)
                 .put(PassthroughController.HEADER_REQUEST_ID, OTHER_REQUEST_ID)
                 .build();
 
@@ -228,6 +237,7 @@ public class PassthroughControllerTest extends PowerMockTestCase {
         when(mockRequest.getContentType()).thenReturn(MIME_TYPE_TEXT_PLAIN);
         when(mockRequest.getHeaderNames()).thenReturn(new Vector<>(requestHeaderMap.keySet()).elements());
         when(mockRequest.getMethod()).thenReturn("POST");
+        when(mockRequest.getRemoteAddr()).thenReturn(IP_ADDRESS);
         when(mockRequest.getRequestURI()).thenReturn(URL);
 
         when(mockRequest.getHeader(any())).thenAnswer(invocation -> {
@@ -249,6 +259,7 @@ public class PassthroughControllerTest extends PowerMockTestCase {
         // Verify request. Note that we filter out the Content-Length.
         Map<String, String> expectedHeaderMap = ImmutableMap.<String, String>builder()
                 .put("Dummy-Header", "dummy header value")
+                .put(PassthroughController.HEADER_IP_ADDRESS, OTHER_IP_ADDRESS)
                 .put(PassthroughController.HEADER_REQUEST_ID, OTHER_REQUEST_ID)
                 .build();
 
@@ -263,6 +274,7 @@ public class PassthroughControllerTest extends PowerMockTestCase {
         HttpServletRequest mockRequest = mock(HttpServletRequest.class);
         when(mockRequest.getHeaderNames()).thenReturn(new Vector<String>().elements());
         when(mockRequest.getMethod()).thenReturn("GET");
+        when(mockRequest.getRemoteAddr()).thenReturn(IP_ADDRESS);
         when(mockRequest.getRequestURI()).thenReturn(URL);
 
         // Mock HTTP client.
@@ -286,7 +298,7 @@ public class PassthroughControllerTest extends PowerMockTestCase {
         // Verify request.
         verifyStatic(Request.class);
         Request.Get(EXPECTED_FULL_URL);
-        assertRequest(mockPfRequest, EXPECTED_HEADER_MAP_WITH_REQUEST_ID, null, null,
+        assertRequest(mockPfRequest, EXPECTED_DEFAULT_HEADER_MAP, null, null,
                 null);
     }
 


### PR DESCRIPTION
Setting the X-Forwarded-For header reports the original IP address (at least according to the caller), so that IP-locking on sessions works correctly.