### PR TITLE
convert exceptions to JSON instead of generic HTML error page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,8 +144,9 @@
                         <!-- config is inherently not testable -->
                         <exclude>org/sagebionetworks/bridge/config/*</exclude>
 
-                        <!-- EchoController doesn't need tests -->
+                        <!-- Test controllers don't need tests -->
                         <exclude>org/sagebionetworks/bridge/spring/controllers/EchoController*</exclude>
+                        <exclude>org/sagebionetworks/bridge/spring/controllers/ErrorController*</exclude>
                     </excludes>
                     <rules>
                         <rule>

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ErrorController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ErrorController.java
@@ -1,0 +1,16 @@
+package org.sagebionetworks.bridge.spring.controllers;
+
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Test controller to test error handling. Throws an exception. */
+@CrossOrigin
+@RestController
+public class ErrorController {
+    @RequestMapping(path = "/error", method = RequestMethod.GET)
+    public void handle() {
+        throw new UnsupportedOperationException("This API is not supported.");
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandler.java
@@ -1,0 +1,26 @@
+package org.sagebionetworks.bridge.spring.handlers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import org.sagebionetworks.bridge.spring.util.HttpUtil;
+
+/** Exception handler to convert exceptions into JSON instead of a generic HTML error page. */
+@ControllerAdvice
+public class BridgeExceptionHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(BridgeExceptionHandler.class);
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleException(Exception ex) throws JsonProcessingException {
+        // Spring by default doesn't log the exception if it's caught by a handler, so we need to log it ourselves.
+        LOG.error(ex.getMessage(), ex);
+
+        return HttpUtil.convertErrorToJsonResponse(HttpStatus.INTERNAL_SERVER_ERROR, ex.getClass().getSimpleName(),
+                ex.getMessage());
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/spring/util/HttpUtil.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/util/HttpUtil.java
@@ -1,0 +1,42 @@
+package org.sagebionetworks.bridge.spring.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import org.sagebionetworks.bridge.json.DefaultObjectMapper;
+
+/** Utilities for Spring HTTP. */
+public class HttpUtil {
+    public static final String CONTENT_TYPE_HEADER = "Content-Type";
+    public static final String CONTENT_TYPE_JSON = "application/json; charset=utf-8";
+
+    static final String KEY_MESSAGE = "message";
+    static final String KEY_STATUS_CODE = "statusCode";
+    static final String KEY_TYPE = "type";
+
+    /**
+     * Makes a JSON response entity with the given code, error type, and message. Note that this returns a
+     * ResponseEntity<String> and not ResponseEntity<JsonNode> because some of our APIs expect a string.
+     */
+    public static ResponseEntity<String> convertErrorToJsonResponse(HttpStatus status, String type, String message)
+            throws JsonProcessingException {
+        // Make JSON.
+        ObjectNode responseNode = DefaultObjectMapper.INSTANCE.createObjectNode();
+        responseNode.put(KEY_STATUS_CODE, status.value());
+        responseNode.put(KEY_MESSAGE, message);
+        responseNode.put(KEY_TYPE, type);
+
+        // Convert to pretty-printed string.
+        String responseString = DefaultObjectMapper.INSTANCE.writerWithDefaultPrettyPrinter().writeValueAsString(
+                responseNode);
+
+        // Make content-type header.
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(CONTENT_TYPE_HEADER, CONTENT_TYPE_JSON);
+
+        return new ResponseEntity<>(responseString, headers, status);
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/PassthroughControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/PassthroughControllerTest.java
@@ -39,6 +39,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.config.Config;
+import org.sagebionetworks.bridge.spring.util.HttpUtilTest;
 
 @PrepareForTest({ EntityUtils.class, Request.class })
 public class PassthroughControllerTest extends PowerMockTestCase {
@@ -199,7 +200,8 @@ public class PassthroughControllerTest extends PowerMockTestCase {
 
         // Execute.
         ResponseEntity<String> response = controller.handleDefault(mockRequest, null);
-        assertEquals(response.getStatusCode(), HttpStatus.BAD_REQUEST);
+        HttpUtilTest.assertErrorResponse(response, HttpStatus.BAD_REQUEST, PassthroughController.BAD_REQUEST_EXCEPTION,
+                "Method PUT not supported");
     }
 
     // branch coverage
@@ -220,7 +222,8 @@ public class PassthroughControllerTest extends PowerMockTestCase {
 
         // Execute.
         ResponseEntity<String> response = controller.handleDefault(mockRequest, null);
-        assertEquals(response.getStatusCode(), HttpStatus.NOT_IMPLEMENTED);
+        HttpUtilTest.assertErrorResponse(response, HttpStatus.NOT_IMPLEMENTED,
+                PassthroughController.NOT_IMPLEMENTED_EXCEPTION, "Unrecognized status code 499");
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandlerTest.java
@@ -1,0 +1,18 @@
+package org.sagebionetworks.bridge.spring.handlers;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.spring.util.HttpUtilTest;
+
+public class BridgeExceptionHandlerTest {
+    @Test
+    public void test() throws Exception {
+        String message = "dummy error message";
+        Exception ex = new IllegalArgumentException(message);
+        ResponseEntity<String> response = new BridgeExceptionHandler().handleException(ex);
+        HttpUtilTest.assertErrorResponse(response, HttpStatus.INTERNAL_SERVER_ERROR,
+                "IllegalArgumentException", message);
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/spring/util/HttpUtilTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/util/HttpUtilTest.java
@@ -1,0 +1,34 @@
+package org.sagebionetworks.bridge.spring.util;
+
+import static org.testng.Assert.assertEquals;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.json.DefaultObjectMapper;
+
+@SuppressWarnings("ConstantConditions")
+public class HttpUtilTest {
+    @Test
+    public void convertErrorToJsonResponse() throws Exception {
+        String message = "This is a message.";
+        String type = "TestException";
+        ResponseEntity<String> response = HttpUtil.convertErrorToJsonResponse(HttpStatus.CREATED, type, message);
+        assertErrorResponse(response, HttpStatus.CREATED, type, message);
+    }
+
+    public static void assertErrorResponse(ResponseEntity<String> actualResponse, HttpStatus expectedStatus,
+            String expectedType, String expectedMessage) throws IOException {
+        assertEquals(actualResponse.getStatusCode(), expectedStatus);
+        assertEquals(actualResponse.getHeaders().get(HttpUtil.CONTENT_TYPE_HEADER).get(0), HttpUtil.CONTENT_TYPE_JSON);
+
+        JsonNode responseNode = DefaultObjectMapper.INSTANCE.readTree(actualResponse.getBody());
+        assertEquals(responseNode.get(HttpUtil.KEY_STATUS_CODE).intValue(), expectedStatus.value());
+        assertEquals(responseNode.get(HttpUtil.KEY_TYPE).textValue(), expectedType);
+        assertEquals(responseNode.get(HttpUtil.KEY_MESSAGE).textValue(), expectedMessage);
+    }
+}


### PR DESCRIPTION
This is the Spring equivalent of https://github.com/Sage-Bionetworks/BridgePF/blob/develop/app/org/sagebionetworks/bridge/play/http/BridgeErrorHandler.java

Note that we don't have a EndpointNotFound handler. This is because BridgeServer2 currently forwards all unrecognized calls to BridgePF. We'll have to add one later at the end of the migration.

Testing done:
* mvn verify (unit tests, FindBugs, Jacoco test coverage)
* Manually tested error handler and verified result.
* Manually tested sign-in passthrough call to verify that nothing broke.