### PR TITLE
Mark a survey option as exclusive (NOTA)

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/models/surveys/SurveyQuestionOption.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/surveys/SurveyQuestionOption.java
@@ -12,18 +12,21 @@ public final class SurveyQuestionOption {
     private final String detail;
     private final String value;
     private final Image image;
+    private final Boolean exclusive;
     
     @JsonCreator
     public SurveyQuestionOption(@JsonProperty("label") String label, @JsonProperty("detail") String detail,
-        @JsonProperty("value") String value, @JsonProperty("image") Image image) {
+            @JsonProperty("value") String value, @JsonProperty("image") Image image,
+            @JsonProperty("exclusive") Boolean exclusive) {
         this.label = label;
         this.detail = detail;
         this.value = value;
         this.image = image;
+        this.exclusive = exclusive;
     }
     
     public SurveyQuestionOption(String label) {
-        this(label, null, label, null);
+        this(label, null, label, null, null);
     }
     
     public String getLabel() {
@@ -38,16 +41,13 @@ public final class SurveyQuestionOption {
     public Image getImage() {
         return image;
     }
+    public Boolean isExclusive() { 
+        return exclusive;
+    }
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + Objects.hashCode(image);
-        result = prime * result + Objects.hashCode(label);
-        result = prime * result + Objects.hashCode(detail);
-        result = prime * result + Objects.hashCode(value);
-        return result;
+        return Objects.hash(label, detail, value, image, exclusive);
     }
 
     @Override
@@ -57,15 +57,18 @@ public final class SurveyQuestionOption {
         } else if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final SurveyQuestionOption that = (SurveyQuestionOption) obj;
-        return Objects.equals(image, that.image) && Objects.equals(label, that.label)
-                && Objects.equals(detail, that.detail) && Objects.equals(value, that.value);
+        final SurveyQuestionOption other = (SurveyQuestionOption) obj;
+        return Objects.equals(label, other.label) &&
+                Objects.equals(detail, other.detail) &&
+                Objects.equals(value, other.value) &&
+                Objects.equals(image, other.image) &&
+                Objects.equals(exclusive, other.exclusive);
     }
 
     @Override
     public String toString() {
-        return String.format("SurveyQuestionOption [label=%s, detail=%s, value=%s, image=%s]", 
-            label, detail, value, image);
+        return String.format("SurveyQuestionOption [label=%s, detail=%s, value=%s, image=%s, exclusive=%s]", 
+            label, detail, value, image, exclusive);
     }
     
 }

--- a/src/test/java/org/sagebionetworks/bridge/TestSurvey.java
+++ b/src/test/java/org/sagebionetworks/bridge/TestSurvey.java
@@ -62,10 +62,11 @@ public class TestSurvey extends DynamoSurvey {
             Image great = new Image("http://great.svg", 600, 300);
             MultiValueConstraints mvc = new MultiValueConstraints(DataType.INTEGER);
             List<SurveyQuestionOption> options = Lists.newArrayList(
-                    new SurveyQuestionOption("Terrible", null, "1", terrible),
-                    new SurveyQuestionOption("Poor", null, "2", poor), new SurveyQuestionOption("OK", null, "3", ok),
-                    new SurveyQuestionOption("Good", null, "4", good),
-                    new SurveyQuestionOption("Great", null, "5", great));
+                    new SurveyQuestionOption("Terrible", null, "1", terrible, null),
+                    new SurveyQuestionOption("Poor", null, "2", poor, null), 
+                    new SurveyQuestionOption("OK", null, "3", ok, null),
+                    new SurveyQuestionOption("Good", null, "4", good, null),
+                    new SurveyQuestionOption("Great", null, "5", great, null));
             mvc.setEnumeration(options);
             mvc.setAllowOther(false);
             mvc.setAllowMultiple(true);

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSurveyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSurveyTest.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.dynamodb;
 
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -21,6 +22,7 @@ import org.sagebionetworks.bridge.models.surveys.DateConstraints;
 import org.sagebionetworks.bridge.models.surveys.DateTimeConstraints;
 import org.sagebionetworks.bridge.models.surveys.Image;
 import org.sagebionetworks.bridge.models.surveys.IntegerConstraints;
