### PR TITLE
Fix bootstrapping.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/DefaultStudyBootstrapper.java
+++ b/src/main/java/org/sagebionetworks/bridge/DefaultStudyBootstrapper.java
@@ -11,7 +11,6 @@ import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 
 import java.util.List;
 import java.util.Set;
-import javax.annotation.PostConstruct;
 
 import com.amazonaws.services.dynamodbv2.model.TableDescription;
 import com.google.common.collect.ImmutableSet;
@@ -37,9 +36,8 @@ import org.springframework.stereotype.Component;
 @Component("defaultStudyBootstrapper")
 public class DefaultStudyBootstrapper  implements ApplicationListener<ContextRefreshedEvent> {
 
-    private static final SubpopulationGuid SHARED_SUBPOP = SubpopulationGuid.create(SHARED_STUDY_ID_STRING);
-    private static final SubpopulationGuid API_SUBPOP = SubpopulationGuid.create(API_STUDY_ID_STRING);
-    private static final PasswordPolicy MIN_PASSWORD_POLICY = new PasswordPolicy(2, false, false, false, false);
+    static final SubpopulationGuid SHARED_SUBPOP = SubpopulationGuid.create(SHARED_STUDY_ID_STRING);
+    static final SubpopulationGuid API_SUBPOP = SubpopulationGuid.create(API_STUDY_ID_STRING);
     
     /**
      * The data group set in the test (api) study. This includes groups that are required for the SDK integration tests.
@@ -92,20 +90,19 @@ public class DefaultStudyBootstrapper  implements ApplicationListener<ContextRef
             study.setPasswordPolicy(new PasswordPolicy(2, false, false, false, false));
             study.setEmailVerificationEnabled(true);
             study.setVerifyChannelOnSignInEnabled(true);
-            study.setPasswordPolicy(MIN_PASSWORD_POLICY);
             study = studyService.createStudy(study);
             
             BridgeUtils.setRequestContext(new RequestContext.Builder().withCallerStudyId(API_STUDY_ID)
                     .withCallerRoles(ImmutableSet.of(ADMIN, DEVELOPER, RESEARCHER)).build());
             StudyParticipant admin = new StudyParticipant.Builder()
-                    .withEmail(config.get("admin.email").trim())
-                    .withPassword(config.get("admin.password").trim())
+                    .withEmail(config.get("admin.email"))
+                    .withPassword(config.get("admin.password"))
                     .withRoles(ImmutableSet.of(ADMIN, RESEARCHER)).build();
             userAdminService.createUser(study, admin, API_SUBPOP, false, false);
 
             StudyParticipant dev = new StudyParticipant.Builder()
-                    .withEmail(config.get("api.developer.email").trim())
-                    .withPassword(config.get("api.developer.password").trim())
+                    .withEmail(config.get("api.developer.email"))
+                    .withPassword(config.get("api.developer.password"))
                     .withRoles(ImmutableSet.of(DEVELOPER)).build();
             userAdminService.createUser(study, dev, API_SUBPOP, false, false);
         }
@@ -122,14 +119,13 @@ public class DefaultStudyBootstrapper  implements ApplicationListener<ContextRef
             study.setSupportEmail("bridgeit@sagebridge.org");
             study.setTechnicalEmail("bridgeit@sagebridge.org");
             study.setConsentNotificationEmail("bridgeit@sagebridge.org");
-            study.setPasswordPolicy(MIN_PASSWORD_POLICY);
             study.setEmailVerificationEnabled(true);
             study.setVerifyChannelOnSignInEnabled(true);
-            studyService.createStudy(study);
+            study = studyService.createStudy(study);
             
             StudyParticipant dev = new StudyParticipant.Builder()
-                    .withEmail(config.get("shared.developer.email").trim())
-                    .withPassword(config.get("shared.developer.password").trim())
+                    .withEmail(config.get("shared.developer.email"))
+                    .withPassword(config.get("shared.developer.password"))
                     .withRoles(ImmutableSet.of(DEVELOPER)).build();
             userAdminService.createUser(study, dev, SHARED_SUBPOP, false, false);
         }

--- a/src/main/resources/BridgeServer2.conf
+++ b/src/main/resources/BridgeServer2.conf
@@ -158,3 +158,16 @@ local.usersigned.consents.bucket = local.usersigned.consents.bucket
 dev.usersigned.consents.bucket = bridgepf-develop-awss3usersignedconsentsdownloadb-apwbxc8ldmj2
 uat.usersigned.consents.bucket = bridgepf-uat-awss3usersignedconsentsdownloadbucke-hcuoz4eztd8g
 prod.usersigned.consents.bucket = bridgepf-prod-awss3usersignedconsentsdownloadbuck-1slz1bcz0mls7
+
+# Bootstrap credentials for integration tests (will only be used when first initializing your database). 
+# Whatever values you select here to initialize your server, must be mirrored in the Bridge SDK's 
+# bridge-sdk.properties file.
+
+admin.email = dummy-value
+admin.password = dummy-value
+
+api.developer.email = dummy-value
+api.developer.password = dummy-value
+
+shared.developer.email = dummy-value
+shared.developer.password = dummy-value

--- a/src/main/resources/db/changelog/changelog.sql
+++ b/src/main/resources/db/changelog/changelog.sql
@@ -2,6 +2,40 @@
 
 --changeset bridge:1
 
+CREATE TABLE IF NOT EXISTS `Accounts` (
+  `id` varchar(255) NOT NULL,
+  `studyId` varchar(255) NOT NULL,
+  `email` varchar(255) DEFAULT NULL,
+  `createdOn` bigint(20) NOT NULL,
+  `healthCode` varchar(255) DEFAULT NULL,
+  `healthId` varchar(255) DEFAULT NULL,
+  `modifiedOn` bigint(20) NOT NULL,
+  `firstName` varchar(255) DEFAULT NULL,
+  `lastName` varchar(255) DEFAULT NULL,
+  `passwordAlgorithm` enum('STORMPATH_HMAC_SHA_256','BCRYPT','PBKDF2_HMAC_SHA_256') DEFAULT NULL,
+  `passwordHash` varchar(255) DEFAULT NULL,
+  `passwordModifiedOn` bigint(20) NOT NULL,
+  `status` enum('DISABLED','ENABLED','UNVERIFIED') NOT NULL DEFAULT 'UNVERIFIED',
+  `version` int(10) unsigned NOT NULL DEFAULT '0',
+  `clientData` mediumtext COLLATE utf8_unicode_ci,
+  `phone` varchar(20) DEFAULT NULL,
+  `phoneVerified` tinyint(1) DEFAULT NULL,
+  `emailVerified` tinyint(1) DEFAULT NULL,
+  `phoneRegion` varchar(2) DEFAULT NULL,
+  `externalId` varchar(255) DEFAULT NULL,
+  `timeZone` varchar(6) DEFAULT NULL,
+  `sharingScope` enum('NO_SHARING','SPONSORS_AND_PARTNERS','ALL_QUALIFIED_RESEARCHERS') DEFAULT NULL,
+  `notifyByEmail` tinyint(1) DEFAULT '1',
+  `migrationVersion` int(10) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `Accounts-StudyId-Email-Index` (`studyId`,`email`),
+  UNIQUE KEY `Accounts-StudyId-Phone-Index` (`studyId`,`phone`),
+  UNIQUE KEY `Accounts-StudyId-ExternalId-Index` (`studyId`,`externalId`),
+  UNIQUE KEY `Accounts-StudyId-HealthCode-Index` (`studyId`,`healthCode`),
+  KEY `Accounts-StudyId-Index` (`studyId`),
+  KEY `Accounts-HealthCode-Index` (`healthCode`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
 CREATE TABLE IF NOT EXISTS `AccountAttributes` (
   `accountId` varchar(255) NOT NULL,
   `attributeKey` varchar(255) NOT NULL,
@@ -62,38 +96,15 @@ CREATE TABLE IF NOT EXISTS `AccountSecrets` (
   CONSTRAINT `fk_account_secrets` FOREIGN KEY (`accountId`) REFERENCES `Accounts` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
-CREATE TABLE IF NOT EXISTS `Accounts` (
-  `id` varchar(255) NOT NULL,
-  `studyId` varchar(255) NOT NULL,
-  `email` varchar(255) DEFAULT NULL,
-  `createdOn` bigint(20) NOT NULL,
-  `healthCode` varchar(255) DEFAULT NULL,
-  `healthId` varchar(255) DEFAULT NULL,
-  `modifiedOn` bigint(20) NOT NULL,
-  `firstName` varchar(255) DEFAULT NULL,
-  `lastName` varchar(255) DEFAULT NULL,
-  `passwordAlgorithm` enum('STORMPATH_HMAC_SHA_256','BCRYPT','PBKDF2_HMAC_SHA_256') DEFAULT NULL,
-  `passwordHash` varchar(255) DEFAULT NULL,
-  `passwordModifiedOn` bigint(20) NOT NULL,
-  `status` enum('DISABLED','ENABLED','UNVERIFIED') NOT NULL DEFAULT 'UNVERIFIED',
+CREATE TABLE IF NOT EXISTS `Substudies` (
+  `id` varchar(60) NOT NULL,
+  `studyId` varchar(60) NOT NULL,
+  `name` varchar(255) DEFAULT NULL,
   `version` int(10) unsigned NOT NULL DEFAULT '0',
-  `clientData` mediumtext COLLATE utf8_unicode_ci,
-  `phone` varchar(20) DEFAULT NULL,
-  `phoneVerified` tinyint(1) DEFAULT NULL,
-  `emailVerified` tinyint(1) DEFAULT NULL,
-  `phoneRegion` varchar(2) DEFAULT NULL,
-  `externalId` varchar(255) DEFAULT NULL,
-  `timeZone` varchar(6) DEFAULT NULL,
-  `sharingScope` enum('NO_SHARING','SPONSORS_AND_PARTNERS','ALL_QUALIFIED_RESEARCHERS') DEFAULT NULL,
-  `notifyByEmail` tinyint(1) DEFAULT '1',
-  `migrationVersion` int(10) unsigned NOT NULL DEFAULT '0',
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `Accounts-StudyId-Email-Index` (`studyId`,`email`),
-  UNIQUE KEY `Accounts-StudyId-Phone-Index` (`studyId`,`phone`),
-  UNIQUE KEY `Accounts-StudyId-ExternalId-Index` (`studyId`,`externalId`),
-  UNIQUE KEY `Accounts-StudyId-HealthCode-Index` (`studyId`,`healthCode`),
-  KEY `Accounts-StudyId-Index` (`studyId`),
-  KEY `Accounts-HealthCode-Index` (`healthCode`)
+  `deleted` tinyint(1) DEFAULT '0',
+  `createdOn` bigint(20) NOT NULL,
+  `modifiedOn` bigint(20) NOT NULL,
+  PRIMARY KEY (`id`,`studyId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `AccountsSubstudies` (
@@ -131,17 +142,6 @@ CREATE TABLE IF NOT EXISTS `SharedModuleTags` (
   KEY `MetadataKey_idx` (`id`,`version`),
   CONSTRAINT `MetadataKey` FOREIGN KEY (`id`, `version`) REFERENCES `SharedModuleMetadata` (`id`, `version`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-CREATE TABLE IF NOT EXISTS `Substudies` (
-  `id` varchar(60) NOT NULL,
-  `studyId` varchar(60) NOT NULL,
-  `name` varchar(255) DEFAULT NULL,
-  `version` int(10) unsigned NOT NULL DEFAULT '0',
-  `deleted` tinyint(1) DEFAULT '0',
-  `createdOn` bigint(20) NOT NULL,
-  `modifiedOn` bigint(20) NOT NULL,
-  PRIMARY KEY (`id`,`studyId`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `Templates` (
   `guid` varchar(60) NOT NULL,

--- a/src/test/java/org/sagebionetworks/bridge/DefaultStudyBootstrapperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/DefaultStudyBootstrapperTest.java
@@ -6,7 +6,6 @@ import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 import java.util.List;

--- a/src/test/java/org/sagebionetworks/bridge/DefaultStudyBootstrapperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/DefaultStudyBootstrapperTest.java
@@ -23,29 +23,31 @@ import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.services.StudyService;
+import org.sagebionetworks.bridge.services.UserAdminService;
 import org.sagebionetworks.bridge.validators.StudyValidator;
 import org.sagebionetworks.bridge.validators.Validate;
 
 public class DefaultStudyBootstrapperTest {
 
     private StudyService studyService;
+    
+    private UserAdminService userAdminService;
 
     private DefaultStudyBootstrapper defaultStudyBootstrapper;
 
     @BeforeMethod
     public void before() {
         studyService = mock(StudyService.class);
+        userAdminService = mock(UserAdminService.class);
 
         when(studyService.getStudy(any(StudyIdentifier.class))).thenThrow(EntityNotFoundException.class);
-        defaultStudyBootstrapper = new DefaultStudyBootstrapper(studyService,
-                mock(AnnotationBasedTableCreator.class),
-                mock(DynamoInitializer.class)
-        );
+        defaultStudyBootstrapper = new DefaultStudyBootstrapper(userAdminService, studyService,
+                mock(AnnotationBasedTableCreator.class), mock(DynamoInitializer.class)        );
     }
 
     @Test
     public void createsDefaultStudyWhenMissing() {
-        defaultStudyBootstrapper.initializeDatabase();
+        defaultStudyBootstrapper.onApplicationEvent(null);
 
         ArgumentCaptor<Study> argument = ArgumentCaptor.forClass(Study.class);
         verify(studyService, times(2)).createStudy(argument.capture());


### PR DESCRIPTION
1) The initial Liquibase SQL was not in the right order and failed on foreign key constraints. This has been fixed. You should delete the DATABASECHANGELOG and DATABASECHANGELOGLOCK tables before starting Bridge server for the first time in a new environment, including local environments.

2) Added creation of the admin, api.developer and shared.developer accounts to the DefaultStudyBootstrapper. It's overly difficult for interns and new users to get up and running without these accounts, which should mirror the accounts defined in bridge-sdk.properties so the integration tests will run as well.

3) The order of SQL/DDB table creation matters: we need Liquibase to run first. Changed the code so this happens.

Finally, the bootstrapping document was updated to reflect these changes.