### PR TITLE
Persist languages in list order

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAccount.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAccount.java
@@ -25,6 +25,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.MapKeyClass;
 import javax.persistence.MapKeyColumn;
 import javax.persistence.OneToMany;
+import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.persistence.Version;
@@ -402,6 +403,7 @@ public class HibernateAccount implements Account {
      * list of unique ISO 639-1 language codes. */
     @CollectionTable(name = "AccountLanguages", joinColumns = @JoinColumn(name = "accountId", referencedColumnName = "id"))
     @Column(name = "language")
+    @OrderColumn(name="order_index", insertable=true, updatable=true)
     @ElementCollection(fetch = FetchType.EAGER)
     public List<String> getLanguages() {
         if (languages == null) {

--- a/src/main/resources/db/changelog/changelog.sql
+++ b/src/main/resources/db/changelog/changelog.sql
@@ -203,3 +203,8 @@ CREATE TABLE IF NOT EXISTS `RequestInfos` (
   PRIMARY KEY (`userId`),
   CONSTRAINT `RequestInfo-UserId-Constraint` FOREIGN KEY (`userId`) REFERENCES `Accounts` (`id`) ON DELETE CASCADE
 ) CHARACTER SET utf8 COLLATE utf8_unicode_ci;
+
+-- changeset bridge:6
+
+ALTER TABLE `AccountLanguages`
+ADD COLUMN `order_index` int(8) DEFAULT 0;


### PR DESCRIPTION
Languages are being persisted essentially as a set. An index property needs to be in the AccountLanguages table so Hibernate can restore the list in list order. 