### PR TITLE
Disable Hibernate Logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,12 +284,6 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>2.6.1</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-c3p0</artifactId>
             <version>${hibernate.version}</version>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -11,4 +11,7 @@
     </root>
 
     <logger name="org.sagebionetworks.bridge" level="INFO" />
+
+    <!-- Hibernate logs are noisy and they also leak email addresses. Disable this logging completely. -->
+    <logger name="org.hibernate" level="OFF" />
 </configuration>


### PR DESCRIPTION
This change does two thing:

1. This removes the log4j dependency (which we don't actually use) to force Hibernate to use slf4j instead. This makes Hibernate use the same logging that the rest of our service uses, which fixes some logging issues we've been seeing.
2. Logback configs to turn off Hibernate logging altogether. Hibernate logging is very noisy and it also leaks email addresses.

See also https://sagebionetworks.jira.com/browse/BRIDGE-2470

Testing done
* Signed up with an email address that already has an account. Verified the log messages in the old code. Verified lack of log messages in the new code.