### PR TITLE
Better verification messaging

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/AccountWorkflowService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AccountWorkflowService.java
@@ -218,7 +218,7 @@ public class AccountWorkflowService {
 
         String sptoken = getNextToken();
         long expiresOn = getDateTimeInMillis() + (VERIFY_OR_RESET_EXPIRE_IN_SECONDS*1000);
-
+        
         saveVerification(sptoken, new VerificationData(study.getIdentifier(), ChannelType.EMAIL, userId, expiresOn));
 
         String oldUrl = getVerifyEmailURL(study, sptoken);

--- a/src/main/java/org/sagebionetworks/bridge/services/AccountWorkflowService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AccountWorkflowService.java
@@ -217,7 +217,7 @@ public class AccountWorkflowService {
         }
 
         String sptoken = getNextToken();
-        long expiresOn = getDateTime() + (VERIFY_OR_RESET_EXPIRE_IN_SECONDS*1000);
+        long expiresOn = getDateTimeInMillis() + (VERIFY_OR_RESET_EXPIRE_IN_SECONDS*1000);
 
         saveVerification(sptoken, new VerificationData(study.getIdentifier(), ChannelType.EMAIL, userId, expiresOn));
 
@@ -251,7 +251,7 @@ public class AccountWorkflowService {
             return;
         }
         String sptoken = getNextPhoneToken();
-        long expiresOn = getDateTime() + (VERIFY_OR_RESET_EXPIRE_IN_SECONDS*1000);
+        long expiresOn = getDateTimeInMillis() + (VERIFY_OR_RESET_EXPIRE_IN_SECONDS*1000);
 
         saveVerification(sptoken, new VerificationData(study.getIdentifier(), ChannelType.PHONE, userId, expiresOn));
         
@@ -310,7 +310,7 @@ public class AccountWorkflowService {
         } else if (type == ChannelType.PHONE && TRUE.equals(account.getPhoneVerified())) {
             throw new BadRequestException(String.format(ALREADY_VERIFIED, "phone number"));
         }
-        if (data.getExpiresOn() < getDateTime()) {
+        if (data.getExpiresOn() < getDateTimeInMillis()) {
             throw new BadRequestException(VERIFY_TOKEN_EXPIRED);
         }
         return account;
@@ -705,7 +705,7 @@ public class AccountWorkflowService {
         }
     }
     
-    long getDateTime() {
+    long getDateTimeInMillis() {
         return DateTime.now().getMillis();
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/services/AccountWorkflowService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AccountWorkflowService.java
@@ -108,7 +108,7 @@ public class AccountWorkflowService {
     static final int VERIFY_CACHE_IN_SECONDS = 60*60*24*30; // 30 days
     static final int SIGNIN_EXPIRE_IN_SECONDS = 60*60; // 1 hour
 
-    private static class VerificationData {
+    static class VerificationData {
         private final String studyId;
         private final String userId;
         private final ChannelType type;

--- a/src/main/resources/templates/verifyEmail.html
+++ b/src/main/resources/templates/verifyEmail.html
@@ -32,9 +32,9 @@ function success() {
     $("#m1").text("Your email address has now been verified.");
     $("#m2").html("You can now leave this web page and go back to the "+studyName+" application.");
 }
-function failure() {
-    $("#m1").text("Your email address could not be verified.");
-    $("#m2").html("Please refresh the page; if the problem persists, contact <a href='mailto:"+supportEmail+"'>"+supportEmail+"</a> to receive further assistance.");
+function failure(message) {
+    $("#m1").text(message);
+    $("#m2").html("Contact <a href='mailto:"+supportEmail+"'>"+supportEmail+"</a> to receive further assistance.");
 }
 try {
     if (!params.study) {
@@ -52,22 +52,11 @@ try {
         if (response.status === 412) {
             success();
         } else {
-            try {
-                var message = response.responseJSON.message;
-                if (message === "Account not found.") {
-                    $("#m1").text("It looks like your email address has already been verified.");
-                    $("#m2").html("You can try using the "+studyName+" application at this point.");
-                } else {
-                    failure();
-                }
-            } catch(e) {
-                failure();
-            }
+            failure(response.responseJSON.message);
         }
     });
 } catch(e) { // happens if the query string is wrong.
-    console.log(e);
-    failure();
+    failure(e.message);
 }
 
 </script>

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
@@ -410,7 +410,7 @@ public class AccountWorkflowServiceTest extends Mockito {
     
     @Test
     public void verifyEmail() {
-        when(service.getDateTime()).thenReturn(TIMESTAMP.getMillis());
+        when(service.getDateTimeInMillis()).thenReturn(TIMESTAMP.getMillis());
         when(mockCacheProvider.getObject(SPTOKEN_CACHE_KEY, String.class)).thenReturn(
             createJson("{'studyId':'api','type':'email','userId':'userId','expiresOn':"+
                     TIMESTAMP.getMillis()+"}"));
@@ -439,7 +439,7 @@ public class AccountWorkflowServiceTest extends Mockito {
     @Test(expectedExceptions = EntityNotFoundException.class, 
             expectedExceptionsMessageRegExp = ".*Account not found.*")
     public void verifyNoAccount() {
-        when(service.getDateTime()).thenReturn(TIMESTAMP.getMillis());
+        when(service.getDateTimeInMillis()).thenReturn(TIMESTAMP.getMillis());
         when(mockCacheProvider.getObject(SPTOKEN_CACHE_KEY, String.class)).thenReturn(
             createJson("{'studyId':'api','type':'email','userId':'userId','expiresOn':"+
                     TIMESTAMP.getMillis()+"}"));
@@ -452,7 +452,7 @@ public class AccountWorkflowServiceTest extends Mockito {
     @Test(expectedExceptions = BadRequestException.class, 
             expectedExceptionsMessageRegExp=VERIFY_TOKEN_EXPIRED)
     public void verifyWithMismatchedChannel() {
-        when(service.getDateTime()).thenReturn(TIMESTAMP.getMillis());
+        when(service.getDateTimeInMillis()).thenReturn(TIMESTAMP.getMillis());
         when(mockCacheProvider.getObject(SPTOKEN_CACHE_KEY, String.class)).thenReturn(
             createJson("{'studyId':'api','type':'email','userId':'userId','expiresOn':"+
                     TIMESTAMP.getMillis()+"}"));
@@ -466,7 +466,7 @@ public class AccountWorkflowServiceTest extends Mockito {
     @Test(expectedExceptions = BadRequestException.class, 
             expectedExceptionsMessageRegExp=VERIFY_TOKEN_EXPIRED)
     public void verifyEmailExpired() {
-        when(service.getDateTime()).thenReturn(TIMESTAMP.getMillis()+1);
+        when(service.getDateTimeInMillis()).thenReturn(TIMESTAMP.getMillis()+1);
         when(mockCacheProvider.getObject(SPTOKEN_CACHE_KEY, String.class)).thenReturn(
             createJson("{'studyId':'api','type':'email','userId':'userId','expiresOn':"+
                     TIMESTAMP.getMillis()+"}"));
@@ -480,7 +480,7 @@ public class AccountWorkflowServiceTest extends Mockito {
     @Test(expectedExceptions = BadRequestException.class, 
             expectedExceptionsMessageRegExp=".*That email address has already been verified.*")
     public void verifyEmailAlreadyVerified() {
-        when(service.getDateTime()).thenReturn(TIMESTAMP.getMillis()+1);
+        when(service.getDateTimeInMillis()).thenReturn(TIMESTAMP.getMillis()+1);
         when(mockCacheProvider.getObject(SPTOKEN_CACHE_KEY, String.class)).thenReturn(
             createJson("{'studyId':'api','type':'email','userId':'userId','expiresOn':"+
                     TIMESTAMP.getMillis()+"}"));
@@ -504,7 +504,7 @@ public class AccountWorkflowServiceTest extends Mockito {
     
     @Test
     public void verifyPhone() {
-        when(service.getDateTime()).thenReturn(TIMESTAMP.getMillis());
+        when(service.getDateTimeInMillis()).thenReturn(TIMESTAMP.getMillis());
         when(mockCacheProvider.getObject(SPTOKEN_CACHE_KEY, String.class)).thenReturn(
                 TestUtils.createJson("{'studyId':'api','type':'phone','userId':'userId','expiresOn':"+
                         TIMESTAMP.getMillis()+"}"));
@@ -522,7 +522,7 @@ public class AccountWorkflowServiceTest extends Mockito {
     @Test(expectedExceptions = BadRequestException.class,
             expectedExceptionsMessageRegExp=".*That phone number has already been verified.*")
     public void verifyPhoneAlreadyVerified() {
-        when(service.getDateTime()).thenReturn(TIMESTAMP.getMillis());
+        when(service.getDateTimeInMillis()).thenReturn(TIMESTAMP.getMillis());
         when(mockCacheProvider.getObject(SPTOKEN_CACHE_KEY, String.class)).thenReturn(
                 TestUtils.createJson("{'studyId':'api','type':'phone','userId':'userId','expiresOn':"+
                         TIMESTAMP.getMillis()+"}"));
@@ -538,7 +538,7 @@ public class AccountWorkflowServiceTest extends Mockito {
     @Test(expectedExceptions = BadRequestException.class, 
             expectedExceptionsMessageRegExp=VERIFY_TOKEN_EXPIRED)
     public void verifyPhoneExpired() {
-        when(service.getDateTime()).thenReturn(TIMESTAMP.getMillis()+1);
+        when(service.getDateTimeInMillis()).thenReturn(TIMESTAMP.getMillis()+1);
         when(mockCacheProvider.getObject(SPTOKEN_CACHE_KEY, String.class)).thenReturn(
                 TestUtils.createJson("{'studyId':'api','type':'phone','userId':'userId','expiresOn':"+
                         TIMESTAMP.getMillis()+"}"));

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.services;
 
 import static java.lang.Boolean.TRUE;
+import static org.sagebionetworks.bridge.RequestContext.NULL_INSTANCE;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 import static org.sagebionetworks.bridge.TestConstants.TIMESTAMP;
 import static org.sagebionetworks.bridge.TestUtils.createJson;
@@ -32,6 +33,7 @@ import java.util.Map;
 
 import javax.mail.internet.MimeBodyPart;
 
+import org.joda.time.DateTimeUtils;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
@@ -39,6 +41,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -72,7 +75,6 @@ import org.sagebionetworks.bridge.services.email.EmailType;
 import org.sagebionetworks.bridge.services.email.MimeTypeEmail;
 import org.sagebionetworks.bridge.sms.SmsMessageProvider;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Iterables;
 
@@ -209,6 +211,12 @@ public class AccountWorkflowServiceTest extends Mockito {
 
         // Add params to mock account.
         when(mockAccount.getId()).thenReturn(USER_ID);
+        when(service.getDateTimeInMillis()).thenReturn(TIMESTAMP.getMillis());
+    }
+    
+    @AfterMethod
+    public void afterMethod() {
+        BridgeUtils.setRequestContext(NULL_INSTANCE);
     }
     
     private void mockRevision(TemplateType templateType, String subject, String body, MimeType type) {
@@ -233,6 +241,8 @@ public class AccountWorkflowServiceTest extends Mockito {
         assertEquals(node.get("studyId").textValue(), "api");
         assertEquals(node.get("userId").textValue(), "userId");
         assertEquals(node.get("type").textValue(), "email");
+        assertEquals(node.get("expiresOn").longValue(),
+                TIMESTAMP.getMillis() + (VERIFY_OR_RESET_EXPIRE_IN_SECONDS * 1000));
         
         BasicEmailProvider provider = emailProviderCaptor.getValue();
         Map<String,String> tokens = provider.getTokenMap();
@@ -288,6 +298,8 @@ public class AccountWorkflowServiceTest extends Mockito {
         assertEquals(node.get("studyId").textValue(), "api");
         assertEquals(node.get("userId").textValue(), "userId");
         assertEquals(node.get("type").textValue(), "phone");
+        assertEquals(node.get("expiresOn").longValue(),
+                TIMESTAMP.getMillis() + (VERIFY_OR_RESET_EXPIRE_IN_SECONDS * 1000));
         
         SmsMessageProvider provider = smsMessageProviderCaptor.getValue();
         Map<String,String> tokens = provider.getTokenMap();

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
@@ -72,6 +72,7 @@ import org.sagebionetworks.bridge.services.email.EmailType;
 import org.sagebionetworks.bridge.services.email.MimeTypeEmail;
 import org.sagebionetworks.bridge.sms.SmsMessageProvider;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Iterables;
 
@@ -1318,5 +1319,24 @@ public class AccountWorkflowServiceTest extends Mockito {
         assertEquals(userId, USER_ID);
 
         verify(mockSmsService, times(2)).sendSmsMessage(any(), any());
+    }
+    
+    @Test
+    public void serializeVerificationData() throws Exception { 
+        AccountWorkflowService.VerificationData data = new AccountWorkflowService.VerificationData(
+                TEST_STUDY_IDENTIFIER, ChannelType.PHONE, USER_ID, TIMESTAMP.getMillis());
+        
+        JsonNode node = BridgeObjectMapper.get().valueToTree(data);
+        assertEquals(node.get("studyId").textValue(), TEST_STUDY_IDENTIFIER);
+        assertEquals(node.get("type").textValue(), "phone");
+        assertEquals(node.get("userId").textValue(), USER_ID);
+        assertEquals(node.get("expiresOn").longValue(), TIMESTAMP.getMillis());
+        
+        AccountWorkflowService.VerificationData deser = BridgeObjectMapper.get().readValue(node.toString(),
+                AccountWorkflowService.VerificationData.class);
+        assertEquals(deser.getStudyId(), TEST_STUDY_IDENTIFIER);
+        assertEquals(deser.getType(), ChannelType.PHONE);
+        assertEquals(deser.getUserId(), USER_ID);
+        assertEquals(deser.getExpiresOn(), TIMESTAMP.getMillis());
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
@@ -1,15 +1,9 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
+import static java.lang.Boolean.TRUE;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
+import static org.sagebionetworks.bridge.TestConstants.TIMESTAMP;
+import static org.sagebionetworks.bridge.TestUtils.createJson;
 import static org.sagebionetworks.bridge.models.studies.MimeType.TEXT;
 import static org.sagebionetworks.bridge.models.templates.TemplateType.EMAIL_ACCOUNT_EXISTS;
 import static org.sagebionetworks.bridge.models.templates.TemplateType.EMAIL_RESET_PASSWORD;
@@ -19,6 +13,12 @@ import static org.sagebionetworks.bridge.models.templates.TemplateType.SMS_ACCOU
 import static org.sagebionetworks.bridge.models.templates.TemplateType.SMS_PHONE_SIGN_IN;
 import static org.sagebionetworks.bridge.models.templates.TemplateType.SMS_RESET_PASSWORD;
 import static org.sagebionetworks.bridge.models.templates.TemplateType.SMS_VERIFY_PHONE;
+import static org.sagebionetworks.bridge.services.AccountWorkflowService.CONFIG_KEY_CHANNEL_THROTTLE_MAX_REQUESTS;
+import static org.sagebionetworks.bridge.services.AccountWorkflowService.CONFIG_KEY_CHANNEL_THROTTLE_TIMEOUT_SECONDS;
+import static org.sagebionetworks.bridge.services.AccountWorkflowService.SIGNIN_EXPIRE_IN_SECONDS;
+import static org.sagebionetworks.bridge.services.AccountWorkflowService.VERIFY_CACHE_IN_SECONDS;
+import static org.sagebionetworks.bridge.services.AccountWorkflowService.VERIFY_OR_RESET_EXPIRE_IN_SECONDS;
+import static org.sagebionetworks.bridge.services.AccountWorkflowService.VERIFY_TOKEN_EXPIRED;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -34,7 +34,9 @@ import javax.mail.internet.MimeBodyPart;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.testng.annotations.BeforeMethod;
@@ -73,8 +75,7 @@ import org.sagebionetworks.bridge.sms.SmsMessageProvider;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Iterables;
 
-@SuppressWarnings("unchecked")
-public class AccountWorkflowServiceTest {
+public class AccountWorkflowServiceTest extends Mockito {
     private static final String SUPPORT_EMAIL = "support@support.com";
     private static final String STUDY_ID = TestConstants.TEST_STUDY_IDENTIFIER;
     private static final String SPTOKEN = "GHI-JKL";
@@ -152,10 +153,12 @@ public class AccountWorkflowServiceTest {
     private Study study;
     
     @Spy
+    @InjectMocks
     private AccountWorkflowService service;
 
     private Map<String, Object> mockCacheProviderMap;
 
+    @SuppressWarnings("unchecked")
     @BeforeMethod
     public void before() {
         MockitoAnnotations.initMocks(this);
@@ -178,10 +181,10 @@ public class AccountWorkflowServiceTest {
         study.setSupportEmail(SUPPORT_EMAIL);
 
         // Mock bridge config
-        when(mockBridgeConfig.getInt(AccountWorkflowService.CONFIG_KEY_CHANNEL_THROTTLE_MAX_REQUESTS)).thenReturn(2);
-        when(mockBridgeConfig.getInt(AccountWorkflowService.CONFIG_KEY_CHANNEL_THROTTLE_TIMEOUT_SECONDS)).thenReturn(
-                300);
-
+        when(mockBridgeConfig.getInt(CONFIG_KEY_CHANNEL_THROTTLE_MAX_REQUESTS)).thenReturn(2);
+        when(mockBridgeConfig.getInt(CONFIG_KEY_CHANNEL_THROTTLE_TIMEOUT_SECONDS)).thenReturn(300);
+        service.setBridgeConfig(mockBridgeConfig);
+        
         // Mock cache provider to do a basic in-memory map for simple gets and sets.
         mockCacheProviderMap = new HashMap<>();
 
@@ -203,18 +206,8 @@ public class AccountWorkflowServiceTest {
             return null;
         }).when(mockCacheProvider).removeObject(any());
 
-        // Set up service
-        service.setAccountDao(mockAccountDao);
-        service.setBridgeConfig(mockBridgeConfig);
-        service.setCacheProvider(mockCacheProvider);
-        service.setSendMailService(mockSendMailService);
-        service.setSmsService(mockSmsService);
-        service.setStudyService(mockStudyService);
-        service.setTemplateService(mockTemplateService);
-
         // Add params to mock account.
         when(mockAccount.getId()).thenReturn(USER_ID);
-        // */when(mockAccount.getHealthCode()).thenReturn(HEALTH_CODE);
     }
     
     private void mockRevision(TemplateType templateType, String subject, String body, MimeType type) {
@@ -232,8 +225,7 @@ public class AccountWorkflowServiceTest {
         service.sendEmailVerificationToken(study, USER_ID, EMAIL);
         
         verify(mockSendMailService).sendEmail(emailProviderCaptor.capture());
-        verify(mockCacheProvider).setObject(eq(SPTOKEN_CACHE_KEY), stringCaptor.capture(),
-                eq(AccountWorkflowService.VERIFY_OR_RESET_EXPIRE_IN_SECONDS));
+        verify(mockCacheProvider).setObject(eq(SPTOKEN_CACHE_KEY), stringCaptor.capture(), eq(VERIFY_CACHE_IN_SECONDS));
         
         String string = stringCaptor.getValue();
         JsonNode node = BridgeObjectMapper.get().readTree(string);
@@ -288,7 +280,7 @@ public class AccountWorkflowServiceTest {
         service.sendPhoneVerificationToken(study, USER_ID, TestConstants.PHONE);
 
         verify(mockSmsService).sendSmsMessage(eq(USER_ID), smsMessageProviderCaptor.capture());
-        verify(mockCacheProvider).setObject(eq(PHONE_TOKEN_CACHE_KEY), stringCaptor.capture(), eq(AccountWorkflowService.VERIFY_OR_RESET_EXPIRE_IN_SECONDS));
+        verify(mockCacheProvider).setObject(eq(PHONE_TOKEN_CACHE_KEY), stringCaptor.capture(), eq(VERIFY_CACHE_IN_SECONDS));
         
         String string = stringCaptor.getValue();
         JsonNode node = BridgeObjectMapper.get().readTree(string);
@@ -340,8 +332,7 @@ public class AccountWorkflowServiceTest {
         service.resendVerificationToken(ChannelType.EMAIL, ACCOUNT_ID_WITH_EMAIL);
         
         verify(service).sendEmailVerificationToken(study, USER_ID, EMAIL);
-        verify(mockCacheProvider).setObject(eq(TOKEN_CACHE_KEY), any(),
-                eq(AccountWorkflowService.VERIFY_OR_RESET_EXPIRE_IN_SECONDS));
+        verify(mockCacheProvider).setObject(eq(TOKEN_CACHE_KEY), any(), eq(VERIFY_CACHE_IN_SECONDS));
     }
     
     @Test(expectedExceptions = UnsupportedOperationException.class)
@@ -356,8 +347,6 @@ public class AccountWorkflowServiceTest {
     @Test
     public void resendEmailVerificationTokenFailsWithMissingStudy() {
         when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenThrow(new EntityNotFoundException(Study.class));
-     // */when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(mockAccount);
-     // */when(mockAccount.getId()).thenReturn(USER_ID);
         
         try {
             service.resendVerificationToken(ChannelType.EMAIL, ACCOUNT_ID_WITH_EMAIL);
@@ -371,9 +360,7 @@ public class AccountWorkflowServiceTest {
     
     @Test
     public void resendEmailVerificationTokenFailsQuietlyWithMissingAccount() {
-     // */when(mockStudyService.getStudy(TEST_STUDY)).thenReturn(study);
         when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(null);
-     // */when(mockAccount.getId()).thenReturn(USER_ID);
         
         service.resendVerificationToken(ChannelType.EMAIL, ACCOUNT_ID_WITH_EMAIL);
         
@@ -394,14 +381,12 @@ public class AccountWorkflowServiceTest {
         verify(service).sendPhoneVerificationToken(study, USER_ID, TestConstants.PHONE);
         
         verify(mockCacheProvider).setObject(eq(PHONE_TOKEN_CACHE_KEY), stringCaptor.capture(),
-                eq(AccountWorkflowService.VERIFY_OR_RESET_EXPIRE_IN_SECONDS));
+                eq(VERIFY_CACHE_IN_SECONDS));
     }
     
     @Test
     public void resendPhoneVerificationTokenFailsWithMissingStudy() {
         when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenThrow(new EntityNotFoundException(Study.class));
-     // */when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
-     // */when(mockAccount.getId()).thenReturn(USER_ID);
         
         try {
             service.resendVerificationToken(ChannelType.EMAIL, ACCOUNT_ID_WITH_PHONE);
@@ -415,9 +400,7 @@ public class AccountWorkflowServiceTest {
     
     @Test
     public void resendPhoneVerificationTokenFailsQuietlyWithMissingAccount() {
-     // */when(mockStudyService.getStudy(TEST_STUDY)).thenReturn(study);
         when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(null);
-     // */when(mockAccount.getId()).thenReturn(USER_ID);
         
         service.resendVerificationToken(ChannelType.EMAIL, ACCOUNT_ID_WITH_PHONE);
         
@@ -426,25 +409,11 @@ public class AccountWorkflowServiceTest {
     }
     
     @Test
-    public void verifyEmailWithLegacyJson() {
-        when(mockCacheProvider.getObject(SPTOKEN_CACHE_KEY, String.class)).thenReturn(
-            TestUtils.createJson("{'studyId':'api','userId':'userId'}"));
-        when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
-        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_ID)).thenReturn(mockAccount);
-        when(mockAccount.getId()).thenReturn("accountId");
-        
-        Verification verification = new Verification(SPTOKEN);
-        
-        Account account = service.verifyChannel(ChannelType.EMAIL, verification);
-        assertEquals(account.getId(), "accountId");
-        verify(mockCacheProvider).getObject(SPTOKEN_CACHE_KEY, String.class);
-        verify(mockCacheProvider).removeObject(SPTOKEN_CACHE_KEY);
-    }
-    
-    @Test
     public void verifyEmail() {
+        when(service.getDateTime()).thenReturn(TIMESTAMP.getMillis());
         when(mockCacheProvider.getObject(SPTOKEN_CACHE_KEY, String.class)).thenReturn(
-            TestUtils.createJson("{'studyId':'api','type':'email','userId':'userId'}"));
+            createJson("{'studyId':'api','type':'email','userId':'userId','expiresOn':"+
+                    TIMESTAMP.getMillis()+"}"));
         when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
         when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_ID)).thenReturn(mockAccount);
         when(mockAccount.getId()).thenReturn("accountId");
@@ -454,60 +423,153 @@ public class AccountWorkflowServiceTest {
         Account account = service.verifyChannel(ChannelType.EMAIL, verification);
         assertEquals(account.getId(), "accountId");
         verify(mockCacheProvider).getObject(SPTOKEN_CACHE_KEY, String.class);
-        verify(mockCacheProvider).removeObject(SPTOKEN_CACHE_KEY);
     }
     
-    @Test(expectedExceptions = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class, 
+            expectedExceptionsMessageRegExp=VERIFY_TOKEN_EXPIRED)
+    public void verifyWithoutCreatedFailsCorrectly() {
+        // This is a dumb test, but prior to the introduction of the expiresOn value, the verification 
+        // object's TTL is the timeout value for the link working... the cache returns null and 
+        // the correct error is thrown.
+        service.verifyChannel(ChannelType.EMAIL, new Verification(SPTOKEN));
+    }
+    
+    // This almost seems logically impossible, but maybe if an admin deleted an account
+    // and an email was hanging out there...
+    @Test(expectedExceptions = EntityNotFoundException.class, 
+            expectedExceptionsMessageRegExp = ".*Account not found.*")
+    public void verifyNoAccount() {
+        when(service.getDateTime()).thenReturn(TIMESTAMP.getMillis());
+        when(mockCacheProvider.getObject(SPTOKEN_CACHE_KEY, String.class)).thenReturn(
+            createJson("{'studyId':'api','type':'email','userId':'userId','expiresOn':"+
+                    TIMESTAMP.getMillis()+"}"));
+        when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
+        
+        Verification verification = new Verification(SPTOKEN);
+        service.verifyChannel(ChannelType.EMAIL, verification);
+    }
+    
+    @Test(expectedExceptions = BadRequestException.class, 
+            expectedExceptionsMessageRegExp=VERIFY_TOKEN_EXPIRED)
+    public void verifyWithMismatchedChannel() {
+        when(service.getDateTime()).thenReturn(TIMESTAMP.getMillis());
+        when(mockCacheProvider.getObject(SPTOKEN_CACHE_KEY, String.class)).thenReturn(
+            createJson("{'studyId':'api','type':'email','userId':'userId','expiresOn':"+
+                    TIMESTAMP.getMillis()+"}"));
+        when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
+        
+        Verification verification = new Verification(SPTOKEN);
+        // Should be email but was called through the phone API
+        service.verifyChannel(ChannelType.PHONE, verification);
+    }    
+    
+    @Test(expectedExceptions = BadRequestException.class, 
+            expectedExceptionsMessageRegExp=VERIFY_TOKEN_EXPIRED)
+    public void verifyEmailExpired() {
+        when(service.getDateTime()).thenReturn(TIMESTAMP.getMillis()+1);
+        when(mockCacheProvider.getObject(SPTOKEN_CACHE_KEY, String.class)).thenReturn(
+            createJson("{'studyId':'api','type':'email','userId':'userId','expiresOn':"+
+                    TIMESTAMP.getMillis()+"}"));
+        when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
+        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_ID)).thenReturn(mockAccount);
+        
+        Verification verification = new Verification(SPTOKEN);
+        service.verifyChannel(ChannelType.EMAIL, verification);
+    }
+    
+    @Test(expectedExceptions = BadRequestException.class, 
+            expectedExceptionsMessageRegExp=".*That email address has already been verified.*")
+    public void verifyEmailAlreadyVerified() {
+        when(service.getDateTime()).thenReturn(TIMESTAMP.getMillis()+1);
+        when(mockCacheProvider.getObject(SPTOKEN_CACHE_KEY, String.class)).thenReturn(
+            createJson("{'studyId':'api','type':'email','userId':'userId','expiresOn':"+
+                    TIMESTAMP.getMillis()+"}"));
+        when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
+        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_ID)).thenReturn(mockAccount);
+        when(mockAccount.getId()).thenReturn("accountId");
+        when(mockAccount.getEmailVerified()).thenReturn(TRUE);
+        
+        Verification verification = new Verification(SPTOKEN);
+        service.verifyChannel(ChannelType.EMAIL, verification);        
+    }
+    
+    @Test(expectedExceptions = BadRequestException.class, 
+            expectedExceptionsMessageRegExp=VERIFY_TOKEN_EXPIRED)
     public void verifyEmailBadSptokenThrowsException() {
         when(mockCacheProvider.getObject(SPTOKEN_CACHE_KEY, String.class)).thenReturn(null);
         
         Verification verification = new Verification(SPTOKEN);
-        
         service.verifyChannel(ChannelType.EMAIL, verification);
-        verifyNoMoreInteractions(mockCacheProvider);
     }
     
     @Test
     public void verifyPhone() {
+        when(service.getDateTime()).thenReturn(TIMESTAMP.getMillis());
         when(mockCacheProvider.getObject(SPTOKEN_CACHE_KEY, String.class)).thenReturn(
-                TestUtils.createJson("{'studyId':'api','type':'phone','userId':'userId'}"));
+                TestUtils.createJson("{'studyId':'api','type':'phone','userId':'userId','expiresOn':"+
+                        TIMESTAMP.getMillis()+"}"));
         when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
         when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_ID)).thenReturn(mockAccount);
         when(mockAccount.getId()).thenReturn("accountId");
         
         Verification verification = new Verification(SPTOKEN);
-        
         Account account = service.verifyChannel(ChannelType.PHONE, verification);
+        
         assertEquals(account.getId(), "accountId");
         verify(mockCacheProvider).getObject(SPTOKEN_CACHE_KEY, String.class);
-        verify(mockCacheProvider).removeObject(SPTOKEN_CACHE_KEY);
     }
     
-    @Test(expectedExceptions = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class,
+            expectedExceptionsMessageRegExp=".*That phone number has already been verified.*")
+    public void verifyPhoneAlreadyVerified() {
+        when(service.getDateTime()).thenReturn(TIMESTAMP.getMillis());
+        when(mockCacheProvider.getObject(SPTOKEN_CACHE_KEY, String.class)).thenReturn(
+                TestUtils.createJson("{'studyId':'api','type':'phone','userId':'userId','expiresOn':"+
+                        TIMESTAMP.getMillis()+"}"));
+        when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
+        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_ID)).thenReturn(mockAccount);
+        when(mockAccount.getId()).thenReturn("accountId");
+        when(mockAccount.getPhoneVerified()).thenReturn(TRUE);
+        
+        Verification verification = new Verification(SPTOKEN);
+        service.verifyChannel(ChannelType.PHONE, verification);
+    }
+    
+    @Test(expectedExceptions = BadRequestException.class, 
+            expectedExceptionsMessageRegExp=VERIFY_TOKEN_EXPIRED)
+    public void verifyPhoneExpired() {
+        when(service.getDateTime()).thenReturn(TIMESTAMP.getMillis()+1);
+        when(mockCacheProvider.getObject(SPTOKEN_CACHE_KEY, String.class)).thenReturn(
+                TestUtils.createJson("{'studyId':'api','type':'phone','userId':'userId','expiresOn':"+
+                        TIMESTAMP.getMillis()+"}"));
+        when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
+        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_ID)).thenReturn(mockAccount);
+        
+        Verification verification = new Verification(SPTOKEN);
+        service.verifyChannel(ChannelType.PHONE, verification);
+    }
+    
+    @Test(expectedExceptions = BadRequestException.class, 
+            expectedExceptionsMessageRegExp=VERIFY_TOKEN_EXPIRED)
     public void verifyEmailViaPhoneFails() {
         when(mockCacheProvider.getObject(SPTOKEN_CACHE_KEY, String.class)).thenReturn(
                 TestUtils.createJson("{'studyId':'api','type':'email','userId':'userId'}"));
-     // */when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
-     // */when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_ID)).thenReturn(mockAccount);
-     // */when(mockAccount.getId()).thenReturn("accountId");
         
         Verification verification = new Verification(SPTOKEN);
-        
         service.verifyChannel(ChannelType.PHONE, verification);
+        
         verifyNoMoreInteractions(mockCacheProvider);
     }
     
-    @Test(expectedExceptions = BadRequestException.class)
+    @Test(expectedExceptions = BadRequestException.class, 
+            expectedExceptionsMessageRegExp=VERIFY_TOKEN_EXPIRED)
     public void verifyPhoneViaEmailFails() {
         when(mockCacheProvider.getObject(SPTOKEN_CACHE_KEY, String.class)).thenReturn(
                 TestUtils.createJson("{'studyId':'api','type':'phone','userId':'userId'}"));
-     // */when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
-     // */when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_ID)).thenReturn(mockAccount);
-     // */when(mockAccount.getId()).thenReturn("accountId");
         
         Verification verification = new Verification(SPTOKEN);
-        
         service.verifyChannel(ChannelType.EMAIL, verification);
+        
         verifyNoMoreInteractions(mockCacheProvider);
     }
     
@@ -531,7 +593,6 @@ public class AccountWorkflowServiceTest {
         verify(mockSendMailService).sendEmail(emailProviderCaptor.capture());
         
         BasicEmailProvider provider = emailProviderCaptor.getValue();
-        
         assertEquals(provider.getTokenMap().get("token"), TOKEN);
         assertEquals(provider.getTokenMap().get("sptoken"), SPTOKEN);
         assertEquals(provider.getTokenMap().get("expirationPeriod"), "2 hours");
@@ -571,12 +632,10 @@ public class AccountWorkflowServiceTest {
         study.setEmailSignInEnabled(false);
         study.setEmailVerificationEnabled(true);
         AccountId accountId = AccountId.forId(TEST_STUDY_IDENTIFIER, USER_ID);
-     // */when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
         when(service.getNextToken()).thenReturn(SPTOKEN);
         when(mockAccount.getEmail()).thenReturn(EMAIL);
         when(mockAccount.getEmailVerified()).thenReturn(Boolean.TRUE);
         when(mockAccountDao.getAccount(accountId)).thenReturn(mockAccount);
-     // */when(mockAccountDao.getAccount(AccountId.forEmail(TEST_STUDY_IDENTIFIER, EMAIL))).thenReturn(mockAccount);
         
         service.notifyAccountExists(study, accountId);
         
@@ -584,11 +643,9 @@ public class AccountWorkflowServiceTest {
         verify(mockSendMailService).sendEmail(emailProviderCaptor.capture());
         
         BasicEmailProvider provider = emailProviderCaptor.getValue();
-        
         // not set, no email sign in
         assertNull(provider.getTokenMap().get("token"));
         assertNull(provider.getTokenMap().get("email"));
-        
         assertEquals(provider.getTokenMap().get("sptoken"), SPTOKEN);
         assertEquals(provider.getTokenMap().get("expirationPeriod"), "2 hours");
         assertEquals(provider.getTokenMap().get("expirationWindow"), "2");
@@ -651,7 +708,7 @@ public class AccountWorkflowServiceTest {
             assertFalse(bodyString.contains("${shortEmailSignInUrl}"));
         }
         verify(mockCacheProvider, times(3)).setObject(PASSWORD_RESET_FOR_EMAIL, EMAIL,
-                AccountWorkflowService.VERIFY_OR_RESET_EXPIRE_IN_SECONDS);
+                VERIFY_OR_RESET_EXPIRE_IN_SECONDS);
     }
 
     @Test
@@ -675,11 +732,10 @@ public class AccountWorkflowServiceTest {
         assertEquals(provider.getTokenMap().get("expirationPeriod"), "2 hours");
 
         String bodyString = (String) provider.getMimeTypeEmail().getMessageParts().get(0).getContent();
-        
         assertTrue(bodyString.contains("${emailSignInUrl}"));
         
         verify(mockCacheProvider).setObject(PASSWORD_RESET_FOR_EMAIL, EMAIL,
-                AccountWorkflowService.VERIFY_OR_RESET_EXPIRE_IN_SECONDS);
+                VERIFY_OR_RESET_EXPIRE_IN_SECONDS);
     }    
     
     @Test
@@ -697,7 +753,7 @@ public class AccountWorkflowServiceTest {
         
         verify(mockCacheProvider).setObject(PASSWORD_RESET_FOR_PHONE, 
                 BridgeObjectMapper.get().writeValueAsString(TestConstants.PHONE), 
-                AccountWorkflowService.VERIFY_OR_RESET_EXPIRE_IN_SECONDS);
+                VERIFY_OR_RESET_EXPIRE_IN_SECONDS);
         verify(mockSmsService).sendSmsMessage(eq(USER_ID), smsMessageProviderCaptor.capture());
         
         String message = smsMessageProviderCaptor.getValue().getSmsRequest().getMessage();
@@ -709,11 +765,9 @@ public class AccountWorkflowServiceTest {
     
     @Test
     public void notifyAccountExistsForPhoneNoSignIn() throws Exception {
-     // */when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
         study.setPhoneSignInEnabled(false);
         AccountId accountId = AccountId.forPhone(TEST_STUDY_IDENTIFIER, TestConstants.PHONE);
         when(service.getNextToken()).thenReturn(SPTOKEN);
-     // */when(service.getNextPhoneToken()).thenReturn(PHONE_TOKEN);
         when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
         when(mockAccount.getPhoneVerified()).thenReturn(Boolean.TRUE);
         when(mockAccountDao.getAccount(accountId)).thenReturn(mockAccount);
@@ -722,7 +776,7 @@ public class AccountWorkflowServiceTest {
         
         verify(mockCacheProvider).setObject(PASSWORD_RESET_FOR_PHONE, 
                 BridgeObjectMapper.get().writeValueAsString(TestConstants.PHONE), 
-                AccountWorkflowService.VERIFY_OR_RESET_EXPIRE_IN_SECONDS);
+                VERIFY_OR_RESET_EXPIRE_IN_SECONDS);
         verify(mockSmsService).sendSmsMessage(eq(USER_ID), smsMessageProviderCaptor.capture());
         
         String message = smsMessageProviderCaptor.getValue().getSmsRequest().getMessage();
@@ -735,13 +789,10 @@ public class AccountWorkflowServiceTest {
     
     @Test
     public void notifyAccountExistsWithPhoneAutoVerifySuppressed() {
-     // */when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
         study.setPhoneSignInEnabled(true);
         study.setAutoVerificationPhoneSuppressed(true);
         
         AccountId accountId = AccountId.forPhone(TEST_STUDY_IDENTIFIER, TestConstants.PHONE);
-     // */when(service.getNextToken()).thenReturn(SPTOKEN);
-     // */when(service.getNextPhoneToken()).thenReturn(PHONE_TOKEN);
         when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
         when(mockAccount.getPhoneVerified()).thenReturn(Boolean.TRUE);
         when(mockAccountDao.getAccount(accountId)).thenReturn(mockAccount);
@@ -760,12 +811,9 @@ public class AccountWorkflowServiceTest {
         study.setAutoVerificationEmailSuppressed(true);
         
         AccountId accountId = AccountId.forId(TEST_STUDY_IDENTIFIER, USER_ID);
-     // */when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
-     // */when(service.getNextToken()).thenReturn(SPTOKEN, TOKEN);
         when(mockAccount.getEmail()).thenReturn(EMAIL);
         when(mockAccount.getEmailVerified()).thenReturn(Boolean.TRUE);
         when(mockAccountDao.getAccount(accountId)).thenReturn(mockAccount);
-     // */when(mockAccountDao.getAccount(AccountId.forEmail(TEST_STUDY_IDENTIFIER, EMAIL))).thenReturn(mockAccount);
         
         service.notifyAccountExists(study, accountId);
         
@@ -782,12 +830,9 @@ public class AccountWorkflowServiceTest {
         study.setEmailVerificationEnabled(false);
         
         AccountId accountId = AccountId.forId(TEST_STUDY_IDENTIFIER, USER_ID);
-     // */when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
-     // */when(service.getNextToken()).thenReturn(SPTOKEN, TOKEN);
         when(mockAccount.getEmail()).thenReturn(EMAIL);
         when(mockAccount.getEmailVerified()).thenReturn(Boolean.TRUE);
         when(mockAccountDao.getAccount(accountId)).thenReturn(mockAccount);
-     // */when(mockAccountDao.getAccount(AccountId.forEmail(TEST_STUDY_IDENTIFIER, EMAIL))).thenReturn(mockAccount);
         
         service.notifyAccountExists(study, accountId);
         
@@ -845,17 +890,15 @@ public class AccountWorkflowServiceTest {
     public void requestResetPasswordWithEmail() throws Exception {
         when(service.getNextToken()).thenReturn(SPTOKEN);
         when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(mockAccount);
-     // */when(mockStudyService.getStudy(TEST_STUDY)).thenReturn(study);
         when(mockAccount.getEmail()).thenReturn(EMAIL);
         when(mockAccount.getEmailVerified()).thenReturn(Boolean.TRUE);        
-     // */when(mockAccount.getStudyId()).thenReturn(TEST_STUDY_IDENTIFIER);
         
         service.requestResetPassword(study, false, ACCOUNT_ID_WITH_EMAIL);
         
         verify(mockCacheProvider).setObject(PASSWORD_RESET_FOR_EMAIL, EMAIL, 60*60*2);
         verify(mockSendMailService).sendEmail(emailProviderCaptor.capture());
-        BasicEmailProvider provider = emailProviderCaptor.getValue();
         
+        BasicEmailProvider provider = emailProviderCaptor.getValue();
         assertEquals(provider.getTokenMap().get("sptoken"), SPTOKEN);
         assertEquals(provider.getTokenMap().get("expirationWindow"), "2");
         assertEquals(provider.getTokenMap().get("expirationPeriod"), "2 hours");
@@ -876,10 +919,8 @@ public class AccountWorkflowServiceTest {
     public void requestResetPasswordWithPhone() throws Exception {
         when(service.getNextToken()).thenReturn(SPTOKEN);
         when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
-     // */when(mockStudyService.getStudy(TEST_STUDY)).thenReturn(study);
         when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
         when(mockAccount.getPhoneVerified()).thenReturn(Boolean.TRUE);        
-     // */when(mockAccount.getStudyId()).thenReturn(TEST_STUDY_IDENTIFIER);
         
         service.requestResetPassword(study, false, ACCOUNT_ID_WITH_PHONE);
         
@@ -904,7 +945,6 @@ public class AccountWorkflowServiceTest {
         when(mockAccount.getEmail()).thenReturn(EMAIL);
         when(mockAccount.getPhoneVerified()).thenReturn(Boolean.FALSE);
         when(mockAccount.getEmailVerified()).thenReturn(Boolean.FALSE);
-     // */when(mockAccount.getStudyId()).thenReturn(TEST_STUDY_IDENTIFIER);
 
         service.requestResetPassword(study, false, ACCOUNT_ID_WITH_PHONE);
         
@@ -919,7 +959,6 @@ public class AccountWorkflowServiceTest {
         when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
         when(mockAccount.getPhoneVerified()).thenReturn(Boolean.FALSE);
         when(mockAccount.getEmailVerified()).thenReturn(Boolean.FALSE);
-     // */when(mockAccount.getStudyId()).thenReturn(TEST_STUDY_IDENTIFIER);
         
         service.requestResetPassword(study, false, ACCOUNT_ID_WITH_PHONE);
         
@@ -930,7 +969,6 @@ public class AccountWorkflowServiceTest {
     
     @Test
     public void requestResetPasswordInvalidEmailFailsQuietly() {
-     // */when(service.getNextToken()).thenReturn(TOKEN);
         when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(null);
         
         service.requestResetPassword(study, false, ACCOUNT_ID_WITH_EMAIL);
@@ -942,7 +980,6 @@ public class AccountWorkflowServiceTest {
 
     @Test
     public void requestRestPasswordUnverifiedEmailFailsQuietly() {
-     // */when(service.getNextToken()).thenReturn(TOKEN);
         when(mockAccount.getEmail()).thenReturn(EMAIL);
         when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(mockAccount);
         
@@ -955,7 +992,6 @@ public class AccountWorkflowServiceTest {
     
     @Test
     public void requestRestPasswordUnverifiedPhoneFailsQuietly() {
-     // */when(service.getNextToken()).thenReturn(TOKEN);
         when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
         when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
         
@@ -970,7 +1006,6 @@ public class AccountWorkflowServiceTest {
     public void requestResetPasswordByAdminDoesNotRequireEmailVerification() {
         when(service.getNextToken()).thenReturn(SPTOKEN);
         when(mockAccount.getEmail()).thenReturn(EMAIL);
-     // */when(mockAccount.getEmailVerified()).thenReturn(false);
         when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
         
         service.requestResetPassword(study, true, ACCOUNT_ID_WITH_PHONE);
@@ -984,7 +1019,6 @@ public class AccountWorkflowServiceTest {
         when(service.getNextToken()).thenReturn(SPTOKEN);
         when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
         when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
-     // */when(mockAccount.getPhoneVerified()).thenReturn(false);        
         
         service.requestResetPassword(study, true, ACCOUNT_ID_WITH_PHONE);
         
@@ -995,10 +1029,6 @@ public class AccountWorkflowServiceTest {
     @Test
     public void requestResetPasswordQuietlyFailsForDisabledAccount() {
         when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
-     // */when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
-     // */when(mockAccount.getPhoneVerified()).thenReturn(Boolean.TRUE);
-     // */when(mockAccount.getEmailVerified()).thenReturn(Boolean.TRUE);
-     // */when(mockAccount.getStudyId()).thenReturn(TEST_STUDY_IDENTIFIER);
         when(mockAccount.getStatus()).thenReturn(AccountStatus.DISABLED);
         
         service.requestResetPassword(study, false, ACCOUNT_ID_WITH_PHONE);
@@ -1054,7 +1084,6 @@ public class AccountWorkflowServiceTest {
     
     @Test
     public void resetPasswordInvalidAccount() {
-     // */when(service.getNextToken()).thenReturn("777777");
         when(mockCacheProvider.getObject(PASSWORD_RESET_FOR_EMAIL, String.class)).thenReturn(EMAIL);
         when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
         when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(null);
@@ -1090,7 +1119,7 @@ public class AccountWorkflowServiceTest {
         
         verify(mockAccountDao).getAccount(SIGN_IN_REQUEST_WITH_EMAIL.getAccountId());
         
-        verify(mockCacheProvider).setObject(eq(EMAIL_SIGNIN_CACHE_KEY), stringCaptor.capture(), eq(AccountWorkflowService.SIGNIN_EXPIRE_IN_SECONDS));
+        verify(mockCacheProvider).setObject(eq(EMAIL_SIGNIN_CACHE_KEY), stringCaptor.capture(), eq(SIGNIN_EXPIRE_IN_SECONDS));
         assertNotNull(stringCaptor.getValue());
 
         verify(mockSendMailService).sendEmail(emailProviderCaptor.capture());
@@ -1183,7 +1212,6 @@ public class AccountWorkflowServiceTest {
 
         verify(mockSendMailService, times(2)).sendEmail(any());
     }
-    
 
     @Test
     public void requestEmailSignInTwiceReturnsSameToken() throws Exception {
@@ -1216,7 +1244,6 @@ public class AccountWorkflowServiceTest {
     public void requestEmailSignInEmailNotRegistered() {
         // Mock.
         study.setEmailSignInEnabled(true);
-     // */when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_ID)).thenReturn(null);
         when(mockStudyService.getStudy(study.getIdentifier())).thenReturn(study);
 
         // Execute. Returns null userId.
@@ -1244,7 +1271,7 @@ public class AccountWorkflowServiceTest {
 
         // Verify dependent services.
         verify(mockCacheProvider).getObject(PHONE_SIGNIN_CACHE_KEY, String.class);
-        verify(mockCacheProvider).setObject(PHONE_SIGNIN_CACHE_KEY, "123456", AccountWorkflowService.SIGNIN_EXPIRE_IN_SECONDS);
+        verify(mockCacheProvider).setObject(PHONE_SIGNIN_CACHE_KEY, "123456", SIGNIN_EXPIRE_IN_SECONDS);
         verify(mockSmsService).sendSmsMessage(eq(USER_ID), smsMessageProviderCaptor.capture());
 
         assertEquals(smsMessageProviderCaptor.getValue().getStudy(), study);


### PR DESCRIPTION
We now keep the token around so we can reidentify the account and return a more helpful message when we can conclude the token was already used to verify the email address/phone number.