### PR TITLE
Relax the rules around adding substudies and external IDs to accounts.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
@@ -42,7 +42,6 @@ import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.json.BridgeTypeName;
 import org.sagebionetworks.bridge.time.DateUtils;
-import org.sagebionetworks.bridge.util.BridgeCollectors;
 import org.sagebionetworks.bridge.models.Tuple;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;

--- a/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.Integer.parseInt;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.sagebionetworks.bridge.util.BridgeCollectors.toImmutableSet;
 import static org.springframework.util.StringUtils.commaDelimitedListToSet;
@@ -135,6 +136,12 @@ public class BridgeUtils {
                 .collect(toImmutableSet());
     }
     
+    public static Set<String> collectSubstudyIds(Account account) {
+        return account.getAccountSubstudies().stream()
+                .map(AccountSubstudy::getSubstudyId)
+                .collect(toImmutableSet());
+    }
+    
     /** Gets the request context for the current thread. See also RequestInterceptor. */
     public static RequestContext getRequestContext() {
         RequestContext context = REQUEST_CONTEXT_THREAD_LOCAL.get();
@@ -158,9 +165,12 @@ public class BridgeUtils {
             }
             Set<AccountSubstudy> matched = account.getAccountSubstudies().stream()
                     .filter(as -> callerSubstudies.isEmpty() || callerSubstudies.contains(as.getSubstudyId()))
-                    .collect(BridgeCollectors.toImmutableSet());
+                    .collect(toSet());
             
             if (!matched.isEmpty()) {
+                // Hibernate managed objects use a collection implementation that tracks changes,
+                // and shouldn't be set with a Java library collection. Here it is okay because 
+                // we're filtering an object to return through the API, and it won't be persisted.
                 account.setAccountSubstudies(matched);
                 return account;
             }

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/BaseJsonAttributeConverter.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/BaseJsonAttributeConverter.java
@@ -11,8 +11,6 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMappingException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 
-import org.apache.commons.lang3.StringUtils;
-
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
 /**

--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -537,9 +537,7 @@ public class ParticipantService {
             accountDao.updateAccount(account,
                     (modifiedAccount) -> externalIdService.commitAssignExternalId(externalId));
         } catch (Exception e) {
-            if (externalId != null) {
-                externalIdService.unassignExternalId(account, externalId.getIdentifier());
-            }
+            externalIdService.unassignExternalId(account, externalId.getIdentifier());
             throw e;
         }
     }

--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -3,13 +3,12 @@ package org.sagebionetworks.bridge.services;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.Boolean.TRUE;
-import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.sagebionetworks.bridge.BridgeUtils.collectSubstudyIds;
 import static org.sagebionetworks.bridge.BridgeUtils.substudyAssociationsVisibleToCaller;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.ADMINISTRATIVE_ROLES;
 import static org.sagebionetworks.bridge.Roles.CAN_BE_EDITED_BY;
-import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.WORKER;
 
 import java.security.InvalidKeyException;
@@ -18,7 +17,6 @@ import java.security.spec.InvalidKeySpecException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
@@ -41,6 +39,7 @@ import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.ScheduledActivityDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
+import org.sagebionetworks.bridge.exceptions.ConstraintViolationException;
 import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.LimitExceededException;
@@ -191,12 +190,32 @@ public class ParticipantService {
         this.requestInfoService = requestInfoService;
     }
     
-    public void assignExternalId(AccountId accountId, ExternalIdentifier externalId) {
+    public ExternalIdentifier assignExternalId(AccountId accountId, String externalId) {
         Account account = getAccountThrowingException(accountId);
-        ExternalIdentifier extIdObj = beginAssignExternalId(account, externalId.getIdentifier());
-        externalIdService.commitAssignExternalId(extIdObj);
+        ExternalIdentifier extIdObj = beginAssignExternalId(account, externalId);
+        if (extIdObj != null) {
+            AccountSubstudy acctSubstudy = AccountSubstudy.create(account.getStudyId(),
+                    extIdObj.getSubstudyId(), account.getId());
+            // If a substudy relationship exists without the external ID, remove it because
+            // we're about to create it with an external ID
+            if (account.getAccountSubstudies().contains(acctSubstudy)) {
+                account.getAccountSubstudies().remove(acctSubstudy);
+            }
+            acctSubstudy.setExternalId(extIdObj.getIdentifier());
+            account.getAccountSubstudies().add(acctSubstudy);
+            try {
+                accountDao.updateAccount(account,
+                        (modifiedAccount) -> externalIdService.commitAssignExternalId(extIdObj));
+            } catch(Exception e) {
+                if (extIdObj != null) {
+                    externalIdService.unassignExternalId(account, extIdObj.getIdentifier());    
+                }
+                throw e;
+            }
+        }
+        return extIdObj;
     }
-    
+
     /**
      * This is a researcher API to backfill SMS notification registrations for a user. We generally prefer the app
      * register notifications, but sometimes the work can't be done on time, so we want study developers to have the
@@ -219,8 +238,7 @@ public class ParticipantService {
             throw new BadRequestException("Can't create SMS notification registration for user " + userId +
                     ": user has no request info");
         }
-        Set<String> substudyIds = account.getAccountSubstudies().stream()
-                .map(AccountSubstudy::getSubstudyId).collect(BridgeCollectors.toImmutableSet());
+        Set<String> substudyIds = BridgeUtils.collectSubstudyIds(account);
         CriteriaContext criteriaContext = new CriteriaContext.Builder()
                 .withStudyIdentifier(study.getStudyIdentifier())
                 .withUserId(userId)
@@ -412,20 +430,6 @@ public class ParticipantService {
             throwExceptionIfLimitMetOrExceeded(study);
         }
         
-        // Ensure the validator sees the substudy of an external ID assignment as it's being made. 
-        // Otherwise, researchers need to add the substudy ID along with the external ID when 
-        // creating a user, which is unexpected and annoying.
-        Optional<ExternalIdentifier> optionalId = externalIdService.getExternalId(
-                study.getStudyIdentifier(), participant.getExternalId());
-        if (optionalId.isPresent()) {
-            Set<String> substudyIds = new ImmutableSet.Builder<String>()
-                    .addAll(participant.getSubstudyIds())
-                    .add(optionalId.get().getSubstudyId()).build();
-            participant = new StudyParticipant.Builder()
-                    .copyOf(participant)
-                    .withSubstudyIds(substudyIds).build();
-        }
-        
         StudyParticipantValidator validator = new StudyParticipantValidator(externalIdService, substudyService, study,
                 true);
         Validate.entityThrowingException(validator, participant);
@@ -532,33 +536,21 @@ public class ParticipantService {
         Validate.entityThrowingException(validator, participant);
         
         Account account = getAccountThrowingExceptionIfSubstudyMatches(
-        AccountId.forId(study.getIdentifier(), participant.getId()));
+                AccountId.forId(study.getIdentifier(), participant.getId()));
         
-        Set<String> allExternalIds = BridgeUtils.collectExternalIds(account);
-        Set<Roles> callerRoles = BridgeUtils.getRequestContext().getCallerRoles();
-        
-        // Legacy behavior: a user can add an external ID to their account on an update, we refer to 
-        // this as a "simple add." A researcher can assign an external ID to any user if it has not yet 
-        // been assigned (if it has been assigned, beginAssignExternalId() throws an exception and 
-        // aborts this entire call).
-        
-        boolean isSimpleAdd = allExternalIds.isEmpty() && participant.getExternalId() != null;
-        boolean isResearcherAdd = callerRoles.contains(RESEARCHER)
-                && !allExternalIds.contains(participant.getExternalId())
-                && participant.getExternalId() != null;
-        boolean assigningExternalId = isSimpleAdd || isResearcherAdd;
-
-        ExternalIdentifier externalId = beginAssignExternalId(account, participant.getExternalId());
+        final ExternalIdentifier externalId = beginAssignExternalId(account, participant.getExternalId());
         updateAccountAndRoles(study, account, participant, externalId, false);
         
         // Allow admin and worker accounts to toggle status; in particular, to disable/enable accounts.
         if (participant.getStatus() != null) {
+            Set<Roles> callerRoles = BridgeUtils.getRequestContext().getCallerRoles();
             if (callerRoles.contains(ADMIN) || callerRoles.contains(WORKER)) {
                 account.setStatus(participant.getStatus());
             }
         }
-        // Simple case, not trying to assign an external ID 
-        if (!assigningExternalId) {
+        
+        // Simple case, not trying to assign an external ID
+        if (externalId == null) {
             accountDao.updateAccount(account, null);
             return;
         }
@@ -597,19 +589,19 @@ public class ParticipantService {
         account.setLanguages(participant.getLanguages());
         account.setMigrationVersion(AccountDao.MIGRATION_VERSION);
        
+        // Sign out the user if you make alterations that will change the security state of 
+        // the account. Otherwise very strange bugs can results.
+        boolean clearCache = false;
+        
         // Only allow the setting of substudies on new accounts. Note that while administrators can change this 
         // after the account is created, for admin accounts, it can create some very strange security behavior 
         // for that account if it is signed in, so we MUST destroy the session. 
         Set<Roles> callerRoles = BridgeUtils.getRequestContext().getCallerRoles();
         if (isNew || callerRoles.contains(ADMIN)) {
-            // Sign out the user if you make alterations that will change the security state of 
-            // the account. Otherwise very strange bugs can results.
-            boolean clearCache = false;
-            
             // Copy to prevent concurrent modification exceptions
             Set<AccountSubstudy> accountSubstudies = ImmutableSet.copyOf(account.getAccountSubstudies());
             
-            // remove external ID if it exists and unassign the external ID
+            // Remove substudy relationship if it's not desired and unassign external ID
             for (AccountSubstudy acctSubstudy : accountSubstudies) {
                 if (!participant.getSubstudyIds().contains(acctSubstudy.getSubstudyId())) {
                     externalIdService.unassignExternalId(account, acctSubstudy.getExternalId());
@@ -617,16 +609,9 @@ public class ParticipantService {
                     clearCache = true;
                 }
             }
-            // add external ID if it doesn't exist
-            Set<String> existingSubstudyIds = account.getAccountSubstudies().stream()
-                    .map(AccountSubstudy::getSubstudyId).collect(toSet());
+            // Add substudy relationship
+            Set<String> existingSubstudyIds = collectSubstudyIds(account);
             for (String substudyId : participant.getSubstudyIds()) {
-                // Edge case: when creating user if the external ID and the substudy ID it is associated to are 
-                // both set, the persist fails. To work correctly, we want to ignore the substudy ID assignment 
-                // because it's going to be established by the external ID assignment.
-                if (externalId != null && externalId.getSubstudyId().equals(substudyId)) {
-                    continue;
-                }
                 if (!existingSubstudyIds.contains(substudyId)) {
                     AccountSubstudy newSubstudy = AccountSubstudy.create(
                             account.getStudyId(), substudyId, account.getId());
@@ -634,14 +619,27 @@ public class ParticipantService {
                     clearCache = true;
                 }
             }
-            
-            // We have to clear the cache if we make changes that can alter the security profile of 
-            // the account, otherwise very strange behavior can occur if that user is signed in with 
-            // a stale session.
-            if (!isNew && clearCache) {
-                cacheProvider.removeSessionByUserId(account.getId());    
-            }
         }
+        if (externalId != null) {
+            AccountSubstudy acctSubstudy = AccountSubstudy.create(account.getStudyId(),
+                    externalId.getSubstudyId(), account.getId());
+            
+            // If a substudy relationship exists without the external ID, remove it because
+            // we're about to create it with an external ID
+            if (account.getAccountSubstudies().contains(acctSubstudy)) {
+                account.getAccountSubstudies().remove(acctSubstudy);
+            }
+            acctSubstudy.setExternalId(externalId.getIdentifier());
+            account.getAccountSubstudies().add(acctSubstudy);
+            clearCache = true;
+        }
+        // We have to clear the cache if we make changes that can alter the security profile of 
+        // the account, otherwise very strange behavior can occur if that user is signed in with 
+        // a stale session.
+        if (!isNew && clearCache) {
+            cacheProvider.removeSessionByUserId(account.getId());    
+        }
+        
         // Do not copy timezone (external ID field exists only to submit the value on create).
         
         for (String attribute : study.getUserProfileAttributes()) {
@@ -650,6 +648,24 @@ public class ParticipantService {
         }
         if (callerIsAdmin(callerRoles)) {
             updateRoles(callerRoles, participant, account);
+        }
+        
+        // If the caller is not in a substudy, any substudy tags are allowed. If there 
+        // are any substudies assigned to the caller, then the participant must be assigned 
+        // to one or more of those substudies, and only those substudies.
+        Set<String> callerSubstudies = BridgeUtils.getRequestContext().getCallerSubstudies();
+        if (!callerSubstudies.isEmpty()) {
+            Set<String> accountSubstudies = BridgeUtils.collectSubstudyIds(account);
+            if (accountSubstudies.isEmpty()) {
+                throw new BadRequestException("Participant must be assigned to one or more of these substudies: "
+                        + BridgeUtils.COMMA_JOINER.join(callerSubstudies));
+            } else {
+                for (String substudyId : accountSubstudies) {
+                    if (!callerSubstudies.contains(substudyId)) {
+                        throw new BadRequestException(substudyId + " is not a substudy of the caller");
+                    }
+                }
+            }
         }
     }
     
@@ -862,9 +878,7 @@ public class ParticipantService {
         }
         
         // reload account, or you will get an optimistic lock exception
-        account = getAccountThrowingExceptionIfSubstudyMatches(AccountId.forId(study.getIdentifier(), account.getId()));
-        
-        // Update if account has an empty field and there's an update
+        AccountId accountId = AccountId.forId(study.getIdentifier(), account.getId());
         boolean sendEmailVerification = false;
         boolean assignExternalId = false;
         boolean accountUpdated = false;
@@ -881,21 +895,13 @@ public class ParticipantService {
         }
         Set<String> externalIds = BridgeUtils.collectExternalIds(account);
         if (update.getExternalIdUpdate() != null && !externalIds.contains(update.getExternalIdUpdate())) {
-            accountUpdated = true;
             assignExternalId = true;
+            accountUpdated = true;
         }
         if (accountUpdated) {
             if (assignExternalId) {
-                ExternalIdentifier externalId = beginAssignExternalId(account, update.getExternalIdUpdate());
-                try {
-                    accountDao.updateAccount(account, (oneAccount) -> externalIdService.commitAssignExternalId(externalId));
-                    updateRequestContext(externalId);
-                } catch (Exception e) {
-                    if (externalId != null) {
-                        externalIdService.unassignExternalId(account, externalId.getIdentifier());
-                    }
-                    throw e;
-                }                
+                ExternalIdentifier externalId = assignExternalId(accountId, update.getExternalIdUpdate());
+                updateRequestContext(externalId);
             } else {
                 accountDao.updateAccount(account, null);
             }
@@ -914,31 +920,27 @@ public class ParticipantService {
         checkNotNull(account.getStudyId());
         checkNotNull(account.getHealthCode());
         
-        if (externalId == null) {
+        Set<String> allExternalIds = BridgeUtils.collectExternalIds(account);
+        if (externalId == null || allExternalIds.contains(externalId)) {
             return null;
         }
-        StudyIdentifier studyId = new StudyIdentifierImpl(account.getStudyId());
         
-        Optional<ExternalIdentifier> optionalId = externalIdService.getExternalId(studyId, externalId);
-        if (!optionalId.isPresent()) {
+        StudyIdentifier studyId = new StudyIdentifierImpl(account.getStudyId());
+        ExternalIdentifier identifier = externalIdService.getExternalId(studyId, externalId).orElse(null);
+        if (identifier == null) {
             return null;
         }
-        ExternalIdentifier identifier = optionalId.get();
         if (identifier.getHealthCode() != null && !account.getHealthCode().equals(identifier.getHealthCode())) {
             throw new EntityAlreadyExistsException(ExternalIdentifier.class, "identifier", identifier.getIdentifier()); 
         }
-        // Whether already assigned or not, we will adjust the account, in case we are repairing
-        // an existing broken data association
-
-        identifier.setHealthCode(account.getHealthCode());
-        if (identifier.getSubstudyId() != null) {
-            AccountSubstudy acctSubstudy = AccountSubstudy.create(account.getStudyId(),
-                    identifier.getSubstudyId(), account.getId());
-            acctSubstudy.setExternalId(identifier.getIdentifier());
-            if (!account.getAccountSubstudies().contains(acctSubstudy)) {
-                account.getAccountSubstudies().add(acctSubstudy);    
-            }
+        Set<Roles> callerRoles = BridgeUtils.getRequestContext().getCallerRoles();
+        Set<String> substudies = BridgeUtils.collectSubstudyIds(account);
+        if (callerRoles.isEmpty() && substudies.contains(identifier.getSubstudyId())) {
+            throw new ConstraintViolationException.Builder()
+                .withMessage("Account already associated to substudy.")
+                .withEntityKey("substudyId", identifier.getSubstudyId()).build();
         }
+        identifier.setHealthCode(account.getHealthCode());
         return identifier;
     }
 

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/UserProfileController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/UserProfileController.java
@@ -30,7 +30,6 @@ import org.sagebionetworks.bridge.json.JsonUtils;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
-import org.sagebionetworks.bridge.models.accounts.ExternalIdentifier;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.accounts.UserSessionInfo;
@@ -122,23 +121,6 @@ public class UserProfileController extends BaseController {
         
         CacheKey cacheKey = viewCache.getCacheKey(ObjectNode.class, userId, study.getIdentifier());
         viewCache.removeView(cacheKey);
-        
-        return UserSessionInfo.toJSON(session);
-    }
-    
-    @Deprecated
-    @PostMapping({"/v3/users/self/externalId", "/api/v1/profile/external-id"})
-    public JsonNode createExternalIdentifier() throws Exception {
-        UserSession session = getAuthenticatedSession();
-        
-        AccountId accountId = AccountId.forHealthCode(session.getStudyIdentifier().getIdentifier(),
-                session.getHealthCode());
-        
-        ExternalIdentifier externalId = parseJson(ExternalIdentifier.class);
-        externalId.setStudyId(accountId.getStudyId());
-        
-        participantService.assignExternalId(accountId, externalId.getIdentifier());
-        sessionUpdateService.updateExternalId(session, externalId);
         
         return UserSessionInfo.toJSON(session);
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/UserProfileController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/UserProfileController.java
@@ -137,7 +137,7 @@ public class UserProfileController extends BaseController {
         ExternalIdentifier externalId = parseJson(ExternalIdentifier.class);
         externalId.setStudyId(accountId.getStudyId());
         
-        participantService.assignExternalId(accountId, externalId);
+        participantService.assignExternalId(accountId, externalId.getIdentifier());
         sessionUpdateService.updateExternalId(session, externalId);
         
         return UserSessionInfo.toJSON(session);

--- a/src/main/java/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
@@ -27,7 +27,6 @@ public class StudyParticipantValidator implements Validator {
     private final ExternalIdService externalIdService;
     private final SubstudyService substudyService;
     private final Study study;
-    private final Set<String> callerSubstudies;
     private final boolean isNew;
     
     public StudyParticipantValidator(ExternalIdService externalIdService, SubstudyService substudyService, Study study,
@@ -35,7 +34,6 @@ public class StudyParticipantValidator implements Validator {
         this.externalIdService = externalIdService;
         this.substudyService = substudyService;
         this.study = study;
-        this.callerSubstudies = BridgeUtils.getRequestContext().getCallerSubstudies();
         this.isNew = isNew;
     }
     
@@ -82,20 +80,6 @@ public class StudyParticipantValidator implements Validator {
             }
         }
 
-        // If the caller is not in a substudy, any substudy tags are allowed. If there 
-        // are any substudies assigned to the caller, then the participant must be assigned 
-        // to one or more of those substudies, and only those substudies.
-        if (!callerSubstudies.isEmpty()) {
-            if (participant.getSubstudyIds().isEmpty()) {
-                errors.rejectValue("substudyIds", "must be assigned to this participant");
-            } else {
-                for (String substudyId : participant.getSubstudyIds()) {
-                    if (!callerSubstudies.contains(substudyId)) {
-                        errors.rejectValue("substudyIds["+substudyId+"]", "is not a substudy of the caller");
-                    }
-                }
-            }
-        }
         for (String substudyId : participant.getSubstudyIds()) {
             Substudy substudy = substudyService.getSubstudy(study.getStudyIdentifier(), substudyId, false);
             if (substudy == null) {

--- a/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge;
 
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 import static org.sagebionetworks.bridge.models.templates.TemplateType.EMAIL_SIGNED_CONSENT;
 import static org.sagebionetworks.bridge.models.templates.TemplateType.SMS_APP_INSTALL_LINK;
 import static org.sagebionetworks.bridge.services.StudyConsentService.SIGNATURE_BLOCK;
@@ -215,11 +216,11 @@ public class BridgeUtilsTest {
     @Test
     public void collectExternalIds() {
         Account account = Account.create();
-        AccountSubstudy as1 = AccountSubstudy.create(TestConstants.TEST_STUDY_IDENTIFIER, "substudyA", "userId");
+        AccountSubstudy as1 = AccountSubstudy.create(TEST_STUDY_IDENTIFIER, "substudyA", "userId");
         as1.setExternalId("subAextId");
-        AccountSubstudy as2 = AccountSubstudy.create(TestConstants.TEST_STUDY_IDENTIFIER, "substudyB", "userId");
+        AccountSubstudy as2 = AccountSubstudy.create(TEST_STUDY_IDENTIFIER, "substudyB", "userId");
         as2.setExternalId("subBextId");
-        AccountSubstudy as3 = AccountSubstudy.create(TestConstants.TEST_STUDY_IDENTIFIER, "substudyC", "userId");
+        AccountSubstudy as3 = AccountSubstudy.create(TEST_STUDY_IDENTIFIER, "substudyC", "userId");
         account.setAccountSubstudies(ImmutableSet.of(as1, as2, as3));
         
         Set<String> externalIds = BridgeUtils.collectExternalIds(account);
@@ -230,7 +231,25 @@ public class BridgeUtilsTest {
     public void collectExternalIdsNullsAreIgnored() {
         Set<String> externalIds = BridgeUtils.collectExternalIds(Account.create());
         assertEquals(externalIds, ImmutableSet.of());
-    }    
+    } 
+    
+    @Test
+    public void collectSubstudyIds() {
+        Account account = Account.create();
+        AccountSubstudy as1 = AccountSubstudy.create(TEST_STUDY_IDENTIFIER, "substudyA", "userId");
+        AccountSubstudy as2 = AccountSubstudy.create(TEST_STUDY_IDENTIFIER, "substudyB", "userId");
+        AccountSubstudy as3 = AccountSubstudy.create(TEST_STUDY_IDENTIFIER, "substudyC", "userId");
+        account.setAccountSubstudies(ImmutableSet.of(as1, as2, as3));
+        
+        Set<String> externalIds = BridgeUtils.collectSubstudyIds(account);
+        assertEquals(externalIds, ImmutableSet.of("substudyA","substudyB", "substudyC"));
+    }
+    
+    @Test
+    public void collectSubstudyIdsNullsAreIgnored() {
+        Set<String> externalIds = BridgeUtils.collectSubstudyIds(Account.create());
+        assertEquals(externalIds, ImmutableSet.of());
+    }
     
     @Test
     public void filterForSubstudyAccountRemovesUnsharedSubstudyIds() {

--- a/src/test/java/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -654,6 +654,15 @@ public class ParticipantServiceTest {
         assertFalse(account.getPhoneVerified());
         assertFalse(account.getEmailVerified());
     }
+    
+    @Test(expectedExceptions = BadRequestException.class,
+            expectedExceptionsMessageRegExp=".*must be assigned to one or more of these substudies: substudyId.*")
+    public void createParticipantMustIncludeCallerSubstudy() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerSubstudies(ImmutableSet.of(SUBSTUDY_ID)).build());
+        
+        participantService.createParticipant(STUDY, PARTICIPANT, false);
+    }
 
     @Test
     public void createSmsNotificationRegistration_PhoneNotVerified() {
@@ -1198,6 +1207,16 @@ public class ParticipantServiceTest {
                 .filter((as) -> as.getSubstudyId().equals("substudyA")).findAny().get();
         accountSubstudies.stream()
                 .filter((as) -> as.getSubstudyId().equals("substudyB")).findAny().get();
+    }
+    
+    // The exception here results from the fact that the caller can't see the existance of the 
+    // participant, because the substudy IDs don't overlap
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void updateParticipantMustIncludeCallerSubstudy() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerSubstudies(ImmutableSet.of(SUBSTUDY_ID)).build());
+
+        participantService.updateParticipant(STUDY, PARTICIPANT);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserProfileControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserProfileControllerTest.java
@@ -172,7 +172,6 @@ public class UserProfileControllerTest extends Mockito {
         assertCrossOrigin(UserProfileController.class);
         assertGet(UserProfileController.class, "getUserProfile");
         assertPost(UserProfileController.class, "updateUserProfile");
-        assertPost(UserProfileController.class, "createExternalIdentifier");
         assertGet(UserProfileController.class, "getDataGroups");
         assertPost(UserProfileController.class, "updateDataGroups");
     }
@@ -265,21 +264,6 @@ public class UserProfileControllerTest extends Mockito {
         assertEquals(persisted.getAttributes().get("foo"), "belgium");
     }
     
-    @Test
-    @SuppressWarnings("deprecation")
-    public void canSubmitExternalIdentifier() throws Exception {
-        mockRequestBody(mockRequest, "{\"identifier\":\"ABC-123-XYZ\"}");
-                
-        JsonNode result = controller.createExternalIdentifier();
-        
-        assertEquals(result.get("externalId").textValue(), "ABC-123-XYZ");
-        
-        verify(mockParticipantService).assignExternalId(accountIdCaptor.capture(), eq("ABC-123-XYZ"));
-        
-        assertEquals(accountIdCaptor.getValue().getHealthCode(), HEALTH_CODE);
-        assertEquals(accountIdCaptor.getValue().getStudyId(), TEST_STUDY_IDENTIFIER);
-    }
-
     @Test
     @SuppressWarnings("deprecation")
     public void validDataGroupsCanBeAdded() throws Exception {

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserProfileControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserProfileControllerTest.java
@@ -274,12 +274,10 @@ public class UserProfileControllerTest extends Mockito {
         
         assertEquals(result.get("externalId").textValue(), "ABC-123-XYZ");
         
-        verify(mockParticipantService).assignExternalId(accountIdCaptor.capture(), externalIdCaptor.capture());
+        verify(mockParticipantService).assignExternalId(accountIdCaptor.capture(), eq("ABC-123-XYZ"));
         
         assertEquals(accountIdCaptor.getValue().getHealthCode(), HEALTH_CODE);
         assertEquals(accountIdCaptor.getValue().getStudyId(), TEST_STUDY_IDENTIFIER);
-        assertEquals(externalIdCaptor.getValue().getIdentifier(), "ABC-123-XYZ");
-        assertEquals(externalIdCaptor.getValue().getStudyId(), TEST_STUDY_IDENTIFIER);
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
@@ -352,34 +352,6 @@ public class StudyParticipantValidatorTest {
         Validate.entityThrowingException(validator, participant);
     }
     @Test
-    public void substudyRequiredIfCallerHasSubstudies() {
-        BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("substudyA")).build());
-        try {
-            // Once a user has a substudy taint, it must be passed to any accounts that user creates (or a subset of it)
-            StudyParticipant participant = withEmail("email@email.com");
-            
-            validator = new StudyParticipantValidator(externalIdService, substudyService, study, true);
-            assertValidatorMessage(validator, participant, "substudyIds", "must be assigned to this participant");
-        } finally {
-            BridgeUtils.setRequestContext(RequestContext.NULL_INSTANCE);
-        }
-    }
-    @Test
-    public void invalidSubstudyIfCallerHasSubstudies() { 
-        BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("substudyA", "substudyC")).build());
-        try {
-            // Nor can the user add a participant to substudies that they do not belong to
-            StudyParticipant participant = withSubstudies("substudyA", "substudyB");
-            
-            validator = new StudyParticipantValidator(externalIdService, substudyService, study, true);
-            assertValidatorMessage(validator, participant, "substudyIds[substudyB]", "is not a substudy of the caller");
-        } finally {
-            BridgeUtils.setRequestContext(RequestContext.NULL_INSTANCE);
-        }
-    }
-    @Test
     public void subsetOfsubstudiesOK() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
                 .withCallerSubstudies(ImmutableSet.of("substudyA", "substudyB", "substudyC")).build());


### PR DESCRIPTION
The "new rules" (BRIDGE-2548):

Users can sign up with external IDs/substudies as before, and they can use the updateIdentifiers API to add an external ID after account creation.

Researchers can add external IDs and substudies on creation, and add external IDs after creation. This in turn would associate the account to new substudies, but they cannot delete these relationships.

Admins can add these relationships on create/update, but unlike everyone else, they can also remove them. This would screw up production data, so it remains difficult to do.

I did have to move code around in the ParticipantService to avoid hacks, for example, I had to move substudy authorization checks out of the validator.