### PR TITLE
Update Bouncy Castle Encryptor (bridge-base), add buffering to decryption

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>bridge-base</artifactId>
-            <version>2.7.18</version>
+            <version>2.7.22</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/org/sagebionetworks/bridge/upload/DecryptHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/upload/DecryptHandler.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.upload;
 
+import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -43,7 +44,9 @@ public class DecryptHandler implements UploadValidationHandler {
         File outputFile = fileHelper.newFile(context.getTempDir(), outputFilename);
 
         // Decrypt - Stream from input file to output file.
-        try (InputStream inputFileStream = fileHelper.getInputStream(context.getDataFile());
+        // Note: Neither FileHelper nor CmsEncryptor introduce any buffering. Since we're creating and closing streams,
+        // it's our responsibility to add the buffered stream.
+        try (InputStream inputFileStream = getBufferedInputStream(fileHelper.getInputStream(context.getDataFile()));
              InputStream decryptedInputFileStream = uploadArchiveService.decrypt(context.getStudy().getIdentifier(),
                      inputFileStream);
              OutputStream outputFileStream = fileHelper.getOutputStream(outputFile)) {
@@ -54,5 +57,12 @@ public class DecryptHandler implements UploadValidationHandler {
 
         // Set file in context.
         context.setDecryptedDataFile(outputFile);
+    }
+
+    // This helper method wraps a stream inside a buffered stream. It exists because our unit tests use
+    // InMemoryFileHelper, which uses a ByteArrayInputStream, which ignores closing. But in Prod, we need to wrap it in
+    // a BufferedInputStream because the files can get big, and a closed BufferedInputStream breaks unit tests.
+    InputStream getBufferedInputStream(InputStream inputStream) {
+        return new BufferedInputStream(inputStream);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/upload/DecryptHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/DecryptHandlerTest.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge.upload;
 
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
@@ -50,9 +52,12 @@ public class DecryptHandlerTest {
                 "decrypted test data".getBytes(Charsets.UTF_8)));
 
         // set up test handler
-        DecryptHandler handler = new DecryptHandler();
+        DecryptHandler handler = spy(new DecryptHandler());
         handler.setFileHelper(fileHelper);
         handler.setUploadArchiveService(mockSvc);
+
+        // Don't actually buffer the input stream, as this breaks the test.
+        doAnswer(invocation -> invocation.getArgument(0)).when(handler).getBufferedInputStream(any());
 
         // execute and validate
         handler.handle(ctx);


### PR DESCRIPTION
Pulls in the update from https://github.com/Sage-Bionetworks/bridge-base/pull/52 to decrypt streaming from disk. Adds a buffered stream to both the input and output file streams.