### PR TITLE
point passthrough controller to bridgepf-* instead of ws-*

### DIFF
--- a/src/main/resources/BridgeServer2.conf
+++ b/src/main/resources/BridgeServer2.conf
@@ -4,6 +4,6 @@ bridge.user=your-username-here
 heartbeat.interval.minutes=30
 
 local.bridge.pf.host = http://localhost:9000
-dev.bridge.pf.host = https://ws-develop.sagebridge.org
-uat.bridge.pf.host = https://ws-staging.sagebridge.org
-prod.bridge.pf.host = https://ws.sagebridge.org
+dev.bridge.pf.host = https://bridgepf-develop.sagebridge.org
+uat.bridge.pf.host = https://bridgepf-uat.sagebridge.org
+prod.bridge.pf.host = https://bridgepf-prod.sagebridge.org


### PR DESCRIPTION
ws-* is a DNS entry that currently points to bridgepf-*. PassthroughController should point to bridgepf-* so that we can flip ws-* to point to bridgeserver2-* instead.