### PR TITLE
remove stormpath hashes

### DIFF
--- a/src/main/resources/db/changelog/changelog.sql
+++ b/src/main/resources/db/changelog/changelog.sql
@@ -235,3 +235,8 @@ CREATE TABLE IF NOT EXISTS `FileRevisions` (
     PRIMARY KEY (`fileGuid`, `createdOn`),
     CONSTRAINT `FileMetadata-Guid-Constraint` FOREIGN KEY (`fileGuid`) REFERENCES `FileMetadata` (`guid`) ON DELETE CASCADE
 ) CHARACTER SET utf8 COLLATE utf8_unicode_ci;
+
+-- changeset bridge:8
+
+ALTER TABLE `Accounts`
+DROP COLUMN `stormpathPasswordHash`;


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-2539

We added the stormpath hashes field to backup stormpath hashes in case the hash migration went wrong. It's been about a month since we migrated the hashes, and everything seems fine.

For security reasons, we now want to remove the insecure hashes. (Note that this field isn't used in Bridge anywhere.)