### PR TITLE
Channel SignIn no longer resets throttle timer

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/cache/CacheKey.java
+++ b/src/main/java/org/sagebionetworks/bridge/cache/CacheKey.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.cache;
 import java.util.List;
 import java.util.Objects;
 
+import org.sagebionetworks.bridge.models.ThrottleRequestType;
 import org.sagebionetworks.bridge.models.accounts.Phone;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
@@ -48,8 +49,8 @@ public final class CacheKey {
         return new CacheKey(signInToken, "channel-signin-to-session-token");
     }
 
-    public static final CacheKey channelThrottling(String throttleType, String userId) {
-        return new CacheKey(userId, throttleType, "channel-throttling");
+    public static CacheKey channelThrottling(ThrottleRequestType throttleType, String userId) {
+        return new CacheKey(userId, throttleType.name().toLowerCase(), "channel-throttling");
     }
     public static final CacheKey emailSignInRequest(SignIn signIn) {
         return new CacheKey(signIn.getEmail(), signIn.getStudyId(), "signInRequest");

--- a/src/main/java/org/sagebionetworks/bridge/models/ThrottleRequestType.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/ThrottleRequestType.java
@@ -1,0 +1,12 @@
+package org.sagebionetworks.bridge.models;
+
+/**
+ * Enumeration of request types that we want to throttle on. Used to differentiate between request types and generate
+ * cache keys.
+ */
+public enum ThrottleRequestType {
+    EMAIL_SIGNIN,
+    PHONE_SIGNIN,
+    VERIFY_EMAIL,
+    VERIFY_PHONE
+}

--- a/src/test/java/org/sagebionetworks/bridge/cache/CacheKeyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/cache/CacheKeyTest.java
@@ -7,6 +7,7 @@ import static org.testng.Assert.assertTrue;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.models.ThrottleRequestType;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 
@@ -49,7 +50,8 @@ public class CacheKeyTest {
 
     @Test
     public void channelThrottling() {
-        assertEquals(CacheKey.channelThrottling("email", "userId").toString(), "userId:email:channel-throttling");
+        assertEquals(CacheKey.channelThrottling(ThrottleRequestType.EMAIL_SIGNIN, "userId").toString(),
+                "userId:email_signin:channel-throttling");
     }
     
     @Test


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-2413

Note that we don't have a good way to test Redis expiration, so neither the unit tests nor integ tests have changed. This was tested manually by setting channel throttle timeout to 60 seconds and then making requests 45 seconds apart. Under the old code, the third request would still be throttled. Under the new code, the third request would go through.

Alternate implementations:

* Instead of resetting the expiration, set the expiration to the current TTL. This however will allow the participant to burst requests at the end of the expiration period, and it's more complicated to implement.
* Instead of setting a count, just set a boolean that expires after the timeout. This is simple to implement, but we won't be able to use X requests in Y minutes logic. (That said, currently, X is always 1.)