### PR TITLE
Move some functionality of CriteriaContext to RequestContext which is available across all code paths.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/RequestContext.java
+++ b/src/main/java/org/sagebionetworks/bridge/RequestContext.java
@@ -1,9 +1,14 @@
 package org.sagebionetworks.bridge;
 
+import static org.sagebionetworks.bridge.models.ClientInfo.UNKNOWN_CLIENT;
+
+import java.util.List;
 import java.util.Set;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
+import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.Metrics;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
@@ -11,22 +16,27 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 public class RequestContext {
     
     public static final RequestContext NULL_INSTANCE = new RequestContext(null, null, null, ImmutableSet.of(),
-            ImmutableSet.of(), null);
+            ImmutableSet.of(), null, UNKNOWN_CLIENT, ImmutableList.of());
 
     private final String requestId;
     private final StudyIdentifier callerStudyId;
     private final Set<String> callerSubstudies;
     private final Set<Roles> callerRoles;
     private final String callerUserId;
+    private final ClientInfo callerClientInfo;
+    private final List<String> callerLanguages;    
     private final Metrics metrics;
     
-    private RequestContext(Metrics metrics, String requestId, String callerStudyId, Set<String> callerSubstudies, Set<Roles> callerRoles, String callerUserId) {
+    private RequestContext(Metrics metrics, String requestId, String callerStudyId, Set<String> callerSubstudies,
+            Set<Roles> callerRoles, String callerUserId, ClientInfo callerClientInfo, List<String> callerLanguages) {
         this.requestId = requestId;
         this.callerStudyId = (callerStudyId == null) ? null : new StudyIdentifierImpl(callerStudyId);
         this.callerSubstudies = callerSubstudies;
         this.callerRoles = callerRoles;
-        this.metrics = metrics;
         this.callerUserId = callerUserId;
+        this.callerClientInfo = callerClientInfo;
+        this.callerLanguages = callerLanguages;
+        this.metrics = metrics;
     }
     
     public Metrics getMetrics() {
@@ -50,6 +60,23 @@ public class RequestContext {
     public String getCallerUserId() { 
         return callerUserId;
     }
+    public ClientInfo getCallerClientInfo() {
+        return callerClientInfo;
+    }
+    public List<String> getCallerLanguages() {
+        return callerLanguages;
+    }
+    public RequestContext.Builder toBuilder() {
+        return new RequestContext.Builder()
+            .withRequestId(requestId)
+            .withCallerClientInfo(callerClientInfo)
+            .withCallerStudyId(callerStudyId)
+            .withCallerLanguages(callerLanguages)
+            .withCallerRoles(callerRoles)
+            .withCallerSubstudies(callerSubstudies)
+            .withCallerUserId(callerUserId)
+            .withMetrics(metrics);
+    }
     
     public static class Builder {
         private Metrics metrics;
@@ -58,6 +85,8 @@ public class RequestContext {
         private Set<Roles> callerRoles;
         private String requestId;
         private String callerUserId;
+        private ClientInfo callerClientInfo;
+        private List<String> callerLanguages;    
 
         public Builder withMetrics(Metrics metrics) {
             this.metrics = metrics;
@@ -83,6 +112,14 @@ public class RequestContext {
             this.callerUserId = callerUserId;
             return this;
         }
+        public Builder withCallerClientInfo(ClientInfo callerClientInfo) {
+            this.callerClientInfo = callerClientInfo;
+            return this;
+        }
+        public Builder withCallerLanguages(List<String> callerLanguages) {
+            this.callerLanguages = callerLanguages;
+            return this;
+        }
         
         public RequestContext build() {
             if (requestId == null) {
@@ -94,16 +131,25 @@ public class RequestContext {
             if (callerRoles == null) {
                 callerRoles = ImmutableSet.of();
             }
+            if (callerLanguages == null) {
+                callerLanguages = ImmutableList.of();
+            }
+            if (callerClientInfo == null) {
+                callerClientInfo = ClientInfo.UNKNOWN_CLIENT;
+            }
             if (metrics == null) {
                 metrics = new Metrics(requestId);
             }
-            return new RequestContext(metrics, requestId, callerStudyId, callerSubstudies, callerRoles, callerUserId);
+            return new RequestContext(metrics, requestId, callerStudyId, callerSubstudies, callerRoles, callerUserId,
+                    callerClientInfo, callerLanguages);
         }
     }
 
     @Override
     public String toString() {
-        return "RequestContext [callerStudyId=" + callerStudyId + ", callerSubstudies=" + callerSubstudies
-                + ", callerRoles=" + callerRoles + ", callerUserId=" + callerUserId + ", requestId=" + requestId + "]";
+        return "RequestContext [requestId=" + requestId + ", callerStudyId=" + callerStudyId + ", callerSubstudies="
+                + callerSubstudies + ", callerRoles=" + callerRoles + ", callerUserId=" + callerUserId
+                + ", callerClientInfo=" + callerClientInfo + ", callerLanguages=" + callerLanguages + ", metrics="
+                + metrics + "]";
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateTemplateRevisionDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateTemplateRevisionDao.java
@@ -8,7 +8,6 @@ import static org.sagebionetworks.bridge.models.ResourceList.PAGE_SIZE;
 import static org.sagebionetworks.bridge.models.ResourceList.TOTAL;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AppConfigController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AppConfigController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.cache.CacheKey;
 import org.sagebionetworks.bridge.cache.ViewCache;
 import org.sagebionetworks.bridge.models.ClientInfo;
@@ -55,9 +56,11 @@ public class AppConfigController extends BaseController {
     public String getStudyAppConfig(@PathVariable String studyId) {
         Study study = studyService.getStudy(studyId);
         
+        RequestContext reqContext = BridgeUtils.getRequestContext();
+        
         CriteriaContext context = new CriteriaContext.Builder()
-                .withLanguages(getLanguagesFromAcceptLanguageHeader())
-                .withClientInfo(getClientInfoFromUserAgentHeader())
+                .withLanguages(reqContext.getCallerLanguages())
+                .withClientInfo(reqContext.getCallerClientInfo())
                 .withStudyIdentifier(study.getStudyIdentifier())
                 .build();
         

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
@@ -36,6 +36,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
@@ -143,9 +144,11 @@ public class ParticipantController extends BaseController {
                 .withId(session.getId()).build();
         participantService.updateParticipant(study, updated);
         
+        RequestContext reqContext = BridgeUtils.getRequestContext();
+        
         CriteriaContext context = new CriteriaContext.Builder()
                 .withLanguages(session.getParticipant().getLanguages())
-                .withClientInfo(getClientInfoFromUserAgentHeader())
+                .withClientInfo(reqContext.getCallerClientInfo())
                 .withHealthCode(session.getHealthCode())
                 .withUserId(session.getId())
                 .withUserDataGroups(updated.getDataGroups())

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ScheduleController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ScheduleController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
@@ -73,7 +74,8 @@ public class ScheduleController extends BaseController {
     private List<Schedule> getSchedulesInternal() {
         UserSession session = getAuthenticatedAndConsentedSession();
         StudyIdentifier studyId = session.getStudyIdentifier();
-        ClientInfo clientInfo = getClientInfoFromUserAgentHeader();
+        
+        ClientInfo clientInfo = BridgeUtils.getRequestContext().getCallerClientInfo();
 
         ScheduleContext context = new ScheduleContext.Builder()
                 .withLanguages(getLanguages(session))

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ScheduledActivityController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ScheduledActivityController.java
@@ -30,6 +30,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.models.DateTimeRangeResourceList;
 import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
@@ -223,6 +224,9 @@ public class ScheduledActivityController extends BaseController {
     
     private ScheduleContext getScheduledActivitiesInternal(UserSession session, DateTimeZone requestTimeZone,
             DateTime startsOn, DateTime endsOn, int minPerSchedule) {
+        
+        RequestContext reqContext = BridgeUtils.getRequestContext();
+        
         ScheduleContext.Builder builder = new ScheduleContext.Builder();
         
         // This time zone is the time zone of the user upon first contacting the server for activities, and
@@ -244,7 +248,7 @@ public class ScheduledActivityController extends BaseController {
         builder.withStudyIdentifier(session.getStudyIdentifier());
         builder.withAccountCreatedOn(session.getParticipant().getCreatedOn());
         builder.withLanguages(getLanguages(session));
-        builder.withClientInfo(getClientInfoFromUserAgentHeader());
+        builder.withClientInfo(reqContext.getCallerClientInfo());
         builder.withMinimumPerSchedule(minPerSchedule);
         
         ScheduleContext context = builder.build();

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/UserProfileController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/UserProfileController.java
@@ -21,6 +21,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.cache.CacheKey;
 import org.sagebionetworks.bridge.cache.ViewCache;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
@@ -180,9 +182,11 @@ public class UserProfileController extends BaseController {
         
         participantService.updateParticipant(study, updated);
         
+        RequestContext reqContext = BridgeUtils.getRequestContext();
+        
         CriteriaContext context = new CriteriaContext.Builder()
                 .withLanguages(session.getParticipant().getLanguages())
-                .withClientInfo(getClientInfoFromUserAgentHeader())
+                .withClientInfo(reqContext.getCallerClientInfo())
                 .withHealthCode(session.getHealthCode())
                 .withUserId(session.getId())
                 .withUserDataGroups(updated.getDataGroups())

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AppConfigControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AppConfigControllerTest.java
@@ -30,6 +30,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -118,6 +119,11 @@ public class AppConfigControllerTest extends Mockito {
                 .withRoles(ImmutableSet.of(DEVELOPER))
                 .withHealthCode(HEALTH_CODE)
                 .build());
+    }
+    
+    @AfterMethod
+    public void afterMethod() {
+        BridgeUtils.setRequestContext(null);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationControllerTest.java
@@ -38,6 +38,8 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.BridgeConstants;
+import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
@@ -52,6 +54,7 @@ import org.sagebionetworks.bridge.exceptions.NotAuthenticatedException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.exceptions.UnsupportedVersionException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.Metrics;
 import org.sagebionetworks.bridge.models.OperatingSystem;
@@ -714,10 +717,15 @@ public class AuthenticationControllerTest extends Mockito {
                 "{'study':'" + TEST_STUDY_ID_STRING + 
                 "','email':'email@email.com','password':'bar'}");
         mockRequestBody(mockRequest, BridgeObjectMapper.get().readTree(json));
-        when(mockRequest.getHeader(USER_AGENT)).thenReturn("App/14 (Unknown iPhone; iOS/9.0.2) BridgeSDK/4");
+        
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerClientInfo(ClientInfo.fromUserAgentCache("App/14 (Unknown iPhone; iOS/9.0.2) BridgeSDK/4"))
+                .build());
         study.getMinSupportedAppVersions().put(OperatingSystem.IOS, 20);
         
         controller.emailSignIn();
+        
+        BridgeUtils.setRequestContext(null);
     }
 
     @Test(expectedExceptions = UnsupportedVersionException.class)

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ExternalIdControllerV4Test.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ExternalIdControllerV4Test.java
@@ -32,7 +32,6 @@ import org.mockito.Spy;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.exceptions.NotAuthenticatedException;
 import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
@@ -271,7 +271,7 @@ public class ParticipantControllerTest extends Mockito {
 
     @AfterMethod
     public void after() {
-        BridgeUtils.setRequestContext(RequestContext.NULL_INSTANCE);
+        BridgeUtils.setRequestContext(null);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ScheduleControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ScheduleControllerTest.java
@@ -23,9 +23,12 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.springframework.validation.Errors;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -93,10 +96,15 @@ public class ScheduleControllerTest extends Mockito {
         session.setStudyIdentifier(studyId);
         
         doReturn(session).when(controller).getAuthenticatedAndConsentedSession();
-        doReturn(clientInfo).when(controller).getClientInfoFromUserAgentHeader();
+        BridgeUtils.setRequestContext(new RequestContext.Builder().withCallerClientInfo(clientInfo).build());
         
         doReturn(mockRequest).when(controller).request();
         doReturn(mockResponse).when(controller).response();
+    }
+    
+    @AfterMethod
+    public void afterMethod() {
+        BridgeUtils.setRequestContext(null);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ScheduledActivityControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ScheduledActivityControllerTest.java
@@ -42,10 +42,12 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.BridgeConfig;
@@ -188,9 +190,15 @@ public class ScheduledActivityControllerTest extends Mockito {
         when(mockBridgeConfig.getEnvironment()).thenReturn(UAT);
         
         doReturn(session).when(controller).getAuthenticatedAndConsentedSession();
-        doReturn(CLIENT_INFO).when(controller).getClientInfoFromUserAgentHeader();
         doReturn(mockRequest).when(controller).request();
         doReturn(mockResponse).when(controller).response();
+        
+        BridgeUtils.setRequestContext(new RequestContext.Builder().withCallerClientInfo(CLIENT_INFO).build());
+    }
+    
+    @AfterMethod
+    public void afterMethod( ) {
+        BridgeUtils.setRequestContext(null);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/spring/filters/RequestFilterTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/filters/RequestFilterTest.java
@@ -1,15 +1,26 @@
 package org.sagebionetworks.bridge.spring.filters;
 
+import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_API_STATUS_HEADER;
+import static org.sagebionetworks.bridge.BridgeConstants.WARN_NO_ACCEPT_LANGUAGE;
+import static org.sagebionetworks.bridge.BridgeConstants.WARN_NO_USER_AGENT;
+import static org.sagebionetworks.bridge.TestConstants.UA;
+import static org.springframework.http.HttpHeaders.ACCEPT_LANGUAGE;
+import static org.springframework.http.HttpHeaders.USER_AGENT;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
+import java.util.Collection;
 import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Vector;
 
 import javax.servlet.FilterChain;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import com.google.common.collect.ImmutableList;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -23,6 +34,7 @@ import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.RequestContext;
+import org.sagebionetworks.bridge.models.ClientInfo;
 
 public class RequestFilterTest extends Mockito {
 
@@ -108,5 +120,194 @@ public class RequestFilterTest extends Mockito {
         assertEquals("AAABAAA", context.getId());
         
         assertNull(contextCaptor.getAllValues().get(1));
+    }
+    
+    @Test
+    public void getLanguagesFromAcceptLanguageHeader() {
+        when(mockRequest.getHeader(ACCEPT_LANGUAGE))
+            .thenReturn("de-de;q=0.4,de;q=0.2,en-ca,en;q=0.8,en-us;q=0.6,fr;q=0.1");
+
+        List<String> langs = RequestFilter.getLanguagesFromAcceptLanguageHeader(mockRequest, mockResponse);
+        assertEquals(langs, ImmutableList.of("en", "de", "fr"));
+    }
+    
+    @Test
+    public void getLanguagesFromAcceptLanguageHeaderMissing() {
+        List<String> langs = RequestFilter.getLanguagesFromAcceptLanguageHeader(mockRequest, mockResponse);
+        assertTrue(langs.isEmpty());
+    }
+
+    @Test
+    public void getClientInfoFromUserAgentHeader() {
+        when(mockRequest.getHeader(USER_AGENT)).thenReturn(UA);
+
+        ClientInfo info = RequestFilter.getClientInfoFromUserAgentHeader(mockRequest, mockResponse);
+        
+        assertEquals(info, ClientInfo.fromUserAgentCache(UA));
+    }
+
+    @Test
+    public void getClientInfoFromUserAgentHeaderMissing() {
+        ClientInfo info = RequestFilter.getClientInfoFromUserAgentHeader(mockRequest, mockResponse);
+        
+        assertEquals(info, ClientInfo.UNKNOWN_CLIENT);
+    }
+    
+    @Test
+    public void addWarningMessage() {
+        Collection<String> headerNames = new HashSet<>();
+        when(mockResponse.getHeaderNames()).thenReturn(headerNames);
+        
+        RequestFilter.addWarningMessage(mockResponse, "first message");
+        
+        verify(mockResponse).setHeader(BRIDGE_API_STATUS_HEADER, "first message");
+        
+        // Mock what will change once the header is added, then add a second message
+        headerNames.add(BRIDGE_API_STATUS_HEADER);
+        when(mockResponse.getHeader(BRIDGE_API_STATUS_HEADER)).thenReturn("first message");
+        
+        RequestFilter.addWarningMessage(mockResponse, "second message");
+        
+        verify(mockResponse).setHeader(BRIDGE_API_STATUS_HEADER, "first message; second message");
+    }
+    
+    // Tests from original Play tests.
+    
+    @Test
+    public void doesNotThrowErrorWhenUserAgentStringInvalid() throws Exception {
+        when(mockRequest.getHeader(USER_AGENT)).thenReturn(
+                "Amazon Route 53 Health Check Service; ref:c97cd53f-2272-49d6-a8cd-3cd658d9d020; report http://amzn.to/1vsZADi");
+        
+        ClientInfo info = RequestFilter.getClientInfoFromUserAgentHeader(mockRequest, mockResponse);
+        assertEquals(info, ClientInfo.UNKNOWN_CLIENT);
+        assertNull(info.getAppName());
+        assertNull(info.getAppVersion());
+        assertNull(info.getOsName());
+        assertNull(info.getOsVersion());
+        assertNull(info.getSdkName());
+        assertNull(info.getSdkVersion());
+    }
+
+    @Test
+    public void doesNotSetWarningHeaderWhenHasUserAgent() throws Exception {
+        when(mockRequest.getHeader(USER_AGENT)).thenReturn(UA);
+        
+        RequestFilter.getClientInfoFromUserAgentHeader(mockRequest, mockResponse);
+        
+        verify(mockResponse, never()).setHeader(any(), any());
+    }
+
+    @Test
+    public void setWarningHeaderWhenNoUserAgent() throws Exception {
+        RequestFilter.getClientInfoFromUserAgentHeader(mockRequest, mockResponse);
+
+        verify(mockResponse).setHeader(BRIDGE_API_STATUS_HEADER, WARN_NO_USER_AGENT);
+    }
+
+    @Test
+    public void setWarningHeaderWhenEmptyUserAgent() throws Exception {
+        when(mockRequest.getHeader(USER_AGENT)).thenReturn("");
+
+        RequestFilter.getClientInfoFromUserAgentHeader(mockRequest, mockResponse);
+
+        verify(mockResponse).setHeader(BRIDGE_API_STATUS_HEADER, WARN_NO_USER_AGENT);
+    }
+
+    @Test
+    public void setWarningHeaderWhenNullUserAgent() throws Exception {
+        when(mockRequest.getHeader(USER_AGENT)).thenReturn(null);
+
+        RequestFilter.getClientInfoFromUserAgentHeader(mockRequest, mockResponse);
+
+        verify(mockResponse).setHeader(BRIDGE_API_STATUS_HEADER, WARN_NO_USER_AGENT);
+    }
+
+    @Test
+    public void canRetrieveLanguagesWhenHeaderIsNull() throws Exception {
+        when(mockRequest.getHeader(ACCEPT_LANGUAGE)).thenReturn(null);
+        
+        List<String> langs = RequestFilter.getLanguagesFromAcceptLanguageHeader(mockRequest, mockResponse);
+        assertEquals(ImmutableList.of(), langs);
+    }        
+    
+    @Test
+    public void canRetrieveLanguagesWhenHeaderIsEmpty() throws Exception {
+        when(mockRequest.getHeader(ACCEPT_LANGUAGE)).thenReturn("");
+        
+        List<String> langs = RequestFilter.getLanguagesFromAcceptLanguageHeader(mockRequest, mockResponse);
+        assertEquals(ImmutableList.of(), langs);
+    }
+    
+    @Test
+    public void canRetrieveLanguagesWhenHeaderIsSimple() throws Exception {
+        when(mockRequest.getHeader(ACCEPT_LANGUAGE)).thenReturn("en-US");
+        
+        List<String> langs = RequestFilter.getLanguagesFromAcceptLanguageHeader(mockRequest, mockResponse);
+        assertEquals(ImmutableList.of("en"), langs);
+    }
+    
+    @Test
+    public void canRetrieveLanguagesWhenHeaderIsCompoundWithoutWeights() throws Exception {
+        when(mockRequest.getHeader(ACCEPT_LANGUAGE)).thenReturn("FR,en-US");
+        
+        List<String> langs = RequestFilter.getLanguagesFromAcceptLanguageHeader(mockRequest, mockResponse);
+        assertEquals(ImmutableList.of("fr", "en"), langs);
+    }
+    
+    // We don't want to throw a BadRequestException due to a malformed header. Just return no languages.
+    @Test
+    public void badAcceptLanguageHeaderSilentlyIgnored() throws Exception {
+        when(mockRequest.getHeader(ACCEPT_LANGUAGE)).thenReturn("chrome://global/locale/intl.properties");
+        
+        List<String> langs = RequestFilter.getLanguagesFromAcceptLanguageHeader(mockRequest, mockResponse);
+        assertTrue(langs.isEmpty());
+    }
+    
+
+    @Test
+    public void setWarnHeaderWhenNoAcceptLanguage() throws Exception {
+        // with no accept language header at all, things don't break;
+        List<String> langs = RequestFilter.getLanguagesFromAcceptLanguageHeader(mockRequest, mockResponse);
+        assertEquals(ImmutableList.of(), langs);
+
+        // verify if it set warning header
+        verify(mockResponse).setHeader(BRIDGE_API_STATUS_HEADER, WARN_NO_ACCEPT_LANGUAGE);
+    }
+
+    @Test
+    public void setWarnHeaderWhenEmptyAcceptLanguage() throws Exception {
+        when(mockRequest.getHeader(ACCEPT_LANGUAGE)).thenReturn("");
+
+        // with no accept language header at all, things don't break;
+        List<String> langs = RequestFilter.getLanguagesFromAcceptLanguageHeader(mockRequest, mockResponse);
+        assertEquals(ImmutableList.of(), langs);
+
+        // verify if it set warning header
+        verify(mockResponse).setHeader(BRIDGE_API_STATUS_HEADER, WARN_NO_ACCEPT_LANGUAGE);
+    }
+
+
+    @Test
+    public void setWarnHeaderWhenNullAcceptLanguage() throws Exception {
+        when(mockRequest.getHeader(ACCEPT_LANGUAGE)).thenReturn(null);
+
+        // with no accept language header at all, things don't break;
+        List<String> langs = RequestFilter.getLanguagesFromAcceptLanguageHeader(mockRequest, mockResponse);
+        assertEquals(ImmutableList.of(), langs);
+
+        // verify if it set warning header
+        verify(mockResponse).setHeader(BRIDGE_API_STATUS_HEADER, WARN_NO_ACCEPT_LANGUAGE);
+    }
+
+    @Test
+    public void setWarnHeaderWhenInvalidAcceptLanguage() throws Exception {
+        when(mockRequest.getHeader(ACCEPT_LANGUAGE)).thenReturn("ThisIsAnVvalidAcceptLanguage");
+
+        // with no accept language header at all, things don't break;
+        List<String> langs = RequestFilter.getLanguagesFromAcceptLanguageHeader(mockRequest, mockResponse);
+        assertEquals(ImmutableList.of(), langs);
+
+        // verify if it set warning header
+        verify(mockResponse).setHeader(BRIDGE_API_STATUS_HEADER, WARN_NO_ACCEPT_LANGUAGE);
     }
 }


### PR DESCRIPTION
We're now heading toward selecting templates all over the place based on what we know about the user... most importantly their app version and possibly their preferred language. Toward that end I think CriteriaContext can be phased out in favor of carrying over the same information in RequestContext as a thread local variable. (SchedulingContext is different because a lot of the context is passed in by the user and will probably stay.) RequestContext is all about what we know about the caller that could influence the response.