### PR TITLE
Study admin

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/BaseController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/BaseController.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.sagebionetworks.bridge.BridgeConstants.API_STUDY_ID;
 import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS;
 import static org.sagebionetworks.bridge.BridgeConstants.SESSION_TOKEN_HEADER;
 import static org.springframework.http.HttpHeaders.USER_AGENT;
@@ -42,6 +43,8 @@ import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.Metrics;
 import org.sagebionetworks.bridge.models.RequestInfo;
+import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.Study;
@@ -250,6 +253,17 @@ public abstract class BaseController {
         
         if (!clientInfo.isSupportedAppVersion(minVersionForOs)) {
             throw new UnsupportedVersionException(clientInfo);
+        }
+    }
+
+    /**
+     * For admin calls, the admin should either be in the API study, or the current target study.
+     */
+    void verifyCrossStudyAdmin(String userId, String errorMessage) {
+        AccountId accountId = AccountId.forId(API_STUDY_ID.getIdentifier(), userId);
+        Account account = accountDao.getAccount(accountId);
+        if (account == null) {
+            throw new UnauthorizedException(errorMessage);
         }
     }
 

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/CacheAdminController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/CacheAdminController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import org.sagebionetworks.bridge.models.StatusMessage;
+import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.services.CacheAdminService;
 
 @CrossOrigin
