### PR TITLE
Upgrading Mockito 1.10.19 --> 2.23.4 to match BridgeServerLogic (along with powermock dependencies).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,19 +118,19 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.10.19</version>
+            <version>2.23.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <version>1.7.4</version>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>2.0.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-testng</artifactId>
-            <version>1.7.4</version>
+            <version>2.0.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/sagebionetworks/bridge/TestUtils.java
+++ b/src/test/java/org/sagebionetworks/bridge/TestUtils.java
@@ -249,7 +249,7 @@ public class TestUtils {
         Mockito.mockingDetails(mockAccountDao).isMock();
         Mockito.mockingDetails(mockAccount).isMock();
         doAnswer(invocation -> {
-            Consumer<Account> accountEdits = (Consumer<Account>)invocation.getArgumentAt(2, Consumer.class);
+            Consumer<Account> accountEdits = invocation.getArgument(2);
             accountEdits.accept(mockAccount);
             return null;
         }).when(mockAccountDao).editAccount(Mockito.any(), Mockito.any(), Mockito.any());

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/BaseControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/BaseControllerTest.java
@@ -815,7 +815,7 @@ public class BaseControllerTest extends Mockito {
     public void canGetLanguagesWhenInHeader() throws Exception {
         Account account = Account.create();
         doAnswer(invocation -> {
-            Consumer<Account> consumer = invocation.getArgumentAt(2, Consumer.class);
+            Consumer<Account> consumer = invocation.getArgument(2);
             consumer.accept(account);
             return null;
         }).when(mockAccountDao).editAccount(any(), any(), any());

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserDataDownloadControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserDataDownloadControllerTest.java
@@ -19,7 +19,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
-import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.models.DateRange;
 import org.sagebionetworks.bridge.models.StatusMessage;


### PR DESCRIPTION
On the BridgeServerLogic side, we will switch to TestNG, then it that project should copy over to BridgeServer2 without further adjustments.