### PR TITLE
remove _all_ conflicting Bouncy Castle packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,11 +64,23 @@
                  -->
                 <exclusion>
                     <groupId>bouncycastle</groupId>
+                    <artifactId>bcmail-jdk14</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>bouncycastle</groupId>
                     <artifactId>bcprov-jdk14</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcmail-jdk14</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
                     <artifactId>bcprov-jdk14</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bctsp-jdk14</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
We continue to get weird errors with Bouncy Castle packages. Recommendation was to exclude _all_ conflicting Bouncy Castle packages.

See https://stackoverflow.com/questions/51136704/class-org-bouncycastle-cms-cmsprocessables-signer-information-does-not-match

Tested by building a war file, manually deploying it to Dev, and running integ tests against it.