### PR TITLE
Some final changes before adding migration code

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.Integer.parseInt;
+import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.springframework.util.StringUtils.commaDelimitedListToSet;
 
@@ -11,6 +12,7 @@ import java.net.URI;
 import java.net.URLEncoder;
 import java.security.SecureRandom;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -41,6 +43,8 @@ import org.sagebionetworks.bridge.models.schedules.ActivityType;
 import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.substudies.AccountSubstudy;
+import org.sagebionetworks.bridge.models.templates.TemplateType;
+
 import org.springframework.core.annotation.AnnotationUtils;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper.FailedBatch;
@@ -590,4 +594,18 @@ public class BridgeUtils {
         
         return value; 
     }
+    
+    public static String templateTypeToLabel(TemplateType type) {
+        List<String> words = Arrays.asList(type.name().toLowerCase().split("_"));
+        List<String> capitalized = words.stream().map(StringUtils::capitalize).collect(toList());
+        if (capitalized.get(0).equals("Sms")) {
+            capitalized.remove(0);
+            capitalized.add("Default (SMS)");
+        }
+        if (capitalized.get(0).equals("Email")) {
+            capitalized.remove(0);
+            capitalized.add("Default (Email)");
+        }
+        return Joiner.on(" ").join(capitalized);
+    }    
 }

--- a/src/main/java/org/sagebionetworks/bridge/dao/TemplateDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dao/TemplateDao.java
@@ -21,4 +21,5 @@ public interface TemplateDao {
     
     void deleteTemplatePermanently(StudyIdentifier studyId, String guid);
     
+    void deleteTemplatesForStudy(StudyIdentifier studyId);
 }

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateTemplateDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateTemplateDao.java
@@ -38,6 +38,8 @@ public class HibernateTemplateDao implements TemplateDao {
     private static final String GET_ACTIVE = "FROM HibernateTemplate as template " + 
             "WHERE templateType = :templateType AND studyId = :studyId AND deleted = 0 ORDER BY createdOn DESC";
     
+    private static final String DELETE_STUDY = "DELETE FROM HibernateTemplate WHERE studyId = :studyId";
+    
     private HibernateHelper hibernateHelper;
     
     @Resource(name = "templateHibernateHelper")
@@ -103,5 +105,9 @@ public class HibernateTemplateDao implements TemplateDao {
             hibernateHelper.deleteById(HibernateTemplate.class, guid);    
         }
     }
-
+    
+    @Override
+    public void deleteTemplatesForStudy(StudyIdentifier studyId) {
+        hibernateHelper.query(DELETE_STUDY, ImmutableMap.of("studyId", studyId.getIdentifier()));
+    }
 }

--- a/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
@@ -66,7 +66,6 @@ import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
-import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.IdentifierHolder;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.studies.EmailTemplate;
@@ -76,9 +75,7 @@ import org.sagebionetworks.bridge.models.studies.SmsTemplate;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyAndUsers;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
-import org.sagebionetworks.bridge.models.templates.Template;
 import org.sagebionetworks.bridge.models.templates.TemplateRevision;
-import org.sagebionetworks.bridge.models.templates.TemplateType;
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.models.upload.UploadValidationStrictness;
 import org.sagebionetworks.bridge.services.email.BasicEmailProvider;
