### PR TITLE
Exclude old version of Bouncy Castle bcprov which is causing bootup issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,12 @@
             <groupId>org.sagebionetworks</groupId>
             <artifactId>BridgeServerLogic</artifactId>
             <version>1.0.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk14</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Server2 depends on bcprov-jdk15on via bridge-base and bcprov-jdk14 via BridgeServerLogic via flying-saucer-pdf. Because for some silly reason, these two packages are two separate artifacts rather than different versions of the same artifact, and because for some silly reason, these two artifacts conflict with each other, we get a circular dependency error and can't launch Server2 (but only in Elastic Beanstalk for some reason).

To solve this, we simply exclude the older bcprov-jdk14.

For more info, see https://stackoverflow.com/questions/17584495/unable-to-complete-the-scan-for-annotations-for-web-application-app-due-to-a/35914143#35914143