### PR TITLE
Context refactor

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/RequestContext.java
+++ b/src/main/java/org/sagebionetworks/bridge/RequestContext.java
@@ -16,7 +16,7 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 public class RequestContext {
     
     public static final RequestContext NULL_INSTANCE = new RequestContext(null, null, null, ImmutableSet.of(),
-            ImmutableSet.of(), null, UNKNOWN_CLIENT, ImmutableList.of());
+            ImmutableSet.of(), null, UNKNOWN_CLIENT, ImmutableList.of(), null);
 
     private final String requestId;
     private final StudyIdentifier callerStudyId;
@@ -26,9 +26,11 @@ public class RequestContext {
     private final ClientInfo callerClientInfo;
     private final List<String> callerLanguages;    
     private final Metrics metrics;
+    private final String callerIpAddress;
     
     private RequestContext(Metrics metrics, String requestId, String callerStudyId, Set<String> callerSubstudies,
-            Set<Roles> callerRoles, String callerUserId, ClientInfo callerClientInfo, List<String> callerLanguages) {
+            Set<Roles> callerRoles, String callerUserId, ClientInfo callerClientInfo, List<String> callerLanguages,
+            String callerIpAddress) {
         this.requestId = requestId;
         this.callerStudyId = (callerStudyId == null) ? null : new StudyIdentifierImpl(callerStudyId);
         this.callerSubstudies = callerSubstudies;
@@ -37,6 +39,7 @@ public class RequestContext {
         this.callerClientInfo = callerClientInfo;
         this.callerLanguages = callerLanguages;
         this.metrics = metrics;
+        this.callerIpAddress = callerIpAddress;
     }
     
     public Metrics getMetrics() {
@@ -66,6 +69,10 @@ public class RequestContext {
     public List<String> getCallerLanguages() {
         return callerLanguages;
     }
+    /** The user's IP Address, as reported by Amazon. */
+    public String getCallerIpAddress() {
+        return callerIpAddress;
+    }
     public RequestContext.Builder toBuilder() {
         return new RequestContext.Builder()
             .withRequestId(requestId)
@@ -75,7 +82,8 @@ public class RequestContext {
             .withCallerRoles(callerRoles)
             .withCallerSubstudies(callerSubstudies)
             .withCallerUserId(callerUserId)
-            .withMetrics(metrics);
+            .withMetrics(metrics)
+            .withCallerIpAddress(callerIpAddress);
     }
     
     public static class Builder {
@@ -86,7 +94,8 @@ public class RequestContext {
         private String requestId;
         private String callerUserId;
         private ClientInfo callerClientInfo;
-        private List<String> callerLanguages;    
+        private List<String> callerLanguages;
+        private String callerIpAddress;
 
         public Builder withMetrics(Metrics metrics) {
             this.metrics = metrics;
@@ -120,6 +129,10 @@ public class RequestContext {
             this.callerLanguages = callerLanguages;
             return this;
         }
+        public Builder withCallerIpAddress(String callerIpAddress) {
+            this.callerIpAddress = callerIpAddress;
+            return this;
+        }
         
         public RequestContext build() {
             if (requestId == null) {
@@ -141,7 +154,7 @@ public class RequestContext {
                 metrics = new Metrics(requestId);
             }
             return new RequestContext(metrics, requestId, callerStudyId, callerSubstudies, callerRoles, callerUserId,
-                    callerClientInfo, callerLanguages);
+                    callerClientInfo, callerLanguages, callerIpAddress);
         }
     }
 
@@ -149,7 +162,7 @@ public class RequestContext {
     public String toString() {
         return "RequestContext [requestId=" + requestId + ", callerStudyId=" + callerStudyId + ", callerSubstudies="
                 + callerSubstudies + ", callerRoles=" + callerRoles + ", callerUserId=" + callerUserId
-                + ", callerClientInfo=" + callerClientInfo + ", callerLanguages=" + callerLanguages + ", metrics="
-                + metrics + "]";
+                + ", callerClientInfo=" + callerClientInfo + ", callerIpAddress=" + callerIpAddress
+                + ", callerLanguages=" + callerLanguages + ", metrics=" + metrics + "]";
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/models/CriteriaContext.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/CriteriaContext.java
@@ -18,19 +18,17 @@ public final class CriteriaContext {
     private final String healthCode;
     private final String userId;
     private final ClientInfo clientInfo;
-    private final String ipAddress;
     private final Set<String> userDataGroups;
     private final Set<String> userSubstudyIds;
     // This set has ordered keys (most to least preferential)
     private final List<String> languages;
     
     private CriteriaContext(StudyIdentifier studyId, String healthCode, String userId, ClientInfo clientInfo,
-            String ipAddress, Set<String> userDataGroups, Set<String> userSubstudyIds, List<String> languages) {
+            Set<String> userDataGroups, Set<String> userSubstudyIds, List<String> languages) {
         this.studyId = studyId;
         this.healthCode = healthCode;
         this.userId = userId;
         this.clientInfo = clientInfo;
-        this.ipAddress = ipAddress;
         this.userDataGroups = (userDataGroups == null) ? ImmutableSet.of() : ImmutableSet.copyOf(userDataGroups);
         this.userSubstudyIds = (userSubstudyIds == null) ? ImmutableSet.of() : ImmutableSet.copyOf(userSubstudyIds);
         this.languages = (languages == null) ? ImmutableList.of() : languages;
@@ -45,11 +43,6 @@ public final class CriteriaContext {
     */
     public ClientInfo getClientInfo() {
         return clientInfo;
-    }
-
-    /** The user's IP Address, as reported by Amazon. */
-    public String getIpAddress() {
-        return ipAddress;
     }
 
     public Set<String> getUserDataGroups() {
@@ -85,8 +78,7 @@ public final class CriteriaContext {
 
     @Override
     public int hashCode() {
-        return Objects.hash(studyId, healthCode, userId, clientInfo, ipAddress, userDataGroups, userSubstudyIds,
-                languages);
+        return Objects.hash(studyId, healthCode, userId, clientInfo, userDataGroups, userSubstudyIds, languages);
     }
 
     @Override
@@ -97,7 +89,6 @@ public final class CriteriaContext {
             return false;
         CriteriaContext other = (CriteriaContext)obj;
         return (Objects.equals(clientInfo, other.clientInfo) &&
-                Objects.equals(ipAddress, other.ipAddress) &&
                 Objects.equals(userDataGroups, other.userDataGroups) &&
                 Objects.equals(userSubstudyIds, other.userSubstudyIds) &&
                 Objects.equals(studyId, other.studyId) && 
@@ -109,8 +100,8 @@ public final class CriteriaContext {
     @Override
     public String toString() {
         return "CriteriaContext [studyId=" + studyId + ", userId=" + userId + ", clientInfo=" + clientInfo
-                + ", ipAddress=" + ipAddress + ", userDataGroups=" + userDataGroups + ", userSubstudies=" 
-                + userSubstudyIds + ", languages=" + languages + "]";
+                + ", userDataGroups=" + userDataGroups + ", userSubstudies=" + userSubstudyIds + ", languages="
+                + languages + "]";
     }
 
     public static class Builder {
@@ -118,7 +109,6 @@ public final class CriteriaContext {
         private String healthCode;
         private String userId;
         private ClientInfo clientInfo;
-        private String ipAddress;
         private Set<String> userDataGroups;
         private Set<String> userSubstudyIds;
         private List<String> languages;
@@ -139,13 +129,6 @@ public final class CriteriaContext {
             this.clientInfo = clientInfo;
             return this;
         }
-
-        /** @see #getIpAddress */
-        public Builder withIpAddress(String ipAddress) {
-            this.ipAddress = ipAddress;
-            return this;
-        }
-
         public Builder withUserDataGroups(Set<String> userDataGroups) {
             this.userDataGroups = userDataGroups;
             return this;
@@ -164,7 +147,6 @@ public final class CriteriaContext {
             this.healthCode = context.healthCode;
             this.userId = context.userId;
             this.clientInfo = context.clientInfo;
-            this.ipAddress = context.ipAddress;
             this.userDataGroups = context.userDataGroups;
             this.userSubstudyIds = context.userSubstudyIds;
             this.languages = context.languages;
@@ -176,7 +158,7 @@ public final class CriteriaContext {
             if (clientInfo == null) {
                 clientInfo = ClientInfo.UNKNOWN_CLIENT;
             }
-            return new CriteriaContext(studyId, healthCode, userId, clientInfo, ipAddress, userDataGroups,
+            return new CriteriaContext(studyId, healthCode, userId, clientInfo, userDataGroups,
                     userSubstudyIds, languages);
         }
     }

--- a/src/main/java/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.PasswordGenerator;
+import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.SecureTokenGenerator;
 import org.sagebionetworks.bridge.cache.CacheKey;
@@ -460,13 +461,15 @@ public class AuthenticationService {
                     accountToEdit -> accountToEdit.setLanguages(context.getLanguages()));
         }
 
+        RequestContext reqContext = BridgeUtils.getRequestContext();
+        
         // Create new session.
         UserSession session = new UserSession(participant);
         session.setSessionToken(getGuid());
         session.setInternalSessionToken(getGuid());
         session.setAuthenticated(true);
         session.setEnvironment(config.getEnvironment());
-        session.setIpAddress(context.getIpAddress());
+        session.setIpAddress(reqContext.getCallerIpAddress());
         session.setStudyIdentifier(study.getStudyIdentifier());
         session.setReauthToken(account.getReauthToken());
         

--- a/src/main/java/org/sagebionetworks/bridge/spring/filters/RequestFilter.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/filters/RequestFilter.java
@@ -1,10 +1,12 @@
 package org.sagebionetworks.bridge.spring.filters;
 
 import static java.util.stream.Collectors.toCollection;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_API_STATUS_HEADER;
 import static org.sagebionetworks.bridge.BridgeConstants.WARN_NO_ACCEPT_LANGUAGE;
 import static org.sagebionetworks.bridge.BridgeConstants.WARN_NO_USER_AGENT;
+import static org.sagebionetworks.bridge.BridgeConstants.X_FORWARDED_FOR_HEADER;
 import static org.sagebionetworks.bridge.BridgeConstants.X_REQUEST_ID_HEADER;
 import static org.sagebionetworks.bridge.models.ClientInfo.UNKNOWN_CLIENT;
 import static org.springframework.http.HttpHeaders.ACCEPT_LANGUAGE;
@@ -87,6 +89,7 @@ public class RequestFilter implements Filter {
         }
         RequestContext.Builder builder = new RequestContext.Builder()
                 .withRequestId(requestId)
+                .withCallerIpAddress(parseIpAddress(getRemoteAddress(request)))
                 .withCallerClientInfo(getClientInfoFromUserAgentHeader(request, response))
                 .withCallerLanguages(getLanguagesFromAcceptLanguageHeader(request, response));
         setRequestContext(builder.build());
@@ -171,5 +174,29 @@ public class RequestFilter implements Filter {
         } else {
             response.setHeader(BRIDGE_API_STATUS_HEADER, msg);
         }
-    }    
+    }
+    
+    /** The user's IP Address, as reported by Amazon. Package-scoped for unit tests. */
+    static String getRemoteAddress(HttpServletRequest request) {
+        String forwardHeader = request.getHeader(X_FORWARDED_FOR_HEADER);
+        return (forwardHeader == null) ? request.getRemoteAddr() : forwardHeader;
+    }
+
+    // Helper method to parse an IP address from a raw string, as specified by getRemoteAddress().
+    static String parseIpAddress(String fullIpAddressString) {
+        if (isBlank(fullIpAddressString)) {
+            // Canonicalize unspecified IP address to null.
+            return null;
+        }
+
+        // Remote address comes from the X-Forwarded-For header. Since we're behind Amazon, this is almost always
+        // 2 IP addresses, separated by a comma and a space. The second is an Amazon router. The first one is probably
+        // the real IP address.
+        //
+        // Note that this isn't fool-proof. X-Forwarded-For can be spoofed. Also, double-proxies might exist, or the
+        // first IP address might simply resolve to 192.168.X.1. In local, this is probably just 127.0.0.1. But at
+        // least this is an added layer of defense vs not IP-locking at all.
+        String[] ipAddressArray = fullIpAddressString.split(",");
+        return ipAddressArray[0];
+    }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
@@ -229,7 +229,7 @@ public class AuthenticationServiceMockTest {
         account.setAccountSubstudies(ImmutableSet.of(as1, as2));
         account.setId(USER_ID);
         
-        BridgeUtils.setRequestContext(new RequestContext.Builder().withCallerIpAddress(IP_ADDRESS).build());
+        setIpAddress(IP_ADDRESS);
         
         CriteriaContext context = new CriteriaContext.Builder()
             .withStudyIdentifier(TestConstants.TEST_STUDY)
@@ -304,7 +304,7 @@ public class AuthenticationServiceMockTest {
         account.setAccountSubstudies(ImmutableSet.of(as1, as2));
         account.setId(USER_ID);
         
-        BridgeUtils.setRequestContext(new RequestContext.Builder().withCallerIpAddress(IP_ADDRESS).build());
+        setIpAddress(IP_ADDRESS);
         
         CriteriaContext context = new CriteriaContext.Builder()
             .withStudyIdentifier(TestConstants.TEST_STUDY)
@@ -1268,7 +1268,7 @@ public class AuthenticationServiceMockTest {
         study.setIdentifier(TestConstants.TEST_STUDY_IDENTIFIER);
         study.setReauthenticationEnabled(true);
         
-        BridgeUtils.setRequestContext(new RequestContext.Builder().withCallerIpAddress(IP_ADDRESS).build());
+        setIpAddress(IP_ADDRESS);
 
         CriteriaContext context = new CriteriaContext.Builder().withStudyIdentifier(TestConstants.TEST_STUDY).build();
 
@@ -1302,7 +1302,7 @@ public class AuthenticationServiceMockTest {
         Study study = Study.create();
         study.setReauthenticationEnabled(false);
 
-        BridgeUtils.setRequestContext(new RequestContext.Builder().withCallerIpAddress(IP_ADDRESS).build());
+        setIpAddress(IP_ADDRESS);
 
         CriteriaContext context = new CriteriaContext.Builder().withStudyIdentifier(TestConstants.TEST_STUDY).build();
 
@@ -1328,7 +1328,7 @@ public class AuthenticationServiceMockTest {
         Study study = Study.create();
         study.setReauthenticationEnabled(null);
 
-        BridgeUtils.setRequestContext(new RequestContext.Builder().withCallerIpAddress(IP_ADDRESS).build());
+        setIpAddress(IP_ADDRESS);
 
         CriteriaContext context = new CriteriaContext.Builder().withStudyIdentifier(TestConstants.TEST_STUDY).build();
 

--- a/src/test/java/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.bridge.RequestContext.NULL_INSTANCE;
 import static org.sagebionetworks.bridge.models.accounts.AccountSecretType.REAUTH;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -209,7 +210,11 @@ public class AuthenticationServiceMockTest {
     
     @AfterMethod
     public void after() {
-        BridgeUtils.setRequestContext(RequestContext.NULL_INSTANCE);
+        BridgeUtils.setRequestContext(NULL_INSTANCE);
+    }
+    
+    void setIpAddress(String ipAddress) {
+        BridgeUtils.setRequestContext(new RequestContext.Builder().withCallerIpAddress(ipAddress).build());
     }
     
     @Test // Test some happy path stuff, like the correct initialization of the user session
@@ -224,11 +229,12 @@ public class AuthenticationServiceMockTest {
         account.setAccountSubstudies(ImmutableSet.of(as1, as2));
         account.setId(USER_ID);
         
+        BridgeUtils.setRequestContext(new RequestContext.Builder().withCallerIpAddress(IP_ADDRESS).build());
+        
         CriteriaContext context = new CriteriaContext.Builder()
             .withStudyIdentifier(TestConstants.TEST_STUDY)
             .withLanguages(LANGUAGES)
-            .withClientInfo(ClientInfo.fromUserAgentCache("app/13"))
-            .withIpAddress("127.1.1.11").build();
+            .withClientInfo(ClientInfo.fromUserAgentCache("app/13")).build();
         
         doReturn(account).when(accountDao).authenticate(study, EMAIL_PASSWORD_SIGN_IN);
         doReturn(PARTICIPANT_WITH_ATTRIBUTES).when(participantService).getParticipant(study, account, false);
@@ -245,7 +251,7 @@ public class AuthenticationServiceMockTest {
         
         assertEquals(session.getConsentStatuses(), CONSENTED_STATUS_MAP);
         assertTrue(session.isAuthenticated());
-        assertEquals(session.getIpAddress(), "127.1.1.11");
+        assertEquals(session.getIpAddress(), IP_ADDRESS);
         assertEquals(session.getSessionToken(), SESSION_TOKEN);
         assertEquals(session.getInternalSessionToken(), SESSION_TOKEN);
         assertEquals(session.getReauthToken(), REAUTH_TOKEN);
@@ -298,11 +304,12 @@ public class AuthenticationServiceMockTest {
         account.setAccountSubstudies(ImmutableSet.of(as1, as2));
         account.setId(USER_ID);
         
+        BridgeUtils.setRequestContext(new RequestContext.Builder().withCallerIpAddress(IP_ADDRESS).build());
+        
         CriteriaContext context = new CriteriaContext.Builder()
             .withStudyIdentifier(TestConstants.TEST_STUDY)
             .withLanguages(LANGUAGES)
-            .withClientInfo(ClientInfo.fromUserAgentCache("app/13"))
-            .withIpAddress("127.1.1.11").build();
+            .withClientInfo(ClientInfo.fromUserAgentCache("app/13")).build();
         
         doReturn(account).when(accountDao).authenticate(study, EMAIL_PASSWORD_SIGN_IN);
         doReturn(PARTICIPANT_WITH_ATTRIBUTES).when(participantService).getParticipant(study, account, false);
@@ -324,7 +331,7 @@ public class AuthenticationServiceMockTest {
         
         assertEquals(session.getConsentStatuses(), UNCONSENTED_STATUS_MAP);
         assertTrue(session.isAuthenticated());
-        assertEquals(session.getIpAddress(), "127.1.1.11");
+        assertEquals(session.getIpAddress(), IP_ADDRESS);
         assertEquals(session.getSessionToken(), SESSION_TOKEN);
         assertEquals(session.getInternalSessionToken(), SESSION_TOKEN);
         assertEquals(session.getReauthToken(), REAUTH_TOKEN);
@@ -1260,9 +1267,10 @@ public class AuthenticationServiceMockTest {
         Study study = Study.create();
         study.setIdentifier(TestConstants.TEST_STUDY_IDENTIFIER);
         study.setReauthenticationEnabled(true);
+        
+        BridgeUtils.setRequestContext(new RequestContext.Builder().withCallerIpAddress(IP_ADDRESS).build());
 
-        CriteriaContext context = new CriteriaContext.Builder().withIpAddress(IP_ADDRESS)
-                .withStudyIdentifier(TestConstants.TEST_STUDY).build();
+        CriteriaContext context = new CriteriaContext.Builder().withStudyIdentifier(TestConstants.TEST_STUDY).build();
 
         Account account = Account.create();
         account.setId(USER_ID);
@@ -1294,8 +1302,9 @@ public class AuthenticationServiceMockTest {
         Study study = Study.create();
         study.setReauthenticationEnabled(false);
 
-        CriteriaContext context = new CriteriaContext.Builder().withIpAddress(IP_ADDRESS)
-                .withStudyIdentifier(TestConstants.TEST_STUDY).build();
+        BridgeUtils.setRequestContext(new RequestContext.Builder().withCallerIpAddress(IP_ADDRESS).build());
+
+        CriteriaContext context = new CriteriaContext.Builder().withStudyIdentifier(TestConstants.TEST_STUDY).build();
 
         Account account = Account.create();
 
@@ -1319,8 +1328,9 @@ public class AuthenticationServiceMockTest {
         Study study = Study.create();
         study.setReauthenticationEnabled(null);
 
-        CriteriaContext context = new CriteriaContext.Builder().withIpAddress(IP_ADDRESS)
-                .withStudyIdentifier(TestConstants.TEST_STUDY).build();
+        BridgeUtils.setRequestContext(new RequestContext.Builder().withCallerIpAddress(IP_ADDRESS).build());
+
+        CriteriaContext context = new CriteriaContext.Builder().withStudyIdentifier(TestConstants.TEST_STUDY).build();
 
         Account account = Account.create();
 

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
@@ -74,7 +74,6 @@ import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.Roles;
-import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.dynamodb.DynamoActivityEvent;
@@ -123,7 +122,6 @@ import org.sagebionetworks.bridge.services.SessionUpdateService;
 import org.sagebionetworks.bridge.services.StudyService;
 import org.sagebionetworks.bridge.services.UserAdminService;
 import org.sagebionetworks.bridge.services.AuthenticationService.ChannelType;
-import org.springframework.web.bind.annotation.PathVariable;
 
 public class ParticipantControllerTest extends Mockito {
 

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
@@ -11,6 +11,7 @@ import static org.sagebionetworks.bridge.TestConstants.CONSENTED_STATUS_MAP;
 import static org.sagebionetworks.bridge.TestConstants.EMAIL;
 import static org.sagebionetworks.bridge.TestConstants.ENCRYPTED_HEALTH_CODE;
 import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
+import static org.sagebionetworks.bridge.TestConstants.IP_ADDRESS;
 import static org.sagebionetworks.bridge.TestConstants.LANGUAGES;
 import static org.sagebionetworks.bridge.TestConstants.NOTIFICATION_MESSAGE;
 import static org.sagebionetworks.bridge.TestConstants.PASSWORD;
@@ -702,8 +703,8 @@ public class ParticipantControllerTest extends Mockito {
 
     @Test
     public void updateSelfParticipant() throws Exception {
-        BridgeUtils.setRequestContext(
-                new RequestContext.Builder().withCallerSubstudies(ImmutableSet.of("substudyA", "substudyB")).build());
+        BridgeUtils.setRequestContext(new RequestContext.Builder().withCallerIpAddress(IP_ADDRESS)
+                .withCallerSubstudies(ImmutableSet.of("substudyA", "substudyB")).build());
 
         // All values should be copied over here, also add a healthCode to verify it is not unset.
         StudyParticipant participant = new StudyParticipant.Builder()
@@ -712,6 +713,7 @@ public class ParticipantControllerTest extends Mockito {
                 .withDataGroups(USER_DATA_GROUPS).withSubstudyIds(USER_SUBSTUDY_IDS)
                 .withHealthCode(HEALTH_CODE).build();
         session.setParticipant(participant);
+        session.setIpAddress(IP_ADDRESS); // if this is not the same as request, you get an authentication error
 
         doReturn(participant).when(mockParticipantService).getParticipant(study, USER_ID, true);
 
@@ -725,6 +727,7 @@ public class ParticipantControllerTest extends Mockito {
 
         // verify the object is passed to service, one field is sufficient
         verify(mockCacheProvider).setUserSession(any());
+        
         // No roles are passed in this method, and the substudies of the user are passed
         verify(mockParticipantService).updateParticipant(eq(study), participantCaptor.capture());
 
@@ -744,7 +747,6 @@ public class ParticipantControllerTest extends Mockito {
         assertEquals(context.getHealthCode(), HEALTH_CODE);
         assertEquals(context.getUserId(), USER_ID);
         assertEquals(context.getClientInfo(), ClientInfo.UNKNOWN_CLIENT);
-        assertNull(context.getIpAddress());
         assertEquals(context.getUserDataGroups(), USER_DATA_GROUPS);
         assertEquals(context.getUserSubstudyIds(), USER_SUBSTUDY_IDS);
         assertEquals(context.getLanguages(), LANGUAGES);

--- a/src/test/java/org/sagebionetworks/bridge/spring/filters/RequestFilterTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/filters/RequestFilterTest.java
@@ -3,6 +3,8 @@ package org.sagebionetworks.bridge.spring.filters;
 import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_API_STATUS_HEADER;
 import static org.sagebionetworks.bridge.BridgeConstants.WARN_NO_ACCEPT_LANGUAGE;
 import static org.sagebionetworks.bridge.BridgeConstants.WARN_NO_USER_AGENT;
+import static org.sagebionetworks.bridge.BridgeConstants.X_FORWARDED_FOR_HEADER;
+import static org.sagebionetworks.bridge.TestConstants.IP_ADDRESS;
 import static org.sagebionetworks.bridge.TestConstants.UA;
 import static org.springframework.http.HttpHeaders.ACCEPT_LANGUAGE;
 import static org.springframework.http.HttpHeaders.USER_AGENT;
@@ -320,5 +322,41 @@ public class RequestFilterTest extends Mockito {
 
         // verify if it set warning header
         verify(mockResponse).setHeader(BRIDGE_API_STATUS_HEADER, WARN_NO_ACCEPT_LANGUAGE);
+    }
+    
+    @Test
+    public void getRemoteAddress() {
+        when(mockRequest.getHeader(X_FORWARDED_FOR_HEADER)).thenReturn(IP_ADDRESS);
+        
+        String address = RequestFilter.getRemoteAddress(mockRequest);
+        assertEquals(address, IP_ADDRESS);
+    }
+    
+    @Test
+    public void getRemoteAddressFallsBackToServletAPI() {
+        when(mockRequest.getRemoteAddr()).thenReturn(IP_ADDRESS);
+        
+        String address = RequestFilter.getRemoteAddress(mockRequest);
+        assertEquals(address, IP_ADDRESS);
+    }
+    
+    @Test
+    public void getRemoteAddressFails() {
+        String address = RequestFilter.getRemoteAddress(mockRequest);
+        assertNull(address);
+    }
+    
+    @Test
+    public void getRemoteAddressFromHeader() throws Exception {
+        when(mockRequest.getHeader(X_FORWARDED_FOR_HEADER)).thenReturn(IP_ADDRESS);
+
+        assertEquals(IP_ADDRESS, RequestFilter.getRemoteAddress(mockRequest));
+    }
+
+    @Test
+    public void getRemoteAddressFromFallback() throws Exception {
+        when(mockRequest.getRemoteAddr()).thenReturn(IP_ADDRESS);
+        
+        assertEquals(IP_ADDRESS, RequestFilter.getRemoteAddress(mockRequest));
     }
 }


### PR DESCRIPTION
Move the extraction of IP address from the HTTP request from the CriteriaContext to the RequestContext. It's about the request and not needed for criteria filtering.

This is probably the only cleanup I'm going to make for BRIDGE-2536.