### PR TITLE
Change sms/email providers to work with a TemplateRevision object.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateTemplateRevisionDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateTemplateRevisionDao.java
@@ -8,7 +8,6 @@ import static org.sagebionetworks.bridge.models.ResourceList.PAGE_SIZE;
 import static org.sagebionetworks.bridge.models.ResourceList.TOTAL;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/main/java/org/sagebionetworks/bridge/models/templates/TemplateRevision.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/templates/TemplateRevision.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge.models.templates;
 
+import static org.sagebionetworks.bridge.models.studies.MimeType.TEXT;
+
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import org.joda.time.DateTime;
@@ -7,7 +9,9 @@ import org.joda.time.DateTime;
 import org.sagebionetworks.bridge.hibernate.HibernateTemplateRevision;
 import org.sagebionetworks.bridge.json.BridgeTypeName;
 import org.sagebionetworks.bridge.models.BridgeEntity;
+import org.sagebionetworks.bridge.models.studies.EmailTemplate;
 import org.sagebionetworks.bridge.models.studies.MimeType;
+import org.sagebionetworks.bridge.models.studies.SmsTemplate;
 
 @BridgeTypeName("TemplateRevision")
 @JsonDeserialize(as=HibernateTemplateRevision.class)
@@ -15,6 +19,25 @@ public interface TemplateRevision extends BridgeEntity {
     
     public static TemplateRevision create() { 
         return new HibernateTemplateRevision();
+    }
+    
+    // This is a temporary bridging method while migrating. Eventually we will directly
+    // retrieve a template revision object for templates.
+    public static TemplateRevision create(EmailTemplate template) {
+        TemplateRevision revision = new HibernateTemplateRevision();
+        revision.setSubject(template.getSubject());
+        revision.setDocumentContent(template.getBody());
+        revision.setMimeType(template.getMimeType());
+        return revision;
+    }
+    
+    // This is a temporary bridging method while migrating. Eventually we will directly
+    // retrieve a template revision object for templates.
+    public static TemplateRevision create(SmsTemplate template) {
+        TemplateRevision revision = new HibernateTemplateRevision();
+        revision.setDocumentContent(template.getMessage());
+        revision.setMimeType(TEXT);
+        return revision;
     }
     
     /**

--- a/src/main/java/org/sagebionetworks/bridge/services/IntentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/IntentService.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.services;
 
+
 import java.util.List;
 import java.util.Map;
 
@@ -15,6 +16,7 @@ import org.sagebionetworks.bridge.models.itp.IntentToParticipate;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
+import org.sagebionetworks.bridge.models.templates.TemplateRevision;
 import org.sagebionetworks.bridge.services.email.BasicEmailProvider;
 import org.sagebionetworks.bridge.services.email.EmailType;
 import org.sagebionetworks.bridge.sms.SmsMessageProvider;
@@ -130,9 +132,10 @@ public class IntentService {
                     // The URL being sent does not expire. We send with a transaction delivery type because
                     // this is a critical step in onboarding through this workflow and message needs to be 
                     // sent immediately after consenting.
+                    TemplateRevision revision = TemplateRevision.create(study.getAppInstallLinkSmsTemplate());
                     SmsMessageProvider provider = new SmsMessageProvider.Builder()
                             .withStudy(study)
-                            .withSmsTemplate(study.getAppInstallLinkSmsTemplate())
+                            .withTemplateRevision(revision)
                             .withTransactionType()
                             .withPhone(intent.getPhone())
                             .withToken(APP_INSTALL_URL_KEY, url).build();
@@ -140,9 +143,11 @@ public class IntentService {
                     // SMS Service.
                     smsService.sendSmsMessage(null, provider);
                 } else {
+                    TemplateRevision revision = TemplateRevision.create(study.getAppInstallLinkTemplate());
+                    
                     BasicEmailProvider provider = new BasicEmailProvider.Builder()
                             .withStudy(study)
-                            .withEmailTemplate(study.getAppInstallLinkTemplate())
+                            .withTemplateRevision(revision)
                             .withRecipientEmail(intent.getEmail())
                             .withType(EmailType.APP_INSTALL)
                             .withToken(APP_INSTALL_URL_KEY, url)

--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -72,6 +72,7 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.models.substudies.AccountSubstudy;
+import org.sagebionetworks.bridge.models.templates.TemplateRevision;
 import org.sagebionetworks.bridge.models.upload.UploadView;
 import org.sagebionetworks.bridge.services.AuthenticationService.ChannelType;
 import org.sagebionetworks.bridge.sms.SmsMessageProvider;
@@ -769,7 +770,7 @@ public class ParticipantService {
         
         SmsMessageProvider.Builder builder = new SmsMessageProvider.Builder()
                 .withPhone(account.getPhone())
-                .withSmsTemplate(template)
+                .withTemplateRevision(TemplateRevision.create(template))
                 .withPromotionType()
                 .withStudy(study);
         for (Map.Entry<String, String> entry : variables.entrySet()) {

--- a/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.sagebionetworks.bridge.models.studies.MimeType.HTML;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -74,6 +75,7 @@ import org.sagebionetworks.bridge.models.studies.SmsTemplate;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyAndUsers;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+import org.sagebionetworks.bridge.models.templates.TemplateRevision;
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.models.upload.UploadValidationStrictness;
 import org.sagebionetworks.bridge.services.email.BasicEmailProvider;
@@ -883,10 +885,12 @@ public class StudyService {
         String studyId = BridgeUtils.encodeURIComponent(study.getIdentifier());
         String shortUrl = String.format(VERIFY_STUDY_EMAIL_URL, BASE_URL, studyId, token, type.toString().toLowerCase());
         
-        EmailTemplate template = new EmailTemplate(studyEmailVerificationTemplateSubject,
-                studyEmailVerificationTemplate, MimeType.HTML);
+        TemplateRevision revision = TemplateRevision.create();
+        revision.setSubject(studyEmailVerificationTemplateSubject);
+        revision.setDocumentContent(studyEmailVerificationTemplate);
+        revision.setMimeType(HTML);
 
-        BasicEmailProvider provider = new BasicEmailProvider.Builder().withStudy(study).withEmailTemplate(template)
+        BasicEmailProvider provider = new BasicEmailProvider.Builder().withStudy(study).withTemplateRevision(revision)
                 .withOverrideSenderEmail(bridgeSupportEmailPlain).withRecipientEmail(email)
                 .withToken(STUDY_EMAIL_VERIFICATION_URL, shortUrl)
                 .withExpirationPeriod(STUDY_EMAIL_VERIFICATION_EXPIRATION_PERIOD, VERIFY_STUDY_EMAIL_EXPIRE_IN_SECONDS)

--- a/src/main/java/org/sagebionetworks/bridge/sms/SmsMessageProvider.java
+++ b/src/main/java/org/sagebionetworks/bridge/sms/SmsMessageProvider.java
@@ -10,8 +10,8 @@ import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.models.accounts.Phone;
 import org.sagebionetworks.bridge.models.sms.SmsType;
-import org.sagebionetworks.bridge.models.studies.SmsTemplate;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.templates.TemplateRevision;
 
 import com.amazonaws.services.sns.model.MessageAttributeValue;
 import com.amazonaws.services.sns.model.PublishRequest;
@@ -23,13 +23,13 @@ public class SmsMessageProvider {
     private final Map<String,String> tokenMap;
     private final Phone phone;
     private final SmsType smsType;
-    private final SmsTemplate template;
+    private final TemplateRevision revision;
 
-    private SmsMessageProvider(Study study, SmsTemplate template, SmsType smsType, Phone phone,
+    private SmsMessageProvider(Study study, TemplateRevision revision, SmsType smsType, Phone phone,
             Map<String, String> tokenMap) {
         this.study = study;
         this.smsType = smsType;
-        this.template = template;
+        this.revision = revision;
         this.phone = phone;
         this.tokenMap = tokenMap;
     }
@@ -37,8 +37,8 @@ public class SmsMessageProvider {
     public Study getStudy() {
         return study;
     }
-    public SmsTemplate getTemplate() {
-        return template;
+    public TemplateRevision getTemplateRevision() {
+        return revision;
     }
     public Phone getPhone() {
         return phone;
@@ -63,7 +63,7 @@ public class SmsMessageProvider {
 
     /** SMS message to send, with template variables resolved. */
     public String getFormattedMessage() {
-        return BridgeUtils.resolveTemplate(template.getMessage(), tokenMap).trim();
+        return BridgeUtils.resolveTemplate(revision.getDocumentContent(), tokenMap).trim();
     }
 
     public PublishRequest getSmsRequest() {
@@ -88,14 +88,14 @@ public class SmsMessageProvider {
         private Map<String,String> tokenMap = Maps.newHashMap();
         private Phone phone;
         private SmsType smsType;
-        private SmsTemplate template;
+        private TemplateRevision revision;
 
         public Builder withStudy(Study study) {
             this.study = study;
             return this;
         }
-        public Builder withSmsTemplate(SmsTemplate template) {
-            this.template = template;
+        public Builder withTemplateRevision(TemplateRevision revision) {
+            this.revision = revision;
             return this;
         }
         public Builder withToken(String name, String value) {
@@ -120,7 +120,7 @@ public class SmsMessageProvider {
         }
         public SmsMessageProvider build() {
             checkNotNull(study);
-            checkNotNull(template);
+            checkNotNull(revision);
             checkNotNull(phone);
             checkNotNull(smsType);
             tokenMap.putAll(BridgeUtils.studyTemplateVariables(study));
@@ -131,7 +131,7 @@ public class SmsMessageProvider {
             // remove nulls, these will cause ImmutableMap.of to fail
             tokenMap.values().removeIf(Objects::isNull);
 
-            return new SmsMessageProvider(study, template, smsType, phone, ImmutableMap.copyOf(tokenMap));
+            return new SmsMessageProvider(study, revision, smsType, phone, ImmutableMap.copyOf(tokenMap));
         }
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/templates/TemplateRevisionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/templates/TemplateRevisionTest.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.models.templates;
 
 import static org.sagebionetworks.bridge.TestConstants.TIMESTAMP;
 import static org.sagebionetworks.bridge.models.studies.MimeType.HTML;
+import static org.sagebionetworks.bridge.models.studies.MimeType.TEXT;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
@@ -10,6 +11,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.studies.EmailTemplate;
+import org.sagebionetworks.bridge.models.studies.SmsTemplate;
 import org.sagebionetworks.bridge.models.templates.TemplateRevision;
 
 public class TemplateRevisionTest {
@@ -42,5 +45,23 @@ public class TemplateRevisionTest {
         assertEquals(deser.getSubject(), "A subject");
         assertEquals(deser.getDocumentContent(), "The content we retrieved from S3");
     }
+    
+    @Test
+    public void testCreationWithSmsMessage() {
+        SmsTemplate template = new SmsTemplate("body");
+        
+        TemplateRevision revision = TemplateRevision.create(template);
+        assertEquals(revision.getDocumentContent(), "body");
+        assertEquals(TEXT, revision.getMimeType());
+    }
 
+    @Test
+    public void testCreationWithEmailMessage() {
+        EmailTemplate template = new EmailTemplate("subject", "body", HTML);
+        
+        TemplateRevision revision = TemplateRevision.create(template);
+        assertEquals(revision.getSubject(), "subject");
+        assertEquals(revision.getDocumentContent(), "body");
+        assertEquals(HTML, revision.getMimeType());
+    }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ConsentServiceMockTest.java
@@ -863,7 +863,8 @@ public class ConsentServiceMockTest {
         assertEquals(provider.getStudy(), study);
         assertEquals(provider.getSmsType(), "Transactional");
         assertEquals(provider.getTokenMap().get("consentUrl"), SHORT_URL);
-        assertEquals(provider.getTemplate(), study.getSignedConsentSmsTemplate());
+        assertEquals(provider.getTemplateRevision().getDocumentContent(),
+                study.getSignedConsentSmsTemplate().getMessage());
     }
 
     @Test
@@ -932,7 +933,8 @@ public class ConsentServiceMockTest {
         assertEquals(provider.getStudy(), study);
         assertEquals(provider.getSmsType(), "Transactional");
         assertEquals(provider.getTokenMap().get("consentUrl"), SHORT_URL);
-        assertEquals(provider.getTemplate(), study.getSignedConsentSmsTemplate());
+        assertEquals(provider.getTemplateRevision().getDocumentContent(),
+                study.getSignedConsentSmsTemplate().getMessage());
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceConsentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceConsentTest.java
@@ -28,6 +28,7 @@ import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsent;
 import org.sagebionetworks.bridge.models.subpopulations.StudyConsentView;
 import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
+import org.sagebionetworks.bridge.models.templates.TemplateRevision;
 import org.sagebionetworks.bridge.services.email.BasicEmailProvider;
 
 import com.amazonaws.regions.Region;
@@ -109,7 +110,7 @@ public class SendMailViaAmazonServiceConsentTest {
         
         BasicEmailProvider provider = new BasicEmailProvider.Builder()
                 .withStudy(study)
-                .withEmailTemplate(study.getSignedConsentTemplate())
+                .withTemplateRevision(TemplateRevision.create(study.getSignedConsentTemplate()))
                 .withBinaryAttachment("consent.pdf", MimeType.PDF, consentPdf.getBytes())
                 .withRecipientEmail("test-user@sagebase.org").build();
         service.sendEmail(provider);
@@ -150,7 +151,7 @@ public class SendMailViaAmazonServiceConsentTest {
         
         BasicEmailProvider provider = new BasicEmailProvider.Builder()
                 .withStudy(study)
-                .withEmailTemplate(study.getSignedConsentTemplate())
+                .withTemplateRevision(TemplateRevision.create(study.getSignedConsentTemplate()))
                 .withBinaryAttachment("consent.pdf", MimeType.PDF, consentPdf.getBytes())
                 .withRecipientEmail("test-user@sagebase.org").build();
         
@@ -197,7 +198,7 @@ public class SendMailViaAmazonServiceConsentTest {
         
         BasicEmailProvider provider = new BasicEmailProvider.Builder()
                 .withStudy(study)
-                .withEmailTemplate(study.getSignedConsentTemplate())
+                .withTemplateRevision(TemplateRevision.create(study.getSignedConsentTemplate()))
                 .withBinaryAttachment("consent.pdf", MimeType.PDF, consentPdf.getBytes())
                 .withRecipientEmail("test-user@sagebase.org").build();
 
@@ -225,7 +226,7 @@ public class SendMailViaAmazonServiceConsentTest {
         
         BasicEmailProvider provider = new BasicEmailProvider.Builder()
                 .withStudy(study)
-                .withEmailTemplate(study.getSignedConsentTemplate())
+                .withTemplateRevision(TemplateRevision.create(study.getSignedConsentTemplate()))
                 .withBinaryAttachment("consent.pdf", MimeType.PDF, consentPdf.getBytes())
                 .withRecipientEmail("test-user@sagebase.org").build();
 

--- a/src/test/java/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/SendMailViaAmazonServiceTest.java
@@ -14,6 +14,7 @@ import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.models.studies.EmailTemplate;
 import org.sagebionetworks.bridge.models.studies.MimeType;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.templates.TemplateRevision;
 import org.sagebionetworks.bridge.services.email.BasicEmailProvider;
 
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
@@ -57,7 +58,7 @@ public class SendMailViaAmazonServiceTest {
         BasicEmailProvider provider = new BasicEmailProvider.Builder()
                 .withStudy(study)
                 .withRecipientEmail(RECIPIENT_EMAIL)
-                .withEmailTemplate(new EmailTemplate("subject", "body", MimeType.HTML))
+                .withTemplateRevision(TemplateRevision.create(new EmailTemplate("subject", "body", MimeType.HTML)))
                 .build();
         try {
             service.sendEmail(provider);
@@ -75,7 +76,7 @@ public class SendMailViaAmazonServiceTest {
         BasicEmailProvider provider = new BasicEmailProvider.Builder()
                 .withStudy(study)
                 .withRecipientEmail(RECIPIENT_EMAIL)
-                .withEmailTemplate(new EmailTemplate("subject", "body", MimeType.HTML))
+                .withTemplateRevision(TemplateRevision.create(new EmailTemplate("subject", "body", MimeType.HTML)))
                 .build();
         service.sendEmail(provider);
     }

--- a/src/test/java/org/sagebionetworks/bridge/services/SmsServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/SmsServiceTest.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.services;
 
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
@@ -21,6 +22,7 @@ import com.amazonaws.services.sns.model.OptInPhoneNumberRequest;
 import com.amazonaws.services.sns.model.PublishRequest;
 import com.amazonaws.services.sns.model.PublishResult;
 import com.fasterxml.jackson.databind.JsonNode;
+
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
@@ -41,8 +43,8 @@ import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataSubmission;
 import org.sagebionetworks.bridge.models.sms.SmsMessage;
 import org.sagebionetworks.bridge.models.sms.SmsType;
-import org.sagebionetworks.bridge.models.studies.SmsTemplate;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.templates.TemplateRevision;
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.models.upload.UploadFieldType;
 import org.sagebionetworks.bridge.models.upload.UploadSchema;
@@ -60,6 +62,10 @@ public class SmsServiceTest {
     private static final String STUDY_SHORT_NAME = "My Study";
     private static final DateTimeZone TIME_ZONE = DateTimeZone.forOffsetHours(-7);
     private static final String USER_ID = "test-user";
+    private static final TemplateRevision REVISION = TemplateRevision.create();
+    static {
+        REVISION.setDocumentContent(MESSAGE_BODY);
+    }
 
     private static final StudyParticipant PARTICIPANT_WITH_TIME_ZONE = new StudyParticipant.Builder()
             .withId(USER_ID).withHealthCode(HEALTH_CODE).withTimeZone(TIME_ZONE).build();
@@ -124,7 +130,7 @@ public class SmsServiceTest {
         // Set up test and execute.
         SmsMessageProvider provider = new SmsMessageProvider.Builder()
                 .withStudy(study)
-                .withSmsTemplate(new SmsTemplate(MESSAGE_BODY))
+                .withTemplateRevision(REVISION)
                 .withTransactionType()
                 .withPhone(TestConstants.PHONE).build();
 
@@ -155,7 +161,7 @@ public class SmsServiceTest {
         // Set up test and execute.
         SmsMessageProvider provider = new SmsMessageProvider.Builder()
                 .withStudy(study)
-                .withSmsTemplate(new SmsTemplate(MESSAGE_BODY))
+                .withTemplateRevision(REVISION)
                 .withPromotionType()
                 .withPhone(TestConstants.PHONE).build();
 
@@ -181,7 +187,7 @@ public class SmsServiceTest {
         // Set up test and execute.
         SmsMessageProvider provider = new SmsMessageProvider.Builder()
                 .withStudy(study)
-                .withSmsTemplate(new SmsTemplate(MESSAGE_BODY))
+                .withTemplateRevision(REVISION)
                 .withPromotionType()
                 .withPhone(TestConstants.PHONE).build();
         svc.sendSmsMessage(null, provider);
@@ -202,7 +208,7 @@ public class SmsServiceTest {
         // Set up test and execute.
         SmsMessageProvider provider = new SmsMessageProvider.Builder()
                 .withStudy(study)
-                .withSmsTemplate(new SmsTemplate(MESSAGE_BODY))
+                .withTemplateRevision(REVISION)
                 .withPromotionType()
                 .withPhone(TestConstants.PHONE).build();
         svc.sendSmsMessage(null, provider);
@@ -223,7 +229,7 @@ public class SmsServiceTest {
         // Set up test and execute.
         SmsMessageProvider provider = new SmsMessageProvider.Builder()
                 .withStudy(study)
-                .withSmsTemplate(new SmsTemplate(MESSAGE_BODY))
+                .withTemplateRevision(REVISION)
                 .withPromotionType()
                 .withPhone(TestConstants.PHONE).build();
         svc.sendSmsMessage(HEALTH_CODE, provider);
@@ -245,7 +251,7 @@ public class SmsServiceTest {
         // Set up test and execute.
         SmsMessageProvider provider = new SmsMessageProvider.Builder()
                 .withStudy(study)
-                .withSmsTemplate(new SmsTemplate(MESSAGE_BODY))
+                .withTemplateRevision(REVISION)
                 .withPromotionType()
                 .withPhone(TestConstants.PHONE).build();
         svc.sendSmsMessage(HEALTH_CODE, provider);
@@ -277,13 +283,12 @@ public class SmsServiceTest {
 
     @Test(expectedExceptions = BridgeServiceException.class)
     public void sendSMSMessageTooLongInvalid() {
-        String message = "This is my SMS message.";
-        for (int i=0; i < 5; i++) {
-            message += message;
-        }
+        TemplateRevision revision = TemplateRevision.create();
+        revision.setDocumentContent(randomAlphabetic(601));
+        
         SmsMessageProvider provider = new SmsMessageProvider.Builder()
                 .withStudy(study)
-                .withSmsTemplate(new SmsTemplate(message))
+                .withTemplateRevision(revision)
                 .withTransactionType()
                 .withPhone(TestConstants.PHONE).build();
 

--- a/src/test/java/org/sagebionetworks/bridge/services/email/EmailSignInEmailProviderTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/email/EmailSignInEmailProviderTest.java
@@ -12,6 +12,7 @@ import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.models.studies.EmailTemplate;
 import org.sagebionetworks.bridge.models.studies.MimeType;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.templates.TemplateRevision;
 
 public class EmailSignInEmailProviderTest {
 
@@ -33,7 +34,7 @@ public class EmailSignInEmailProviderTest {
         // in the template.
         BasicEmailProvider provider = new BasicEmailProvider.Builder()
                 .withStudy(study)
-                .withEmailTemplate(study.getEmailSignInTemplate())
+                .withTemplateRevision(TemplateRevision.create(study.getEmailSignInTemplate()))
                 .withRecipientEmail(RECIPIENT_EMAIL)
                 .withToken("email", BridgeUtils.encodeURIComponent(RECIPIENT_EMAIL))
                 .withToken("token", "ABC").build();

--- a/src/test/java/org/sagebionetworks/bridge/sms/SmsMessageProviderTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/sms/SmsMessageProviderTest.java
@@ -10,8 +10,8 @@ import org.testng.annotations.Test;
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.models.sms.SmsType;
-import org.sagebionetworks.bridge.models.studies.SmsTemplate;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.templates.TemplateRevision;
 
 import com.amazonaws.services.sns.model.PublishRequest;
 
@@ -28,14 +28,16 @@ public class SmsMessageProviderTest {
         study.setTechnicalEmail("tech@email.com");
         study.setConsentNotificationEmail("consent@email.com,consent2@email.com");
 
-        SmsTemplate template = new SmsTemplate("${studyShortName} ${url} ${supportEmail} ${expirationPeriod}");
+        TemplateRevision revision = TemplateRevision.create();
+        revision.setDocumentContent("${studyShortName} ${url} ${supportEmail} ${expirationPeriod}");
+        
         String expectedMessage = "ShortName some-url support@email.com 4 hours";
         
         // Create
         SmsMessageProvider provider = new SmsMessageProvider.Builder()
             .withStudy(study)
             .withPhone(TestConstants.PHONE)
-            .withSmsTemplate(template)
+            .withTemplateRevision(revision)
             .withTransactionType()
             .withExpirationPeriod("expirationPeriod", 60*60*4) // 4 hours
             .withToken("url", "some-url").build();
@@ -67,13 +69,14 @@ public class SmsMessageProviderTest {
     public void defaultsShortNameToBridge() {
         // Set up dependencies
         Study study = Study.create();
-        SmsTemplate template = new SmsTemplate("${studyShortName} ${url} ${supportEmail}");
+        TemplateRevision revision = TemplateRevision.create();
+        revision.setDocumentContent("${studyShortName} ${url} ${supportEmail}");
         
         // Create
         SmsMessageProvider provider = new SmsMessageProvider.Builder()
             .withStudy(study)
             .withPhone(TestConstants.PHONE)
-            .withSmsTemplate(template)
+            .withTemplateRevision(revision)
             .withPromotionType()
             .withToken("url", "some-url").build();
         PublishRequest request = provider.getSmsRequest();
@@ -85,7 +88,7 @@ public class SmsMessageProviderTest {
         SmsMessageProvider provider = new SmsMessageProvider.Builder()
                 .withStudy(Study.create())
                 .withPhone(TestConstants.PHONE)
-                .withSmsTemplate(new SmsTemplate(""))
+                .withTemplateRevision(TemplateRevision.create())
                 .withPromotionType()
                 .withToken("url", null).build();
         
@@ -98,7 +101,7 @@ public class SmsMessageProviderTest {
         SmsMessageProvider provider = new SmsMessageProvider.Builder()
                 .withStudy(Study.create())
                 .withPhone(TestConstants.PHONE)
-                .withSmsTemplate(new SmsTemplate(""))
+                .withTemplateRevision(TemplateRevision.create())
                 .withPromotionType().build();
         assertEquals("Promotional", provider.getSmsType());
         assertEquals(SmsType.PROMOTIONAL, provider.getSmsTypeEnum());

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ExternalIdControllerV4Test.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ExternalIdControllerV4Test.java
@@ -32,7 +32,6 @@ import org.mockito.Spy;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.exceptions.NotAuthenticatedException;
 import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;


### PR DESCRIPTION
In all the locations where we're retrieving SmsTemplate/EmailTemplate from a study object, we're going to instead retrieve the appropriate template revision for the caller and use that instead. So prepare for this by changing SmsMessageProvider/BasicEmailProvider to accept this instead.