### PR TITLE
Remove creation of Synapse user accounts when creating a study

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
@@ -116,6 +116,7 @@ public class StudyService {
     private UploadCertificateService uploadCertService;
     private StudyDao studyDao;
     private StudyValidator validator;
+    private StudyAndUsersValidator studyAndUsersValidator;
     private CacheProvider cacheProvider;
     private SubpopulationService subpopService;
     private NotificationTopicService topicService;
@@ -175,6 +176,10 @@ public class StudyService {
     @Autowired
     final void setValidator(StudyValidator validator) {
         this.validator = validator;
+    }
+    @Autowired
+    final void setStudyAndUsersValidator(StudyAndUsersValidator studyAndUsersValidator) {
+        this.studyAndUsersValidator = studyAndUsersValidator;
     }
     @Autowired
     final void setStudyDao(StudyDao studyDao) {
@@ -271,7 +276,7 @@ public class StudyService {
         Errors errors = Validate.getErrorsFor(studyAndUsers);
         
         // Validate StudyAndUsers
-        Validate.entity(new StudyAndUsersValidator(synapseClient), errors, studyAndUsers);
+        Validate.entity(studyAndUsersValidator, errors, studyAndUsers);
         Validate.throwException(errors, studyAndUsers);
         
         // Validate each StudyParticipant object

--- a/src/main/java/org/sagebionetworks/bridge/validators/StudyAndUsersValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/StudyAndUsersValidator.java
@@ -11,6 +11,8 @@ import java.util.List;
 import com.google.common.collect.ImmutableSet;
 
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
@@ -22,11 +24,13 @@ import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
 
+@Component
 public class StudyAndUsersValidator implements Validator {
 
-    private final SynapseClient synapseClient;
+    private SynapseClient synapseClient;
 
-    public StudyAndUsersValidator(SynapseClient synapseClient) {
+    @Autowired
+    public final void setSynapseClient(SynapseClient synapseClient) {
         this.synapseClient = synapseClient;
     }
     

--- a/src/main/java/org/sagebionetworks/bridge/validators/StudyAndUsersValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/StudyAndUsersValidator.java
@@ -1,0 +1,112 @@
+package org.sagebionetworks.bridge.validators;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.sagebionetworks.bridge.Roles.ADMIN;
+import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
+import static org.sagebionetworks.bridge.Roles.WORKER;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.google.common.collect.ImmutableSet;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.studies.StudyAndUsers;
+import org.sagebionetworks.client.SynapseClient;
+import org.sagebionetworks.client.exceptions.SynapseException;
+import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
+
+public class StudyAndUsersValidator implements Validator {
+
+    private final SynapseClient synapseClient;
+
+    public StudyAndUsersValidator(SynapseClient synapseClient) {
+        this.synapseClient = synapseClient;
+    }
+    
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return StudyAndUsers.class.isAssignableFrom(clazz);
+    }
+
+    @Override
+    public void validate(Object object, Errors errors) {
+        StudyAndUsers studyAndUsers = (StudyAndUsers)object;
+        
+        List<String> adminIds = studyAndUsers.getAdminIds();
+        if (adminIds == null || adminIds.isEmpty()) {
+            errors.rejectValue("adminIds", "are required");
+        } else {
+            for (int i=0; i < adminIds.size(); i++) {
+                String adminId = adminIds.get(i);
+                errors.pushNestedPath("adminIds["+i+"]");
+                if (isBlank(adminId)) {
+                    errors.rejectValue("", "cannot be blank or null");
+                }
+                try {
+                    synapseClient.getUserProfile(adminId);
+                } catch (SynapseNotFoundException e) {
+                    errors.rejectValue("", "is invalid");
+                } catch (SynapseException se) {
+                    throw new RuntimeException(se);
+                }
+                errors.popNestedPath();
+            }
+        }
+        
+        List<StudyParticipant> users = studyAndUsers.getUsers();
+        if (users == null || users.isEmpty()) {
+            errors.rejectValue("users", "are required");
+        } else {
+            for (int i=0; i < users.size(); i++) {
+                StudyParticipant user = users.get(i);
+                errors.pushNestedPath("users["+i+"]");
+                if (isBlank(user.getSynapseUserId())) {
+                    errors.rejectValue("synapseUserId", "cannot be blank");
+                } else {
+                    try {
+                        synapseClient.getUserProfile(user.getSynapseUserId());
+                    } catch (SynapseNotFoundException e) {
+                        errors.rejectValue("synapseUserId", "is invalid");
+                    } catch (SynapseException se) {
+                        throw new RuntimeException(se);
+                    }
+                }
+                
+                // validate roles for each user
+                if (user.getRoles() == null || user.getRoles().isEmpty()) {
+                    errors.rejectValue("roles", "should have at least one role");
+                } else if (!Collections.disjoint(user.getRoles(), ImmutableSet.of(ADMIN, WORKER, SUPERADMIN))) {
+                    errors.rejectValue("roles", "can only have roles developer and/or researcher");
+                }
+                
+                errors.popNestedPath();
+            }
+        }
+        
+        Study study = studyAndUsers.getStudy();
+        if (study == null) {
+            errors.rejectValue("study", "cannot be null");
+        } else {
+            errors.pushNestedPath("study");
+            try {
+                BridgeUtils.toSynapseFriendlyName(study.getName());    
+            } catch(NullPointerException | IllegalArgumentException e) {
+                errors.rejectValue("name", "is an invalid Synapse project name");
+            }
+            if (StringUtils.isBlank(study.getSponsorName())) {
+                errors.rejectValue("sponsorName", "is required");
+            }
+            if (StringUtils.isBlank(study.getIdentifier())) {
+                errors.rejectValue("identifier", "is required");
+            }
+            errors.popNestedPath();
+        }
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/TestUtils.java
+++ b/src/test/java/org/sagebionetworks/bridge/TestUtils.java
@@ -314,7 +314,6 @@ public class TestUtils {
             Validate.entityThrowingException(validator, object);
             fail("Should have thrown exception");
         } catch(InvalidEntityException e) {
-            System.out.println(e.getErrors());
             if (e.getErrors().get(fieldName).contains(fieldNameAsLabel+error)) {
                 return;
             }

--- a/src/test/java/org/sagebionetworks/bridge/TestUtils.java
+++ b/src/test/java/org/sagebionetworks/bridge/TestUtils.java
@@ -314,6 +314,7 @@ public class TestUtils {
             Validate.entityThrowingException(validator, object);
             fail("Should have thrown exception");
         } catch(InvalidEntityException e) {
+            System.out.println(e.getErrors());
             if (e.getErrors().get(fieldName).contains(fieldNameAsLabel+error)) {
                 return;
             }

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/UserSessionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/UserSessionTest.java
@@ -2,7 +2,6 @@ package org.sagebionetworks.bridge.models.accounts;
 
 import static java.lang.Boolean.TRUE;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
-import static org.sagebionetworks.bridge.Roles.ADMINISTRATIVE_ROLES;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.SUPERADMIN;

--- a/src/test/java/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -91,6 +91,7 @@ import org.sagebionetworks.bridge.models.upload.UploadValidationStrictness;
 import org.sagebionetworks.bridge.services.email.BasicEmailProvider;
 import org.sagebionetworks.bridge.services.email.EmailType;
 import org.sagebionetworks.bridge.services.email.MimeTypeEmail;
+import org.sagebionetworks.bridge.validators.StudyAndUsersValidator;
 import org.sagebionetworks.bridge.validators.StudyValidator;
 
 public class StudyServiceMockTest extends Mockito {
@@ -153,7 +154,7 @@ public class StudyServiceMockTest extends Mockito {
     TemplateService mockTemplateService;
     @Mock
     FileService mockFileService;
-    
+
     @Captor
     ArgumentCaptor<Project> projectCaptor;
     @Captor
@@ -191,6 +192,10 @@ public class StudyServiceMockTest extends Mockito {
         service.setStudyEmailVerificationTemplate(mockTemplateAsSpringResource(
                 "Click here ${studyEmailVerificationUrl} ${studyEmailVerificationExpirationPeriod}"));
         service.setValidator(new StudyValidator());
+        
+        StudyAndUsersValidator studyAndUsersValidator = new StudyAndUsersValidator();
+        studyAndUsersValidator.setSynapseClient(mockSynapseClient);
+        service.setStudyAndUsersValidator(studyAndUsersValidator);
 
         when(service.getNameScopingToken()).thenReturn(TEST_NAME_SCOPING_TOKEN);
         

--- a/src/test/java/org/sagebionetworks/bridge/validators/StudyAndUsersValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/StudyAndUsersValidatorTest.java
@@ -1,0 +1,141 @@
+package org.sagebionetworks.bridge.validators;
+
+import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
+import static org.sagebionetworks.bridge.Roles.WORKER;
+import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
+import static org.testng.collections.Lists.newArrayList;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.studies.StudyAndUsers;
+import org.sagebionetworks.client.SynapseClient;
+import org.sagebionetworks.client.exceptions.SynapseException;
+import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
+
+public class StudyAndUsersValidatorTest extends Mockito {
+
+    @Mock
+    SynapseClient mockSynapseClient;
+    
+    StudyAndUsersValidator validator;
+    
+    @BeforeMethod
+    public void beforeMethod() {
+        MockitoAnnotations.initMocks(this);
+        validator = new StudyAndUsersValidator(mockSynapseClient);
+    }
+    
+    @Test
+    public void adminIdsNull() {
+        StudyAndUsers model = new StudyAndUsers(null, Study.create(), ImmutableList.of());
+        assertValidatorMessage(validator, model, "adminIds", "are required");
+    }
+    
+    @Test
+    public void adminIdsEmpty() {
+        StudyAndUsers model = new StudyAndUsers(ImmutableList.of(), Study.create(), ImmutableList.of());
+        assertValidatorMessage(validator, model, "adminIds", "are required");
+    }
+
+    @Test
+    public void adminIdNull() {
+        StudyAndUsers model = new StudyAndUsers(newArrayList((String)null), Study.create(), ImmutableList.of());
+        assertValidatorMessage(validator, model, "adminIds[0]", "cannot be blank or null");
+    }
+    
+    @Test
+    public void adminIdInvalid() throws SynapseException {
+        when(mockSynapseClient.getUserProfile("userId")).thenThrow(new SynapseNotFoundException());
+        
+        StudyAndUsers model = new StudyAndUsers(newArrayList("userId"), Study.create(), ImmutableList.of());
+        assertValidatorMessage(validator, model, "adminIds[0]", "is invalid");
+        
+        verify(mockSynapseClient).getUserProfile("userId");
+    }
+    
+    @Test
+    public void usersNull() {
+        StudyAndUsers model = new StudyAndUsers(null, Study.create(), null);
+        assertValidatorMessage(validator, model, "users", "are required");
+    }
+    
+    @Test
+    public void usersEmpty() {
+        StudyAndUsers model = new StudyAndUsers(null, Study.create(), ImmutableList.of());
+        assertValidatorMessage(validator, model, "users", "are required");
+    }
+    
+    @Test
+    public void userSynapseUserIdNull() {
+        StudyParticipant participant = new StudyParticipant.Builder().build();
+        StudyAndUsers model = new StudyAndUsers(null, Study.create(), ImmutableList.of(participant));
+        assertValidatorMessage(validator, model, "users[0].synapseUserId", "cannot be blank");
+    }
+    
+    @Test
+    public void userSynapseUserIdInvalid() throws SynapseException {
+        when(mockSynapseClient.getUserProfile("userId")).thenThrow(new SynapseNotFoundException());
+        
+        StudyParticipant participant = new StudyParticipant.Builder().withSynapseUserId("userId").build();
+        StudyAndUsers model = new StudyAndUsers(null, Study.create(), ImmutableList.of(participant));
+        assertValidatorMessage(validator, model, "users[0].synapseUserId", "is invalid");
+        
+        verify(mockSynapseClient).getUserProfile("userId");
+    }
+    
+    @Test
+    public void userRolesNull() {
+        StudyParticipant participant = new StudyParticipant.Builder().withRoles(null).build();
+        StudyAndUsers model = new StudyAndUsers(null, Study.create(), ImmutableList.of(participant));
+        assertValidatorMessage(validator, model, "users[0].roles", "should have at least one role");
+    }
+    
+    @Test
+    public void userRolesEmpty() {
+        StudyParticipant participant = new StudyParticipant.Builder().withRoles(ImmutableSet.of()).build();
+        StudyAndUsers model = new StudyAndUsers(null, Study.create(), ImmutableList.of(participant));
+        assertValidatorMessage(validator, model, "users[0].roles", "should have at least one role");
+    }
+    
+    @Test
+    public void userRolesInvalid() {
+        StudyParticipant participant = new StudyParticipant.Builder().withRoles(ImmutableSet.of(WORKER, SUPERADMIN)).build();
+        StudyAndUsers model = new StudyAndUsers(null, Study.create(), ImmutableList.of(participant));
+        assertValidatorMessage(validator, model, "users[0].roles", "can only have roles developer and/or researcher");
+    }
+    
+    @Test
+    public void studyNull() {
+        StudyAndUsers model = new StudyAndUsers(null, null, null);
+        assertValidatorMessage(validator, model, "study", "cannot be null");
+    }
+    
+    @Test
+    public void studyNameInvalidForSynapse() {
+        Study study = Study.create();
+        study.setName("  "); // blank is not okay
+        StudyAndUsers model = new StudyAndUsers(null, study, null);
+        assertValidatorMessage(validator, model, "study.name", "is an invalid Synapse project name");
+    }
+    
+    @Test
+    public void studySponsorNameRequired() { 
+        StudyAndUsers model = new StudyAndUsers(null, Study.create(), null);
+        assertValidatorMessage(validator, model, "study.sponsorName", "is required");
+    }
+    
+    @Test
+    public void studyIdentifierRequired() { 
+        StudyAndUsers model = new StudyAndUsers(null, Study.create(), null);
+        assertValidatorMessage(validator, model, "study.identifier", "is required");
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/validators/StudyAndUsersValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/StudyAndUsersValidatorTest.java
@@ -1,9 +1,13 @@
 package org.sagebionetworks.bridge.validators;
 
+import static org.sagebionetworks.bridge.Roles.DEVELOPER;
+import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
 import static org.sagebionetworks.bridge.Roles.WORKER;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 import static org.testng.collections.Lists.newArrayList;
+
+import java.util.List;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -14,12 +18,14 @@ import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyAndUsers;
 import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
+import org.sagebionetworks.repo.model.UserProfile;
 
 public class StudyAndUsersValidatorTest extends Mockito {
 
@@ -31,7 +37,30 @@ public class StudyAndUsersValidatorTest extends Mockito {
     @BeforeMethod
     public void beforeMethod() {
         MockitoAnnotations.initMocks(this);
-        validator = new StudyAndUsersValidator(mockSynapseClient);
+        validator = new StudyAndUsersValidator();
+        validator.setSynapseClient(mockSynapseClient);
+    }
+    
+    @Test
+    public void validStudyAndUsers() throws Exception {
+        // The synapse client as mocked, throws no exception that would make the IDs used
+        // here invalid.
+        
+        List<String> adminIds = ImmutableList.of("abc", "def", "ghi");
+        
+        Study study = Study.create();
+        study.setIdentifier("test-identifier");
+        study.setName("Test Name");
+        study.setSponsorName("Test Sponsor Name");
+        
+        StudyParticipant user1 = new StudyParticipant.Builder().withSynapseUserId("jkl")
+                .withRoles(ImmutableSet.of(DEVELOPER)).build();
+        StudyParticipant user2 = new StudyParticipant.Builder().withSynapseUserId("mno")
+                .withRoles(ImmutableSet.of(RESEARCHER)).build();
+        List<StudyParticipant> userIds = ImmutableList.of(user1, user2);
+        
+        StudyAndUsers model = new StudyAndUsers(adminIds, study, userIds);
+        Validate.entityThrowingException(validator, model);
     }
     
     @Test


### PR DESCRIPTION
Part of switching to the user of Synapse for administrative accounts, is that we now ask for Synapse accounts up front and then we add them to the Bridge and Synapse models we create. So this PR removes the assumption that we're creating a Synapse account, and invites existing users into the new access team that we are creating.

Also I took the opportunity to refactor a bunch of BadRequestExceptions into a StudyAndUsersValidator.