+import org.sagebionetworks.bridge.models.surveys.MultiValueConstraints;
 import org.sagebionetworks.bridge.models.surveys.Survey;
 import org.sagebionetworks.bridge.models.surveys.SurveyElement;
 import org.sagebionetworks.bridge.models.surveys.SurveyInfoScreen;
@@ -137,6 +139,11 @@ public class DynamoSurveyTest {
         
         SurveyInfoScreen retrievedScreen = (SurveyInfoScreen)convertedSurvey.getElements().get(convertedSurvey.getElements().size()-1);
         assertEquals(retrievedScreen.getAfterRules().get(0), rule);
+        
+        MultiValueConstraints mvc = (MultiValueConstraints)((SurveyQuestion)convertedSurvey.getElements().get(7)).getConstraints();
+        assertFalse(mvc.getEnumeration().get(3).isExclusive());
+        assertNull(mvc.getEnumeration().get(4).isExclusive());
+        assertTrue(mvc.getEnumeration().get(5).isExclusive());
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/models/surveys/SurveyQuestionOptionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/surveys/SurveyQuestionOptionTest.java
@@ -1,10 +1,15 @@
 package org.sagebionetworks.bridge.models.surveys;
 
+import static java.lang.Boolean.TRUE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -47,5 +52,28 @@ public class SurveyQuestionOptionTest {
         // Make sure toString() doesn't throw if all fields are null.
         SurveyQuestionOption option = new SurveyQuestionOption(null, null, null, null, null);
         assertNotNull(option.toString());
+    }
+    
+    @Test
+    public void canSerialize() throws Exception {
+        SurveyQuestionOption option = new SurveyQuestionOption("oneLabel", "oneDetail",
+                "oneValue", new Image("oneSource", 100, 200), TRUE);
+        
+        JsonNode node = BridgeObjectMapper.get().valueToTree(option);
+        
+        assertEquals(node.get("label").textValue(), "oneLabel");
+        assertEquals(node.get("detail").textValue(), "oneDetail");
+        assertEquals(node.get("value").textValue(), "oneValue");
+        assertTrue(node.get("exclusive").booleanValue());
+        assertEquals(node.get("type").textValue(), "SurveyQuestionOption");
+        
+        JsonNode image = node.get("image");
+        assertEquals(image.get("source").textValue(), "oneSource");
+        assertEquals(image.get("width").intValue(), 100);
+        assertEquals(image.get("height").intValue(), 200);
+        assertEquals(image.get("type").textValue(), "Image");
+        
+        SurveyQuestionOption deser = BridgeObjectMapper.get().readValue(node.toString(), SurveyQuestionOption.class);
+        assertEquals(deser, option);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/surveys/SurveyQuestionOptionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/surveys/SurveyQuestionOptionTest.java
@@ -13,24 +13,26 @@ public class SurveyQuestionOptionTest {
 
     @Test
     public void allValues() {
-        SurveyQuestionOption option = new SurveyQuestionOption("test-label", "test-detail", "test-value", DUMMY_IMAGE);
+        SurveyQuestionOption option = new SurveyQuestionOption("test-label", "test-detail", "test-value", DUMMY_IMAGE, true);
         assertEquals(option.getLabel(), "test-label");
         assertEquals(option.getDetail(), "test-detail");
         assertEquals(option.getValue(), "test-value");
         assertEquals(option.getImage(), DUMMY_IMAGE);
-
+        assertTrue(option.isExclusive());
+        
         String optionString = option.toString();
         assertTrue(optionString.contains(option.getLabel()));
         assertTrue(optionString.contains(option.getDetail()));
         assertTrue(optionString.contains(option.getValue()));
         assertTrue(optionString.contains(option.getImage().toString()));
+        assertTrue(optionString.contains("exclusive=true"));
     }
 
     @Test
     public void blankValue() {
         String[] testCaseArr = { null, "", "   " };
         for (String oneTestCase : testCaseArr) {
-            SurveyQuestionOption option = new SurveyQuestionOption("test-label", null, oneTestCase, null);
+            SurveyQuestionOption option = new SurveyQuestionOption("test-label", null, oneTestCase, null, null);
             assertEquals(option.getValue(), "test-label");
         }
     }
@@ -41,9 +43,9 @@ public class SurveyQuestionOptionTest {
     }
 
     @Test
-    public void toStringAllNulls() {
+    public void toStringAllNulls() throws Exception {
         // Make sure toString() doesn't throw if all fields are null.
-        SurveyQuestionOption option = new SurveyQuestionOption(null, null, null, null);
+        SurveyQuestionOption option = new SurveyQuestionOption(null, null, null, null, null);
         assertNotNull(option.toString());
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/surveys/TestSurvey.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/surveys/TestSurvey.java
@@ -41,11 +41,12 @@ public class TestSurvey extends DynamoSurvey {
             Image great = new Image("http://great.svg", 600, 300);
             MultiValueConstraints mvc = new MultiValueConstraints(DataType.INTEGER);
             List<SurveyQuestionOption> options = Lists.newArrayList(
-                new SurveyQuestionOption("Terrible", null, "1", terrible),
-                new SurveyQuestionOption("Poor", null, "2", poor),
-                new SurveyQuestionOption("OK", null, "3", ok),
-                new SurveyQuestionOption("Good", null, "4", good),
-                new SurveyQuestionOption("Great", null, "5", great)
+                new SurveyQuestionOption("Terrible", null, "1", terrible, null),
+                new SurveyQuestionOption("Poor", null, "2", poor, null),
+                new SurveyQuestionOption("OK", null, "3", ok, null),
+                new SurveyQuestionOption("Good", null, "4", good, false),
+                new SurveyQuestionOption("Great", null, "5", great, null),
+                new SurveyQuestionOption("NOTA", null, "6", null, true)
             );
             mvc.setEnumeration(options);
             mvc.setAllowOther(false);

--- a/src/test/java/org/sagebionetworks/bridge/validators/SurveySaveValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/SurveySaveValidatorTest.java
@@ -303,7 +303,7 @@ public class SurveySaveValidatorTest {
     public void multiValueWithOptionWithInvalidValue() {
         String answerChoice = "@invalid#answer$";
         List<SurveyQuestionOption> optionList = ImmutableList
-                .of(new SurveyQuestionOption("My Question", null, answerChoice, null));
+                .of(new SurveyQuestionOption("My Question", null, answerChoice, null, null));
 
         SurveyQuestion question = ((TestSurvey) survey).getMultiValueQuestion();
         ((MultiValueConstraints) question.getConstraints()).setEnumeration(optionList);
@@ -314,10 +314,14 @@ public class SurveySaveValidatorTest {
 
     @Test
     public void multiValueWithDupeOptions() {
-        List<SurveyQuestionOption> optionList = ImmutableList.of(new SurveyQuestionOption("a", null, "a", null),
-                new SurveyQuestionOption("b1", null, "b", null), new SurveyQuestionOption("b2", null, "b", null),
-                new SurveyQuestionOption("c", null, "c", null), new SurveyQuestionOption("d1", null, "d", null),
-                new SurveyQuestionOption("d2", null, "d", null), new SurveyQuestionOption("e", null, "e", null));
+        List<SurveyQuestionOption> optionList = ImmutableList.of(
+                new SurveyQuestionOption("a", null, "a", null, null),
+                new SurveyQuestionOption("b1", null, "b", null, null),
+                new SurveyQuestionOption("b2", null, "b", null, null),
+                new SurveyQuestionOption("c", null, "c", null, null),
+                new SurveyQuestionOption("d1", null, "d", null, null),
+                new SurveyQuestionOption("d2", null, "d", null, null),
+                new SurveyQuestionOption("e", null, "e", null, null));
 
         SurveyQuestion question = ((TestSurvey) survey).getMultiValueQuestion();
         ((MultiValueConstraints) question.getConstraints()).setEnumeration(optionList);


### PR DESCRIPTION
The survey engine will deselect all other options when an exclusive option is checked, and probably disable them as well. It is used for a "none of the above" option which is not the same as an "other" option.