### PR TITLE
Do not allow healthCode lookups if health code access is disabled for a study.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.spring.controllers;
 import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeUtils.getDateTimeOrDefault;
 import static org.sagebionetworks.bridge.BridgeUtils.getIntOrDefault;
+import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.WORKER;
 import static org.sagebionetworks.bridge.models.ResourceList.END_DATE;
@@ -269,8 +270,10 @@ public class ParticipantController extends BaseController {
         UserSession session = getAuthenticatedSession(RESEARCHER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
 
-        // Do not allow lookup by health code if health code access is disabled.
-        if (!study.isHealthCodeExportEnabled() && userId.toLowerCase().startsWith("healthcode:")) {
+        // Do not allow lookup by health code if health code access is disabled. Allow it however
+        // if the user is an administrator.
+        if (!session.isInRole(ADMIN) && !study.isHealthCodeExportEnabled()
+                && userId.toLowerCase().startsWith("healthcode:")) {
             throw new EntityNotFoundException(Account.class);
         }
         

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
@@ -45,6 +45,7 @@ import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.RequestInfo;
 import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.StatusMessage;
+import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountSummary;
 import org.sagebionetworks.bridge.models.accounts.IdentifierHolder;
 import org.sagebionetworks.bridge.models.accounts.IdentifierUpdate;
@@ -268,6 +269,11 @@ public class ParticipantController extends BaseController {
         UserSession session = getAuthenticatedSession(RESEARCHER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
 
+        // Do not allow lookup by health code if health code access is disabled.
+        if (!study.isHealthCodeExportEnabled() && userId.toLowerCase().startsWith("healthcode:")) {
+            throw new EntityNotFoundException(Account.class);
+        }
+        
         StudyParticipant participant = participantService.getParticipant(study, userId, consents);
 
         ObjectWriter writer = (study.isHealthCodeExportEnabled()) ?

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.spring.controllers;
 
 import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
+import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.WORKER;
@@ -407,7 +408,18 @@ public class ParticipantControllerTest extends Mockito {
     }
     
     @Test(expectedExceptions = EntityNotFoundException.class)
-    public void getParticipantWhereHealthCodeIsPrevented() throws Exception { 
+    public void getParticipantWhereHealthCodeIsPrevented() throws Exception {
+        study.setHealthCodeExportEnabled(false);
+        
+        controller.getParticipant("healthCode:"+USER_ID, true);
+    }
+    
+    @Test
+    public void getParticipantWithHealthCodeIfAdmin() throws Exception {
+        participant = new StudyParticipant.Builder().copyOf(participant)
+                .withRoles(ImmutableSet.of(RESEARCHER, ADMIN)).build();
+        session.setParticipant(participant);
+        
         study.setHealthCodeExportEnabled(false);
         
         controller.getParticipant("healthCode:"+USER_ID, true);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
@@ -4,6 +4,7 @@ import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
+import static org.sagebionetworks.bridge.Roles.WORKER;
 import static org.sagebionetworks.bridge.TestConstants.ACTIVITY_1;
 import static org.sagebionetworks.bridge.TestConstants.EMAIL;
 import static org.sagebionetworks.bridge.TestConstants.ENCRYPTED_HEALTH_CODE;
@@ -403,6 +404,31 @@ public class ParticipantControllerTest extends Mockito {
 
         assertEquals(retrievedParticipant.getFirstName(), "Test");
         assertNull(retrievedParticipant.getHealthCode());
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void getParticipantWhereHealthCodeIsPrevented() throws Exception { 
+        study.setHealthCodeExportEnabled(false);
+        
+        controller.getParticipant("healthCode:"+USER_ID, true);
+    }
+    
+    @Test
+    public void getParticipantForWorkerWithHealthCodeNotPrevented() throws Exception {
+        // The caller is a worker
+        participant = new StudyParticipant.Builder().copyOf(participant).withRoles(ImmutableSet.of(WORKER)).build();
+        session.setParticipant(participant);
+        
+        // Health codes are disabled
+        study.setHealthCodeExportEnabled(false);
+        
+        StudyParticipant studyParticipant = new StudyParticipant.Builder().withFirstName("Test")
+                .withHealthCode(HEALTH_CODE).build();
+        when(mockParticipantService.getParticipant(study, "healthCode:" + USER_ID, true)).thenReturn(studyParticipant);
+        
+        // You can still retrieve the user with a health code
+        String result = controller.getParticipantForWorker(TEST_STUDY_IDENTIFIER, "healthCode:"+USER_ID, true);
+        assertNotNull(result);
     }
 
     @Test


### PR DESCRIPTION
There is a change to one integration test to ensure health codes are being returned from the API where we're expecting them.