### PR TITLE
The only environment that supports SSL is production

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/FileService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/FileService.java
@@ -8,6 +8,7 @@ import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.PAGE_SIZE_ERROR;
 import static org.sagebionetworks.bridge.config.Environment.LOCAL;
+import static org.sagebionetworks.bridge.config.Environment.PROD;
 import static org.sagebionetworks.bridge.models.files.FileRevisionStatus.AVAILABLE;
 import static org.sagebionetworks.bridge.models.files.FileRevisionStatus.PENDING;
 import static org.sagebionetworks.bridge.validators.FileRevisionValidator.INSTANCE;
@@ -163,7 +164,7 @@ public class FileService {
         }        
         PagedResourceList<FileRevision> revisions = fileRevisionDao.getFileRevisions(guid, offset, pageSize);
         for (FileRevision rev : revisions.getItems()) {
-            String protocol = (env == LOCAL) ? "http" : "https";
+            String protocol = (env == PROD) ? "https" : "http";
             rev.setDownloadURL(protocol + "://" + revisionsBucket + "/" + getFileName(rev));
         }
         return revisions;


### PR DESCRIPTION
The only docs bucket that has CloudFront fronting it (and thus, the only bucket that supports SSL) is the production bucket. So change the logic here: use http unless it's production, then use https.