### PR TITLE
Change study apis

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/src/main/java/org/sagebionetworks/bridge/BridgeConstants.java
@@ -11,6 +11,8 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import com.google.common.collect.ImmutableList;
 
 public class BridgeConstants {
+    public static final String STUDY_ACCESS_EXCEPTION_MSG = "Account does not have access to that study.";
+    
     public static final String SYNAPSE_OAUTH_CLIENT_SECRET = "synapse.oauth.client.secret";
     public static final String SYNAPSE_OAUTH_CLIENT_ID = "synapse.oauth.client.id";
     public static final String SYNAPSE_OAUTH_URL = "synapse.oauth.url";

--- a/src/main/java/org/sagebionetworks/bridge/dao/AccountDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dao/AccountDao.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.dao;
 
 import java.util.List;
-import java.util.Set;
 import java.util.function.Consumer;
 
 import org.sagebionetworks.bridge.models.AccountSummarySearch;
@@ -25,7 +24,7 @@ public interface AccountDao {
     
     int MIGRATION_VERSION = 1;
     
-    Set<String> getStudyIdsForUser(Study study, String userId);
+    List<String> getStudyIdsForUser(StudyIdentifier studyId, String userId);
     
     /**
      * Set the verified flag for the channel (email or phone) to true, and enable the account (if needed).

--- a/src/main/java/org/sagebionetworks/bridge/dao/AccountDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dao/AccountDao.java
@@ -25,9 +25,8 @@ public interface AccountDao {
     int MIGRATION_VERSION = 1;
     
     /**
-     * Search for all accounts across studies that have the email or Synapse user ID in common, 
-     * and return a list of the study IDs where these accounts are found. The email should be 
-     * a verified email address.
+     * Search for all accounts across studies that have the same Synapse user ID in common, 
+     * and return a list of the study IDs where these accounts are found.
      * @param synapseUserId
      * @return list of study identifiers
      */

--- a/src/main/java/org/sagebionetworks/bridge/dao/AccountDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dao/AccountDao.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge.dao;
 
+import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import org.sagebionetworks.bridge.models.AccountSummarySearch;
@@ -22,6 +24,8 @@ import org.sagebionetworks.bridge.services.AuthenticationService.ChannelType;
 public interface AccountDao {
     
     int MIGRATION_VERSION = 1;
+    
+    Set<String> getStudyIdsForUser(Study study, String userId);
     
     /**
      * Set the verified flag for the channel (email or phone) to true, and enable the account (if needed).

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -10,6 +10,7 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -24,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.BridgeUtils.SubstudyAssociations;
@@ -84,6 +86,35 @@ public class HibernateAccountDao implements AccountDao {
     // Provided to override in tests
     protected String generateGUID() {
         return BridgeUtils.generateGuid();
+    }
+    
+    @Override
+    public Set<String> getStudyIdsForUser(Study study, String userId) {
+        AccountId accountId = AccountId.forId(study.getIdentifier(), userId);
+        Account account = getAccount(accountId);
+        if (account == null) {
+            throw new EntityNotFoundException(Account.class);
+        }
+        
+        QueryBuilder builder = new QueryBuilder();
+        builder.append("SELECT DISTINCT acct.studyId FROM HibernateAccount AS acct WHERE ");
+        
+        boolean hasEmail = (account.getEmail() != null && TRUE.equals(account.getEmailVerified()));
+        
+        if (hasEmail) {
+            builder.append("email = :email", "email", account.getEmail());
+        }
+        if (hasEmail && account.getSynapseUserId() != null) {
+            builder.append(" OR ");
+        }
+        if (account.getSynapseUserId() != null) {
+            builder.append("synapseUserId = :synapseUserId", "synapseUserId", account.getSynapseUserId());
+        }
+        
+        System.out.println(builder.getQuery());
+        
+        List<String> studyIds = hibernateHelper.queryGet(builder.getQuery(), builder.getParameters(), 0, 1000, String.class); 
+        return ImmutableSet.copyOf(studyIds);
     }
     
     /**

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -339,8 +339,8 @@ public class HibernateAccountDao implements AccountDao {
         
         AccountId unguarded = accountId.getUnguardedAccountId();
         if (unguarded.getId() != null) {
-            // Now that we allow study switching, we must enforce study membership here
-            // as well as in the queries below.
+            // Now that we allow study switching, we must enforce study membership here in the getById()
+            // method as well as in the queries below.
             Account account = hibernateHelper.getById(HibernateAccount.class, unguarded.getId());
             if (account != null && !account.getStudyId().equals(accountId.getStudyId())) {
                 return null;

--- a/src/main/java/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -164,6 +164,9 @@ public class AuthenticationService {
         checkNotNull(context);
 
         Account account = accountDao.getAccount(context.getAccountId());
+        if (account == null) {
+            throw new EntityNotFoundException(Account.class);
+        }
         return getSessionFromAccount(study, context, account);
     }
 

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationController.java
@@ -4,7 +4,6 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.sagebionetworks.bridge.BridgeConstants.CLEAR_SITE_DATA_HEADER;
 import static org.sagebionetworks.bridge.BridgeConstants.CLEAR_SITE_DATA_VALUE;
 import static org.sagebionetworks.bridge.BridgeConstants.STUDY_PROPERTY;
-import static org.sagebionetworks.bridge.Roles.ADMIN;
 
 import javax.servlet.http.Cookie;
 
@@ -297,28 +296,21 @@ public class AuthenticationController extends BaseController {
     public JsonNode changeStudy() throws Exception {
         UserSession session = getAuthenticatedSession();
         
+        if (session.getParticipant().getRoles().isEmpty()) {
+            throw new UnauthorizedException("Only administrative accounts can change studies.");
+        }
+        
         // The only part of this payload we care about is the study property
         SignIn signIn = parseJson(SignIn.class);
         String studyId = signIn.getStudyId();
 
         // Verify the study exists
         Study study = studyService.getStudy(studyId);
-        
-        // Verify the user exists. We only use synapse ID for this (and will eventually only show
-        // studies that are linked by Synapse ID, once everyone has migrated):
-        AccountId accountId = AccountId.forSynapseUserId(study.getIdentifier(), session.getParticipant().getSynapseUserId());
-        Account account = accountDao.getAccount(accountId);
-        if (account == null) {
-            throw new EntityNotFoundException(Account.class);
-        }
+        CriteriaContext context = getCriteriaContext(session);
         
         authenticationService.signOut(session);
-        CriteriaContext context = getCriteriaContext(study.getStudyIdentifier());
-        
         UserSession newSession = authenticationService.getSession(study, context);
-        
-        
-        
+        cacheProvider.setUserSession(newSession);
         
         return UserSessionInfo.toJSON(newSession);
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationController.java
@@ -320,7 +320,7 @@ public class AuthenticationController extends BaseController {
         List<String> studyIds = accountDao.getStudyIdsForUser(participant.getSynapseUserId());
         
         // Cross study administrator can switch to any study. Same implementation as UserManagementController
-        // because clients cannot tell who is a cross-study administration
+        // because clients cannot tell who is a cross-study administrator once they've switched studies.
         if (session.isInRole(ADMIN) && studyIds.contains(API_STUDY_ID_STRING)) {
             sessionUpdateService.updateStudy(session, targetStudy.getStudyIdentifier());
             return UserSessionInfo.toJSON(session);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationController.java
@@ -4,6 +4,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.sagebionetworks.bridge.BridgeConstants.API_STUDY_ID_STRING;
 import static org.sagebionetworks.bridge.BridgeConstants.CLEAR_SITE_DATA_HEADER;
 import static org.sagebionetworks.bridge.BridgeConstants.CLEAR_SITE_DATA_VALUE;
+import static org.sagebionetworks.bridge.BridgeConstants.STUDY_ACCESS_EXCEPTION_MSG;
 import static org.sagebionetworks.bridge.BridgeConstants.STUDY_PROPERTY;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
@@ -45,8 +47,6 @@ import org.sagebionetworks.bridge.services.AuthenticationService.ChannelType;
 @RestController
 public class AuthenticationController extends BaseController {
 
-    private static final String STUDY_ACCESS_EXCEPTION_MSG = "Account does not have access to that study.";
-    
     private AccountWorkflowService accountWorkflowService;
     
     @Autowired

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyController.java
@@ -181,7 +181,7 @@ public class StudyController extends BaseController {
         List<String> studyIds = accountDao.getStudyIdsForUser(session.getParticipant().getSynapseUserId());
         Stream<Study> stream = studyService.getStudies().stream();
 
-        // In our current study permissions model is that an admin in the API study is a 
+        // In our current study permissions model, an admin in the API study is a 
         // "cross-study admin" and can see all studies and can switch between all studies, 
         // so check for this condition.
         if (session.isInRole(ADMIN) && studyIds.contains(API_STUDY_ID_STRING)) {

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyController.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.spring.controllers;
 
 import static java.util.stream.Collectors.toList;
 import static org.sagebionetworks.bridge.BridgeConstants.API_STUDY_ID_STRING;
+import static org.sagebionetworks.bridge.BridgeConstants.STUDY_ACCESS_EXCEPTION_MSG;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
@@ -177,7 +178,10 @@ public class StudyController extends BaseController {
     @GetMapping(path="/v3/studies/memberships", produces={APPLICATION_JSON_UTF8_VALUE})
     public String getStudyMemberships() throws Exception {   
         UserSession session = getAuthenticatedSession();
-
+        
+        if (session.getParticipant().getRoles().isEmpty()) {
+            throw new UnauthorizedException(STUDY_ACCESS_EXCEPTION_MSG);
+        }
         List<String> studyIds = accountDao.getStudyIdsForUser(session.getParticipant().getSynapseUserId());
         Stream<Study> stream = studyService.getStudies().stream();
 

--- a/src/main/resources/db/changelog/changelog.sql
+++ b/src/main/resources/db/changelog/changelog.sql
@@ -257,3 +257,7 @@ MODIFY COLUMN `uploadURL` VARCHAR(1024) DEFAULT NULL;
 ALTER TABLE `Accounts`
 ADD COLUMN `synapseUserId` varchar(255) DEFAULT NULL,
 ADD UNIQUE KEY `Accounts-StudyId-SynapseUserId-Index` (`studyId`,`synapseUserId`);
+
+-- changeset bridge:11
+
+CREATE INDEX `Accounts-SynapseUserId-Index` ON `Accounts`(`synapseUserId`);

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
@@ -1815,6 +1815,12 @@ public class HibernateAccountDaoTest {
         Map<String,Object> params = paramCaptor.getValue();
         assertEquals(params.get("synapseUserId"), SYNAPSE_USER_ID);
     }
+    
+    @Test
+    public void getStudyIdsForUserNoSynapseUserId() throws Exception {
+        List<String> results = dao.getStudyIdsForUser(null);
+        assertTrue(results.isEmpty());
+    }
 
     private void verifyCreatedHealthCode() {
         ArgumentCaptor<HibernateAccount> updatedAccountCaptor = ArgumentCaptor.forClass(HibernateAccount.class);

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
@@ -975,6 +975,21 @@ public class HibernateAccountDaoTest {
     }
 
     @Test
+    public void getByIdWrongStudy() throws Exception {
+        HibernateAccount hibernateAccount = makeValidHibernateAccount(false);
+        hibernateAccount.setHealthCode(null);
+        hibernateAccount.setStudyId(TEST_STUDY_IDENTIFIER);
+        when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
+
+        // execute and validate
+        AccountId wrongStudy = AccountId.forId("wrong-study", ACCOUNT_ID);
+        Account account = dao.getAccount(wrongStudy);
+        assertNull(account);
+        
+        verify(mockHibernateHelper).getById(HibernateAccount.class, wrongStudy.getUnguardedAccountId().getId());
+    }
+    
+    @Test
     public void getByEmailSuccessWithHealthCode() throws Exception {
         String expQuery = "SELECT acct FROM HibernateAccount AS acct LEFT JOIN acct.accountSubstudies "
                 + "AS acctSubstudy WITH acct.id = acctSubstudy.accountId WHERE acct.studyId = :studyId AND "
@@ -1800,10 +1815,6 @@ public class HibernateAccountDaoTest {
     
     @Test
     public void getStudyIdsForUser() throws Exception {
-        HibernateAccount hibernateAccount = makeValidHibernateAccount(false);
-        hibernateAccount.setSynapseUserId(SYNAPSE_USER_ID);
-        when(mockHibernateHelper.getById(HibernateAccount.class, ACCOUNT_ID)).thenReturn(hibernateAccount);
-        
         List<String> queryResult = ImmutableList.of("studyA", "studyB");
         when(mockHibernateHelper.queryGet(any(), any(), any(), any(), eq(String.class))).thenReturn(queryResult);
         

--- a/src/test/java/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
@@ -259,7 +259,7 @@ public class AuthenticationServiceMockTest {
         assertEquals(updatedContext.getLanguages(), LANGUAGES);
         assertEquals(updatedContext.getUserDataGroups(), DATA_GROUP_SET);
         assertEquals(updatedContext.getUserSubstudyIds(), TestConstants.USER_SUBSTUDY_IDS);
-        assertEquals(updatedContext.getAccountId(), ACCOUNT_ID);
+        assertEquals(updatedContext.getUserId(), USER_ID);
         
         verify(accountSecretDao).createSecret(AccountSecretType.REAUTH, USER_ID, REAUTH_TOKEN);
     }
@@ -339,7 +339,7 @@ public class AuthenticationServiceMockTest {
         assertEquals(updatedContext.getLanguages(), LANGUAGES);
         assertEquals(updatedContext.getUserDataGroups(), DATA_GROUP_SET);
         assertEquals(updatedContext.getUserSubstudyIds(), TestConstants.USER_SUBSTUDY_IDS);
-        assertEquals(updatedContext.getAccountId(), ACCOUNT_ID);
+        assertEquals(updatedContext.getUserId(), USER_ID);
         
         verify(accountSecretDao).createSecret(AccountSecretType.REAUTH, USER_ID, REAUTH_TOKEN);
     }
@@ -948,8 +948,8 @@ public class AuthenticationServiceMockTest {
         // This specifically has to be a mock to easily mock the editAccount method on the DAO.
         Account mockAccount = mock(Account.class);
 
-        CriteriaContext context = new CriteriaContext.Builder().withLanguages(LANGUAGES)
-                .withUserId(USER_ID).withStudyIdentifier(TestConstants.TEST_STUDY).build();
+        CriteriaContext context = new CriteriaContext.Builder().withLanguages(LANGUAGES).withUserId(USER_ID)
+                .withStudyIdentifier(TestConstants.TEST_STUDY).build();
         TestUtils.mockEditAccount(accountDao, mockAccount);
         doReturn(mockAccount).when(accountDao).getAccount(any());
         

--- a/src/test/java/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.RequestContext.NULL_INSTANCE;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 import static org.sagebionetworks.bridge.models.accounts.AccountSecretType.REAUTH;
 import static org.testng.Assert.assertEquals;
@@ -1346,6 +1347,15 @@ public class AuthenticationServiceMockTest {
     public void getSession() {
         service.getSession(TOKEN);
         verify(cacheProvider).getUserSession(TOKEN);
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class,
+            expectedExceptionsMessageRegExp="Account not found.")
+    public void getSessionNotFound() {
+        CriteriaContext context = new CriteriaContext.Builder().withUserId(USER_ID)
+                .withStudyIdentifier(TEST_STUDY).build();        
+        
+        service.getSession(study, context);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationControllerTest.java
@@ -1187,11 +1187,8 @@ public class AuthenticationControllerTest extends Mockito {
     public void changeStudy() throws Exception {
         mockRequestBody(mockRequest, new SignIn.Builder().withStudy("my-new-study").build());
         userSession.setParticipant(new StudyParticipant.Builder().withSynapseUserId(SYNAPSE_USER_ID)
-                .withRoles(ImmutableSet.of(DEVELOPER, ADMIN)).build());
+                .withId(TEST_ACCOUNT_ID).withRoles(ImmutableSet.of(DEVELOPER, ADMIN)).build());
         doReturn(userSession).when(controller).getAuthenticatedSession();
-        
-        when(mockAccountDao.getStudyIdsForUser(SYNAPSE_USER_ID))
-            .thenReturn(ImmutableList.of("my-new-study"));
         
         Account account = Account.create();
         AccountId accountId = AccountId.forSynapseUserId("my-new-study", SYNAPSE_USER_ID);
@@ -1236,16 +1233,13 @@ public class AuthenticationControllerTest extends Mockito {
     @Test
     public void changeStudySupportsCrossStudyAdmin() throws Exception {
         mockRequestBody(mockRequest, new SignIn.Builder().withStudy("my-new-study").build());
-        userSession.setParticipant(new StudyParticipant.Builder().withSynapseUserId(SYNAPSE_USER_ID)
-                .withRoles(ImmutableSet.of(ADMIN)).build());
+        // Note that the cross-study administrator does not have a synapse user ID
+        userSession.setParticipant(new StudyParticipant.Builder()
+                .withId(TEST_ACCOUNT_ID).withRoles(ImmutableSet.of(ADMIN)).build());
         doReturn(userSession).when(controller).getAuthenticatedSession();
         
-        when(mockAccountDao.getStudyIdsForUser(SYNAPSE_USER_ID))
-            .thenReturn(ImmutableList.of("my-new-study", TEST_STUDY_IDENTIFIER));
-        
-        Account account = Account.create();
-        AccountId accountId = AccountId.forSynapseUserId("my-new-study", SYNAPSE_USER_ID);
-        when(mockAccountDao.getAccount(accountId)).thenReturn(account);
+        AccountId accountId = AccountId.forId(TEST_STUDY_IDENTIFIER, TEST_ACCOUNT_ID);
+        when(mockAccountDao.getAccount(accountId)).thenReturn(Account.create());
         
         Study newStudy = Study.create();
         newStudy.setIdentifier("my-new-study");
@@ -1288,11 +1282,8 @@ public class AuthenticationControllerTest extends Mockito {
     public void changeStudyWhereTheAccountSomehowDoesNotExist() throws Exception {
         mockRequestBody(mockRequest, new SignIn.Builder().withStudy("my-new-study").build());
         userSession.setParticipant(new StudyParticipant.Builder().withSynapseUserId(SYNAPSE_USER_ID)
-                .withRoles(ImmutableSet.of(DEVELOPER, ADMIN)).build());
+                .withRoles(ImmutableSet.of(DEVELOPER)).build());
         doReturn(userSession).when(controller).getAuthenticatedSession();
-        
-        when(mockAccountDao.getStudyIdsForUser(SYNAPSE_USER_ID))
-            .thenReturn(ImmutableList.of("my-new-study"));
         
         Study newStudy = Study.create();
         newStudy.setIdentifier("my-new-study");

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationControllerTest.java
@@ -1281,7 +1281,7 @@ public class AuthenticationControllerTest extends Mockito {
     }
     
     // This would not appear to be logically possible, but to avoid a potention NPE exception
-    // and a 500 error, check this.
+    // and a 500 error, so we check this.
     @Test(expectedExceptions = UnauthorizedException.class, 
             expectedExceptionsMessageRegExp=".*Account does not have access to that study.*")
     public void changeStudyWhereTheAccountSomehowDoesNotExist() throws Exception {

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationControllerTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
 import static com.google.common.net.HttpHeaders.USER_AGENT;
+import static org.sagebionetworks.bridge.BridgeConstants.STUDY_ACCESS_EXCEPTION_MSG;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.TestConstants.REQUIRED_SIGNED_CURRENT;
@@ -1214,7 +1215,7 @@ public class AuthenticationControllerTest extends Mockito {
     }
     
     @Test(expectedExceptions = UnauthorizedException.class, 
-            expectedExceptionsMessageRegExp=".*Account does not have access to that study.*")
+            expectedExceptionsMessageRegExp = ".*" + STUDY_ACCESS_EXCEPTION_MSG + ".*")
     public void changeStudyNotAuthorized() throws Exception {
         mockRequestBody(mockRequest, new SignIn.Builder().withStudy("my-new-study").build());
         doReturn(userSession).when(controller).getAuthenticatedSession();
@@ -1263,7 +1264,7 @@ public class AuthenticationControllerTest extends Mockito {
     }
     
     @Test(expectedExceptions = UnauthorizedException.class, 
-            expectedExceptionsMessageRegExp=".*Account does not have access to that study.*")
+            expectedExceptionsMessageRegExp = ".*" + STUDY_ACCESS_EXCEPTION_MSG + ".*")
     public void changeStudyUserHasNoAccessToStudy() throws Exception {
         mockRequestBody(mockRequest, new SignIn.Builder().withStudy("my-new-study").build());
         userSession.setParticipant(new StudyParticipant.Builder().withSynapseUserId(SYNAPSE_USER_ID)
@@ -1283,7 +1284,7 @@ public class AuthenticationControllerTest extends Mockito {
     // This would not appear to be logically possible, but to avoid a potention NPE exception
     // and a 500 error, so we check this.
     @Test(expectedExceptions = UnauthorizedException.class, 
-            expectedExceptionsMessageRegExp=".*Account does not have access to that study.*")
+            expectedExceptionsMessageRegExp = ".*" + STUDY_ACCESS_EXCEPTION_MSG + ".*")
     public void changeStudyWhereTheAccountSomehowDoesNotExist() throws Exception {
         mockRequestBody(mockRequest, new SignIn.Builder().withStudy("my-new-study").build());
         userSession.setParticipant(new StudyParticipant.Builder().withSynapseUserId(SYNAPSE_USER_ID)

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyControllerTest.java
@@ -813,11 +813,10 @@ public class StudyControllerTest extends Mockito {
         when(mockSession.getParticipant()).thenReturn(participant);
         doReturn(mockSession).when(controller).getAuthenticatedSession();
 
-        Study studyA = createStudy("Study A", "studyA", false);
-        Study studyB = createStudy("Study B", "studyB", true);
-        Study studyC = createStudy("Study C", "studyC", true);
-        Study studyD = createStudy("Study D", "studyD", true);
-        when(mockStudyService.getStudies()).thenReturn(ImmutableList.of(studyA, studyB, studyC, studyD));
+        mockStudy("Study D", "studyD", true);
+        mockStudy("Study C", "studyC", true);
+        mockStudy("Study B", "studyB", true);
+        mockStudy("Study A", "studyA", false);
         
         List<String> list = ImmutableList.of("studyA", "studyB", "studyC");
         when(mockAccountDao.getStudyIdsForUser(SYNAPSE_USER_ID)).thenReturn(list);
@@ -842,10 +841,10 @@ public class StudyControllerTest extends Mockito {
         
         doReturn(mockSession).when(controller).getAuthenticatedSession();
 
-        Study studyA = createStudy("Study A", "studyA", false);
-        Study studyB = createStudy("Study B", "studyB", true);
-        Study studyC = createStudy("Study C", "studyC", true);
-        Study studyD = createStudy("Study D", "studyD", true);
+        Study studyD = mockStudy("Study D", "studyD", true);
+        Study studyC = mockStudy("Study C", "studyC", true);
+        Study studyB = mockStudy("Study B", "studyB", true);
+        Study studyA = mockStudy("Study A", "studyA", false);
         when(mockStudyService.getStudies()).thenReturn(ImmutableList.of(studyA, studyB, studyC, studyD));
         
         // This user is only associated to the API study, but they are an admin
@@ -877,11 +876,12 @@ public class StudyControllerTest extends Mockito {
         controller.getStudyMemberships();
     }
     
-    private Study createStudy(String name, String identifier, boolean active) {
+    private Study mockStudy(String name, String identifier, boolean active) {
         Study study = Study.create();
         study.setName(name);
         study.setIdentifier(identifier);
         study.setActive(active);
+        when(mockStudyService.getStudy(identifier)).thenReturn(study);
         return study;
     }
     


### PR DESCRIPTION
Two new APIs for https://sagebionetworks.jira.com/browse/BRIDGE-2624:

- The cross-study admin API to switch studies without signing out has been expanded for all administrative users (it also continues to support cross-study admins, because given the information in the user session today, a client cannot know who is a cross-study admin once they change studies);

- There is a new API to return the studies that a user is a member of. As with the change study API, for cross-study admins this is all studies; for other users, it is every study that has the same Synapse user ID as the signed in user.