@@ -29,14 +30,18 @@ public class CacheAdminController extends BaseController {
     
     @GetMapping
     public Set<String> listItems() throws Exception {
-        getAuthenticatedSession(ADMIN);
+        UserSession session = getAuthenticatedSession(ADMIN);
+        
+        verifyCrossStudyAdmin(session.getId(), "Study admins cannot list cache keys.");
         
         return cacheAdminService.listItems();
     }
     
     @DeleteMapping("{cacheKey}")
     public StatusMessage removeItem(@PathVariable String cacheKey) throws Exception {
-        getAuthenticatedSession(ADMIN);
+        UserSession session = getAuthenticatedSession(ADMIN);
+        
+        verifyCrossStudyAdmin(session.getId(), "Study admins cannot delete cache keys.");
         
         cacheAdminService.removeItem(cacheKey);
         

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/FPHSController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/FPHSController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.StatusMessage;
 import org.sagebionetworks.bridge.models.accounts.ExternalIdentifier;
@@ -32,7 +33,7 @@ import org.sagebionetworks.bridge.services.FPHSService;
 @RestController
 public class FPHSController extends BaseController {
     
-    private static final StudyIdentifier FPHS_ID = new StudyIdentifierImpl("fphs");
+    static final StudyIdentifier FPHS_ID = new StudyIdentifierImpl("fphs");
     
     private static final TypeReference<List<FPHSExternalIdentifier>> EXTERNAL_ID_TYPE_REF = 
             new TypeReference<List<FPHSExternalIdentifier>>() {};
@@ -77,7 +78,11 @@ public class FPHSController extends BaseController {
     @PostMapping("/fphs/externalIds")
     @ResponseStatus(HttpStatus.CREATED)
     public StatusMessage addExternalIdentifiers() throws Exception {
-        getAuthenticatedSession(ADMIN);
+        UserSession session = getAuthenticatedSession(ADMIN);
+        
+        if (!FPHS_ID.equals(session.getStudyIdentifier())) {
+            throw new UnauthorizedException("Cannot create identifiers in FPHS study.");
+        }
         
         List<FPHSExternalIdentifier> externalIds = MAPPER.convertValue(parseJson(JsonNode.class),
                 EXTERNAL_ID_TYPE_REF);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyController.java
@@ -131,11 +131,10 @@ public class StudyController extends BaseController {
     public Study getStudy(@PathVariable String identifier) throws Exception {
         UserSession session = getAuthenticatedSession(ADMIN, WORKER);
         
-        // Caller must have permissions to operate on this study. However worker may be used
+        // Caller must be a full admin to get any study, however worker may be used
         // cross study, so exclude it from this check
-        if (!session.isInRole(WORKER) &&
-            !session.getStudyIdentifier().getIdentifier().equals(identifier)) {
-            throw new UnauthorizedException("Study admin cannot retrieve other studies.");
+        if (!session.isInRole(WORKER)) {
+            verifyCrossStudyAdmin(session.getId(), "Study admin cannot retrieve other studies.");
         }
         // since only admin and worker can call this method, we need to return all studies including deactivated ones
         return studyService.getStudy(identifier, true);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/UploadController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/UploadController.java
@@ -165,7 +165,7 @@ public class UploadController extends BaseController {
     
     @GetMapping("/v3/uploads/{uploadId}")
     public UploadView getUpload(@PathVariable String uploadId) {
-        getAuthenticatedSession(Roles.ADMIN, Roles.WORKER);
+        UserSession session = getAuthenticatedSession(Roles.ADMIN, Roles.WORKER);
 
         if (uploadId.startsWith("recordId:")) {
             String recordId = uploadId.split(":")[1];
@@ -174,6 +174,10 @@ public class UploadController extends BaseController {
             HealthDataRecord record = healthDataService.getRecordById(recordId);
             if (record == null) {
                 throw new EntityNotFoundException(HealthDataRecord.class);
+            }
+            // You cannot authenticate in one study, and then retrieve a record from another study
+            if (!session.getStudyIdentifier().getIdentifier().equals(record.getStudyId())) {
+                throw new UnauthorizedException("Study admin cannot retrieve upload in another study.");
             }
             uploadId = record.getUploadId();
         }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/UploadController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/UploadController.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
+import static org.sagebionetworks.bridge.BridgeConstants.API_STUDY_ID;
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
 
 import java.io.IOException;
@@ -20,6 +21,8 @@ import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.Metrics;
 import org.sagebionetworks.bridge.models.RequestInfo;
+import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
@@ -175,8 +178,12 @@ public class UploadController extends BaseController {
             if (record == null) {
                 throw new EntityNotFoundException(HealthDataRecord.class);
             }
-            // You cannot authenticate in one study, and then retrieve a record from another study
-            if (!session.getStudyIdentifier().getIdentifier().equals(record.getStudyId())) {
+
+            AccountId accountId = AccountId.forId(API_STUDY_ID.getIdentifier(), session.getId());
+            Account account = accountDao.getAccount(accountId);
+            boolean hasAccess = account != null || 
+                    session.getStudyIdentifier().getIdentifier().equals(record.getStudyId());
+            if (!hasAccess) {
                 throw new UnauthorizedException("Study admin cannot retrieve upload in another study.");
             }
             uploadId = record.getUploadId();

--- a/src/test/java/org/sagebionetworks/bridge/TestConstants.java
+++ b/src/test/java/org/sagebionetworks/bridge/TestConstants.java
@@ -9,6 +9,7 @@ import org.joda.time.DateTimeZone;
 
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.models.CriteriaContext;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.Phone;
 import org.sagebionetworks.bridge.models.accounts.Withdrawal;
@@ -48,6 +49,7 @@ public class TestConstants {
 
     public static final String TEST_STUDY_IDENTIFIER = "api";
     public static final StudyIdentifier TEST_STUDY = new StudyIdentifierImpl(TEST_STUDY_IDENTIFIER);
+    public static final AccountId ACCOUNT_ID = AccountId.forId(TEST_STUDY_IDENTIFIER, USER_ID);
     public static final CriteriaContext TEST_CONTEXT = new CriteriaContext.Builder()
             .withUserId("user-id").withStudyIdentifier(TestConstants.TEST_STUDY).build();
 

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
@@ -33,7 +33,6 @@ import java.util.Map;
 
 import javax.mail.internet.MimeBodyPart;
 
-import org.joda.time.DateTimeUtils;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/BaseControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/BaseControllerTest.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
+import static org.sagebionetworks.bridge.BridgeConstants.API_STUDY_ID;
 import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_API_STATUS_HEADER;
 import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS;
 import static org.sagebionetworks.bridge.BridgeConstants.SESSION_TOKEN_HEADER;
@@ -78,6 +79,7 @@ import org.sagebionetworks.bridge.models.Metrics;
 import org.sagebionetworks.bridge.models.OperatingSystem;
 import org.sagebionetworks.bridge.models.RequestInfo;
 import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.activities.CustomActivityEventRequest;
@@ -933,4 +935,19 @@ public class BaseControllerTest extends Mockito {
         verify(mockResponse, never()).addCookie(any());
     }
 
+    @Test
+    public void verifyCrossStudyAdmin() {
+        AccountId accountId = AccountId.forId(API_STUDY_ID.getIdentifier(), USER_ID);
+        when(mockAccountDao.getAccount(accountId)).thenReturn(Account.create());
+        
+        controller.verifyCrossStudyAdmin(USER_ID, "An error message");
+        
+        verify(mockAccountDao).getAccount(accountId);
+    }
+    
+    @Test(expectedExceptions = UnauthorizedException.class,
+            expectedExceptionsMessageRegExp = ".*An error message.*")
+    public void verifyCrossStudyAdminFails() {
+        controller.verifyCrossStudyAdmin(USER_ID, "An error message");
+    }
 }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/CacheAdminControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/CacheAdminControllerTest.java
@@ -1,6 +1,9 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
 import static org.sagebionetworks.bridge.Roles.ADMIN;
+import static org.sagebionetworks.bridge.TestConstants.ACCOUNT_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
+import static org.sagebionetworks.bridge.TestConstants.USER_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertCrossOrigin;
 import static org.sagebionetworks.bridge.TestUtils.assertDelete;
 import static org.sagebionetworks.bridge.TestUtils.assertGet;
@@ -21,8 +24,14 @@ import org.mockito.Spy;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.dao.AccountDao;
+import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.StatusMessage;
+import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.services.CacheAdminService;
 
 public class CacheAdminControllerTest extends Mockito {
@@ -35,16 +44,22 @@ public class CacheAdminControllerTest extends Mockito {
     
     @Mock
     private CacheAdminService mockCacheAdminService;
+    
+    @Mock
+    private AccountDao mockAccountDao;
 
     @InjectMocks
     @Spy
     private CacheAdminController controller = new CacheAdminController();
+    
+    private UserSession session;
 
     @BeforeMethod
     private void before() {
         MockitoAnnotations.initMocks(this);
         
-        UserSession session = new UserSession();
+        session = new UserSession();
+        session.setParticipant(new StudyParticipant.Builder().withId(USER_ID).build());
         doReturn(session).when(controller).getAuthenticatedSession(ADMIN);
         
         doReturn(mockRequest).when(controller).request();
@@ -60,6 +75,21 @@ public class CacheAdminControllerTest extends Mockito {
     
     @Test
     public void listItems() throws Exception {
+        session.setStudyIdentifier(TEST_STUDY);
+        when(mockAccountDao.getAccount(ACCOUNT_ID)).thenReturn(Account.create());
+        
+        Set<String> items = ImmutableSet.of("A", "B", "C");
+        when(mockCacheAdminService.listItems()).thenReturn(items);
+        
+        // This should be a ResourceList, but it's not currently, so we're maintaining that.
+        Set<String> cacheItems = controller.listItems();
+        assertEquals(items, cacheItems);
+        
+        verify(mockCacheAdminService).listItems();
+    }
+    
+    @Test(expectedExceptions = UnauthorizedException.class)
+    public void listItemsRejectsStudyAdmin() throws Exception {
         Set<String> items = ImmutableSet.of("A", "B", "C");
         when(mockCacheAdminService.listItems()).thenReturn(items);
         
@@ -72,9 +102,20 @@ public class CacheAdminControllerTest extends Mockito {
     
     @Test
     public void removeItem() throws Exception {
+        session.setStudyIdentifier(TEST_STUDY);
+        when(mockAccountDao.getAccount(ACCOUNT_ID)).thenReturn(Account.create());
+        
         StatusMessage result = controller.removeItem("cacheKey");
         assertEquals("Item removed from cache.", result.getMessage());
         
         verify(mockCacheAdminService).removeItem("cacheKey");
     }
+    
+    @Test(expectedExceptions = UnauthorizedException.class)
+    public void removeItemRejectsStudyAdmin() throws Exception {
+        StatusMessage result = controller.removeItem("cacheKey");
+        assertEquals("Item removed from cache.", result.getMessage());
+        
+        verify(mockCacheAdminService).removeItem("cacheKey");
+    }    
 }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/CacheAdminControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/CacheAdminControllerTest.java
@@ -24,14 +24,12 @@ import org.mockito.Spy;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.StatusMessage;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
-import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.services.CacheAdminService;
 
 public class CacheAdminControllerTest extends Mockito {
@@ -94,10 +92,7 @@ public class CacheAdminControllerTest extends Mockito {
         when(mockCacheAdminService.listItems()).thenReturn(items);
         
         // This should be a ResourceList, but it's not currently, so we're maintaining that.
-        Set<String> cacheItems = controller.listItems();
-        assertEquals(items, cacheItems);
-        
-        verify(mockCacheAdminService).listItems();
+        controller.listItems();
     }
     
     @Test
@@ -113,9 +108,6 @@ public class CacheAdminControllerTest extends Mockito {
     
     @Test(expectedExceptions = UnauthorizedException.class)
     public void removeItemRejectsStudyAdmin() throws Exception {
-        StatusMessage result = controller.removeItem("cacheKey");
-        assertEquals("Item removed from cache.", result.getMessage());
-        
-        verify(mockCacheAdminService).removeItem("cacheKey");
+        controller.removeItem("cacheKey");
     }    
 }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyControllerTest.java
@@ -24,6 +24,7 @@ import static org.sagebionetworks.bridge.spring.controllers.StudyController.RESE
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
 import java.util.List;
@@ -38,6 +39,7 @@ import com.google.common.collect.ImmutableSet;
 
 import org.joda.time.DateTime;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -129,6 +131,12 @@ public class StudyControllerTest extends Mockito {
     @Spy
     @InjectMocks
     StudyController controller;
+    
+    @Captor
+    ArgumentCaptor<Study> studyCaptor;
+    
+    @Captor
+    ArgumentCaptor<StudyAndUsers> studyAndUsersCaptor;
     
     private Study study;
     
@@ -579,6 +587,26 @@ public class StudyControllerTest extends Mockito {
 
         assertTrue(result.contains("healthCodeExportEnabled"));
     }
+
+    @Test
+    public void updateStudy() throws Exception {
+        when(mockSession.getStudyIdentifier()).thenReturn(TEST_STUDY);
+        doReturn(mockSession).when(controller).getAuthenticatedSession(ADMIN);
+        
+        Study created = Study.create();
+        created.setVersion(3L);
+        when(mockStudyService.updateStudy(any(), anyBoolean())).thenReturn(created);
+        
+        Study study = Study.create();
+        study.setName("value to seek");
+        mockRequestBody(mockRequest, study);
+        
+        VersionHolder holder = controller.updateStudy(TEST_STUDY_IDENTIFIER);
+        assertEquals(holder.getVersion(), Long.valueOf(3L));
+        
+        verify(mockStudyService).updateStudy(studyCaptor.capture(), eq(true));
+        assertEquals(studyCaptor.getValue().getName(), "value to seek");
+    }
     
     @Test(expectedExceptions = UnauthorizedException.class)
     public void updateStudyRejectsStudyAdmin() throws Exception {
@@ -588,9 +616,21 @@ public class StudyControllerTest extends Mockito {
         controller.updateStudy("some-study");
     }
     
+    @Test
+    public void getStudy() throws Exception {
+        Study retrieved = Study.create();
+        when(mockStudyService.getStudy("some-study", true)).thenReturn(retrieved);
+        doReturn(mockSession).when(controller).getAuthenticatedSession(ADMIN, WORKER);
+        
+        Study result = controller.getStudy("some-study");
+        assertSame(result, retrieved);
+    }
+    
     @Test(expectedExceptions = UnauthorizedException.class)
     public void getStudyRejectsStudyAdmin() throws Exception { 
         when(mockSession.getStudyIdentifier()).thenReturn(TEST_STUDY);
+        when(mockSession.isInRole(WORKER)).thenReturn(false);
+        when(mockSession.getId()).thenReturn("not-an-id-that-fetches-an-account-in-this-study");
         doReturn(mockSession).when(controller).getAuthenticatedSession(ADMIN, WORKER);
         
         controller.getStudy("some-study");
@@ -605,6 +645,59 @@ public class StudyControllerTest extends Mockito {
         controller.getAllStudies(null, null);
     }
     
+    @Test
+    public void getAllStudiesSummary() throws Exception {
+        // Two active and one deleted study
+        Study study1 = Study.create();
+        study1.setName("study1");
+        study1.setSponsorName("sponsor name"); // this typeof field shouldn't be in summary
+        study1.setActive(true);
+        Study study2 = Study.create();
+        study2.setName("study2");
+        study2.setActive(true);
+        Study study3 = Study.create();
+        study3.setName("study3");
+        study3.setActive(false);
+        List<Study> studies = ImmutableList.of(study1, study2, study3);
+        when(mockStudyService.getStudies()).thenReturn(studies);
+        
+        String json = controller.getAllStudies("summary", null);
+        JsonNode node = BridgeObjectMapper.get().readTree(json);
+        assertEquals(node.get("items").size(), 2);
+        assertEquals(node.get("items").get(0).get("name").textValue(), "study1");
+        assertEquals(node.get("items").get(1).get("name").textValue(), "study2");
+        assertNull(node.get("items").get(0).get("sponsorName"));
+        assertTrue(node.get("requestParams").get("summary").booleanValue());
+    }
+    
+    @Test
+    public void getAllStudies() throws Exception {
+        doReturn(mockSession).when(controller).getAuthenticatedSession(ADMIN);
+        // Two active and one deleted study
+        Study study1 = Study.create();
+        study1.setName("study1");
+        study1.setSponsorName("sponsor name"); // this typeof field shouldn't be in summary
+        study1.setActive(true);
+        Study study2 = Study.create();
+        study2.setName("study2");
+        study2.setActive(true);
+        Study study3 = Study.create();
+        study3.setName("study3");
+        study3.setActive(false);
+        List<Study> studies = ImmutableList.of(study1, study2, study3);
+        when(mockStudyService.getStudies()).thenReturn(studies);
+        
+        String json = controller.getAllStudies(null, null);
+        JsonNode node = BridgeObjectMapper.get().readTree(json);
+        
+        assertEquals(node.get("items").size(), 3);
+        assertEquals(node.get("items").get(0).get("name").textValue(), "study1");
+        assertEquals(node.get("items").get(0).get("sponsorName").textValue(), "sponsor name");
+        assertEquals(node.get("items").get(1).get("name").textValue(), "study2");
+        assertEquals(node.get("items").get(2).get("name").textValue(), "study3");
+        assertFalse(node.get("requestParams").get("summary").booleanValue());
+    }
+    
     @Test(expectedExceptions = UnauthorizedException.class)
     public void createStudyRejectsStudyAdmin() throws Exception {
         when(mockSession.getStudyIdentifier()).thenReturn(new StudyIdentifierImpl("other-study"));
@@ -612,6 +705,24 @@ public class StudyControllerTest extends Mockito {
         doReturn(mockSession).when(controller).getAuthenticatedSession(ADMIN);
         
         controller.createStudy();
+    }
+    
+    @Test
+    public void createStudy() throws Exception {
+        doReturn(mockSession).when(controller).getAuthenticatedSession(ADMIN);
+
+        Study created = Study.create();
+        created.setVersion(3L);
+        when(mockStudyService.createStudy(any())).thenReturn(created);
+        
+        Study newStudy = Study.create();
+        newStudy.setName("some study");
+        mockRequestBody(mockRequest, newStudy);
+        
+        VersionHolder keys = controller.createStudy();
+        assertEquals(keys.getVersion(), Long.valueOf(3L));
+        
+        verify(mockStudyService).createStudy(newStudy);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -622,14 +733,70 @@ public class StudyControllerTest extends Mockito {
         
         controller.createStudyAndUsers();
     }
+    
+    @Test
+    public void createStudyAndusers() throws Exception {
+        doReturn(mockSession).when(controller).getAuthenticatedSession(ADMIN);
         
-    @Test(expectedExceptions = UnauthorizedException.class)
-    public void deleteRejectsStudyAdmin() throws Exception {
+        Study created = Study.create();
+        created.setVersion(3L);
+        when(mockStudyService.createStudyAndUsers(any())).thenReturn(created);
+        
+        Study newStudy = Study.create();
+        newStudy.setName("some study");
+        
+        StudyAndUsers studyAndUsers = new StudyAndUsers(
+                ImmutableList.of("admin1", "admin2"), newStudy,
+                ImmutableList.of(new StudyParticipant.Builder().build()));
+        mockRequestBody(mockRequest, studyAndUsers);
+        
+        VersionHolder keys = controller.createStudyAndUsers();
+        assertEquals(keys.getVersion(), Long.valueOf(3L));
+        
+        verify(mockStudyService).createStudyAndUsers(studyAndUsersCaptor.capture());
+        
+        StudyAndUsers captured =  studyAndUsersCaptor.getValue();
+        assertEquals(captured.getAdminIds(), ImmutableList.of("admin1", "admin2"));
+        assertEquals(captured.getUsers().size(), 1);
+        assertEquals(captured.getStudy(), newStudy);
+    }
+        
+    @Test(expectedExceptions = UnauthorizedException.class,
+            expectedExceptionsMessageRegExp = ".*Study admins cannot delete studies.*")
+    public void deleteStudyRejectsStudyAdmin() throws Exception {
         when(mockSession.getStudyIdentifier()).thenReturn(new StudyIdentifierImpl("other-study"));
         when(mockSession.getId()).thenReturn("other-id");
         doReturn(mockSession).when(controller).getAuthenticatedSession(ADMIN);
         
-        controller.deleteStudy(TEST_STUDY_IDENTIFIER, true);
+        controller.deleteStudy("other-study", true);
+    }
+    
+    @Test(expectedExceptions = UnauthorizedException.class,
+            expectedExceptionsMessageRegExp = ".*Admin cannot delete the study they are associated with.*")
+    public void deleteStudyRejectsCallerInStudy() throws Exception {
+        // API is protected by the whitelist so this test must target some other study
+        when(mockSession.getStudyIdentifier()).thenReturn(new StudyIdentifierImpl("other-study"));
+        doReturn(mockSession).when(controller).getAuthenticatedSession(ADMIN);
+        
+        controller.deleteStudy("other-study", true);
+    }
+    
+    @Test(expectedExceptions = UnauthorizedException.class,
+            expectedExceptionsMessageRegExp = ".*other-study is protected by whitelist.*")
+    public void deleteStudyRejectsWhitelistedStudy() throws Exception {
+        doReturn(mockSession).when(controller).getAuthenticatedSession(ADMIN);
+        
+        when(controller.getStudyWhitelist()).thenReturn(ImmutableSet.of("other-study"));
+        controller.deleteStudy("other-study", true);
+    }
+    
+    @Test
+    public void deleteStudy() throws Exception {
+        doReturn(mockSession).when(controller).getAuthenticatedSession(ADMIN);
+        
+        controller.deleteStudy("delete-study", true);
+        
+        verify(mockStudyService).deleteStudy("delete-study", Boolean.TRUE);
     }
     
     private void testRoleAccessToCurrentStudy(Roles role) throws Exception {

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/UploadControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/UploadControllerTest.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.spring.controllers;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.WORKER;
 import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 import static org.sagebionetworks.bridge.TestUtils.createJson;
 import static org.sagebionetworks.bridge.TestUtils.mockRequestBody;
 import static org.testng.Assert.assertEquals;
@@ -321,11 +322,13 @@ public class UploadControllerTest extends Mockito {
         assertEquals(node.get("healthData").get("healthCode").textValue(), HEALTH_CODE);
     }
 
-    @Test
-    public void getUploadByRecordId() throws Exception {
+    @Test(expectedExceptions = UnauthorizedException.class)
+    public void getUploadByRecordIdRejectsStudyAdmin() throws Exception {
         doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(ADMIN, WORKER);
+        when(mockResearcherSession.getStudyIdentifier()).thenReturn(new StudyIdentifierImpl("researcher-study-id"));
         
         HealthDataRecord record = HealthDataRecord.create();
+        record.setStudyId(TEST_STUDY_IDENTIFIER);
         record.setUploadId(UPLOAD_ID);
         record.setHealthCode(HEALTH_CODE);
         when(mockHealthDataService.getRecordById("record-id")).thenReturn(record);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/UploadControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/UploadControllerTest.java
@@ -2,8 +2,11 @@ package org.sagebionetworks.bridge.spring.controllers;
 
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.WORKER;
+import static org.sagebionetworks.bridge.TestConstants.ACCOUNT_ID;
 import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
+import static org.sagebionetworks.bridge.TestConstants.USER_ID;
 import static org.sagebionetworks.bridge.TestUtils.createJson;
 import static org.sagebionetworks.bridge.TestUtils.mockRequestBody;
 import static org.testng.Assert.assertEquals;
@@ -31,6 +34,7 @@ import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.cache.CacheProvider;
+import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.HealthCodeDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoUpload2;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
@@ -38,6 +42,7 @@ import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.Metrics;
 import org.sagebionetworks.bridge.models.RequestInfo;
+import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
@@ -69,6 +74,9 @@ public class UploadControllerTest extends Mockito {
     
     @Mock
     HealthCodeDao mockHealthCodeDao;
+    
+    @Mock
+    AccountDao mockAccountDao;
     
     @Mock
     RequestInfoService mockRequestInfoService;
@@ -322,10 +330,11 @@ public class UploadControllerTest extends Mockito {
         assertEquals(node.get("healthData").get("healthCode").textValue(), HEALTH_CODE);
     }
 
-    @Test(expectedExceptions = UnauthorizedException.class)
-    public void getUploadByRecordIdRejectsStudyAdmin() throws Exception {
+    @Test
+    public void getUploadByRecordId() throws Exception {
+        doReturn(USER_ID).when(mockResearcherSession).getId();
+        doReturn(TEST_STUDY).when(mockResearcherSession).getStudyIdentifier();
         doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(ADMIN, WORKER);
-        when(mockResearcherSession.getStudyIdentifier()).thenReturn(new StudyIdentifierImpl("researcher-study-id"));
         
         HealthDataRecord record = HealthDataRecord.create();
         record.setStudyId(TEST_STUDY_IDENTIFIER);
@@ -334,7 +343,7 @@ public class UploadControllerTest extends Mockito {
         when(mockHealthDataService.getRecordById("record-id")).thenReturn(record);
         
         DynamoUpload2 upload = new DynamoUpload2();
-        upload.setStudyId("researcher-study-id");
+        upload.setStudyId(TEST_STUDY_IDENTIFIER);
         upload.setCompletedBy(UploadCompletionClient.S3_WORKER);
         UploadView uploadView = new UploadView.Builder().withUpload(upload).withHealthDataRecord(record).build();
         
@@ -346,6 +355,54 @@ public class UploadControllerTest extends Mockito {
         assertEquals(node.get("completedBy").textValue(), "s3_worker");
         assertEquals(node.get("type").textValue(), "Upload");
         assertEquals(node.get("healthData").get("healthCode").textValue(), HEALTH_CODE);
+    }
+
+    @Test(expectedExceptions = UnauthorizedException.class,
+            expectedExceptionsMessageRegExp=".*Study admin cannot retrieve upload in another study.*")
+    public void getUploadByRecordIdRejectsStudyAdmin() throws Exception {
+        doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(ADMIN, WORKER);
+        doReturn(USER_ID).when(mockResearcherSession).getId();
+        when(mockResearcherSession.getStudyIdentifier()).thenReturn(new StudyIdentifierImpl("researcher-study-id"));
+
+        HealthDataRecord record = HealthDataRecord.create();
+        record.setStudyId(TEST_STUDY_IDENTIFIER);
+        record.setUploadId(UPLOAD_ID);
+        record.setHealthCode(HEALTH_CODE);
+        when(mockHealthDataService.getRecordById("record-id")).thenReturn(record);
+        
+        DynamoUpload2 upload = new DynamoUpload2();
+        upload.setStudyId("researcher-study-id");
+        upload.setCompletedBy(UploadCompletionClient.S3_WORKER);
+        UploadView uploadView = new UploadView.Builder().withUpload(upload).withHealthDataRecord(record).build();
+
+        when(mockUploadService.getUploadView(UPLOAD_ID)).thenReturn(uploadView);
+
+        controller.getUpload("recordId:record-id");
+    }
+
+    @Test
+    public void getUploadByRecordIdWorksForFullAdmin() throws Exception {
+        doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(ADMIN, WORKER);
+        doReturn(USER_ID).when(mockResearcherSession).getId();
+        when(mockResearcherSession.getStudyIdentifier()).thenReturn(TEST_STUDY);
+        
+        when(mockAccountDao.getAccount(ACCOUNT_ID)).thenReturn(Account.create());
+
+        HealthDataRecord record = HealthDataRecord.create();
+        record.setStudyId("some-other-study");
+        record.setUploadId(UPLOAD_ID);
+        record.setHealthCode(HEALTH_CODE);
+        when(mockHealthDataService.getRecordById("record-id")).thenReturn(record);
+        
+        DynamoUpload2 upload = new DynamoUpload2();
+        upload.setStudyId("some-other-study");
+        upload.setCompletedBy(UploadCompletionClient.S3_WORKER);
+        UploadView uploadView = new UploadView.Builder().withUpload(upload).withHealthDataRecord(record).build();
+
+        when(mockUploadService.getUploadView(UPLOAD_ID)).thenReturn(uploadView);
+
+        UploadView view = controller.getUpload("recordId:record-id");
+        assertNotNull(view);
     }
     
     @Test(expectedExceptions = EntityNotFoundException.class)

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserManagementControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserManagementControllerTest.java
@@ -4,6 +4,7 @@ import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_SESSION_EXPIRE_I
 import static org.sagebionetworks.bridge.BridgeConstants.SESSION_TOKEN_HEADER;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.WORKER;
+import static org.sagebionetworks.bridge.TestConstants.ACCOUNT_ID;
 import static org.sagebionetworks.bridge.TestConstants.EMAIL;
 import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
 import static org.sagebionetworks.bridge.TestConstants.PASSWORD;
@@ -210,7 +211,7 @@ public class UserManagementControllerTest extends Mockito {
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void changeStudyForStudyAdmin() throws Exception {
+    public void changeStudyRejectsStudyAdmin() throws Exception {
         doReturn(session).when(controller).getAuthenticatedSession(ADMIN);
 
         session.setStudyIdentifier(new StudyIdentifierImpl("some-other-study"));
@@ -236,9 +237,18 @@ public class UserManagementControllerTest extends Mockito {
         mockRequestBody(mockRequest, "{}");
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn("AAA");
 
+        when(mockAccountDao.getAccount(ACCOUNT_ID)).thenReturn(Account.create());
+        
         // same study id as above test
         StatusMessage result = controller.createUserWithStudyId(TEST_STUDY_IDENTIFIER);
         assertEquals(result, UserManagementController.CREATED_MSG);
+    }
+    
+    @Test(expectedExceptions = UnauthorizedException.class)
+    public void createUserWithStudyIdRejectsStudyAdmin() throws Exception {
+        when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn("AAA");
+        
+        controller.createUserWithStudyId(TEST_STUDY_IDENTIFIER);
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserManagementControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserManagementControllerTest.java
@@ -39,13 +39,17 @@ import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.BridgeConfig;
+import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.StatusMessage;
+import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.services.AuthenticationService;
 import org.sagebionetworks.bridge.services.RequestInfoService;
 import org.sagebionetworks.bridge.services.SessionUpdateService;
@@ -81,6 +85,9 @@ public class UserManagementControllerTest extends Mockito {
     @Mock
     HttpServletResponse mockResponse;
     
+    @Mock
+    AccountDao mockAccountDao;
+    
     @Spy
     @InjectMocks
     UserManagementController controller;
@@ -100,7 +107,7 @@ public class UserManagementControllerTest extends Mockito {
         MockitoAnnotations.initMocks(this);
 
         StudyParticipant participant = new StudyParticipant.Builder().withHealthCode(HEALTH_CODE)
-                .withRoles(ImmutableSet.of(ADMIN)).withEmail(EMAIL).build();
+                .withId(USER_ID).withRoles(ImmutableSet.of(ADMIN)).withEmail(EMAIL).build();
 
         session = new UserSession(participant);
         session.setStudyIdentifier(TEST_STUDY);
@@ -186,6 +193,9 @@ public class UserManagementControllerTest extends Mockito {
     @Test
     public void changeStudyForAdmin() throws Exception {
         doReturn(session).when(controller).getAuthenticatedSession(ADMIN);
+        
+        AccountId accountId = AccountId.forId(TEST_STUDY_IDENTIFIER, USER_ID);
+        when(mockAccountDao.getAccount(accountId)).thenReturn(Account.create());
 
         SignIn signIn = new SignIn.Builder().withStudy("nextStudy").build();
         mockRequestBody(mockRequest, signIn);
@@ -197,6 +207,18 @@ public class UserManagementControllerTest extends Mockito {
         controller.changeStudyForAdmin();
         assertEquals(session.getStudyIdentifier().getIdentifier(), "nextStudy");
         verify(mockCacheProvider).setUserSession(session);
+    }
+    
+    @Test(expectedExceptions = UnauthorizedException.class)
+    public void changeStudyForStudyAdmin() throws Exception {
+        doReturn(session).when(controller).getAuthenticatedSession(ADMIN);
+
+        session.setStudyIdentifier(new StudyIdentifierImpl("some-other-study"));
+        
+        SignIn signIn = new SignIn.Builder().withStudy("nextStudy").build();
+        mockRequestBody(mockRequest, signIn);
+        
+        controller.changeStudyForAdmin();
     }
 
     @Test


### PR DESCRIPTION
BRIDGE-2561

Allow the creation of admins within a study that can do all the normal admin things... for that study only. There are some protections that need to be added throughout the API:

1) API calls that operate on all studies (create a study, delete a study, list cache keys, etc.) need to verify the admin is a "full admin" (account is defined in the API study);

2) API calls that allow an admin, need to read the study being used from the caller's session. Study admins can only authenticate to that study and full admins can put themselves in any study, so this is checked by using the session study. We have a very few calls that do not look at this study... in those cases, we need to add a check in the controller to prevent someone authenticating as an admin in study A, doing something like retrieving upload records from study B.

3) FPHS is an odd edge case there are one or two others, that are handled as well.