### PR TITLE
SMS log messages upgraded from debug to info

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/SmsService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/SmsService.java
@@ -121,7 +121,7 @@ public class SmsService {
         PublishResult result = snsClient.publish(provider.getSmsRequest());
         messageId = result.getMessageId();
 
-        LOG.debug("Sent SMS message, study=" + study.getIdentifier() + ", message ID=" + messageId + ", request ID=" +
+        LOG.info("Sent SMS message, study=" + study.getIdentifier() + ", message ID=" + messageId + ", request ID=" +
                 BridgeUtils.getRequestContext().getId());
 
         // Log SMS message.


### PR DESCRIPTION
At some point, we stopped logging debug messages. SMS log messages are critical to tracking down SMS non-delivery. Bumping this from debug to info.