### PR TITLE
Removing reauth token bridge back to the Accounts table.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAccount.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAccount.java
@@ -63,10 +63,7 @@ public class HibernateAccount implements Account {
     private PasswordAlgorithm passwordAlgorithm;
     private String passwordHash;
     private DateTime passwordModifiedOn;
-    private PasswordAlgorithm reauthTokenAlgorithm;
-    private String reauthTokenHash;
     private String reauthToken;
-    private DateTime reauthTokenModifiedOn;
     private Set<Roles> roles;
     private AccountStatus status;
     private int version;
@@ -292,46 +289,6 @@ public class HibernateAccount implements Account {
     /** @see #getPasswordModifiedOn */
     public void setPasswordModifiedOn(DateTime passwordModifiedOn) {
         this.passwordModifiedOn = passwordModifiedOn;
-    }
-
-    /**
-     * The algorithm used to hash the reauthentication token. The hashing algorithms are 
-     * the same as those used for passwords.
-     *
-     * @see PasswordAlgorithm
-     */
-    @Enumerated(EnumType.STRING)
-    public PasswordAlgorithm getReauthTokenAlgorithm() {
-        return reauthTokenAlgorithm;
-    }
-
-    /** @see #getReauthTokenAlgorithm */
-    public void setReauthTokenAlgorithm(PasswordAlgorithm reauthTokenAlgorithm) {
-        this.reauthTokenAlgorithm = reauthTokenAlgorithm;
-    }
-
-    /**
-     * The full reauthentication token hash, as used by {@link PasswordAlgorithm} to
-     * decode it.
-     */
-    public String getReauthTokenHash() {
-        return reauthTokenHash;
-    }
-
-    /** @see #getReauthTokenHash */
-    public void setReauthTokenHash(String reauthTokenHash) {
-        this.reauthTokenHash = reauthTokenHash;
-    }
-
-    /** Epoch milliseconds when the user last changed their reauthentication token. */
-    @Convert(converter = DateTimeToLongAttributeConverter.class)
-    public DateTime getReauthTokenModifiedOn() {
-        return reauthTokenModifiedOn;
-    }
-
-    /** @see #getReauthTokenModifiedOn */
-    public void setReauthTokenModifiedOn(DateTime reauthTokenModifiedOn) {
-        this.reauthTokenModifiedOn = reauthTokenModifiedOn;
     }
 
     /**

--- a/src/main/java/org/sagebionetworks/bridge/models/accounts/Account.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/accounts/Account.java
@@ -221,15 +221,6 @@ public interface Account extends BridgeEntity {
     PasswordAlgorithm getPasswordAlgorithm();
     void setPasswordAlgorithm(PasswordAlgorithm passwordAlgorithm);
     
-    PasswordAlgorithm getReauthTokenAlgorithm();
-    void setReauthTokenAlgorithm(PasswordAlgorithm reauthTokenAlgorithm);
-    
-    String getReauthTokenHash();
-    void setReauthTokenHash(String reauthTokenHash);
-    
-    DateTime getReauthTokenModifiedOn();
-    void setReauthTokenModifiedOn(DateTime reauthTokenModifiedOn);
-    
     void setAccountSubstudies(Set<AccountSubstudy> accountSubstudies);
     Set<AccountSubstudy> getAccountSubstudies();
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -41,7 +41,6 @@ import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.exceptions.SynapseClientException;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
-import org.sagebionetworks.client.exceptions.SynapseServerException;
 import org.sagebionetworks.client.exceptions.UnknownSynapseServerException;
 import org.sagebionetworks.repo.model.AccessControlList;
 import org.sagebionetworks.repo.model.MembershipInvitation;


### PR DESCRIPTION
This could in rare circumstances lead to a race condition, see: BRIDGE-2474. We've switched over months ago so any outstanding tokens in the Account reauth columns are probably in abandoned accounts (but clients can always authenticate again).