### PR TITLE
Re-enable Phone Sign-In Throttling

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/AccountWorkflowService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AccountWorkflowService.java
@@ -647,13 +647,6 @@ public class AccountWorkflowService {
 
     // Check if the request is throttled. Key is either email address or phone, depending on the type.
     private boolean isRequestThrottled(ThrottleRequestType type, String userId) {
-        if (type == ThrottleRequestType.PHONE_SIGNIN) {
-            // mPower 2.0 is currently blocked because of issues with phone sign-in. Long-term, we'll want to add a
-            // grace period for the phone token, similar to reauth. Short-term, we disable throttling for phone sign-in
-            // (but not for email, so it doesn't impact our spam rating).
-            return false;
-        }
-
         // Generate key, which is in the form of channel-throttling:[type]:[userId].
         CacheKey cacheKey = CacheKey.channelThrottling(type, userId);
 


### PR DESCRIPTION
We previously disabled throttling on phone sign-in because people were failing sign-in requests and unable to request a second token. Now that we have (a) grace period (b) fixed the throttling timer resetting issue, phone sign-in is now much more reliable. We should re-enable phone sign-in throttling.