### PR TITLE
Double-Hash Stormpath Passwords

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/PasswordAlgorithmTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/PasswordAlgorithmTest.java
@@ -16,6 +16,11 @@ public class PasswordAlgorithmTest {
     }
 
     @Test
+    public void stormpathDoubleHash() throws Exception {
+        test(PasswordAlgorithm.STORMPATH_PBKDF2_DOUBLE_HASH);
+    }
+
+    @Test
     public void bcrypt() throws Exception {
         test(PasswordAlgorithm.BCRYPT);
     }


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-2385

This creates a new password hashing algorithm which is essentially the Stormpath hashing algorithm wrapped inside the more secure PBKDF2 hashing algorithm. This allows us to take the less secure Stormpath hashes we have and double-hash them without changing the user's password.

Migration path:
* Deploy this code change.
* Update Accounts table field passwordAlgorithm to include 'STORMPATH_PBKDF2_DOUBLE_HASH'.
* Ensure that I have an account with an old Stormpath hash in Prod.
* Run the script on the Bridge-Ops machine.
* Verify the account in Prod still works.
* Verify there are no more accounts in Prod using the old Stormpath hash.