### PR TITLE
disable access logs

### DIFF
--- a/ebextensions/tomcatlogs.config
+++ b/ebextensions/tomcatlogs.config
@@ -15,16 +15,26 @@
 ###################################################################################################
 
 files:
-  "/etc/awslogs/config/tomcatlogs.conf" :
+  "/etc/awslogs/config/beanstalklogs.conf" :
     mode: "000644"
     owner: root
     group: root
     content: |
+      [/var/log/eb-activity.log]
+      log_group_name=`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/log/eb-activity.log"]]}`
+      log_stream_name={instance_id}
+      file=/var/log/eb-activity.log*
+
       [/var/log/tomcat8/catalina.out]
       log_group_name=`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/log/tomcat8/catalina.out"]]}`
       log_stream_name={instance_id}
       file=/var/log/tomcat8/catalina.out*
 
 commands:
-  "01_restart_awslogs":
+  "01_rm_old_confs":
+    command: "rm beanstalklogs.conf.bak tomcatlogs.conf tomcatlogs.conf.bak"
+    cwd: "/etc/awslogs/config"
+    ignoreErrors: true
+
+  "02_restart_awslogs":
     command: service awslogs restart


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-2264

This change replaces the beanstalklogs.conf with our own, which only configures eb-activity.log and catalina.out (the only logs we care about). I added a command to clean up the old configs and backup configs (which awslogs agent will read) before restarting the awslogs agent.

Tested in dev. It appears to work.