### PR TITLE
Update SynapseJavaClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,11 @@
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sns</artifactId>
+            <version>${aws.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sqs</artifactId>
             <version>${aws.version}</version>
         </dependency>
@@ -170,7 +175,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>synapseJavaClient</artifactId>
-            <version>206.0</version>
+            <version>268.02</version>
         </dependency>
         <dependency>
             <groupId>org.xhtmlrenderer</groupId>

--- a/src/main/java/org/sagebionetworks/bridge/services/CompoundActivityDefinitionService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/CompoundActivityDefinitionService.java
@@ -2,7 +2,7 @@ package org.sagebionetworks.bridge.services;
 
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
@@ -565,7 +565,7 @@ public class StudyService {
     }
     
     private void addAdminToACL(AccessControlList acl, String principalId) {
-        addToACL(acl, principalId, ModelConstants.ENITY_ADMIN_ACCESS_PERMISSIONS);
+        addToACL(acl, principalId, ModelConstants.ENTITY_ADMIN_ACCESS_PERMISSIONS);
     }
 
     private void addToACL(AccessControlList acl, String principalId, Set<ACCESS_TYPE> accessTypes) {

--- a/src/test/java/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -42,6 +42,7 @@ import org.sagebionetworks.client.exceptions.SynapseClientException;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
 import org.sagebionetworks.client.exceptions.SynapseServerException;
+import org.sagebionetworks.client.exceptions.UnknownSynapseServerException;
 import org.sagebionetworks.repo.model.AccessControlList;
 import org.sagebionetworks.repo.model.MembershipInvitation;
 import org.sagebionetworks.repo.model.Project;
@@ -1450,7 +1451,7 @@ public class StudyServiceMockTest extends Mockito {
 
         // stub
         when(mockParticipantService.createParticipant(any(), any(), anyBoolean())).thenReturn(mockIdentifierHolder);
-        doThrow(new SynapseServerException(500, "The email address provided is already used.")).when(mockSynapseClient).newAccountEmailValidation(any(), any());
+        doThrow(new UnknownSynapseServerException(500, "The email address provided is already used.")).when(mockSynapseClient).newAccountEmailValidation(any(), any());
 
         // execute
         service.createStudyAndUsers(mockStudyAndUsers);
@@ -1503,15 +1504,15 @@ public class StudyServiceMockTest extends Mockito {
 
         // 1. Exporter (admin)
         ResourceAccess capturedExporterRa = principalIdToAcl.get(Long.valueOf(EXPORTER_SYNAPSE_USER_ID));
-        assertEquals(capturedExporterRa.getAccessType(), ModelConstants.ENITY_ADMIN_ACCESS_PERMISSIONS);
+        assertEquals(capturedExporterRa.getAccessType(), ModelConstants.ENTITY_ADMIN_ACCESS_PERMISSIONS);
 
         // 2. Bridge Admin
         ResourceAccess bridgeAdminAcl = principalIdToAcl.get(BRIDGE_ADMIN_TEAM_ID);
-        assertEquals(bridgeAdminAcl.getAccessType(), ModelConstants.ENITY_ADMIN_ACCESS_PERMISSIONS);
+        assertEquals(bridgeAdminAcl.getAccessType(), ModelConstants.ENTITY_ADMIN_ACCESS_PERMISSIONS);
 
         // 3. Specified admin user
         ResourceAccess capturedUserRa = principalIdToAcl.get(TEST_USER_ID);
-        assertEquals(capturedUserRa.getAccessType(), ModelConstants.ENITY_ADMIN_ACCESS_PERMISSIONS);
+        assertEquals(capturedUserRa.getAccessType(), ModelConstants.ENTITY_ADMIN_ACCESS_PERMISSIONS);
 
         // 4. Bridge Staff
         ResourceAccess bridgeStaffAcl = principalIdToAcl.get(BRIDGE_STAFF_TEAM_ID);


### PR DESCRIPTION
We were asked to update the SynapseJavaClient so that the Synapse team could deprecate some stuff. There were some breaking changes and some dependency conflicts we had to resolve, but there should be no functional changes.