@@ -731,7 +728,7 @@ public class StudyService {
             studyDao.deleteStudy(existing);
 
             // delete study data
-            deleteAllTemplates(existing.getStudyIdentifier());
+            templateService.deleteTemplatesForStudy(existing.getStudyIdentifier());
             compoundActivityDefinitionService.deleteAllCompoundActivityDefinitionsInStudy(
                     existing.getStudyIdentifier());
             subpopService.deleteAllSubpopulations(existing.getStudyIdentifier());
@@ -739,18 +736,6 @@ public class StudyService {
         }
 
         cacheProvider.removeStudy(identifier);
-    }
-    
-    private void deleteAllTemplates(StudyIdentifier studyId) {
-        for (TemplateType type : TemplateType.values()) {
-            PagedResourceList<? extends Template> page;
-            do {
-                page = templateService.getTemplatesForType(studyId, type, 0, 50, true);
-                for (Template template : page.getItems()) {
-                    templateService.deleteTemplatePermanently(studyId, template.getGuid());    
-                }
-            } while(!page.getItems().isEmpty());
-        }
     }
     
     /**

--- a/src/main/java/org/sagebionetworks/bridge/services/TemplateMigrationService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/TemplateMigrationService.java
@@ -1,0 +1,200 @@
+package org.sagebionetworks.bridge.services;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.sagebionetworks.bridge.BridgeUtils.templateTypeToLabel;
+import static org.sagebionetworks.bridge.models.studies.MimeType.TEXT;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.MapDifference;
+import com.google.common.collect.Maps;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
+import org.sagebionetworks.bridge.models.GuidVersionHolder;
+import org.sagebionetworks.bridge.models.studies.EmailTemplate;
+import org.sagebionetworks.bridge.models.studies.SmsTemplate;
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+import org.sagebionetworks.bridge.models.templates.Template;
+import org.sagebionetworks.bridge.models.templates.TemplateRevision;
+import org.sagebionetworks.bridge.models.templates.TemplateType;
+
+/**
+ * A temporary component that works with TemplateService to migrate templates out of the study 
+ * object and into the enhanced Template tables.
+ */
+@Component
+public class TemplateMigrationService {
+    private static final Logger LOG = LoggerFactory.getLogger(TemplateMigrationService.class);
+    
+    private TemplateService templateService;
+    
+    @Autowired
+    final void setTemplateService(TemplateService templateService) {
+        this.templateService = templateService;
+    }
+    
+    /**
+     * Updates a study to use a set of enhanced templates with a default revision. Does not change the study mapping
+     * if it already exists, but if it doesn't, it will create a template and revision from the study object's existing 
+     * template information. If the study is new and doesn't have existing template information, it is created from 
+     * the system defaults. This call does not persist changes in the study. If the study fails to be updated, the 
+     * templates should be picked up on a subsequent run of this method. Eventually the study should have a complete 
+     * set of enhanced templates associated with it.
+     * @param study
+     * @return true if the Study's defaultTemplates mapping has been updated, false otherwise.
+     */
+    public boolean migrateTemplates(Study study) {
+        StudyIdentifier studyId = study.getStudyIdentifier();
+        Map<String,String> studyDefaults = study.getDefaultTemplates();
+        // Shortcut studies that have been entirely  migrated.
+        if (TemplateType.values().length == studyDefaults.size()) {
+            LOG.debug("Study " + study.getIdentifier() + " templates have been migrated");
+            return false;
+        }
+        
+        Map<String,String> defaultTemplates = new HashMap<>();
+        
+        // #1 Copy over existing, functional default references already set in the study
+        for (Map.Entry<String, String> entry : studyDefaults.entrySet()) {
+            String typeName = entry.getKey();
+            String templateGuid = entry.getValue();
+            // Try and load the template and revision to ensure they are consistent
+            if (hasValidTemplate(studyId, templateGuid)) {
+                defaultTemplates.put(typeName, templateGuid);
+            }
+        }
+        
+        // Now fill the remaining templates in any of a few ways
+        for (TemplateType type : TemplateType.values()) {
+            String typeName = type.name().toLowerCase();
+            // #2 Look for a valid template that can be set as the study's default (data integrity or picking up
+            // external saves to system)
+            if (defaultTemplates.get(typeName) == null) {
+                String templateGuid = findValidTemplateGuid(studyId, type);
+                if (templateGuid != null) {
+                    defaultTemplates.put(typeName, templateGuid);
+                }
+            }
+            // #3 Migrate any study object template, since this is no persisted template that would take precedence (migration case)
+            if (defaultTemplates.get(typeName) == null) {
+                migrateExistingTemplate(study, defaultTemplates, type);
+            }
+            // #4 If still missing, create a template from the services's defaults (new study case)
+            if (defaultTemplates.get(typeName) == null) {
+                createNewTemplate(study, defaultTemplates, type);
+            }
+        }
+        
+        // If there are no changes, return false and don't set the mapping
+        MapDifference<String,String> diff = Maps.difference(defaultTemplates, study.getDefaultTemplates());
+        if (diff.areEqual()) {
+            return false;
+        }
+        // Otherwise set the mapping and return true
+        study.setDefaultTemplates(defaultTemplates);
+        return true;
+    }
+    
+    String findValidTemplateGuid(StudyIdentifier studyId, TemplateType type) {
+        List<? extends Template> templates = templateService.getTemplatesForType(studyId, type, 0, 50, false).getItems();
+        for (Template oneTemplate : templates) {
+            if (oneTemplate.getPublishedCreatedOn() != null) {
+                return oneTemplate.getGuid();
+            }
+        }
+        return null;
+    }
+    
+    boolean hasValidTemplate(StudyIdentifier studyId, String templateGuid) {
+        if (templateGuid != null) {
+            try {
+                Template template = templateService.getTemplate(studyId, templateGuid);
+                return (template.getPublishedCreatedOn() != null);
+            } catch(Exception e) {
+                LOG.error("Error verifying template " + templateGuid, e);
+                return false;
+            }
+        }
+        return false;
+    }
+    
+    void migrateExistingTemplate(Study study, Map<String, String> defaultTemplates, TemplateType type) {
+        TemplateRevision revision = getRevisionFromStudy(study, type);
+        if (revision != null) {
+            Template template = Template.create();
+            template.setName(templateTypeToLabel(type));
+            template.setTemplateType(type);
+            GuidVersionHolder keys = templateService.migrateTemplate(study, template, revision);
+            defaultTemplates.put(type.name().toLowerCase(), keys.getGuid());        
+        }
+    }
+    
+    void createNewTemplate(Study study, Map<String, String> defaultTemplates, TemplateType type) {
+        Template template = Template.create();
+        template.setName(templateTypeToLabel(type));
+        template.setTemplateType(type);
+        GuidVersionHolder keys = templateService.createTemplate(study, template);
+        defaultTemplates.put(type.name().toLowerCase(), keys.getGuid());        
+    }
+    
+    public static TemplateRevision getRevisionFromStudy(Study study, TemplateType type) {
+        checkNotNull(study);
+        checkNotNull(type);
+        switch(type) {
+        case EMAIL_ACCOUNT_EXISTS:
+            return emailTemplateToRevision(study.getAccountExistsTemplate());
+        case EMAIL_APP_INSTALL_LINK:
+            return emailTemplateToRevision(study.getAppInstallLinkTemplate());
+        case EMAIL_RESET_PASSWORD:
+            return emailTemplateToRevision(study.getResetPasswordTemplate());
+        case EMAIL_SIGN_IN:
+            return emailTemplateToRevision(study.getEmailSignInTemplate());
+        case EMAIL_SIGNED_CONSENT:
+            return emailTemplateToRevision(study.getSignedConsentTemplate());
+        case EMAIL_VERIFY_EMAIL:
+            return emailTemplateToRevision(study.getVerifyEmailTemplate());
+        case SMS_ACCOUNT_EXISTS:
+            return smsTemplateToRevision(study.getAccountExistsSmsTemplate());
+        case SMS_APP_INSTALL_LINK:
+            return smsTemplateToRevision(study.getAppInstallLinkSmsTemplate());
+        case SMS_PHONE_SIGN_IN:
+            return smsTemplateToRevision(study.getPhoneSignInSmsTemplate());
+        case SMS_RESET_PASSWORD:
+            return smsTemplateToRevision(study.getResetPasswordSmsTemplate());
+        case SMS_SIGNED_CONSENT:
+            return smsTemplateToRevision(study.getSignedConsentSmsTemplate());
+        case SMS_VERIFY_PHONE:            
+            return smsTemplateToRevision(study.getVerifyPhoneSmsTemplate());
+        }
+        throw new BridgeServiceException("Template type does not match template: " + type);
+    }
+    
+    static TemplateRevision emailTemplateToRevision(EmailTemplate template) {
+        if (template == null) {
+            return null;
+        }
+        TemplateRevision revision = TemplateRevision.create();
+        revision.setSubject(template.getSubject());
+        revision.setDocumentContent(template.getBody());
+        revision.setMimeType(template.getMimeType());
+        return revision;
+    }
+    
+    static TemplateRevision smsTemplateToRevision(SmsTemplate template) {
+        if (template == null) {
+            return null;
+        }
+        TemplateRevision revision = TemplateRevision.create();
+        revision.setDocumentContent(template.getMessage());
+        revision.setMimeType(TEXT);
+        return revision;
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/services/TemplateService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/TemplateService.java
@@ -409,11 +409,6 @@ public class TemplateService {
         // Throws exception if template doesn't exist
         Template template = getTemplate(studyId, guid);
         
-        // You cannot delete the default template (logical or physical).
-        if (isDefaultTemplate(template, studyId)) {
-            throw new ConstraintViolationException.Builder().withMessage("The default template for a type cannot be deleted.")
-                .withEntityKey("guid", guid).build();
-        }
         templateDao.deleteTemplatePermanently(studyId, guid);
         criteriaDao.deleteCriteria(getKey(template));
     }

--- a/src/main/java/org/sagebionetworks/bridge/services/TemplateService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/TemplateService.java
@@ -412,6 +412,10 @@ public class TemplateService {
         templateDao.deleteTemplatePermanently(studyId, guid);
         criteriaDao.deleteCriteria(getKey(template));
     }
+    
+    public void deleteTemplatesForStudy(StudyIdentifier studyId) {
+        templateDao.deleteTemplatesForStudy(studyId);
+    }
 
     private boolean isDefaultTemplate(Template template, StudyIdentifier studyId) {
         Study study = studyService.getStudy(studyId);

--- a/src/main/java/org/sagebionetworks/bridge/services/TemplateService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/TemplateService.java
@@ -1,4 +1,4 @@
-package org.sagebionetworks.bridge.services;
+    package org.sagebionetworks.bridge.services;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.joda.time.DateTimeZone.UTC;
@@ -41,6 +41,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.dao.CriteriaDao;
 import org.sagebionetworks.bridge.dao.TemplateDao;
 import org.sagebionetworks.bridge.dao.TemplateRevisionDao;
@@ -209,7 +210,26 @@ public class TemplateService {
         defaultTemplatesMap.put(SMS_VERIFY_PHONE, Triple.of(null, defaultVerifyPhoneSmsTemplate, TEXT));
     }
     
-    public Template getTemplateForUser(CriteriaContext context, TemplateType type) {
+    public TemplateRevision getRevisionForUser(Study study, TemplateType type) {
+        RequestContext reqContext = BridgeUtils.getRequestContext();
+        CriteriaContext context = new CriteriaContext.Builder()
+            .withClientInfo(reqContext.getCallerClientInfo())
+            .withLanguages(reqContext.getCallerLanguages())
+            .withStudyIdentifier(study.getStudyIdentifier())
+            .build();
+
+        Template template = getTemplateForUser(study, context, type);
+        if (template == null) {
+            LOG.info("No migrated template '"+type.name()+"' in study '"+study.getIdentifier()+"', using study template");
+            // During migration, if the template doesn't exist, then look in the study. This makes it 
+            // possible to reduce migration call to updates *only*.
+            return TemplateMigrationService.getRevisionFromStudy(study, type);
+        }
+        return templateRevisionDao.getTemplateRevision(template.getGuid(), template.getPublishedCreatedOn())
+                .orElseThrow(() -> new EntityNotFoundException(TemplateRevision.class));
+    }
+    
+    Template getTemplateForUser(Study study, CriteriaContext context, TemplateType type) {
         checkNotNull(context);
         checkNotNull(type);
 
@@ -228,7 +248,6 @@ public class TemplateService {
             return templateMatches.get(0);
         }
         // If not, fall back to the default specified for this study, if it exists. 
-        Study study = studyService.getStudy(context.getStudyIdentifier());
         String defaultGuid = study.getDefaultTemplates().get(type.name().toLowerCase());
         if (defaultGuid != null) {
             // Specified default may not exist, log as integrity violation, but continue
@@ -238,9 +257,6 @@ public class TemplateService {
             }
             LOG.warn("Default template " + defaultGuid + " no longer exists for template type" + type.name());
         }
-        // NOTE: We will eventually validate that the study object has a default template specified
-        // for every type of template, making the following scenarios effectively impossible.
-        
         // Return a matching template
         if (templateMatches.size() > 1) {
             LOG.warn("Template matching ambiguous without a default, returning first matched template");
@@ -252,7 +268,7 @@ public class TemplateService {
             return results.getItems().get(0);
         }
         // There is nothing to return
-        throw new EntityNotFoundException(Template.class);
+        return null;
     }
     
     public PagedResourceList<? extends Template> getTemplatesForType(StudyIdentifier studyId, TemplateType type,

--- a/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge;
 
+import static org.sagebionetworks.bridge.models.templates.TemplateType.EMAIL_SIGNED_CONSENT;
+import static org.sagebionetworks.bridge.models.templates.TemplateType.SMS_APP_INSTALL_LINK;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -794,6 +796,15 @@ public class BridgeUtilsTest {
     public void emptyStringToSynapseFriendlyName() {
         BridgeUtils.toSynapseFriendlyName("  #");
     }
+    
+    @Test
+    public void templateTypeToLabel() {
+        String label = BridgeUtils.templateTypeToLabel(SMS_APP_INSTALL_LINK);
+        assertEquals(label, "App Install Link Default (SMS)");
+
+        label = BridgeUtils.templateTypeToLabel(EMAIL_SIGNED_CONSENT);
+        assertEquals(label, "Signed Consent Default (Email)");
+    }    
     
     // assertEquals with two sets doesn't verify the order is the same... hence this test method.
     private <T> void orderedSetsEqual(Set<T> first, Set<T> second) {

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateTemplateDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateTemplateDaoTest.java
@@ -155,4 +155,13 @@ public class HibernateTemplateDaoTest extends Mockito {
         verify(mockHelper, never()).deleteById(HibernateTemplate.class, GUID);
     }
     
+    @Test
+    public void deleteTemplatesForStudy() { 
+        dao.deleteTemplatesForStudy(TEST_STUDY);
+        
+        verify(mockHelper).query(eq("DELETE FROM HibernateTemplate WHERE studyId = :studyId"),
+                paramsCaptor.capture());
+        
+        assertEquals(paramsCaptor.getValue().get("studyId"), TEST_STUDY_IDENTIFIER);
+    }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -882,6 +882,7 @@ public class StudyServiceMockTest extends Mockito {
         verify(mockSubpopService).deleteAllSubpopulations(study.getStudyIdentifier());
         verify(mockTopicService).deleteAllTopics(study.getStudyIdentifier());
         verify(mockCacheProvider).removeStudy(TEST_STUDY_ID);
+        verify(mockTemplateService).deleteTemplatesForStudy(TEST_STUDY_IDENTIFIER);
     }
 
     private Template createTemplate(String guid) {

--- a/src/test/java/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -1,10 +1,12 @@
 package org.sagebionetworks.bridge.services;
 
+import static org.mockito.AdditionalMatchers.not;
 import static org.sagebionetworks.bridge.BridgeConstants.TEST_USER_GROUP;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.WORKER;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.sagebionetworks.bridge.models.studies.PasswordPolicy.DEFAULT_PASSWORD_POLICY;
+import static org.sagebionetworks.bridge.models.templates.TemplateType.EMAIL_ACCOUNT_EXISTS;
 import static org.sagebionetworks.bridge.models.upload.UploadValidationStrictness.REPORT;
 import static org.sagebionetworks.bridge.models.upload.UploadValidationStrictness.WARNING;
 import static org.sagebionetworks.bridge.services.StudyService.EXPORTER_SYNAPSE_USER_ID;
@@ -71,6 +73,8 @@ import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.GuidVersionHolder;
+import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.IdentifierHolder;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.studies.EmailTemplate;
@@ -81,6 +85,7 @@ import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyAndUsers;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
+import org.sagebionetworks.bridge.models.templates.Template;
 import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.models.upload.UploadFieldType;
 import org.sagebionetworks.bridge.models.upload.UploadValidationStrictness;
@@ -142,6 +147,8 @@ public class StudyServiceMockTest extends Mockito {
     AccessControlList mockAccessControlList;
     @Mock
     SynapseClient mockSynapseClient;
+    @Mock
+    TemplateService mockTemplateService;
     
     @Captor
     ArgumentCaptor<Project> projectCaptor;
@@ -184,7 +191,10 @@ public class StudyServiceMockTest extends Mockito {
         
         study = getTestStudy();
         when(mockStudyDao.getStudy(TEST_STUDY_ID)).thenReturn(study);
-
+        
+        GuidVersionHolder keys = new GuidVersionHolder("guid", 1L);
+        when(mockTemplateService.createTemplate(any(), any())).thenReturn(keys);
+        
         when(mockStudyDao.createStudy(any())).thenAnswer(invocation -> {
             // Return the same study, except set version to 1.
             Study study = invocation.getArgument(0);
@@ -853,6 +863,15 @@ public class StudyServiceMockTest extends Mockito {
     
     @Test
     public void physicallyDeleteStudy() {
+        PagedResourceList<? extends Template> page1 = new PagedResourceList<>(
+                ImmutableList.of(createTemplate("guid1"), createTemplate("guid2"), createTemplate("guid3")), 3);
+        PagedResourceList<? extends Template> page2 = new PagedResourceList<>(ImmutableList.of(), 3);
+
+        doReturn(page1, page2).when(mockTemplateService).getTemplatesForType(
+                TEST_STUDY_IDENTIFIER, EMAIL_ACCOUNT_EXISTS, 0, 50, true);
+        doReturn(page2).when(mockTemplateService).getTemplatesForType(eq(TEST_STUDY_IDENTIFIER), 
+                not(eq(EMAIL_ACCOUNT_EXISTS)), eq(0), eq(50), eq(true));
+        
         // execute
         service.deleteStudy(TEST_STUDY_ID, true);
 
@@ -864,7 +883,13 @@ public class StudyServiceMockTest extends Mockito {
         verify(mockTopicService).deleteAllTopics(study.getStudyIdentifier());
         verify(mockCacheProvider).removeStudy(TEST_STUDY_ID);
     }
-    
+
+    private Template createTemplate(String guid) {
+        Template template = Template.create();
+        template.setGuid(guid);
+        return template;
+    }
+
     @Test(expectedExceptions = BadRequestException.class)
     public void deactivateStudyAlreadyDeactivatedBefore() {
         Study study = getTestStudy();
@@ -1761,6 +1786,8 @@ public class StudyServiceMockTest extends Mockito {
      */
     @Test
     public void crudStudy() {
+        when(mockTemplateService.getTemplatesForType(any(), any(), anyInt(), anyInt(), anyBoolean()))
+            .thenReturn(new PagedResourceList<>(ImmutableList.of(), 0));
         // developer
         BridgeUtils.setRequestContext(new RequestContext.Builder().withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
         

--- a/src/test/java/org/sagebionetworks/bridge/services/TemplateMigrationServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/TemplateMigrationServiceTest.java
@@ -1,0 +1,465 @@
+package org.sagebionetworks.bridge.services;
+
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
+import static org.sagebionetworks.bridge.TestConstants.TIMESTAMP;
+import static org.sagebionetworks.bridge.models.studies.MimeType.HTML;
+import static org.sagebionetworks.bridge.models.studies.MimeType.TEXT;
+import static org.sagebionetworks.bridge.models.templates.TemplateType.EMAIL_ACCOUNT_EXISTS;
+import static org.sagebionetworks.bridge.models.templates.TemplateType.EMAIL_APP_INSTALL_LINK;
+import static org.sagebionetworks.bridge.models.templates.TemplateType.EMAIL_RESET_PASSWORD;
+import static org.sagebionetworks.bridge.models.templates.TemplateType.EMAIL_SIGNED_CONSENT;
+import static org.sagebionetworks.bridge.models.templates.TemplateType.EMAIL_SIGN_IN;
+import static org.sagebionetworks.bridge.models.templates.TemplateType.EMAIL_VERIFY_EMAIL;
+import static org.sagebionetworks.bridge.models.templates.TemplateType.SMS_ACCOUNT_EXISTS;
+import static org.sagebionetworks.bridge.models.templates.TemplateType.SMS_APP_INSTALL_LINK;
+import static org.sagebionetworks.bridge.models.templates.TemplateType.SMS_PHONE_SIGN_IN;
+import static org.sagebionetworks.bridge.models.templates.TemplateType.SMS_RESET_PASSWORD;
+import static org.sagebionetworks.bridge.models.templates.TemplateType.SMS_SIGNED_CONSENT;
+import static org.sagebionetworks.bridge.models.templates.TemplateType.SMS_VERIFY_PHONE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.MapDifference;
+import com.google.common.collect.Maps;
+
+import org.joda.time.DateTime;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.models.CreatedOnHolder;
+import org.sagebionetworks.bridge.models.GuidVersionHolder;
+import org.sagebionetworks.bridge.models.PagedResourceList;
+import org.sagebionetworks.bridge.models.studies.EmailTemplate;
+import org.sagebionetworks.bridge.models.studies.SmsTemplate;
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.templates.Template;
+import org.sagebionetworks.bridge.models.templates.TemplateRevision;
+import org.sagebionetworks.bridge.models.templates.TemplateType;
+
+public class TemplateMigrationServiceTest extends Mockito {
+    private static final String TEMPLATE_GUID = "oneTemplateGuid";
+    private static final DateTime CREATED_ON = TIMESTAMP;
+    private static final EmailTemplate EMAIL_TEMPLATE = new EmailTemplate("Subject", "Body", HTML);
+    private static final SmsTemplate SMS_TEMPLATE = new SmsTemplate("Message");
+    
+    @Mock
+    TemplateService mockTemplateService;
+    
+    @Mock
+    TemplateRevisionService mockTemplateRevisionService;
+    
+    @InjectMocks
+    TemplateMigrationService service;
+    
+    @Captor
+    ArgumentCaptor<Template> templateCaptor;
+    
+    @Captor
+    ArgumentCaptor<TemplateRevision> revisionCaptor;
+    
+    Study study;
+    
+    @BeforeMethod
+    void beforeMethod() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        
+        study = Study.create();
+        study.setIdentifier(TEST_STUDY_IDENTIFIER);
+        
+        GuidVersionHolder keys = new GuidVersionHolder(TEMPLATE_GUID, 1L);
+        when(mockTemplateService.createTemplate(eq(study), any())).thenReturn(keys);
+        when(mockTemplateService.migrateTemplate(eq(study), any(), any())).thenReturn(keys);
+        
+        CreatedOnHolder revKeys = new CreatedOnHolder(CREATED_ON);
+        when(mockTemplateRevisionService.createTemplateRevision(eq(TEST_STUDY), eq(TEMPLATE_GUID), any())).thenReturn(revKeys);
+    }
+    
+    private Study createNewStudy() {
+        // We're assuming here that no templates are set going forward for new studies,
+        // which will need to be adjusted in the StudyService.
+        Study study = Study.create();
+        study.setIdentifier(TEST_STUDY_IDENTIFIER);
+        return study;
+    }
+    
+    private Study createMigratedStudy() {
+        Study study = Study.create();
+        study.setIdentifier(TEST_STUDY_IDENTIFIER);
+        Map<String,String> map = new HashMap<>();
+        map.put(EMAIL_ACCOUNT_EXISTS.name().toLowerCase(), TEMPLATE_GUID);
+        map.put(EMAIL_APP_INSTALL_LINK.name().toLowerCase(), TEMPLATE_GUID);
+        map.put(EMAIL_RESET_PASSWORD.name().toLowerCase(), TEMPLATE_GUID);
+        map.put(EMAIL_SIGN_IN.name().toLowerCase(), TEMPLATE_GUID);
+        map.put(EMAIL_SIGNED_CONSENT.name().toLowerCase(), TEMPLATE_GUID);
+        map.put(EMAIL_VERIFY_EMAIL.name().toLowerCase(), TEMPLATE_GUID);
+        map.put(SMS_ACCOUNT_EXISTS.name().toLowerCase(), TEMPLATE_GUID);
+        map.put(SMS_APP_INSTALL_LINK.name().toLowerCase(), TEMPLATE_GUID);
+        map.put(SMS_PHONE_SIGN_IN.name().toLowerCase(), TEMPLATE_GUID);
+        map.put(SMS_RESET_PASSWORD.name().toLowerCase(), TEMPLATE_GUID);
+        map.put(SMS_SIGNED_CONSENT.name().toLowerCase(), TEMPLATE_GUID);
+        map.put(SMS_VERIFY_PHONE.name().toLowerCase(), TEMPLATE_GUID);
+        study.setDefaultTemplates(map);
+        return study;
+    }
+    
+    private EmailTemplate emailTemplate(TemplateType type) {
+        return new EmailTemplate(type.name() + " from study", type.name() + " from study", HTML);
+    }
+    
+    private SmsTemplate smsTemplate(TemplateType type) {
+        return new SmsTemplate(type.name() + " from study");
+    }
+    
+    private void mockAllServicesWorking() throws Exception {
+        Template template = Template.create();
+        template.setGuid(TEMPLATE_GUID);
+        template.setPublishedCreatedOn(CREATED_ON);
+        
+        doReturn(template).when(mockTemplateService).getTemplate(TEST_STUDY, TEMPLATE_GUID);
+        
+        PagedResourceList<? extends Template> page = new PagedResourceList<>(ImmutableList.of(template), 1);
+        doReturn(page).when(mockTemplateService).getTemplatesForType(eq(TEST_STUDY), any(), eq(0), eq(50), eq(false));
+        
+        TemplateRevision revision = TemplateRevision.create();
+        revision.setSubject("from db");
+        revision.setDocumentContent("from db");
+        doReturn(revision).when(mockTemplateRevisionService).getTemplateRevision(TEST_STUDY, TEMPLATE_GUID, CREATED_ON);
+    }
+    
+    private void mockNoTemplates() throws Exception {
+        PagedResourceList<? extends Template> page = new PagedResourceList<>(ImmutableList.of(), 0);
+        doReturn(page).when(mockTemplateService).getTemplatesForType(eq(TEST_STUDY), any(), eq(0), eq(50), eq(false));
+    }
+    
+    @Test
+    public void migrationShortCircuitedOnceCompleted() {
+        Study study = createMigratedStudy();
+        service.migrateTemplates(study);
+        verifyZeroInteractions(mockTemplateService);
+    }
+    
+    @Test
+    public void migratedStudyPreserved() throws Exception {
+        mockAllServicesWorking();
+        Study study = createMigratedStudy();
+        
+        boolean result = service.migrateTemplates(study);
+        assertFalse(result);
+        
+        verify(mockTemplateService, never()).createTemplate(any(), any());
+        verify(mockTemplateRevisionService, never()).createTemplateRevision(any(), any(), any());
+    }
+    
+    @Test
+    public void unmigratedStudyMigrated() throws Exception {
+        mockNoTemplates();
+        
+        study.setIdentifier(TEST_STUDY_IDENTIFIER);
+        study.setVerifyEmailTemplate( emailTemplate(EMAIL_VERIFY_EMAIL) );
+        study.setResetPasswordTemplate( emailTemplate(EMAIL_RESET_PASSWORD) );
+        study.setEmailSignInTemplate( emailTemplate(EMAIL_SIGN_IN) );
+        study.setAccountExistsTemplate( emailTemplate(EMAIL_ACCOUNT_EXISTS) );
+        study.setSignedConsentTemplate( emailTemplate(EMAIL_SIGNED_CONSENT) );
+        study.setAppInstallLinkTemplate( emailTemplate(EMAIL_APP_INSTALL_LINK) );
+        study.setResetPasswordSmsTemplate( smsTemplate(SMS_RESET_PASSWORD) );
+        study.setPhoneSignInSmsTemplate( smsTemplate(SMS_PHONE_SIGN_IN) );
+        study.setAppInstallLinkSmsTemplate( smsTemplate(SMS_APP_INSTALL_LINK) );
+        study.setVerifyPhoneSmsTemplate( smsTemplate(SMS_VERIFY_PHONE) );
+        study.setAccountExistsSmsTemplate( smsTemplate(SMS_ACCOUNT_EXISTS) );
+        study.setSignedConsentSmsTemplate( smsTemplate(SMS_SIGNED_CONSENT) );
+        
+        boolean result = service.migrateTemplates(study);
+        assertTrue(result);
+        
+        MapDifference<String, String> diff = Maps.difference(createMigratedStudy().getDefaultTemplates(), study.getDefaultTemplates());
+        assertTrue(diff.areEqual());
+        
+        verify(mockTemplateService, times(12)).migrateTemplate(eq(study), templateCaptor.capture(), revisionCaptor.capture());
+        for (TemplateRevision revision : revisionCaptor.getAllValues()) {
+            assertTrue(revision.getDocumentContent().contains("from study"));
+        }
+    }
+    
+    @Test
+    public void newStudySetsNewDefaultTemplates() throws Exception {
+        mockNoTemplates();
+        
+        Study study = createNewStudy();
+        
+        GuidVersionHolder keys = new GuidVersionHolder("guid", 1L);
+        when(mockTemplateService.createTemplate(any(), any())).thenReturn(keys);
+        
+        boolean result = service.migrateTemplates(study);
+        assertTrue(result);
+        
+        verify(mockTemplateService, times(12)).createTemplate(eq(study), templateCaptor.capture());
+        for (TemplateRevision revision : revisionCaptor.getAllValues()) {
+            assertTrue(revision.getDocumentContent().contains("from service"));
+        }
+    }
+    
+    @Test
+    public void newStudyAdoptsValidTemplates() throws Exception {
+        mockAllServicesWorking();
+        
+        Study study = createNewStudy();
+        
+        boolean result = service.migrateTemplates(study);
+        assertTrue(result);
+
+        verify(mockTemplateService, never()).createTemplate(any(), any());
+        verify(mockTemplateRevisionService, never()).createTemplateRevision(any(), any(), any());
+        MapDifference<String, String> diff = Maps.difference(createMigratedStudy().getDefaultTemplates(), study.getDefaultTemplates());
+        assertTrue(diff.areEqual());
+    }
+    
+    @Test
+    public void defaultTemplatesGuidMissing() throws Exception {
+        mockAllServicesWorking();
+        Study study = createMigratedStudy();
+        
+        // remove two, this should be repaired
+        study.getDefaultTemplates().remove(EMAIL_RESET_PASSWORD.name().toLowerCase());
+        study.getDefaultTemplates().remove(SMS_APP_INSTALL_LINK.name().toLowerCase());
+        assertEquals(study.getDefaultTemplates().size(), 10);
+        
+        boolean result = service.migrateTemplates(study);
+        assertTrue(result);
+        
+        MapDifference<String, String> diff = Maps.difference(createMigratedStudy().getDefaultTemplates(), study.getDefaultTemplates());
+        assertTrue(diff.areEqual());
+    }
+    
+    // Since the migration method does so many substeps, each with many error conditions, it's worth 
+    // testing the protected methods individually
+    
+    @Test
+    public void findValidTemplateGuid() {
+        Template template = Template.create();
+        template.setGuid(TEMPLATE_GUID);
+        template.setPublishedCreatedOn(CREATED_ON);
+        List<? extends Template> list = ImmutableList.of(template);
+        PagedResourceList<? extends Template> page = new PagedResourceList<>(list, 1);
+        doReturn(page).when(mockTemplateService).getTemplatesForType(TEST_STUDY, SMS_VERIFY_PHONE, 0, 50, false);
+        
+        String result = service.findValidTemplateGuid(TEST_STUDY, SMS_VERIFY_PHONE);
+        assertEquals(result, TEMPLATE_GUID);
+    }
+    
+    @Test
+    public void findValidTemplateGuidNoPublishedRevision() {
+        Template template = Template.create();
+        template.setGuid(TEMPLATE_GUID);
+        List<? extends Template> list = ImmutableList.of(template);
+        PagedResourceList<? extends Template> page = new PagedResourceList<>(list, 1);
+        doReturn(page).when(mockTemplateService).getTemplatesForType(TEST_STUDY, SMS_VERIFY_PHONE, 0, 50, false);
+        
+        String result = service.findValidTemplateGuid(TEST_STUDY, SMS_VERIFY_PHONE);
+        assertNull(result);
+    }
+    
+    @Test
+    public void hasValidTemplate() {
+        Template template = Template.create();
+        template.setPublishedCreatedOn(CREATED_ON);
+        when(mockTemplateService.getTemplate(TEST_STUDY, TEMPLATE_GUID)).thenReturn(template);
+        
+        assertTrue(service.hasValidTemplate(TEST_STUDY, TEMPLATE_GUID));
+    }
+
+    @Test
+    public void hasValidTemplateNoTemplateGuid() {
+        assertFalse(service.hasValidTemplate(TEST_STUDY, null));
+    }
+    
+    @Test
+    public void hasValidTemplateNoTemplate() {
+        when(mockTemplateService.getTemplate(TEST_STUDY, TEMPLATE_GUID))
+                .thenThrow(new EntityNotFoundException(Template.class));
+        
+        assertFalse(service.hasValidTemplate(TEST_STUDY, TEMPLATE_GUID));
+    }
+    
+    @Test
+    public void hasValidTemplateNoPublishedRevision() {
+        Template template = Template.create();
+        when(mockTemplateService.getTemplate(TEST_STUDY, TEMPLATE_GUID)).thenReturn(template);
+        
+        assertFalse(service.hasValidTemplate(TEST_STUDY, TEMPLATE_GUID));
+    }
+    
+    @Test
+    public void migrateExistingTemplate() { 
+        Map<String, String> map = new HashMap<>();
+        study.setIdentifier(TEST_STUDY_IDENTIFIER);
+        study.setVerifyPhoneSmsTemplate(new SmsTemplate("One message"));
+        
+        service.migrateExistingTemplate(study, map, SMS_VERIFY_PHONE);
+        assertEquals(map.get(SMS_VERIFY_PHONE.name().toLowerCase()), TEMPLATE_GUID);
+        
+        verify(mockTemplateService).migrateTemplate(eq(study), templateCaptor.capture(), revisionCaptor.capture());
+        assertEquals(templateCaptor.getValue().getName(), "Verify Phone Default (SMS)");
+        assertEquals(templateCaptor.getValue().getTemplateType(), SMS_VERIFY_PHONE);        
+
+        assertEquals(revisionCaptor.getValue().getDocumentContent(), "One message");
+        assertEquals(revisionCaptor.getValue().getMimeType(), TEXT);
+    }
+    
+    @Test
+    public void createNewTemplate() {
+        Map<String, String> map = new HashMap<>();
+        
+        service.createNewTemplate(study, map, SMS_VERIFY_PHONE);
+        assertEquals(map.get(SMS_VERIFY_PHONE.name().toLowerCase()), TEMPLATE_GUID);
+        
+        verify(mockTemplateService).createTemplate(eq(study), templateCaptor.capture());
+        assertEquals(templateCaptor.getValue().getName(), "Verify Phone Default (SMS)");
+        assertEquals(templateCaptor.getValue().getTemplateType(), SMS_VERIFY_PHONE);
+    }
+    
+    @Test
+    public void emailTemplateToRevision() {
+        EmailTemplate template = new EmailTemplate("One subject", "One body", TEXT);
+        
+        TemplateRevision revision = TemplateMigrationService.emailTemplateToRevision(template);
+        assertEquals(revision.getSubject(), "One subject");
+        assertEquals(revision.getDocumentContent(), "One body");
+        assertEquals(revision.getMimeType(), TEXT);        
+    }
+    
+    @Test
+    public void emailTemplateToRevisionNoTemplate() {
+        assertNull(TemplateMigrationService.emailTemplateToRevision(null));
+    }
+    
+    @Test
+    public void smsTemplateToRevision() { 
+        SmsTemplate template = new SmsTemplate("Message");
+        
+        TemplateRevision revision = TemplateMigrationService.smsTemplateToRevision(template);
+        assertNull(revision.getSubject());
+        assertEquals(revision.getDocumentContent(), "Message");
+        assertEquals(revision.getMimeType(), TEXT);
+    }
+    
+    @Test
+    public void smsTemplateToRevisionNoTemplate() { 
+        assertNull(TemplateMigrationService.smsTemplateToRevision(null));
+    }
+    
+    @Test
+    public void getRevisionFromStudy() { 
+        Study study = Study.create();
+        study.setResetPasswordTemplate(new EmailTemplate("Subject", "Body", HTML));
+        TemplateRevision revision = TemplateMigrationService.getRevisionFromStudy(study, EMAIL_RESET_PASSWORD);
+        
+        assertEquals(revision.getSubject(), "Subject");
+        assertEquals(revision.getDocumentContent(), "Body");
+        assertEquals(revision.getMimeType(), HTML);
+    }
+    
+    @Test
+    public void getRevisionFromStudyEmailAccountExists() {
+        Study study = Study.create();
+        study.setAccountExistsTemplate(EMAIL_TEMPLATE);
+        assertNotNull(TemplateMigrationService.getRevisionFromStudy(study, EMAIL_ACCOUNT_EXISTS));
+    }
+    
+    @Test
+    public void getRevisionFromStudyEmailAppInstallLink() {
+        Study study = Study.create();
+        study.setAppInstallLinkTemplate(EMAIL_TEMPLATE);
+        assertNotNull(TemplateMigrationService.getRevisionFromStudy(study, EMAIL_APP_INSTALL_LINK));
+    }
+
+    @Test
+    public void getRevisionFromStudyEmailResetPassword() {
+        Study study = Study.create();
+        study.setResetPasswordTemplate(EMAIL_TEMPLATE);
+        assertNotNull(TemplateMigrationService.getRevisionFromStudy(study, EMAIL_RESET_PASSWORD));
+    }
+    
+    @Test
+    public void getRevisionFromStudyEmailSignIn() {
+        Study study = Study.create();
+        study.setEmailSignInTemplate(EMAIL_TEMPLATE);
+        assertNotNull(TemplateMigrationService.getRevisionFromStudy(study, EMAIL_SIGN_IN));
+    }
+
+    @Test
+    public void getRevisionFromStudyEmailSignedConsent() {
+        Study study = Study.create();
+        study.setSignedConsentTemplate(EMAIL_TEMPLATE);
+        assertNotNull(TemplateMigrationService.getRevisionFromStudy(study, EMAIL_SIGNED_CONSENT));
+    }
+
+    @Test
+    public void getRevisionFromStudyEmailVerifyEmail() {
+        Study study = Study.create();
+        study.setVerifyEmailTemplate(EMAIL_TEMPLATE);
+        assertNotNull(TemplateMigrationService.getRevisionFromStudy(study, EMAIL_VERIFY_EMAIL));
+    }
+    
+    @Test
+    public void getRevisionFromStudySmsAcountExists() {
+        Study study = Study.create();
+        study.setAccountExistsSmsTemplate(SMS_TEMPLATE);
+        assertNotNull(TemplateMigrationService.getRevisionFromStudy(study, SMS_ACCOUNT_EXISTS));
+    }
+
+    @Test
+    public void getRevisionFromStudySmsAppInstallLink() {
+        Study study = Study.create();
+        study.setAppInstallLinkSmsTemplate(SMS_TEMPLATE);
+        assertNotNull(TemplateMigrationService.getRevisionFromStudy(study, SMS_APP_INSTALL_LINK));
+    }
+    
+    @Test
+    public void getRevisionFromStudySmsPhoneSignIn() {
+        Study study = Study.create();
+        study.setPhoneSignInSmsTemplate(SMS_TEMPLATE);
+        assertNotNull(TemplateMigrationService.getRevisionFromStudy(study, SMS_PHONE_SIGN_IN));
+    }
+    
+    @Test
+    public void getRevisionFromStudySmsResetPassword() {
+        Study study = Study.create();
+        study.setResetPasswordSmsTemplate(SMS_TEMPLATE);
+        assertNotNull(TemplateMigrationService.getRevisionFromStudy(study, SMS_RESET_PASSWORD));
+    }
+    
+    @Test
+    public void getRevisionFromStudySmsSignedConsent() {
+        Study study = Study.create();
+        study.setSignedConsentSmsTemplate(SMS_TEMPLATE);
+        assertNotNull(TemplateMigrationService.getRevisionFromStudy(study, SMS_SIGNED_CONSENT));
+    }
+    
+    @Test
+    public void getRevisionFromStudySmsVerifyPhone() {
+        Study study = Study.create();
+        study.setVerifyPhoneSmsTemplate(SMS_TEMPLATE);
+        assertNotNull(TemplateMigrationService.getRevisionFromStudy(study, SMS_VERIFY_PHONE));
+    }
+    
+    @Test
+    public void getRevisionFromStudyTemplateMissing() {
+        assertNull(TemplateMigrationService.getRevisionFromStudy(Study.create(), EMAIL_RESET_PASSWORD));
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/services/TemplateServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/TemplateServiceTest.java
@@ -713,4 +713,11 @@ public class TemplateServiceTest extends Mockito {
         
         service.getRevisionForUser(study, EMAIL_RESET_PASSWORD);
     }
+    
+    @Test
+    public void deleteTemplatesForStudy() {
+        service.deleteTemplatesForStudy(TEST_STUDY);
+        
+        verify(mockTemplateDao).deleteTemplatesForStudy(TEST_STUDY);
+    }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/TemplateServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/TemplateServiceTest.java
@@ -647,18 +647,6 @@ public class TemplateServiceTest extends Mockito {
         service.deleteTemplate(TEST_STUDY, GUID1);
     }
     
-    @Test(expectedExceptions = ConstraintViolationException.class)
-    public void cannotPhysicallyDeleteDefaultTemplate() {
-        study.getDefaultTemplates().put(EMAIL_ACCOUNT_EXISTS.name().toLowerCase(), GUID1);
-        Template existing = Template.create();
-        existing.setStudyId(TEST_STUDY_IDENTIFIER);
-        existing.setGuid(GUID1);
-        existing.setTemplateType(EMAIL_ACCOUNT_EXISTS);
-        when(mockTemplateDao.getTemplate(TEST_STUDY, GUID1)).thenReturn(Optional.of(existing));
-
-        service.deleteTemplatePermanently(TEST_STUDY, GUID1);
-    }
-    
     @Test
     public void getRevisionForUser() throws Exception {
         ClientInfo clientInfo = ClientInfo.fromUserAgentCache(UA);

--- a/src/test/java/org/sagebionetworks/bridge/services/TemplateServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/TemplateServiceTest.java
@@ -1,13 +1,16 @@
 package org.sagebionetworks.bridge.services;
 
 import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
+import static org.sagebionetworks.bridge.TestConstants.LANGUAGES;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 import static org.sagebionetworks.bridge.TestConstants.TIMESTAMP;
+import static org.sagebionetworks.bridge.TestConstants.UA;
 import static org.sagebionetworks.bridge.TestConstants.USER_DATA_GROUPS;
 import static org.sagebionetworks.bridge.TestConstants.USER_ID;
 import static org.sagebionetworks.bridge.TestConstants.USER_SUBSTUDY_IDS;
 import static org.sagebionetworks.bridge.models.studies.MimeType.HTML;
+import static org.sagebionetworks.bridge.models.studies.MimeType.TEXT;
 import static org.sagebionetworks.bridge.models.templates.TemplateType.EMAIL_ACCOUNT_EXISTS;
 import static org.sagebionetworks.bridge.models.templates.TemplateType.EMAIL_APP_INSTALL_LINK;
 import static org.sagebionetworks.bridge.models.templates.TemplateType.EMAIL_RESET_PASSWORD;
@@ -23,6 +26,7 @@ import static org.sagebionetworks.bridge.models.templates.TemplateType.SMS_VERIF
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
@@ -44,9 +48,12 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dao.CriteriaDao;
 import org.sagebionetworks.bridge.dao.TemplateDao;
@@ -55,10 +62,12 @@ import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.ConstraintViolationException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
+import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.Criteria;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.GuidVersionHolder;
 import org.sagebionetworks.bridge.models.PagedResourceList;
+import org.sagebionetworks.bridge.models.studies.EmailTemplate;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.templates.Template;
 import org.sagebionetworks.bridge.models.templates.TemplateRevision;
@@ -97,6 +106,9 @@ public class TemplateServiceTest extends Mockito {
     @Captor
     ArgumentCaptor<TemplateRevision> revisionCaptor;
     
+    @Captor
+    ArgumentCaptor<CriteriaContext> contextCaptor;
+    
     Study study;
     
     @BeforeMethod
@@ -130,6 +142,11 @@ public class TemplateServiceTest extends Mockito {
         study.setDefaultTemplates(new HashMap<>());
         when(mockStudyService.getStudy(TEST_STUDY)).thenReturn(study);
         when(mockSubstudyService.getSubstudyIds(TEST_STUDY)).thenReturn(USER_SUBSTUDY_IDS);
+    }
+    
+    @AfterMethod
+    public void afterMethod() {
+        BridgeUtils.setRequestContext(null);
     }
     
     private Resource res(TemplateType type) {
@@ -167,7 +184,6 @@ public class TemplateServiceTest extends Mockito {
     }
     
     private void mockTemplateDefault(String guid) {
-        Study study = Study.create();
         if (guid == null) {
             study.setDefaultTemplates(ImmutableMap.of());
         } else {
@@ -183,7 +199,7 @@ public class TemplateServiceTest extends Mockito {
         Template t2 = makeTemplate(GUID2, "fr");
         mockGetTemplates(ImmutableList.of(t1, t2));
         
-        Template template = service.getTemplateForUser(makeContext("fr"), EMAIL_RESET_PASSWORD);
+        Template template = service.getTemplateForUser(study, makeContext("fr"), EMAIL_RESET_PASSWORD);
         assertEquals(template, t2);
     }
     
@@ -196,7 +212,7 @@ public class TemplateServiceTest extends Mockito {
         
         mockTemplateDefault(GUID2);
         
-        Template template = service.getTemplateForUser(makeContext("fr"), EMAIL_RESET_PASSWORD);
+        Template template = service.getTemplateForUser(study, makeContext("fr"), EMAIL_RESET_PASSWORD);
         assertEquals(template, t2);
     }
     
@@ -209,7 +225,7 @@ public class TemplateServiceTest extends Mockito {
         
         mockTemplateDefault("guid-matches-nothing");
         
-        Template template = service.getTemplateForUser(makeContext("fr"), EMAIL_RESET_PASSWORD);
+        Template template = service.getTemplateForUser(study, makeContext("fr"), EMAIL_RESET_PASSWORD);
         assertEquals(template, t1);
     }
     
@@ -223,7 +239,7 @@ public class TemplateServiceTest extends Mockito {
         // no default in the study map at all
         mockTemplateDefault(null);
         
-        Template template = service.getTemplateForUser(makeContext("fr"), EMAIL_RESET_PASSWORD);
+        Template template = service.getTemplateForUser(study, makeContext("fr"), EMAIL_RESET_PASSWORD);
         assertEquals(template, t1);
     }
     
@@ -237,26 +253,26 @@ public class TemplateServiceTest extends Mockito {
         // no default in the study map at all
         mockTemplateDefault(null);
         
-        Template template = service.getTemplateForUser(makeContext("fr"), EMAIL_RESET_PASSWORD);
+        Template template = service.getTemplateForUser(study, makeContext("fr"), EMAIL_RESET_PASSWORD);
         assertEquals(template, t1);
     }
     
-    // No templates returned, none matching, default exists but irrelevant, only then do we throw an exception
-    @Test(expectedExceptions = EntityNotFoundException.class)
+    // No templates returned, none matching, default exists but irrelevant, only then do we return null
+    @Test
     public void getTemplateForUserMatchesNoneNoTemplateToReturn() {
         mockGetTemplates(ImmutableList.of());
         
         mockTemplateDefault(GUID1); // doesn't matter
         
-        service.getTemplateForUser(makeContext("fr"), EMAIL_RESET_PASSWORD);
+        assertNull(service.getTemplateForUser(study, makeContext("fr"), EMAIL_RESET_PASSWORD));
     }
     
-    // No templates returned, none matching, no default, throw an exception
-    @Test(expectedExceptions = EntityNotFoundException.class)
+    // No templates returned, none matching, no default, return null
+    @Test
     public void getTemplateForUserMatchesNoneNoDefaultNoTemplateToReturn() {
         mockGetTemplates(ImmutableList.of());
 
-        service.getTemplateForUser(makeContext("fr"), EMAIL_RESET_PASSWORD);
+        assertNull(service.getTemplateForUser(study, makeContext("fr"), EMAIL_RESET_PASSWORD));
     }
 
     @Test
@@ -641,5 +657,72 @@ public class TemplateServiceTest extends Mockito {
         when(mockTemplateDao.getTemplate(TEST_STUDY, GUID1)).thenReturn(Optional.of(existing));
 
         service.deleteTemplatePermanently(TEST_STUDY, GUID1);
+    }
+    
+    @Test
+    public void getRevisionForUser() throws Exception {
+        ClientInfo clientInfo = ClientInfo.fromUserAgentCache(UA);
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerClientInfo(clientInfo).withCallerLanguages(LANGUAGES).build());
+        
+        DateTime createdOn = DateTime.now();
+        Template t1 = makeTemplate(GUID1, "de");
+        t1.setPublishedCreatedOn(createdOn);
+        
+        // This one should match based on languages ("en")
+        Template t2 = makeTemplate(GUID2, "en");
+        t2.setPublishedCreatedOn(createdOn.plusHours(1));
+        mockGetTemplates(ImmutableList.of(t1, t2));
+        
+        TemplateRevision r2 = TemplateRevision.create();
+        when(mockTemplateRevisionDao.getTemplateRevision(GUID2, createdOn.plusHours(1))).thenReturn(Optional.of(r2));
+        
+        study.setIdentifier(TEST_STUDY_IDENTIFIER);
+        
+        TemplateRevision retrieved = service.getRevisionForUser(study, EMAIL_RESET_PASSWORD);
+        assertSame(retrieved, r2);
+        
+        verify(service).getTemplateForUser(eq(study), contextCaptor.capture(), eq(EMAIL_RESET_PASSWORD));
+        
+        CriteriaContext context = contextCaptor.getValue();
+        assertEquals(context.getLanguages(), LANGUAGES);
+        assertEquals(context.getClientInfo(), clientInfo);
+    }
+    
+    @Test
+    public void getRevisionForUserBeforeTemplateMigrated() throws Exception {
+        ClientInfo clientInfo = ClientInfo.fromUserAgentCache(UA);
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerClientInfo(clientInfo).withCallerLanguages(LANGUAGES).build());
+        mockGetTemplates(ImmutableList.of());
+        
+        study.setIdentifier(TEST_STUDY_IDENTIFIER);
+        study.setResetPasswordTemplate(new EmailTemplate("subject", "body", TEXT));
+        
+        TemplateRevision retrieved = service.getRevisionForUser(study, EMAIL_RESET_PASSWORD);
+        assertSame(retrieved.getSubject(), "subject");
+        assertSame(retrieved.getDocumentContent(), "body");
+        assertSame(retrieved.getMimeType(), TEXT);
+        
+        verify(service).getTemplateForUser(eq(study), any(), eq(EMAIL_RESET_PASSWORD));
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class, 
+            expectedExceptionsMessageRegExp = "TemplateRevision not found.")
+    public void getRevisionForUserWhenTemplateExistsButRevisionMissing() throws Exception {
+        ClientInfo clientInfo = ClientInfo.fromUserAgentCache(UA);
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerClientInfo(clientInfo).withCallerLanguages(LANGUAGES).build());
+        
+        DateTime createdOn = DateTime.now();
+        Template t1 = makeTemplate(GUID1, "en");
+        t1.setPublishedCreatedOn(createdOn);
+        mockGetTemplates(ImmutableList.of(t1));
+        
+        when(mockTemplateRevisionDao.getTemplateRevision(GUID1, createdOn)).thenReturn(Optional.empty());
+        
+        study.setIdentifier(TEST_STUDY_IDENTIFIER);
+        
+        service.getRevisionForUser(study, EMAIL_RESET_PASSWORD);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationControllerTest.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
-import com.google.common.net.HttpHeaders;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;

--- a/src/test/java/org/sagebionetworks/bridge/validators/TemplateRevisionValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/TemplateRevisionValidatorTest.java
@@ -15,7 +15,6 @@ import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.models.templates.TemplateRevision;
-import org.sagebionetworks.bridge.models.templates.TemplateType;
 
 public class TemplateRevisionValidatorTest {
 


### PR DESCRIPTION
- Changed TemplateService's `getTemplateForUser` to `getTemplateRevisionForUser` because we actually want the revision, not the template;
- Added the `TemplateMigrationService` which can be called on update idempotently to move over the study templates to the enhanced templates system.
- On a physical delete of a study, physical delete all the templates (this in turn removes all the revisions). A lot of junk was being left behind by tests.