### PR TITLE
Account dao refactor

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/dao/AccountDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dao/AccountDao.java
@@ -104,16 +104,4 @@ public interface AccountDao {
      *      paging parameters.
      */
     PagedResourceList<AccountSummary> getPagedAccountSummaries(Study study, AccountSummarySearch search);
-    
-    /**
-     * For MailChimp, and other external systems, we need a way to get a healthCode for a given email.
-     */
-    default String getHealthCodeForAccount(AccountId accountId) {
-        Account account = getAccount(accountId);
-        if (account != null) {
-            return account.getHealthCode();
-        } else {
-            return null;
-        }
-    }
-}
+}    

--- a/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
@@ -1,0 +1,147 @@
+package org.sagebionetworks.bridge.services;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.sagebionetworks.bridge.dao.AccountDao;
+import org.sagebionetworks.bridge.models.AccountSummarySearch;
+import org.sagebionetworks.bridge.models.PagedResourceList;
+import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
+import org.sagebionetworks.bridge.models.accounts.AccountSummary;
+import org.sagebionetworks.bridge.models.accounts.SignIn;
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+import org.sagebionetworks.bridge.services.AuthenticationService.ChannelType;
+
+@Component
+public class AccountService {
+    
+    private AccountDao accountDao;
+    
+    @Autowired
+    public final void setAccountDao(AccountDao accountDao) {
+        this.accountDao = accountDao;
+    }
+    
+    
+    /**
+     * Search for all accounts across studies that have the same Synapse user ID in common, 
+     * and return a list of the study IDs where these accounts are found.
+     * @param synapseUserId
+     * @return list of study identifiers
+     */
+    public List<String> getStudyIdsForUser(String synapseUserId) {
+        return accountDao.getStudyIdsForUser(synapseUserId);
+    }
+    
+    /**
+     * Set the verified flag for the channel (email or phone) to true, and enable the account (if needed).
+     */
+    public void verifyChannel(AuthenticationService.ChannelType channelType, Account account) {
+        accountDao.verifyChannel(channelType, account);
+    }
+    
+    /**
+     * Call to change a password, possibly verifying the channel used to reset the password. The channel 
+     * type (which is optional, and can be null) is the channel that has been verified through the act 
+     * of successfully resetting the password (sometimes there is no channel that is verified). 
+     */
+    public void changePassword(Account account, ChannelType channelType, String newPassword) {
+        accountDao.changePassword(account, channelType, newPassword);
+    }
+    
+    /**
+     * Authenticate a user with the supplied credentials, returning that user's account record
+     * if successful. 
+     */
+    public Account authenticate(Study study, SignIn signIn) {
+        return accountDao.authenticate(study, signIn);
+    }
+
+    /**
+     * Re-acquire a valid session using a special token passed back on an
+     * authenticate request. Allows the client to re-authenticate without prompting
+     * for a password.
+     */
+    public Account reauthenticate(Study study, SignIn signIn) {
+        return accountDao.reauthenticate(study, signIn);
+    }
+    
+    /**
+     * This clears the user's reauthentication token.
+     */
+    public void deleteReauthToken(AccountId accountId) {
+        accountDao.deleteReauthToken(accountId);
+    }
+    
+    /**
+     * Create an account. If the optional consumer is passed to this method and it throws an 
+     * exception, the account will not be persisted (the consumer is executed after the persist 
+     * is executed in a transaction, however).
+     */
+    public void createAccount(Study study, Account account, Consumer<Account> afterPersistConsumer) {
+        accountDao.createAccount(study, account, afterPersistConsumer);
+    }
+    
+    /**
+     * Save account changes. Account should have been retrieved from the getAccount() method 
+     * (constructAccount() is not sufficient). If the optional consumer is passed to this method and 
+     * it throws an exception, the account will not be persisted (the consumer is executed after 
+     * the persist is executed in a transaction, however).
+     */
+    public void updateAccount(Account account, Consumer<Account> afterPersistConsumer) {
+        accountDao.updateAccount(account, afterPersistConsumer);
+    }
+    
+    /**
+     * Load, and if it exists, edit and save an account. 
+     */
+    public void editAccount(StudyIdentifier studyId, String healthCode, Consumer<Account> accountEdits) {
+        accountDao.editAccount(studyId, healthCode, accountEdits);
+    }
+    
+    /**
+     * Get an account in the context of a study by the user's ID, email address, health code,
+     * or phone number. Returns null if there is no account, it is up to callers to translate 
+     * this into the appropriate exception, if any. 
+     */
+    public Account getAccount(AccountId accountId) {
+        return accountDao.getAccount(accountId);
+    }
+    
+    /**
+     * Delete an account along with the authentication credentials.
+     */
+    public void deleteAccount(AccountId accountId) {
+        accountDao.deleteAccount(accountId);
+    }
+    
+    /**
+     * Get a page of lightweight account summaries (most importantly, the email addresses of 
+     * participants which are required for the rest of the participant APIs). 
+     * @param study
+     *      retrieve participants in this study
+     * @param search
+     *      all the parameters necessary to perform a filtered search of user account summaries, including
+     *      paging parameters.
+     */
+    public PagedResourceList<AccountSummary> getPagedAccountSummaries(Study study, AccountSummarySearch search) {
+        return accountDao.getPagedAccountSummaries(study, search);
+    }
+    
+    /**
+     * For MailChimp, and other external systems, we need a way to get a healthCode for a given email.
+     */
+    public String getHealthCodeForAccount(AccountId accountId) {
+        Account account = getAccount(accountId);
+        if (account != null) {
+            return account.getHealthCode();
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -15,7 +15,6 @@ import org.sagebionetworks.bridge.SecureTokenGenerator;
 import org.sagebionetworks.bridge.cache.CacheKey;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.BridgeConfig;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.AccountSecretDao;
 import org.sagebionetworks.bridge.exceptions.AccountDisabledException;
 import org.sagebionetworks.bridge.exceptions.AuthenticationFailedException;
@@ -65,7 +64,7 @@ public class AuthenticationService {
     private CacheProvider cacheProvider;
     private BridgeConfig config;
     private ConsentService consentService;
-    private AccountDao accountDao;
+    private AccountService accountService;
     private ParticipantService participantService;
     private StudyService studyService;
     private PasswordResetValidator passwordResetValidator;
@@ -88,8 +87,8 @@ public class AuthenticationService {
         this.consentService = consentService;
     }
     @Autowired
-    final void setAccountDao(AccountDao accountDao) {
-        this.accountDao = accountDao;
+    final void setAccountService(AccountService accountService) {
+        this.accountService = accountService;
     }
 
     @Autowired
@@ -169,7 +168,7 @@ public class AuthenticationService {
         checkNotNull(study);
         checkNotNull(context);
 
-        Account account = accountDao.getAccount(context.getAccountId());
+        Account account = accountService.getAccount(context.getAccountId());
         if (account == null) {
             throw new EntityNotFoundException(Account.class);
         }
@@ -183,7 +182,7 @@ public class AuthenticationService {
         
         Validate.entityThrowingException(SignInValidator.PASSWORD_SIGNIN, signIn);
         
-        Account account = accountDao.authenticate(study, signIn);
+        Account account = accountService.authenticate(study, signIn);
         
         clearSession(study.getIdentifier(), account.getId());
         UserSession session = getSessionFromAccount(study, context, account);
@@ -191,7 +190,7 @@ public class AuthenticationService {
         // Do not call sessionUpdateService as we assume system is in sync with the session on sign in
         if (!session.doesConsent() && intentService.registerIntentToParticipate(study, account)) {
             AccountId accountId = AccountId.forId(study.getIdentifier(), account.getId());
-            account = accountDao.getAccount(accountId);
+            account = accountService.getAccount(accountId);
             session = getSessionFromAccount(study, context, account);
         }
         cacheProvider.setUserSession(session);
@@ -221,7 +220,7 @@ public class AuthenticationService {
         int reauthHashMod = signIn.getReauthToken().hashCode() % 1000;
         LOG.debug("Reauth token hash-mod " + reauthHashMod + " submitted in request " + BridgeUtils.getRequestContext().getId());
 
-        Account account = accountDao.reauthenticate(study, signIn);
+        Account account = accountService.reauthenticate(study, signIn);
         
         UserSession session = getSessionFromAccount(study, context, account);
         // If session exists, preserve the session token. Reauthenticating before the session times out will not
@@ -243,7 +242,7 @@ public class AuthenticationService {
     public void signOut(final UserSession session) {
         if (session != null) {
             AccountId accountId = AccountId.forId(session.getStudyIdentifier().getIdentifier(), session.getId());
-            accountDao.deleteReauthToken(accountId);
+            accountService.deleteReauthToken(accountId);
             // session does not have the reauth token so the reauthToken-->sessionToken Redis entry cannot be 
             // removed, but once the reauth token is removed from the user table, the reauth token will no 
             // longer work (and is short-lived in the cache).
@@ -288,7 +287,7 @@ public class AuthenticationService {
 
         Validate.entityThrowingException(VerificationValidator.INSTANCE, verification);
         Account account = accountWorkflowService.verifyChannel(type, verification);
-        accountDao.verifyChannel(type, account);
+        accountService.verifyChannel(type, account);
     }
     
     public void resendVerification(ChannelType type, AccountId accountId) {
@@ -341,7 +340,7 @@ public class AuthenticationService {
         }
 
         AccountId accountId = AccountId.forExternalId(study.getIdentifier(), externalId);
-        Account account = accountDao.getAccount(accountId);
+        Account account = accountService.getAccount(accountId);
         
         // The *target* must be associated to the substudy, if any
         boolean existsButWrongSubstudy = account != null && BridgeUtils.filterForSubstudy(account) == null;
@@ -365,7 +364,7 @@ public class AuthenticationService {
             userId = participantService.createParticipant(study, participant, false).getIdentifier();
         } else {
             // Account exists, so rotate the password
-            accountDao.changePassword(account, null, password);
+            accountService.changePassword(account, null, password);
             userId = account.getId();
         }
         // Return the password and the user ID in case the account was just created.
@@ -389,7 +388,7 @@ public class AuthenticationService {
         }
 
         AccountId accountId = signIn.getAccountId();
-        Account account = accountDao.getAccount(accountId);
+        Account account = accountService.getAccount(accountId);
         // This should be unlikely, but if someone deleted the account while the token was outstanding
         if (account == null) {
             throw new EntityNotFoundException(Account.class);
@@ -398,7 +397,7 @@ public class AuthenticationService {
             throw new AccountDisabledException();
         }
         // Update account state before we create the session, so it's accurate...
-        accountDao.verifyChannel(channelType, account);
+        accountService.verifyChannel(channelType, account);
 
         // Check if we have a cached session for this sign-in token.
         UserSession cachedSession = null;
@@ -421,7 +420,7 @@ public class AuthenticationService {
 
             // Check intent to participate.
             if (!session.doesConsent() && intentService.registerIntentToParticipate(study, account)) {
-                account = accountDao.getAccount(accountId);
+                account = accountService.getAccount(accountId);
                 session = getSessionFromAccount(study, context, account);
             }
             cacheProvider.setUserSession(session);
@@ -466,7 +465,7 @@ public class AuthenticationService {
                     .withLanguages(context.getLanguages()).build();
             
             // Note that the context does not have the healthCode, you must use the participant
-            accountDao.editAccount(study.getStudyIdentifier(), participant.getHealthCode(),
+            accountService.editAccount(study.getStudyIdentifier(), participant.getHealthCode(),
                     accountToEdit -> accountToEdit.setLanguages(context.getLanguages()));
         }
 
@@ -509,7 +508,7 @@ public class AuthenticationService {
         if (accountId == null) {
             throw new EntityNotFoundException(Account.class);
         }
-        Account account = accountDao.getAccount(accountId);
+        Account account = accountService.getAccount(accountId);
         if (account == null) {
             throw new EntityNotFoundException(Account.class);
         }
@@ -531,7 +530,7 @@ public class AuthenticationService {
     // also includes creating a new (valid) reauth token.
     private void clearSession(String studyId, String userId) {
         AccountId accountId = AccountId.forId(studyId, userId);
-        accountDao.deleteReauthToken(accountId);
+        accountService.deleteReauthToken(accountId);
         cacheProvider.removeSessionByUserId(userId);
     }
 

--- a/src/main/java/org/sagebionetworks/bridge/services/FPHSService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/FPHSService.java
@@ -6,7 +6,6 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.util.List;
 
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.FPHSExternalIdentifierDao;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.accounts.ExternalIdentifier;
@@ -21,15 +20,15 @@ import org.springframework.stereotype.Component;
 public class FPHSService {
     
     private FPHSExternalIdentifierDao fphsDao;
-    private AccountDao accountDao;
+    private AccountService accountService;
 
     @Autowired
     final void setFPHSExternalIdentifierDao(FPHSExternalIdentifierDao dao) {
         this.fphsDao = dao;
     }
     @Autowired
-    final void setAccountDao(AccountDao accountDao) {
-        this.accountDao = accountDao;
+    final void setAccountService(AccountService accountService) {
+        this.accountService = accountService;
     }
     
     public void verifyExternalIdentifier(ExternalIdentifier externalId) throws Exception {
@@ -53,7 +52,7 @@ public class FPHSService {
         
         fphsDao.registerExternalId(externalId);
 
-        accountDao.editAccount(studyId, healthCode, account -> {
+        accountService.editAccount(studyId, healthCode, account -> {
             AccountSubstudy acctSubstudy = AccountSubstudy.create(studyId.getIdentifier(), "harvard", account.getId());
             acctSubstudy.setExternalId(externalId.getIdentifier());
             account.getDataGroups().add("football_player");

--- a/src/main/java/org/sagebionetworks/bridge/services/IntentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/IntentService.java
@@ -8,7 +8,6 @@ import java.util.Map;
 
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.cache.CacheKey;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.models.OperatingSystem;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
@@ -50,7 +49,7 @@ public class IntentService {
     
     private CacheProvider cacheProvider;
 
-    private AccountDao accountDao;
+    private AccountService accountService;
     
     private ParticipantService participantService;
     
@@ -88,8 +87,8 @@ public class IntentService {
     }
 
     @Autowired
-    final void setAccountDao(AccountDao accountDao) {
-        this.accountDao = accountDao;
+    final void setAccountService(AccountService accountService) {
+        this.accountService = accountService;
     }
     
     @Autowired
@@ -112,7 +111,7 @@ public class IntentService {
         } else {
             accountId = AccountId.forEmail(intent.getStudyId(), intent.getEmail());
         }
-        Account account = accountDao.getAccount(accountId);
+        Account account = accountService.getAccount(accountId);
         if (account != null) {
             return;
         }

--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -43,7 +43,6 @@ import org.sagebionetworks.bridge.BridgeUtils.SubstudyAssociations;
 import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.cache.CacheProvider;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.ScheduledActivityDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
@@ -97,7 +96,7 @@ import org.sagebionetworks.bridge.validators.Validate;
 public class ParticipantService {
     private static final Logger LOG = LoggerFactory.getLogger(ParticipantService.class);
 
-    private AccountDao accountDao;
+    private AccountService accountService;
 
     private SmsService smsService;
 
@@ -131,8 +130,8 @@ public class ParticipantService {
     }
     
     @Autowired
-    final void setAccountDao(AccountDao accountDao) {
-        this.accountDao = accountDao;
+    final void setAccountService(AccountService accountService) {
+        this.accountService = accountService;
     }
 
     /** SMS Service, used to send text messages to participants. */
@@ -359,7 +358,7 @@ public class ParticipantService {
         
         Validate.entityThrowingException(new AccountSummarySearchValidator(study.getDataGroups()), search);
         
-        return accountDao.getPagedAccountSummaries(study, search);
+        return accountService.getPagedAccountSummaries(study, search);
     }
 
     /**
@@ -392,7 +391,7 @@ public class ParticipantService {
         Account account = getAccountThrowingException(accountId);
 
         if (deleteReauthToken) {
-            accountDao.deleteReauthToken(accountId);
+            accountService.deleteReauthToken(accountId);
         }
         
         cacheProvider.removeSessionByUserId(account.getId());
@@ -467,7 +466,7 @@ public class ParticipantService {
         // within an account transaction, and roll back the account if the external ID save fails. If the 
         // account save fails, catch the exception and rollback the external ID save. 
         try {
-            accountDao.createAccount(study, account,
+            accountService.createAccount(study, account,
                     (modifiedAccount) -> externalIdService.commitAssignExternalId(externalId));
         } catch(Exception e) {
             if (externalId != null) {
@@ -541,7 +540,7 @@ public class ParticipantService {
         
         // Simple case, not trying to assign an external ID
         if (externalId == null) {
-            accountDao.updateAccount(account, null);
+            accountService.updateAccount(account, null);
             return;
         }
         
@@ -550,7 +549,7 @@ public class ParticipantService {
         // the account if the external ID save fails. If the account save fails, catch the exception and 
         // rollback the external ID save. 
         try {
-            accountDao.updateAccount(account,
+            accountService.updateAccount(account,
                     (modifiedAccount) -> externalIdService.commitAssignExternalId(externalId));
         } catch (Exception e) {
             externalIdService.unassignExternalId(account, externalId.getIdentifier());
@@ -859,9 +858,9 @@ public class ParticipantService {
         Account account;
         // These throw exceptions for not found, disabled, and not yet verified.
         if (update.getSignIn().getReauthToken() != null) {
-            account = accountDao.reauthenticate(study, update.getSignIn());
+            account = accountService.reauthenticate(study, update.getSignIn());
         } else {
-            account = accountDao.authenticate(study, update.getSignIn());
+            account = accountService.authenticate(study, update.getSignIn());
         }
         // Verify the account matches the current caller
         if (!account.getId().equals(context.getUserId())) {
@@ -897,7 +896,7 @@ public class ParticipantService {
             acctSubstudy.setExternalId(externalId.getIdentifier());
             account.getAccountSubstudies().add(acctSubstudy);
             try {
-                accountDao.updateAccount(account,
+                accountService.updateAccount(account,
                         (modifiedAccount) -> externalIdService.commitAssignExternalId(externalId));
             } catch(Exception e) {
                 externalIdService.unassignExternalId(account, externalId.getIdentifier());    
@@ -905,7 +904,7 @@ public class ParticipantService {
             }
             updateRequestContext(externalId);
         } else if (accountUpdated) {
-            accountDao.updateAccount(account, null);
+            accountService.updateAccount(account, null);
         }
         if (sendEmailVerification && 
             study.isEmailVerificationEnabled() && 
@@ -1016,7 +1015,7 @@ public class ParticipantService {
     }
     
     private Account getAccountThrowingExceptionIfSubstudyMatches(AccountId accountId) {
-        Account account = accountDao.getAccount(accountId);
+        Account account = accountService.getAccount(accountId);
         if (account != null) {
             Set<String> callerSubstudies = BridgeUtils.getRequestContext().getCallerSubstudies();
             boolean anyMatch = account.getAccountSubstudies().stream()
@@ -1033,7 +1032,7 @@ public class ParticipantService {
     }
     
     private Account getAccountThrowingException(AccountId accountId) {
-        Account account = BridgeUtils.filterForSubstudy(accountDao.getAccount(accountId));
+        Account account = BridgeUtils.filterForSubstudy(accountService.getAccount(accountId));
         if (account == null) {
             throw new EntityNotFoundException(Account.class);
         }

--- a/src/main/java/org/sagebionetworks/bridge/services/UserAdminService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/UserAdminService.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.cache.CacheProvider;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.time.DateUtils;
 import org.sagebionetworks.bridge.models.CriteriaContext;
@@ -35,7 +34,7 @@ public class UserAdminService {
     private AuthenticationService authenticationService;
     private NotificationsService notificationsService;
     private ParticipantService participantService;
-    private AccountDao accountDao;
+    private AccountService accountService;
     private ConsentService consentService;
     private HealthDataService healthDataService;
     private ScheduledActivityService scheduledActivityService;
@@ -61,8 +60,8 @@ public class UserAdminService {
         this.participantService = participantService;
     }
     @Autowired
-    final void setAccountDao(AccountDao accountDao) {
-        this.accountDao = accountDao;
+    final void setAccountService(AccountService accountService) {
+        this.accountService = accountService;
     }
     @Autowired
     final void setConsentService(ConsentService consentService) {
@@ -193,7 +192,7 @@ public class UserAdminService {
         checkArgument(StringUtils.isNotBlank(id));
         
         AccountId accountId = AccountId.forId(study.getIdentifier(), id);
-        Account account = accountDao.getAccount(accountId);
+        Account account = accountService.getAccount(accountId);
         if (account != null) {
             // remove this first so if account is partially deleted, re-authenticating will pick
             // up accurate information about the state of the account (as we can recover it)
@@ -211,7 +210,7 @@ public class UserAdminService {
             }
             // AccountSecret records and AccountsSubstudies records are are deleted on a 
             // cascading delete from Account
-            accountDao.deleteAccount(accountId);
+            accountService.deleteAccount(accountId);
         }
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationController.java
@@ -321,7 +321,7 @@ public class AuthenticationController extends BaseController {
             throw new BadRequestException("Account has not been assigned a Synapse user ID");
         }
         AccountId accountId = AccountId.forSynapseUserId(targetStudyId, participant.getSynapseUserId());
-        Account account = accountDao.getAccount(accountId);
+        Account account = accountService.getAccount(accountId);
         if (account == null) {
             throw new UnauthorizedException(STUDY_ACCESS_EXCEPTION_MSG);
         }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/BaseController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/BaseController.java
@@ -30,7 +30,6 @@ import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.config.Environment;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.exceptions.NotAuthenticatedException;
@@ -45,6 +44,7 @@ import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
+import org.sagebionetworks.bridge.services.AccountService;
 import org.sagebionetworks.bridge.services.AuthenticationService;
 import org.sagebionetworks.bridge.services.RequestInfoService;
 import org.sagebionetworks.bridge.services.SessionUpdateService;
@@ -59,7 +59,7 @@ public abstract class BaseController {
     
     BridgeConfig bridgeConfig;
 
-    AccountDao accountDao;
+    AccountService accountService;
 
     StudyService studyService;
 
@@ -85,8 +85,8 @@ public abstract class BaseController {
     }
     
     @Autowired
-    final void setAccountDao(AccountDao accountDao) {
-        this.accountDao = accountDao;
+    final void setAccountService(AccountService accountService) {
+        this.accountService = accountService;
     }
 
     @Autowired
@@ -267,7 +267,7 @@ public abstract class BaseController {
         RequestContext reqContext = BridgeUtils.getRequestContext();
         List<String> languages = reqContext.getCallerLanguages();
         if (!languages.isEmpty()) {
-            accountDao.editAccount(session.getStudyIdentifier(), session.getHealthCode(),
+            accountService.editAccount(session.getStudyIdentifier(), session.getHealthCode(),
                     account -> account.setLanguages(languages));
 
             CriteriaContext newContext = new CriteriaContext.Builder()

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ConsentController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ConsentController.java
@@ -170,7 +170,7 @@ public class ConsentController extends BaseController {
     private JsonNode changeSharingScope(SharingScope sharingScope, String message) {
         UserSession session = getAuthenticatedAndConsentedSession();
         
-        accountDao.editAccount(session.getStudyIdentifier(), session.getHealthCode(),
+        accountService.editAccount(session.getStudyIdentifier(), session.getHealthCode(),
                 account -> account.setSharingScope(sharingScope));
 
         sessionUpdateService.updateSharingScope(session, sharingScope);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/EmailController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/EmailController.java
@@ -58,11 +58,11 @@ public class EmailController extends BaseController {
             
             // This should always return a healthCode under normal circumstances.
             AccountId accountId = AccountId.forEmail(study.getIdentifier(), email);
-            String healthCode = accountDao.getHealthCodeForAccount(accountId);
+            String healthCode = accountService.getHealthCodeForAccount(accountId);
             if (healthCode == null) {
                 throw new BadRequestException("Email not found.");
             }
-            accountDao.editAccount(study.getStudyIdentifier(), healthCode, account -> account.setNotifyByEmail(false));
+            accountService.editAccount(study.getStudyIdentifier(), healthCode, account -> account.setNotifyByEmail(false));
             
             return "You have been unsubscribed from future email.";
         } catch(Throwable throwable) {

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportController.java
@@ -148,7 +148,7 @@ public class ParticipantReportController extends BaseController {
         LocalDate startDate = getLocalDateOrDefault(startDateString, null);
         LocalDate endDate = getLocalDateOrDefault(endDateString, null);
 
-        Account account = accountDao.getAccount(AccountId.forId(studyId.getIdentifier(), userId));
+        Account account = accountService.getAccount(AccountId.forId(studyId.getIdentifier(), userId));
 
         return reportService.getParticipantReport(studyId, reportId, account.getHealthCode(), startDate, endDate);
     }
@@ -182,7 +182,7 @@ public class ParticipantReportController extends BaseController {
         DateTime endTime = getDateTimeOrDefault(endTimeString, null);
         int pageSize = getIntOrDefault(pageSizeString, API_DEFAULT_PAGE_SIZE);
 
-        Account account = accountDao.getAccount(AccountId.forId(studyId.getIdentifier(), userId));
+        Account account = accountService.getAccount(AccountId.forId(studyId.getIdentifier(), userId));
 
         return reportService.getParticipantReportV4(studyId, reportId, account.getHealthCode(), startTime, endTime,
                 offsetKey, pageSize);
@@ -198,7 +198,7 @@ public class ParticipantReportController extends BaseController {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
         
-        Account account = accountDao.getAccount(AccountId.forId(study.getIdentifier(), userId));
+        Account account = accountService.getAccount(AccountId.forId(study.getIdentifier(), userId));
         
         ReportData reportData = parseJson(ReportData.class);
         reportData.setKey(null); // set in service, but just so no future use depends on it
@@ -244,7 +244,7 @@ public class ParticipantReportController extends BaseController {
         UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
         
-        Account account = accountDao.getAccount(AccountId.forId(study.getIdentifier(), userId));
+        Account account = accountService.getAccount(AccountId.forId(study.getIdentifier(), userId));
         
         reportService.deleteParticipantReport(session.getStudyIdentifier(), identifier, account.getHealthCode());
         
@@ -260,7 +260,7 @@ public class ParticipantReportController extends BaseController {
         UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
         Study study = studyService.getStudy(session.getStudyIdentifier());
         
-        Account account = accountDao.getAccount(AccountId.forId(study.getIdentifier(), userId));
+        Account account = accountService.getAccount(AccountId.forId(study.getIdentifier(), userId));
         
         reportService.deleteParticipantReportRecord(session.getStudyIdentifier(), identifier, date, account.getHealthCode());
         

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ScheduledActivityController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ScheduledActivityController.java
@@ -262,7 +262,7 @@ public class ScheduledActivityController extends BaseController {
     }
 
     DateTimeZone persistTimeZone(UserSession session, DateTimeZone timeZone) {
-        accountDao.editAccount(session.getStudyIdentifier(), session.getHealthCode(),
+        accountService.editAccount(session.getStudyIdentifier(), session.getHealthCode(),
                 account -> account.setTimeZone(timeZone));
         sessionUpdateService.updateTimeZone(session, timeZone);
         return timeZone;

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyController.java
@@ -171,7 +171,7 @@ public class StudyController extends BaseController {
         if (session.getParticipant().getRoles().isEmpty()) {
             throw new UnauthorizedException(STUDY_ACCESS_EXCEPTION_MSG);
         }
-        List<String> studyIds = accountDao.getStudyIdsForUser(session.getParticipant().getSynapseUserId());
+        List<String> studyIds = accountService.getStudyIdsForUser(session.getParticipant().getSynapseUserId());
         
         Stream<Study> stream = null;
         // In our current study permissions model, an admin in the API study is a 

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/UserProfileController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/UserProfileController.java
@@ -133,7 +133,7 @@ public class UserProfileController extends BaseController {
         
         AccountId accountId = AccountId.forHealthCode(session.getStudyIdentifier().getIdentifier(),
                 session.getHealthCode());
-        Account account = accountDao.getAccount(accountId);
+        Account account = accountService.getAccount(accountId);
         if (account == null) {
             throw new EntityNotFoundException(Account.class);
         }

--- a/src/main/java/org/sagebionetworks/bridge/upload/TranscribeConsentHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/upload/TranscribeConsentHandler.java
@@ -16,22 +16,22 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import org.sagebionetworks.bridge.BridgeConstants;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.SharingScope;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
+import org.sagebionetworks.bridge.services.AccountService;
 import org.sagebionetworks.bridge.services.ParticipantService;
 import org.sagebionetworks.bridge.time.DateUtils;
 
 @Component
 public class TranscribeConsentHandler implements UploadValidationHandler {
-    private AccountDao accountDao;
+    private AccountService accountService;
     private ParticipantService participantService;
 
     @Autowired
-    public final void setAccountDao(AccountDao accountDao) {
-        this.accountDao = accountDao;
+    public final void setAccountService(AccountService accountService) {
+        this.accountService = accountService;
     }
 
     @Autowired
@@ -44,7 +44,7 @@ public class TranscribeConsentHandler implements UploadValidationHandler {
         HealthDataRecord record = context.getHealthDataRecord();
 
         AccountId accountId = AccountId.forHealthCode(context.getStudy().getIdentifier(), context.getHealthCode());
-        Account account = accountDao.getAccount(accountId);
+        Account account = accountService.getAccount(accountId);
         if (account != null) {
             
             Set<String> externalIds = collectExternalIds(account);

--- a/src/test/java/org/sagebionetworks/bridge/TestUtils.java
+++ b/src/test/java/org/sagebionetworks/bridge/TestUtils.java
@@ -53,7 +53,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoCriteria;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -85,6 +84,7 @@ import org.sagebionetworks.bridge.models.Criteria;
 import org.sagebionetworks.bridge.models.OperatingSystem;
 import org.sagebionetworks.bridge.models.studies.PasswordPolicy;
 import org.sagebionetworks.bridge.models.upload.UploadValidationStrictness;
+import org.sagebionetworks.bridge.services.AccountService;
 import org.sagebionetworks.bridge.models.schedules.ScheduleType;
 import org.sagebionetworks.bridge.models.schedules.ScheduledActivity;
 import org.sagebionetworks.bridge.time.DateUtils;
@@ -251,20 +251,20 @@ public class TestUtils {
     /**
      * Mocks this DAO method behavior so that you can verify that AccountDao.editAccount() was called, and
      * that your mock account was correctly edited.
-     * @param mockAccountDao
-     *      A mocked version of the AccountDao interface
+     * @param mockAccountService
+     *      A mocked version of the AccountService interface
      * @param mockAccount
      *      A mocked version of the Account interface
      */
     @SuppressWarnings("unchecked")
-    public static void mockEditAccount(AccountDao mockAccountDao, Account mockAccount) {
-        Mockito.mockingDetails(mockAccountDao).isMock();
+    public static void mockEditAccount(AccountService mockAccountService, Account mockAccount) {
+        Mockito.mockingDetails(mockAccountService).isMock();
         Mockito.mockingDetails(mockAccount).isMock();
         doAnswer(invocation -> {
             Consumer<Account> accountEdits = (Consumer<Account>)invocation.getArgument(2);
             accountEdits.accept(mockAccount);
             return null;
-        }).when(mockAccountDao).editAccount(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any());
+        }).when(mockAccountService).editAccount(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any());
     }
 
     public static void assertDatesWithTimeZoneEqual(DateTime date1, DateTime date2) {

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
@@ -1,0 +1,79 @@
+package org.sagebionetworks.bridge.services;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.dao.AccountDao;
+
+public class AccountServiceTest extends Mockito {
+
+    @Mock
+    AccountDao accountDao;
+    
+    AccountService service;
+    
+    @BeforeMethod
+    public void beforeMethod() {
+        MockitoAnnotations.initMocks(this);
+    }
+    
+    @Test
+    public void getStudyIdsForUser() { 
+        
+    }
+    
+    @Test
+    public void verifyChannel() {
+        
+    }
+    
+    @Test
+    public void changePassword() {
+        
+    }
+    
+    @Test
+    public void authenticate() {
+        
+    }
+
+    @Test
+    public void reauthenticate() {
+        
+    }
+    
+    @Test
+    public void deleteReauthToken() {
+    }
+    
+    @Test
+    public void createAccount() {
+    }
+    
+    @Test
+    public void updateAccount() {
+    }
+    
+    @Test
+    public void editAccount() {
+    }
+    
+    @Test
+    public void getAccount() {
+    }
+    
+    @Test
+    public void deleteAccount() {
+    }
+
+    @Test
+    public void getPagedAccountSummaries() {
+    }
+
+    @Test
+    public void getHealthCodeForAccount() {
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
@@ -7,6 +7,7 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 import static org.sagebionetworks.bridge.TestConstants.USER_ID;
 import static org.sagebionetworks.bridge.models.AccountSummarySearch.EMPTY_SEARCH;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -162,6 +163,15 @@ public class AccountServiceTest extends Mockito {
         
         String healthCode = service.getHealthCodeForAccount(ACCOUNT_ID);
         assertEquals(healthCode, HEALTH_CODE);
+        verify(mockAccountDao).getAccount(ACCOUNT_ID);
+    }
+    
+    @Test
+    public void getHealthCodeForAccountNoAccount() {
+        when(mockAccountDao.getAccount(ACCOUNT_ID)).thenReturn(null);
+        
+        String healthCode = service.getHealthCodeForAccount(ACCOUNT_ID);
+        assertNull(healthCode);
         verify(mockAccountDao).getAccount(ACCOUNT_ID);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
@@ -1,5 +1,19 @@
 package org.sagebionetworks.bridge.services;
 
+import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
+import static org.sagebionetworks.bridge.TestConstants.SYNAPSE_USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
+import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.models.AccountSummarySearch.EMPTY_SEARCH;
+import static org.testng.Assert.assertEquals;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import com.google.common.collect.ImmutableList;
+
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -7,12 +21,26 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.dao.AccountDao;
+import org.sagebionetworks.bridge.models.PagedResourceList;
+import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
+import org.sagebionetworks.bridge.models.accounts.AccountSummary;
+import org.sagebionetworks.bridge.models.accounts.SignIn;
+import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.services.AuthenticationService.ChannelType;
 
 public class AccountServiceTest extends Mockito {
 
-    @Mock
-    AccountDao accountDao;
+    private static final AccountId ACCOUNT_ID = AccountId.forId(TEST_STUDY_IDENTIFIER, USER_ID);
     
+    @Mock
+    AccountDao mockAccountDao;
+    
+    @Mock
+    PagedResourceList<AccountSummary> mockAccountSummaries;
+
+    
+    @InjectMocks
     AccountService service;
     
     @BeforeMethod
@@ -22,58 +50,118 @@ public class AccountServiceTest extends Mockito {
     
     @Test
     public void getStudyIdsForUser() { 
+        List<String> studies = ImmutableList.of("study1", "study2");
+        when(mockAccountDao.getStudyIdsForUser(SYNAPSE_USER_ID)).thenReturn(studies);
         
+        List<String> returnVal = service.getStudyIdsForUser(SYNAPSE_USER_ID);
+        assertEquals(returnVal, studies);
+        verify(mockAccountDao).getStudyIdsForUser(SYNAPSE_USER_ID);
     }
     
     @Test
     public void verifyChannel() {
+        Account account = Account.create();
         
+        service.verifyChannel(ChannelType.EMAIL, account);
+        verify(mockAccountDao).verifyChannel(ChannelType.EMAIL, account);
     }
     
     @Test
     public void changePassword() {
+        Account account = Account.create();
         
+        service.changePassword(account, ChannelType.PHONE, "asdf");
+        verify(mockAccountDao).changePassword(account, ChannelType.PHONE, "asdf");
     }
     
     @Test
     public void authenticate() {
+        Study study = Study.create();
+        SignIn signIn = new SignIn.Builder().build();
+        Account account = Account.create();
+        when(mockAccountDao.authenticate(study, signIn)).thenReturn(account);
         
+        Account returnVal = service.authenticate(study, signIn);
+        assertEquals(returnVal, account);
+        verify(mockAccountDao).authenticate(study, signIn);
     }
 
     @Test
     public void reauthenticate() {
+        Study study = Study.create();
+        SignIn signIn = new SignIn.Builder().build();
+        Account account = Account.create();
+        when(mockAccountDao.reauthenticate(study, signIn)).thenReturn(account);
         
+        Account returnVal = service.reauthenticate(study, signIn);
+        assertEquals(returnVal, account);
+        verify(mockAccountDao).reauthenticate(study, signIn);
     }
     
     @Test
     public void deleteReauthToken() {
+        service.deleteReauthToken(ACCOUNT_ID);
+        verify(mockAccountDao).deleteReauthToken(ACCOUNT_ID);
     }
     
     @Test
     public void createAccount() {
+        Study study = Study.create();
+        Account account = Account.create();
+        Consumer<Account> consumer = (oneAccount) -> {};
+        service.createAccount(study, account, consumer);
+        verify(mockAccountDao).createAccount(study, account, consumer);
     }
     
     @Test
     public void updateAccount() {
+        Account account = Account.create();
+        Consumer<Account> consumer = (oneAccount) -> {};
+        service.updateAccount(account, consumer);
+        verify(mockAccountDao).updateAccount(account, consumer);
     }
     
     @Test
     public void editAccount() {
+        Consumer<Account> consumer = (oneAccount) -> {};
+        service.editAccount(TEST_STUDY, HEALTH_CODE, consumer);
+        verify(mockAccountDao).editAccount(TEST_STUDY, HEALTH_CODE, consumer);
     }
     
     @Test
     public void getAccount() {
+        Account account = Account.create();
+        when(mockAccountDao.getAccount(ACCOUNT_ID)).thenReturn(account);
+        
+        Account returnVal = service.getAccount(ACCOUNT_ID);
+        assertEquals(returnVal, account);
+        verify(mockAccountDao).getAccount(ACCOUNT_ID);
     }
     
     @Test
     public void deleteAccount() {
+        service.deleteAccount(ACCOUNT_ID);
+        verify(mockAccountDao).deleteAccount(ACCOUNT_ID);
     }
 
     @Test
     public void getPagedAccountSummaries() {
+        Study study = Study.create();
+        when(mockAccountDao.getPagedAccountSummaries(study, EMPTY_SEARCH)).thenReturn(mockAccountSummaries);
+        
+        PagedResourceList<AccountSummary> returnVal = service.getPagedAccountSummaries(study, EMPTY_SEARCH);
+        assertEquals(returnVal, mockAccountSummaries);
+        verify(mockAccountDao).getPagedAccountSummaries(study, EMPTY_SEARCH);   
     }
 
     @Test
     public void getHealthCodeForAccount() {
+        Account account = Account.create();
+        account.setHealthCode(HEALTH_CODE);
+        when(mockAccountDao.getAccount(ACCOUNT_ID)).thenReturn(account);
+        
+        String healthCode = service.getHealthCodeForAccount(ACCOUNT_ID);
+        assertEquals(healthCode, HEALTH_CODE);
+        verify(mockAccountDao).getAccount(ACCOUNT_ID);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
@@ -50,7 +50,6 @@ import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.cache.CacheKey;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.BridgeConfig;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
@@ -129,7 +128,7 @@ public class AccountWorkflowServiceTest extends Mockito {
     private SendMailService mockSendMailService;
 
     @Mock
-    private AccountDao mockAccountDao;
+    private AccountService mockAccountService;
     
     @Mock
     private CacheProvider mockCacheProvider;
@@ -337,7 +336,7 @@ public class AccountWorkflowServiceTest extends Mockito {
     public void resendEmailVerificationToken() {
         when(service.getNextToken()).thenReturn(TOKEN);
         when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
-        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(mockAccount);
         when(mockAccount.getId()).thenReturn(USER_ID);
         when(mockAccount.getEmail()).thenReturn(EMAIL);
         
@@ -350,7 +349,7 @@ public class AccountWorkflowServiceTest extends Mockito {
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void resendEmailVerificationTokenUnsupportedType() {
         when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
-        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(mockAccount);
         
         // Use null so we don't have to create an unsupported channel type
         service.resendVerificationToken(null, ACCOUNT_ID_WITH_EMAIL);
@@ -372,7 +371,7 @@ public class AccountWorkflowServiceTest extends Mockito {
     
     @Test
     public void resendEmailVerificationTokenFailsQuietlyWithMissingAccount() {
-        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(null);
+        when(mockAccountService.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(null);
         
         service.resendVerificationToken(ChannelType.EMAIL, ACCOUNT_ID_WITH_EMAIL);
         
@@ -384,7 +383,7 @@ public class AccountWorkflowServiceTest extends Mockito {
     public void resendPhoneVerificationToken() {
         when(service.getNextPhoneToken()).thenReturn(PHONE_TOKEN);
         when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
-        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
         when(mockAccount.getId()).thenReturn(USER_ID);
         when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
         
@@ -412,7 +411,7 @@ public class AccountWorkflowServiceTest extends Mockito {
     
     @Test
     public void resendPhoneVerificationTokenFailsQuietlyWithMissingAccount() {
-        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(null);
+        when(mockAccountService.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(null);
         
         service.resendVerificationToken(ChannelType.EMAIL, ACCOUNT_ID_WITH_PHONE);
         
@@ -427,7 +426,7 @@ public class AccountWorkflowServiceTest extends Mockito {
             createJson("{'studyId':'api','type':'email','userId':'userId','expiresOn':"+
                     TIMESTAMP.getMillis()+"}"));
         when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
-        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_ID)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(ACCOUNT_ID_WITH_ID)).thenReturn(mockAccount);
         when(mockAccount.getId()).thenReturn("accountId");
         
         Verification verification = new Verification(SPTOKEN);
@@ -483,7 +482,7 @@ public class AccountWorkflowServiceTest extends Mockito {
             createJson("{'studyId':'api','type':'email','userId':'userId','expiresOn':"+
                     TIMESTAMP.getMillis()+"}"));
         when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
-        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_ID)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(ACCOUNT_ID_WITH_ID)).thenReturn(mockAccount);
         
         Verification verification = new Verification(SPTOKEN);
         service.verifyChannel(ChannelType.EMAIL, verification);
@@ -497,7 +496,7 @@ public class AccountWorkflowServiceTest extends Mockito {
             createJson("{'studyId':'api','type':'email','userId':'userId','expiresOn':"+
                     TIMESTAMP.getMillis()+"}"));
         when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
-        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_ID)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(ACCOUNT_ID_WITH_ID)).thenReturn(mockAccount);
         when(mockAccount.getId()).thenReturn("accountId");
         when(mockAccount.getEmailVerified()).thenReturn(TRUE);
         
@@ -521,7 +520,7 @@ public class AccountWorkflowServiceTest extends Mockito {
                 TestUtils.createJson("{'studyId':'api','type':'phone','userId':'userId','expiresOn':"+
                         TIMESTAMP.getMillis()+"}"));
         when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
-        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_ID)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(ACCOUNT_ID_WITH_ID)).thenReturn(mockAccount);
         when(mockAccount.getId()).thenReturn("accountId");
         
         Verification verification = new Verification(SPTOKEN);
@@ -539,7 +538,7 @@ public class AccountWorkflowServiceTest extends Mockito {
                 TestUtils.createJson("{'studyId':'api','type':'phone','userId':'userId','expiresOn':"+
                         TIMESTAMP.getMillis()+"}"));
         when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
-        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_ID)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(ACCOUNT_ID_WITH_ID)).thenReturn(mockAccount);
         when(mockAccount.getId()).thenReturn("accountId");
         when(mockAccount.getPhoneVerified()).thenReturn(TRUE);
         
@@ -555,7 +554,7 @@ public class AccountWorkflowServiceTest extends Mockito {
                 TestUtils.createJson("{'studyId':'api','type':'phone','userId':'userId','expiresOn':"+
                         TIMESTAMP.getMillis()+"}"));
         when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
-        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_ID)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(ACCOUNT_ID_WITH_ID)).thenReturn(mockAccount);
         
         Verification verification = new Verification(SPTOKEN);
         service.verifyChannel(ChannelType.PHONE, verification);
@@ -596,8 +595,8 @@ public class AccountWorkflowServiceTest extends Mockito {
         when(service.getNextToken()).thenReturn(SPTOKEN, TOKEN);
         when(mockAccount.getEmail()).thenReturn(EMAIL);
         when(mockAccount.getEmailVerified()).thenReturn(Boolean.TRUE);
-        when(mockAccountDao.getAccount(accountId)).thenReturn(mockAccount);
-        when(mockAccountDao.getAccount(AccountId.forEmail(TEST_STUDY_IDENTIFIER, EMAIL))).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(accountId)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(AccountId.forEmail(TEST_STUDY_IDENTIFIER, EMAIL))).thenReturn(mockAccount);
         
         service.notifyAccountExists(study, accountId);
         
@@ -647,7 +646,7 @@ public class AccountWorkflowServiceTest extends Mockito {
         when(service.getNextToken()).thenReturn(SPTOKEN);
         when(mockAccount.getEmail()).thenReturn(EMAIL);
         when(mockAccount.getEmailVerified()).thenReturn(Boolean.TRUE);
-        when(mockAccountDao.getAccount(accountId)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(accountId)).thenReturn(mockAccount);
         
         service.notifyAccountExists(study, accountId);
         
@@ -689,7 +688,7 @@ public class AccountWorkflowServiceTest extends Mockito {
         when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
         when(mockAccount.getEmail()).thenReturn(EMAIL);
         when(mockAccount.getEmailVerified()).thenReturn(Boolean.TRUE);
-        when(mockAccountDao.getAccount(any())).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(any())).thenReturn(mockAccount);
 
         // Note that password reset token (sptoken) is never cached, so we generate it 3 times. The email sign-in token
         // (token), is cached, so we only generate it the first time around.
@@ -732,7 +731,7 @@ public class AccountWorkflowServiceTest extends Mockito {
         when(service.getNextToken()).thenReturn(SPTOKEN);
         when(mockAccount.getEmail()).thenReturn(EMAIL);
         when(mockAccount.getEmailVerified()).thenReturn(Boolean.TRUE);
-        when(mockAccountDao.getAccount(accountId)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(accountId)).thenReturn(mockAccount);
         
         service.notifyAccountExists(study, accountId);
         
@@ -759,7 +758,7 @@ public class AccountWorkflowServiceTest extends Mockito {
         when(service.getNextPhoneToken()).thenReturn(PHONE_TOKEN);
         when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
         when(mockAccount.getPhoneVerified()).thenReturn(Boolean.TRUE);
-        when(mockAccountDao.getAccount(accountId)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(accountId)).thenReturn(mockAccount);
         
         service.notifyAccountExists(study, accountId);
         
@@ -782,7 +781,7 @@ public class AccountWorkflowServiceTest extends Mockito {
         when(service.getNextToken()).thenReturn(SPTOKEN);
         when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
         when(mockAccount.getPhoneVerified()).thenReturn(Boolean.TRUE);
-        when(mockAccountDao.getAccount(accountId)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(accountId)).thenReturn(mockAccount);
         
         service.notifyAccountExists(study, accountId);
         
@@ -807,7 +806,7 @@ public class AccountWorkflowServiceTest extends Mockito {
         AccountId accountId = AccountId.forPhone(TEST_STUDY_IDENTIFIER, TestConstants.PHONE);
         when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
         when(mockAccount.getPhoneVerified()).thenReturn(Boolean.TRUE);
-        when(mockAccountDao.getAccount(accountId)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(accountId)).thenReturn(mockAccount);
         
         service.notifyAccountExists(study, accountId);
         
@@ -825,7 +824,7 @@ public class AccountWorkflowServiceTest extends Mockito {
         AccountId accountId = AccountId.forId(TEST_STUDY_IDENTIFIER, USER_ID);
         when(mockAccount.getEmail()).thenReturn(EMAIL);
         when(mockAccount.getEmailVerified()).thenReturn(Boolean.TRUE);
-        when(mockAccountDao.getAccount(accountId)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(accountId)).thenReturn(mockAccount);
         
         service.notifyAccountExists(study, accountId);
         
@@ -844,7 +843,7 @@ public class AccountWorkflowServiceTest extends Mockito {
         AccountId accountId = AccountId.forId(TEST_STUDY_IDENTIFIER, USER_ID);
         when(mockAccount.getEmail()).thenReturn(EMAIL);
         when(mockAccount.getEmailVerified()).thenReturn(Boolean.TRUE);
-        when(mockAccountDao.getAccount(accountId)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(accountId)).thenReturn(mockAccount);
         
         service.notifyAccountExists(study, accountId);
         
@@ -865,7 +864,7 @@ public class AccountWorkflowServiceTest extends Mockito {
         when(mockAccount.getEmailVerified()).thenReturn(Boolean.FALSE);
         when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
         when(mockAccount.getPhoneVerified()).thenReturn(Boolean.FALSE);
-        when(mockAccountDao.getAccount(accountId)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(accountId)).thenReturn(mockAccount);
 
         // Execute.
         service.notifyAccountExists(study, accountId);
@@ -888,7 +887,7 @@ public class AccountWorkflowServiceTest extends Mockito {
         when(mockAccount.getEmailVerified()).thenReturn(null);
         when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
         when(mockAccount.getPhoneVerified()).thenReturn(null);
-        when(mockAccountDao.getAccount(accountId)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(accountId)).thenReturn(mockAccount);
 
         // Execute.
         service.notifyAccountExists(study, accountId);
@@ -901,7 +900,7 @@ public class AccountWorkflowServiceTest extends Mockito {
     @Test
     public void requestResetPasswordWithEmail() throws Exception {
         when(service.getNextToken()).thenReturn(SPTOKEN);
-        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(mockAccount);
         when(mockAccount.getEmail()).thenReturn(EMAIL);
         when(mockAccount.getEmailVerified()).thenReturn(Boolean.TRUE);        
         
@@ -930,7 +929,7 @@ public class AccountWorkflowServiceTest extends Mockito {
     @Test
     public void requestResetPasswordWithPhone() throws Exception {
         when(service.getNextToken()).thenReturn(SPTOKEN);
-        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
         when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
         when(mockAccount.getPhoneVerified()).thenReturn(Boolean.TRUE);        
         
@@ -953,7 +952,7 @@ public class AccountWorkflowServiceTest extends Mockito {
 
     @Test
     public void requestResetPasswordFailsQuietlyIfEmailPhoneUnverifiedUsingEmail() {
-        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
         when(mockAccount.getEmail()).thenReturn(EMAIL);
         when(mockAccount.getPhoneVerified()).thenReturn(Boolean.FALSE);
         when(mockAccount.getEmailVerified()).thenReturn(Boolean.FALSE);
@@ -967,7 +966,7 @@ public class AccountWorkflowServiceTest extends Mockito {
 
     @Test
     public void requestResetPasswordFailsQuietlyIfEmailPhoneUnverifiedUsingPhone() {
-        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
         when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
         when(mockAccount.getPhoneVerified()).thenReturn(Boolean.FALSE);
         when(mockAccount.getEmailVerified()).thenReturn(Boolean.FALSE);
@@ -981,7 +980,7 @@ public class AccountWorkflowServiceTest extends Mockito {
     
     @Test
     public void requestResetPasswordInvalidEmailFailsQuietly() {
-        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(null);
+        when(mockAccountService.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(null);
         
         service.requestResetPassword(study, false, ACCOUNT_ID_WITH_EMAIL);
         
@@ -993,7 +992,7 @@ public class AccountWorkflowServiceTest extends Mockito {
     @Test
     public void requestRestPasswordUnverifiedEmailFailsQuietly() {
         when(mockAccount.getEmail()).thenReturn(EMAIL);
-        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(mockAccount);
         
         service.requestResetPassword(study, false, ACCOUNT_ID_WITH_EMAIL);
         
@@ -1005,7 +1004,7 @@ public class AccountWorkflowServiceTest extends Mockito {
     @Test
     public void requestRestPasswordUnverifiedPhoneFailsQuietly() {
         when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
-        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
         
         service.requestResetPassword(study, false, ACCOUNT_ID_WITH_PHONE);
         
@@ -1018,7 +1017,7 @@ public class AccountWorkflowServiceTest extends Mockito {
     public void requestResetPasswordByAdminDoesNotRequireEmailVerification() {
         when(service.getNextToken()).thenReturn(SPTOKEN);
         when(mockAccount.getEmail()).thenReturn(EMAIL);
-        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
         
         service.requestResetPassword(study, true, ACCOUNT_ID_WITH_PHONE);
         
@@ -1029,7 +1028,7 @@ public class AccountWorkflowServiceTest extends Mockito {
     @Test
     public void requestResetPasswordByAdminDoesNotRequirePhoneVerification() {
         when(service.getNextToken()).thenReturn(SPTOKEN);
-        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
         when(mockAccount.getPhone()).thenReturn(TestConstants.PHONE);
         
         service.requestResetPassword(study, true, ACCOUNT_ID_WITH_PHONE);
@@ -1040,7 +1039,7 @@ public class AccountWorkflowServiceTest extends Mockito {
     
     @Test
     public void requestResetPasswordQuietlyFailsForDisabledAccount() {
-        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
         when(mockAccount.getStatus()).thenReturn(AccountStatus.DISABLED);
         
         service.requestResetPassword(study, false, ACCOUNT_ID_WITH_PHONE);
@@ -1054,28 +1053,28 @@ public class AccountWorkflowServiceTest extends Mockito {
     public void resetPasswordWithEmail() {
         when(mockCacheProvider.getObject(PASSWORD_RESET_FOR_EMAIL, String.class)).thenReturn(EMAIL);
         when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
-        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(mockAccount);
 
         PasswordReset passwordReset = new PasswordReset("newPassword", SPTOKEN, TEST_STUDY_IDENTIFIER);
         service.resetPassword(passwordReset);
         
         verify(mockCacheProvider).getObject(PASSWORD_RESET_FOR_EMAIL, String.class);
         verify(mockCacheProvider).removeObject(PASSWORD_RESET_FOR_EMAIL);
-        verify(mockAccountDao).changePassword(mockAccount, ChannelType.EMAIL, "newPassword");
+        verify(mockAccountService).changePassword(mockAccount, ChannelType.EMAIL, "newPassword");
     }
     
     @Test
     public void resetPasswordWithPhone() {
         when(mockCacheProvider.getObject(PASSWORD_RESET_FOR_PHONE, Phone.class)).thenReturn(TestConstants.PHONE);
         when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
-        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(ACCOUNT_ID_WITH_PHONE)).thenReturn(mockAccount);
 
         PasswordReset passwordReset = new PasswordReset("newPassword", SPTOKEN, TEST_STUDY_IDENTIFIER);
         service.resetPassword(passwordReset);
         
         verify(mockCacheProvider).getObject(PASSWORD_RESET_FOR_PHONE, Phone.class);
         verify(mockCacheProvider).removeObject(PASSWORD_RESET_FOR_PHONE);
-        verify(mockAccountDao).changePassword(mockAccount, ChannelType.PHONE, "newPassword");
+        verify(mockAccountService).changePassword(mockAccount, ChannelType.PHONE, "newPassword");
     }
     
     @Test
@@ -1091,14 +1090,14 @@ public class AccountWorkflowServiceTest extends Mockito {
         }
         verify(mockCacheProvider).getObject(PASSWORD_RESET_FOR_EMAIL, String.class);
         verify(mockCacheProvider, never()).removeObject(any());
-        verify(mockAccountDao, never()).changePassword(any(), any(ChannelType.class), any());
+        verify(mockAccountService, never()).changePassword(any(), any(ChannelType.class), any());
     }
     
     @Test
     public void resetPasswordInvalidAccount() {
         when(mockCacheProvider.getObject(PASSWORD_RESET_FOR_EMAIL, String.class)).thenReturn(EMAIL);
         when(mockStudyService.getStudy(TEST_STUDY_IDENTIFIER)).thenReturn(study);
-        when(mockAccountDao.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(null);
+        when(mockAccountService.getAccount(ACCOUNT_ID_WITH_EMAIL)).thenReturn(null);
 
         PasswordReset passwordReset = new PasswordReset("newPassword", SPTOKEN, TEST_STUDY_IDENTIFIER);
         
@@ -1110,14 +1109,14 @@ public class AccountWorkflowServiceTest extends Mockito {
         }
         verify(mockCacheProvider).getObject(PASSWORD_RESET_FOR_EMAIL, String.class);
         verify(mockCacheProvider).removeObject(PASSWORD_RESET_FOR_EMAIL);
-        verify(mockAccountDao, never()).changePassword(any(), any(ChannelType.class), any());
+        verify(mockAccountService, never()).changePassword(any(), any(ChannelType.class), any());
     }
     
     @Test
     public void requestEmailSignIn() throws Exception {
         // Mock.
         study.setEmailSignInEnabled(true);
-        when(mockAccountDao.getAccount(SIGN_IN_REQUEST_WITH_EMAIL.getAccountId())).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(SIGN_IN_REQUEST_WITH_EMAIL.getAccountId())).thenReturn(mockAccount);
         when(mockStudyService.getStudy(study.getIdentifier())).thenReturn(study);
         when(service.getNextToken()).thenReturn(TOKEN);
 
@@ -1129,7 +1128,7 @@ public class AccountWorkflowServiceTest extends Mockito {
         verify(mockCacheProvider).getObject(keyCaptor.capture(), eq(String.class));
         assertEquals(keyCaptor.getValue(), EMAIL_SIGNIN_CACHE_KEY);
         
-        verify(mockAccountDao).getAccount(SIGN_IN_REQUEST_WITH_EMAIL.getAccountId());
+        verify(mockAccountService).getAccount(SIGN_IN_REQUEST_WITH_EMAIL.getAccountId());
         
         verify(mockCacheProvider).setObject(eq(EMAIL_SIGNIN_CACHE_KEY), stringCaptor.capture(), eq(SIGNIN_EXPIRE_IN_SECONDS));
         assertNotNull(stringCaptor.getValue());
@@ -1164,7 +1163,7 @@ public class AccountWorkflowServiceTest extends Mockito {
     public void requestEmailSignInFailureDelays() {
         study.setEmailSignInEnabled(true);
         service.getEmailSignInRequestInMillis().set(1000);
-        when(mockAccountDao.getAccount(any())).thenReturn(null);
+        when(mockAccountService.getAccount(any())).thenReturn(null);
         when(mockStudyService.getStudy(study.getIdentifier())).thenReturn(study);
                  
         long start = System.currentTimeMillis();
@@ -1209,7 +1208,7 @@ public class AccountWorkflowServiceTest extends Mockito {
     public void requestEmailSignInThrottles() {
         study.setEmailSignInEnabled(true);
         when(service.getNextToken()).thenReturn(SPTOKEN);
-        when(mockAccountDao.getAccount(any())).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(any())).thenReturn(mockAccount);
         when(mockStudyService.getStudy(study.getIdentifier())).thenReturn(study);
 
         // Throttle limit is 2. Request 3 times. Get 2 emails. (Each call should still return userId.
@@ -1231,7 +1230,7 @@ public class AccountWorkflowServiceTest extends Mockito {
         // we just send the message again.
         study.setEmailSignInEnabled(true);
         when(mockCacheProvider.getObject(EMAIL_SIGNIN_CACHE_KEY, String.class)).thenReturn(TOKEN);
-        when(mockAccountDao.getAccount(any())).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(any())).thenReturn(mockAccount);
         when(mockStudyService.getStudy(study.getIdentifier())).thenReturn(study);
         
         service.requestEmailSignIn(SIGN_IN_REQUEST_WITH_EMAIL);
@@ -1273,7 +1272,7 @@ public class AccountWorkflowServiceTest extends Mockito {
         // Mock.
         study.setPhoneSignInEnabled(true);
         study.setShortName("AppName");
-        when(mockAccountDao.getAccount(SIGN_IN_WITH_PHONE.getAccountId())).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(SIGN_IN_WITH_PHONE.getAccountId())).thenReturn(mockAccount);
         when(service.getNextPhoneToken()).thenReturn("123456");
         when(mockStudyService.getStudy(study.getIdentifier())).thenReturn(study);
 
@@ -1316,7 +1315,7 @@ public class AccountWorkflowServiceTest extends Mockito {
     @Test
     public void requestPhoneSignInThrottles() {
         study.setPhoneSignInEnabled(true);
-        when(mockAccountDao.getAccount(any())).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(any())).thenReturn(mockAccount);
         when(mockStudyService.getStudy(study.getIdentifier())).thenReturn(study);
 
         // Throttle limit is 2. Request 3 times. Get 2 texts. (Each call should still return userId.)

--- a/src/test/java/org/sagebionetworks/bridge/services/FPHSServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/FPHSServiceTest.java
@@ -20,7 +20,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.FPHSExternalIdentifierDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoFPHSExternalIdentifier;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
@@ -43,7 +42,7 @@ public class FPHSServiceTest {
     @Mock
     private FPHSExternalIdentifierDao mockDao;
     @Mock
-    private AccountDao mockAccountDao;
+    private AccountService mockAccountService;
     @Mock
     private Account mockAccount;
     
@@ -55,7 +54,7 @@ public class FPHSServiceTest {
         externalId = ExternalIdentifier.create(TEST_STUDY, EXTERNAL_ID);
         service = new FPHSService();
         service.setFPHSExternalIdentifierDao(mockDao);
-        service.setAccountDao(mockAccountDao);
+        service.setAccountService(mockAccountService);
     }
     
     @Test(expectedExceptions = InvalidEntityException.class)
@@ -83,7 +82,7 @@ public class FPHSServiceTest {
     
     @Test
     public void registerExternalIdentifier() throws Exception {
-        TestUtils.mockEditAccount(mockAccountDao, mockAccount);
+        TestUtils.mockEditAccount(mockAccountService, mockAccount);
         Set<String> dataGroups = Sets.newHashSet();
         Set<AccountSubstudy> accountSubstudies = Sets.newHashSet();
         when(mockAccount.getDataGroups()).thenReturn(dataGroups);
@@ -112,7 +111,7 @@ public class FPHSServiceTest {
             verify(mockDao).verifyExternalId(externalId);
             verify(mockDao).registerExternalId(externalId);
             verifyNoMoreInteractions(mockDao);
-            verifyNoMoreInteractions(mockAccountDao);
+            verifyNoMoreInteractions(mockAccountService);
         }
     }
     
@@ -125,7 +124,7 @@ public class FPHSServiceTest {
         } catch(RuntimeException e) {
             verify(mockDao).verifyExternalId(externalId);
             verifyNoMoreInteractions(mockDao);
-            verifyNoMoreInteractions(mockAccountDao);
+            verifyNoMoreInteractions(mockAccountService);
         }
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/services/IntentServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/IntentServiceTest.java
@@ -32,7 +32,6 @@ import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.cache.CacheKey;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
@@ -87,7 +86,7 @@ public class IntentServiceTest {
     Study mockStudy;
     
     @Mock
-    AccountDao mockAccountDao;
+    AccountService mockAccountService;
     
     @Mock
     TemplateService mockTemplateService;
@@ -270,7 +269,7 @@ public class IntentServiceTest {
         AccountId accountId = AccountId.forPhone(TestConstants.TEST_STUDY_IDENTIFIER, intent.getPhone()); 
         
         Account account = Account.create();
-        when(mockAccountDao.getAccount(accountId)).thenReturn(account);
+        when(mockAccountService.getAccount(accountId)).thenReturn(account);
         
         service.submitIntentToParticipate(intent);
         

--- a/src/test/java/org/sagebionetworks/bridge/services/UserAdminServiceMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/UserAdminServiceMockTest.java
@@ -30,7 +30,6 @@ import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.cache.CacheProvider;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.CriteriaContext;
@@ -67,7 +66,7 @@ public class UserAdminServiceMockTest {
     private ConsentService consentService;
     
     @Mock
-    private AccountDao accountDao;
+    private AccountService accountService;
     
     @Mock
     private Account account;
@@ -297,7 +296,7 @@ public class UserAdminServiceMockTest {
         when(consentService.getConsentStatuses(any())).thenReturn(statuses);
         
         AccountId accountId = AccountId.forId(study.getIdentifier(), USER_ID);
-        when(accountDao.getAccount(accountId)).thenReturn(account);
+        when(accountService.getAccount(accountId)).thenReturn(account);
         
         when(participantService.getParticipant(study, USER_ID, false))
                 .thenThrow(new IllegalStateException("System is unable to complete call"));        
@@ -306,7 +305,7 @@ public class UserAdminServiceMockTest {
             service.createUser(study, participant, null, true, true);    
             fail("Should have thrown exception");
         } catch(IllegalStateException e) {
-            verify(accountDao).deleteAccount(accountId);
+            verify(accountService).deleteAccount(accountId);
         }
     }
     
@@ -325,7 +324,7 @@ public class UserAdminServiceMockTest {
         doReturn("userId").when(account).getId();
         doReturn("healthCode").when(account).getHealthCode();
         doReturn(substudies).when(account).getAccountSubstudies();
-        doReturn(account).when(accountDao).getAccount(accountId);
+        doReturn(account).when(accountService).getAccount(accountId);
         
         service.deleteUser(study, "userId");
         
@@ -339,7 +338,7 @@ public class UserAdminServiceMockTest {
         verify(activityEventService).deleteActivityEvents("healthCode");
         verify(externalIdService).unassignExternalId(accountCaptor.capture(), eq("subAextId"));
         verify(externalIdService).unassignExternalId(accountCaptor.capture(), eq("subBextId"));
-        verify(accountDao).deleteAccount(accountId);
+        verify(accountService).deleteAccount(accountId);
         
         assertEquals(accountCaptor.getValue().getHealthCode(), "healthCode");
     }
@@ -359,6 +358,6 @@ public class UserAdminServiceMockTest {
         verify(scheduledActivityService, never()).deleteActivitiesForUser(any());
         verify(activityEventService, never()).deleteActivityEvents(any());
         verify(externalIdService, never()).unassignExternalId(any(), any());
-        verify(accountDao, never()).deleteAccount(any());
+        verify(accountService, never()).deleteAccount(any());
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationControllerTest.java
@@ -56,7 +56,6 @@ import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.config.Environment;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
@@ -84,6 +83,7 @@ import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
+import org.sagebionetworks.bridge.services.AccountService;
 import org.sagebionetworks.bridge.services.AccountWorkflowService;
 import org.sagebionetworks.bridge.services.AuthenticationService;
 import org.sagebionetworks.bridge.services.StudyService;
@@ -126,7 +126,7 @@ public class AuthenticationControllerTest extends Mockito {
     AccountWorkflowService mockWorkflowService;
     
     @Mock
-    AccountDao mockAccountDao;
+    AccountService mockAccountService;
     
     @Mock
     StudyService mockStudyService;
@@ -1193,7 +1193,7 @@ public class AuthenticationControllerTest extends Mockito {
         
         Account account = Account.create();
         AccountId accountId = AccountId.forSynapseUserId("my-new-study", SYNAPSE_USER_ID);
-        when(mockAccountDao.getAccount(accountId)).thenReturn(account);
+        when(mockAccountService.getAccount(accountId)).thenReturn(account);
         
         Study newStudy = Study.create();
         newStudy.setIdentifier("my-new-study");
@@ -1240,7 +1240,7 @@ public class AuthenticationControllerTest extends Mockito {
         doReturn(userSession).when(controller).getAuthenticatedSession();
         
         AccountId accountId = AccountId.forId(TEST_STUDY_IDENTIFIER, TEST_ACCOUNT_ID);
-        when(mockAccountDao.getAccount(accountId)).thenReturn(Account.create());
+        when(mockAccountService.getAccount(accountId)).thenReturn(Account.create());
         
         Study newStudy = Study.create();
         newStudy.setIdentifier("my-new-study");
@@ -1266,7 +1266,7 @@ public class AuthenticationControllerTest extends Mockito {
                 .withRoles(ImmutableSet.of(DEVELOPER)).build());
         doReturn(userSession).when(controller).getAuthenticatedSession();
         
-        when(mockAccountDao.getStudyIdsForUser(SYNAPSE_USER_ID))
+        when(mockAccountService.getStudyIdsForUser(SYNAPSE_USER_ID))
             .thenReturn(ImmutableList.of(TEST_STUDY_IDENTIFIER));
         
         Study newStudy = Study.create();

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/BaseControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/BaseControllerTest.java
@@ -65,7 +65,6 @@ import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.config.Environment;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.exceptions.NotAuthenticatedException;
@@ -82,6 +81,7 @@ import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.activities.CustomActivityEventRequest;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.services.AccountService;
 import org.sagebionetworks.bridge.services.AuthenticationService;
 import org.sagebionetworks.bridge.services.RequestInfoService;
 import org.sagebionetworks.bridge.services.SessionUpdateService;
@@ -96,7 +96,7 @@ public class BaseControllerTest extends Mockito {
     private BridgeConfig mockBridgeConfig;
 
     @Mock
-    private AccountDao mockAccountDao;
+    private AccountService mockAccountService;
 
     @Mock
     private StudyService mockStudyService;
@@ -353,7 +353,7 @@ public class BaseControllerTest extends Mockito {
         
         controller.getLanguages(session);
         
-        verify(mockAccountDao).editAccount(eq(TEST_STUDY), eq(HEALTH_CODE), any());
+        verify(mockAccountService).editAccount(eq(TEST_STUDY), eq(HEALTH_CODE), any());
         verify(mockSessionUpdateService).updateLanguage(eq(session), contextCaptor.capture());
         
         CriteriaContext context = contextCaptor.getValue();
@@ -371,7 +371,7 @@ public class BaseControllerTest extends Mockito {
         List<String> returnedLangs = controller.getLanguages(session);
         assertEquals(returnedLangs, ImmutableList.of("fr"));
         
-        verify(mockAccountDao, never()).editAccount(any(), any(), any());
+        verify(mockAccountService, never()).editAccount(any(), any(), any());
         verify(mockSessionUpdateService, never()).updateLanguage(any(), any());
     }
 
@@ -648,7 +648,7 @@ public class BaseControllerTest extends Mockito {
         assertEquals(LANGUAGES, languages);
 
         // Participant already has languages. Nothing to save.
-        verifyZeroInteractions(mockAccountDao);
+        verifyZeroInteractions(mockAccountService);
         verifyZeroInteractions(mockSessionUpdateService);
     }
     
@@ -659,7 +659,7 @@ public class BaseControllerTest extends Mockito {
             Consumer<Account> consumer = invocation.getArgument(2);
             consumer.accept(account);
             return null;
-        }).when(mockAccountDao).editAccount(any(), any(), any());
+        }).when(mockAccountService).editAccount(any(), any(), any());
         
         // Set up mocks.
         when(mockRequest.getHeader(ACCEPT_LANGUAGE)).thenReturn("en,fr");
@@ -673,7 +673,7 @@ public class BaseControllerTest extends Mockito {
         assertEquals(LANGUAGES, languages);
 
         // Verify we saved the language to the account.
-        verify(mockAccountDao).editAccount(eq(TEST_STUDY), eq(HEALTH_CODE), any());
+        verify(mockAccountService).editAccount(eq(TEST_STUDY), eq(HEALTH_CODE), any());
         assertEquals(account.getLanguages(), LANGUAGES);
 
         // Verify we call through to the session update service. (This updates both the cache and the participant, as
@@ -698,7 +698,7 @@ public class BaseControllerTest extends Mockito {
         assertTrue(languages.isEmpty());
 
         // No languages means nothing to save.
-        verifyZeroInteractions(mockAccountDao);
+        verifyZeroInteractions(mockAccountService);
         verifyZeroInteractions(mockSessionUpdateService);
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/CacheAdminControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/CacheAdminControllerTest.java
@@ -25,12 +25,12 @@ import org.mockito.Spy;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.StatusMessage;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.services.AccountService;
 import org.sagebionetworks.bridge.services.CacheAdminService;
 
 public class CacheAdminControllerTest extends Mockito {
@@ -45,7 +45,7 @@ public class CacheAdminControllerTest extends Mockito {
     private CacheAdminService mockCacheAdminService;
     
     @Mock
-    private AccountDao mockAccountDao;
+    private AccountService mockAccountService;
 
     @InjectMocks
     @Spy
@@ -81,7 +81,7 @@ public class CacheAdminControllerTest extends Mockito {
     @Test
     public void listItems() throws Exception {
         session.setStudyIdentifier(TEST_STUDY);
-        when(mockAccountDao.getAccount(ACCOUNT_ID)).thenReturn(Account.create());
+        when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(Account.create());
         
         Set<String> items = ImmutableSet.of("A", "B", "C");
         when(mockCacheAdminService.listItems()).thenReturn(items);
@@ -108,7 +108,7 @@ public class CacheAdminControllerTest extends Mockito {
     @Test
     public void removeItem() throws Exception {
         session.setStudyIdentifier(TEST_STUDY);
-        when(mockAccountDao.getAccount(ACCOUNT_ID)).thenReturn(Account.create());
+        when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(Account.create());
         
         StatusMessage result = controller.removeItem("cacheKey");
         assertEquals("Item removed from cache.", result.getMessage());

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ConsentControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ConsentControllerTest.java
@@ -46,7 +46,6 @@ import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.BridgeConfig;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -60,6 +59,7 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
+import org.sagebionetworks.bridge.services.AccountService;
 import org.sagebionetworks.bridge.services.AuthenticationService;
 import org.sagebionetworks.bridge.services.ConsentService;
 import org.sagebionetworks.bridge.services.SessionUpdateService;
@@ -80,7 +80,7 @@ public class ConsentControllerTest extends Mockito {
     ConsentService mockConsentService;
     
     @Mock
-    AccountDao mockAccountDao;
+    AccountService mockAccountService;
     
     @Mock
     CacheProvider mockCacheProvider;
@@ -166,7 +166,7 @@ public class ConsentControllerTest extends Mockito {
         UserSession retrievedSession = BridgeObjectMapper.get().treeToValue(result, UserSession.class);
         assertEquals(retrievedSession.getSessionToken(), ORIGINAL_SESSION_TOKEN);
         
-        verify(mockAccountDao).editAccount(eq(TestConstants.TEST_STUDY), eq(HEALTH_CODE), accountConsumerCaptor.capture());
+        verify(mockAccountService).editAccount(eq(TestConstants.TEST_STUDY), eq(HEALTH_CODE), accountConsumerCaptor.capture());
         verify(mockSessionUpdateService).updateSharingScope(session, SharingScope.ALL_QUALIFIED_RESEARCHERS);
         
         // This works as a verification because the lambda carries a closure that includes the correct sharing 
@@ -386,7 +386,7 @@ public class ConsentControllerTest extends Mockito {
     @SuppressWarnings("deprecation")
     public void dataSharingSuspendedUpdatesSession() throws Exception {
         Account account = Mockito.mock(Account.class);
-        TestUtils.mockEditAccount(mockAccountDao, account);
+        TestUtils.mockEditAccount(mockAccountService, account);
         
         doAnswer((InvocationOnMock invocation) -> {
             session.setParticipant(new StudyParticipant.Builder().copyOf(session.getParticipant())
@@ -401,14 +401,14 @@ public class ConsentControllerTest extends Mockito {
 
         verify(account).setSharingScope(SharingScope.NO_SHARING);
         
-        verify(mockAccountDao).editAccount(eq(TestConstants.TEST_STUDY), eq(HEALTH_CODE), any());
+        verify(mockAccountService).editAccount(eq(TestConstants.TEST_STUDY), eq(HEALTH_CODE), any());
     }
     
     @Test
     @SuppressWarnings("deprecation")
     public void dataSharingResumedUpdatesSession() throws Exception {
         Account account = Mockito.mock(Account.class);
-        TestUtils.mockEditAccount(mockAccountDao, account);
+        TestUtils.mockEditAccount(mockAccountService, account);
 
         doAnswer((InvocationOnMock invocation) -> {
             session.setParticipant(new StudyParticipant.Builder().copyOf(session.getParticipant())

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/EmailControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/EmailControllerTest.java
@@ -21,10 +21,10 @@ import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.config.BridgeConfig;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.services.AccountService;
 import org.sagebionetworks.bridge.services.StudyService;
 
 public class EmailControllerTest extends Mockito {
@@ -42,7 +42,7 @@ public class EmailControllerTest extends Mockito {
     StudyService mockStudyService;
 
     @Mock
-    AccountDao mockAccountDao;
+    AccountService mockAccountService;
     
     @Mock
     Account mockAccount;
@@ -66,10 +66,10 @@ public class EmailControllerTest extends Mockito {
     public void before() {
         MockitoAnnotations.initMocks(this);
         when(mockConfig.getEmailUnsubscribeToken()).thenReturn(UNSUBSCRIBE_TOKEN);
-        when(mockAccountDao.getHealthCodeForAccount(ACCOUNT_ID)).thenReturn(HEALTH_CODE);
+        when(mockAccountService.getHealthCodeForAccount(ACCOUNT_ID)).thenReturn(HEALTH_CODE);
         doReturn(mockRequest).when(controller).request();
         doReturn(mockResponse).when(controller).response();
-        mockEditAccount(mockAccountDao, mockAccount);
+        mockEditAccount(mockAccountService, mockAccount);
         
         study = Study.create();
         study.setIdentifier(TEST_STUDY_IDENTIFIER);
@@ -124,7 +124,7 @@ public class EmailControllerTest extends Mockito {
     @Test
     public void noAccountThrowsException() throws Exception {
         mockContext(DATA_BRACKET_EMAIL, EMAIL_ADDRESS, STUDY2, TEST_STUDY_IDENTIFIER, TOKEN, UNSUBSCRIBE_TOKEN);
-        doReturn(null).when(mockAccountDao).getHealthCodeForAccount(ACCOUNT_ID);
+        doReturn(null).when(mockAccountService).getHealthCodeForAccount(ACCOUNT_ID);
 
         String result = controller.unsubscribeFromEmail();
         assertEquals(result, "Email not found.");

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/FPHSControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/FPHSControllerTest.java
@@ -33,7 +33,6 @@ import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.config.Environment;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.exceptions.NotAuthenticatedException;
@@ -46,6 +45,7 @@ import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
+import org.sagebionetworks.bridge.services.AccountService;
 import org.sagebionetworks.bridge.services.AuthenticationService;
 import org.sagebionetworks.bridge.services.ConsentService;
 import org.sagebionetworks.bridge.services.FPHSService;
@@ -71,7 +71,7 @@ public class FPHSControllerTest extends Mockito {
     CacheProvider mockCacheProvider;
     
     @Mock
-    AccountDao mockAccountDao;
+    AccountService mockAccountService;
     
     @Mock
     NotificationTopicService mockNotificationTopicService;

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/MasterSchedulerControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/MasterSchedulerControllerTest.java
@@ -34,7 +34,6 @@ import org.testng.annotations.Test;
 import com.google.common.collect.ImmutableList;
 
 import org.sagebionetworks.bridge.TestUtils;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.StatusMessage;
 import org.sagebionetworks.bridge.models.DateTimeHolder;
@@ -43,6 +42,7 @@ import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.schedules.MasterSchedulerConfig;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.services.AccountService;
 import org.sagebionetworks.bridge.services.MasterSchedulerService;
 import org.sagebionetworks.bridge.services.StudyService;
 
@@ -62,7 +62,7 @@ public class MasterSchedulerControllerTest extends Mockito {
     private StudyService mockStudyService;
     
     @Mock
-    private AccountDao mockAccountDao;
+    private AccountService mockAccountService;
     
     @Mock
     private HttpServletRequest mockRequest;
@@ -93,7 +93,7 @@ public class MasterSchedulerControllerTest extends Mockito {
         mockSession.setParticipant(new StudyParticipant.Builder().withId(USER_ID).build());
         doReturn(mockSession).when(controller).getAuthenticatedSession(SUPERADMIN);
         
-        when(mockAccountDao.getAccount(ACCOUNT_ID)).thenReturn(Account.create());
+        when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(Account.create());
         
         mockConfig = TestUtils.getMasterSchedulerConfig();
         

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportControllerTest.java
@@ -41,7 +41,6 @@ import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
@@ -60,6 +59,7 @@ import org.sagebionetworks.bridge.models.reports.ReportDataKey;
 import org.sagebionetworks.bridge.models.reports.ReportIndex;
 import org.sagebionetworks.bridge.models.reports.ReportType;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
+import org.sagebionetworks.bridge.services.AccountService;
 import org.sagebionetworks.bridge.services.ReportService;
 import org.sagebionetworks.bridge.services.StudyService;
 
@@ -86,7 +86,7 @@ public class ParticipantReportControllerTest extends Mockito {
     StudyService mockStudyService;
     
     @Mock
-    AccountDao mockAccountDao;
+    AccountService mockAccountService;
     
     @Mock
     Account mockAccount;
@@ -122,7 +122,7 @@ public class ParticipantReportControllerTest extends Mockito {
         StudyParticipant participant = new StudyParticipant.Builder().withHealthCode(HEALTH_CODE)
                 .withRoles(Sets.newHashSet(Roles.DEVELOPER)).build();
         
-        doReturn(mockOtherAccount).when(mockAccountDao).getAccount(OTHER_ACCOUNT_ID);
+        doReturn(mockOtherAccount).when(mockAccountService).getAccount(OTHER_ACCOUNT_ID);
         
         ConsentStatus status = new ConsentStatus.Builder().withName("Name").withGuid(SubpopulationGuid.create("GUID"))
                 .withConsented(true).withRequired(true).withSignedMostRecentConsent(true).build();
@@ -229,7 +229,7 @@ public class ParticipantReportControllerTest extends Mockito {
                 .withRoles(Sets.newHashSet(Roles.RESEARCHER)).build();
         session.setParticipant(participant);
         
-        doReturn(mockAccount).when(mockAccountDao).getAccount(OTHER_ACCOUNT_ID);
+        doReturn(mockAccount).when(mockAccountService).getAccount(OTHER_ACCOUNT_ID);
         
         doReturn(makePagedResults(START_TIME, END_TIME, OFFSET_KEY, PAGE_SIZE_INT)).when(mockReportService)
                 .getParticipantReportV4(session.getStudyIdentifier(), REPORT_ID, HEALTH_CODE, START_TIME, END_TIME,
@@ -244,7 +244,7 @@ public class ParticipantReportControllerTest extends Mockito {
     @Test
     public void getParticipantReportForWorkerV4_DefaultParams() throws Exception {
         // Mock dependencies
-        when(mockAccountDao.getAccount(OTHER_ACCOUNT_ID)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(OTHER_ACCOUNT_ID)).thenReturn(mockAccount);
 
         ForwardCursorPagedResourceList<ReportData> expectedPage = makePagedResults(START_TIME, END_TIME, null,
                 BridgeConstants.API_DEFAULT_PAGE_SIZE);
@@ -265,7 +265,7 @@ public class ParticipantReportControllerTest extends Mockito {
     @Test
     public void getParticipantReportForWorkerV4_OptionalParams() throws Exception {
         // Mock dependencies
-        when(mockAccountDao.getAccount(OTHER_ACCOUNT_ID)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(OTHER_ACCOUNT_ID)).thenReturn(mockAccount);
 
         ForwardCursorPagedResourceList<ReportData> expectedPage = makePagedResults(START_TIME, END_TIME, OFFSET_KEY,
                 PAGE_SIZE_INT);
@@ -292,7 +292,7 @@ public class ParticipantReportControllerTest extends Mockito {
                 .withRoles(Sets.newHashSet(Roles.RESEARCHER)).build();
         session.setParticipant(participant);
         
-        doReturn(mockAccount).when(mockAccountDao).getAccount(OTHER_ACCOUNT_ID);
+        doReturn(mockAccount).when(mockAccountService).getAccount(OTHER_ACCOUNT_ID);
         
         doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getParticipantReport(session.getStudyIdentifier(),
                 REPORT_ID, HEALTH_CODE, START_DATE, END_DATE);
@@ -305,7 +305,7 @@ public class ParticipantReportControllerTest extends Mockito {
     @Test
     public void getParticipantReportForWorker_DefaultParams() throws Exception {
         // Mock dependencies
-        when(mockAccountDao.getAccount(OTHER_ACCOUNT_ID)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(OTHER_ACCOUNT_ID)).thenReturn(mockAccount);
 
         DateRangeResourceList<ReportData> expectedPage = makeResults(START_DATE, END_DATE);
         doReturn(expectedPage).when(mockReportService).getParticipantReport(TEST_STUDY, REPORT_ID, HEALTH_CODE,
@@ -323,7 +323,7 @@ public class ParticipantReportControllerTest extends Mockito {
     @Test
     public void getParticipantReportForWorker_OptionalParams() throws Exception {
         // Mock dependencies
-        when(mockAccountDao.getAccount(OTHER_ACCOUNT_ID)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(OTHER_ACCOUNT_ID)).thenReturn(mockAccount);
 
         DateRangeResourceList<ReportData> expectedPage = makeResults(START_DATE, END_DATE);
         doReturn(expectedPage).when(mockReportService).getParticipantReport(TEST_STUDY, REPORT_ID, HEALTH_CODE,

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ScheduledActivityControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ScheduledActivityControllerTest.java
@@ -51,7 +51,6 @@ import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.BridgeConfig;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoScheduledActivity;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.NotAuthenticatedException;
@@ -69,6 +68,7 @@ import org.sagebionetworks.bridge.models.schedules.ActivityType;
 import org.sagebionetworks.bridge.models.schedules.ScheduleContext;
 import org.sagebionetworks.bridge.models.schedules.ScheduledActivity;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.services.AccountService;
 import org.sagebionetworks.bridge.services.RequestInfoService;
 import org.sagebionetworks.bridge.services.ScheduledActivityService;
 import org.sagebionetworks.bridge.services.SessionUpdateService;
@@ -119,7 +119,7 @@ public class ScheduledActivityControllerTest extends Mockito {
     CacheProvider mockCacheProvider;
     
     @Mock
-    AccountDao mockAccountDao;
+    AccountService mockAccountService;
     
     @Mock
     RequestInfoService mockRequestInfoService;
@@ -220,7 +220,7 @@ public class ScheduledActivityControllerTest extends Mockito {
     @SuppressWarnings("deprecation")
     @Test
     public void timeZoneCapturedFirstTime() throws Exception {
-        mockEditAccount(mockAccountDao, mockAccount);
+        mockEditAccount(mockAccountService, mockAccount);
         
         DateTimeZone MSK = DateTimeZone.forOffsetHours(3);
         controller.getScheduledActivities(null, "+03:00", "3", "5");
@@ -262,7 +262,7 @@ public class ScheduledActivityControllerTest extends Mockito {
     @SuppressWarnings("deprecation")
     @Test
     public void getScheduledActivtiesAssemblesCorrectContext() throws Exception {
-        mockEditAccount(mockAccountDao, mockAccount);
+        mockEditAccount(mockAccountService, mockAccount);
         DateTimeZone MSK = DateTimeZone.forOffsetHours(3);
         List<ScheduledActivity> list = ImmutableList.of();
         when(mockScheduledActivityService.getScheduledActivities(eq(STUDY), any(ScheduleContext.class))).thenReturn(list);
@@ -512,7 +512,7 @@ public class ScheduledActivityControllerTest extends Mockito {
         DateTime startsOn = DateTime.now(zone).minusMinutes(1);
         DateTime endsOn = DateTime.now(zone).plusDays(7);
 
-        mockEditAccount(mockAccountDao, mockAccount);
+        mockEditAccount(mockAccountService, mockAccount);
         
         String result = controller.getScheduledActivitiesByDateRange(startsOn.toString(), endsOn.toString());
         

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyControllerTest.java
@@ -57,7 +57,6 @@ import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.config.Environment;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
@@ -80,6 +79,7 @@ import org.sagebionetworks.bridge.models.studies.StudyIdentifierImpl;
 import org.sagebionetworks.bridge.models.studies.SynapseProjectIdTeamIdHolder;
 import org.sagebionetworks.bridge.models.upload.Upload;
 import org.sagebionetworks.bridge.models.upload.UploadView;
+import org.sagebionetworks.bridge.services.AccountService;
 import org.sagebionetworks.bridge.services.EmailVerificationService;
 import org.sagebionetworks.bridge.services.StudyService;
 import org.sagebionetworks.bridge.services.UploadCertificateService;
@@ -121,7 +121,7 @@ public class StudyControllerTest extends Mockito {
     UploadService mockUploadService;
     
     @Mock
-    AccountDao mockAccountDao;
+    AccountService mockAccountService;
     
     @Mock
     BridgeConfig mockBridgeConfig;
@@ -159,7 +159,7 @@ public class StudyControllerTest extends Mockito {
         study.setSynapseDataAccessTeamId(TEST_TEAM_ID);
         study.setActive(true);
      
-        when(mockAccountDao.getAccount(ACCOUNT_ID)).thenReturn(Account.create());
+        when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(Account.create());
         when(mockStudyService.getStudy(TEST_STUDY)).thenReturn(study);
         when(mockStudyService.createSynapseProjectTeam(any(), any())).thenReturn(study);
         when(mockVerificationService.getEmailStatus(EMAIL_ADDRESS)).thenReturn(VERIFIED);
@@ -825,7 +825,7 @@ public class StudyControllerTest extends Mockito {
         mockStudy("Study A", "studyA", false);
         
         List<String> list = ImmutableList.of("studyA", "studyB", "studyC");
-        when(mockAccountDao.getStudyIdsForUser(SYNAPSE_USER_ID)).thenReturn(list);
+        when(mockAccountService.getStudyIdsForUser(SYNAPSE_USER_ID)).thenReturn(list);
         
         String jsonString = controller.getStudyMemberships();
         JsonNode node = BridgeObjectMapper.get().readTree(jsonString).get("items");
@@ -855,7 +855,7 @@ public class StudyControllerTest extends Mockito {
         
         // This user is only associated to the API study, but they are an admin
         List<String> list = ImmutableList.of(TEST_STUDY_IDENTIFIER);
-        when(mockAccountDao.getStudyIdsForUser(SYNAPSE_USER_ID)).thenReturn(list);
+        when(mockAccountService.getStudyIdsForUser(SYNAPSE_USER_ID)).thenReturn(list);
         
         String jsonString = controller.getStudyMemberships();
         JsonNode node = BridgeObjectMapper.get().readTree(jsonString).get("items");

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyReportControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyReportControllerTest.java
@@ -44,7 +44,6 @@ import org.testng.annotations.Test;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.TestUtils;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
@@ -60,6 +59,7 @@ import org.sagebionetworks.bridge.models.reports.ReportData;
 import org.sagebionetworks.bridge.models.reports.ReportDataKey;
 import org.sagebionetworks.bridge.models.reports.ReportIndex;
 import org.sagebionetworks.bridge.models.reports.ReportType;
+import org.sagebionetworks.bridge.services.AccountService;
 import org.sagebionetworks.bridge.services.ReportService;
 import org.sagebionetworks.bridge.services.StudyService;
 
@@ -88,7 +88,7 @@ public class StudyReportControllerTest extends Mockito {
     StudyService mockStudyService;
     
     @Mock
-    AccountDao mockAccountDao;
+    AccountService mockAccountService;
     
     @Mock
     Account mockAccount;

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/UploadControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/UploadControllerTest.java
@@ -34,7 +34,6 @@ import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.cache.CacheProvider;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.HealthCodeDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoUpload2;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
@@ -53,6 +52,7 @@ import org.sagebionetworks.bridge.models.upload.UploadSession;
 import org.sagebionetworks.bridge.models.upload.UploadStatus;
 import org.sagebionetworks.bridge.models.upload.UploadValidationStatus;
 import org.sagebionetworks.bridge.models.upload.UploadView;
+import org.sagebionetworks.bridge.services.AccountService;
 import org.sagebionetworks.bridge.services.HealthDataService;
 import org.sagebionetworks.bridge.services.RequestInfoService;
 import org.sagebionetworks.bridge.services.UploadService;
@@ -76,7 +76,7 @@ public class UploadControllerTest extends Mockito {
     HealthCodeDao mockHealthCodeDao;
     
     @Mock
-    AccountDao mockAccountDao;
+    AccountService mockAccountService;
     
     @Mock
     RequestInfoService mockRequestInfoService;
@@ -385,7 +385,7 @@ public class UploadControllerTest extends Mockito {
         doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(ADMIN, WORKER);
         doReturn(true).when(mockResearcherSession).isInRole(Roles.SUPERADMIN);
         
-        when(mockAccountDao.getAccount(ACCOUNT_ID)).thenReturn(Account.create());
+        when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(Account.create());
 
         HealthDataRecord record = HealthDataRecord.create();
         record.setStudyId("some-other-study");

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserManagementControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserManagementControllerTest.java
@@ -41,7 +41,6 @@ import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.BridgeConfig;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.StatusMessage;
@@ -51,6 +50,7 @@ import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.services.AccountService;
 import org.sagebionetworks.bridge.services.AuthenticationService;
 import org.sagebionetworks.bridge.services.RequestInfoService;
 import org.sagebionetworks.bridge.services.SessionUpdateService;
@@ -87,7 +87,7 @@ public class UserManagementControllerTest extends Mockito {
     HttpServletResponse mockResponse;
     
     @Mock
-    AccountDao mockAccountDao;
+    AccountService mockAccountService;
     
     @Spy
     @InjectMocks
@@ -196,7 +196,7 @@ public class UserManagementControllerTest extends Mockito {
         doReturn(session).when(controller).getAuthenticatedSession(SUPERADMIN);
         
         AccountId accountId = AccountId.forId(TEST_STUDY_IDENTIFIER, USER_ID);
-        when(mockAccountDao.getAccount(accountId)).thenReturn(Account.create());
+        when(mockAccountService.getAccount(accountId)).thenReturn(Account.create());
 
         SignIn signIn = new SignIn.Builder().withStudy("nextStudy").build();
         mockRequestBody(mockRequest, signIn);
@@ -237,7 +237,7 @@ public class UserManagementControllerTest extends Mockito {
         mockRequestBody(mockRequest, "{}");
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn("AAA");
 
-        when(mockAccountDao.getAccount(ACCOUNT_ID)).thenReturn(Account.create());
+        when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(Account.create());
         
         // same study id as above test
         StatusMessage result = controller.createUserWithStudyId(TEST_STUDY_IDENTIFIER);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserProfileControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserProfileControllerTest.java
@@ -48,7 +48,6 @@ import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.cache.ViewCache;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -62,6 +61,7 @@ import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyIdentifier;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
+import org.sagebionetworks.bridge.services.AccountService;
 import org.sagebionetworks.bridge.services.ConsentService;
 import org.sagebionetworks.bridge.services.NotificationTopicService;
 import org.sagebionetworks.bridge.services.ParticipantService;
@@ -75,7 +75,7 @@ public class UserProfileControllerTest extends Mockito {
     private static final Set<String> TEST_STUDY_ATTRIBUTES = Sets.newHashSet("foo","bar"); 
     
     @Mock
-    AccountDao mockAccountDao;
+    AccountService mockAccountService;
     
     @Mock
     ConsentService mockConsentService;
@@ -335,7 +335,7 @@ public class UserProfileControllerTest extends Mockito {
     @SuppressWarnings("deprecation")
     public void canGetDataGroups() throws Exception {
         when(mockAccount.getDataGroups()).thenReturn(ImmutableSet.of("group1","group2"));
-        when(mockAccountDao.getAccount(any())).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(any())).thenReturn(mockAccount);
         
         JsonNode result = controller.getDataGroups();
         

--- a/src/test/java/org/sagebionetworks/bridge/upload/TranscribeConsentHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/TranscribeConsentHandlerTest.java
@@ -23,12 +23,12 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.SharingScope;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
 import org.sagebionetworks.bridge.models.substudies.AccountSubstudy;
+import org.sagebionetworks.bridge.services.AccountService;
 import org.sagebionetworks.bridge.services.ParticipantService;
 
 public class TranscribeConsentHandlerTest {
@@ -40,7 +40,7 @@ public class TranscribeConsentHandlerTest {
             HEALTH_CODE);
 
     @Mock
-    private AccountDao mockAccountDao;
+    private AccountService mockAccountService;
     
     @Mock
     private Account mockAccount;
@@ -69,7 +69,7 @@ public class TranscribeConsentHandlerTest {
         MockitoAnnotations.initMocks(this);
 
         // Set up mocks.
-        when(mockAccountDao.getAccount(ACCOUNT_ID)).thenReturn(mockAccount);
+        when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(mockAccount);
         when(participantService.getStudyStartTime(ACCOUNT_ID)).thenReturn(STUDY_START_TIME);
 
         // Set up input record and context. Handler expects Health Code and RecordBuilder.
@@ -112,7 +112,7 @@ public class TranscribeConsentHandlerTest {
     @Test
     public void testNoParticipantOptions() {
         // account is null
-        when(mockAccountDao.getAccount(ACCOUNT_ID)).thenReturn(null);
+        when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(null);
 
         handler.handle(context);
         HealthDataRecord outputRecord = context.getHealthDataRecord();

--- a/src/test/java/org/sagebionetworks/bridge/upload/UploadHandlersEndToEndTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/UploadHandlersEndToEndTest.java
@@ -34,7 +34,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
-import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.UploadDao;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.dynamodb.DynamoSurvey;
@@ -55,6 +54,7 @@ import org.sagebionetworks.bridge.models.upload.UploadSchema;
 import org.sagebionetworks.bridge.models.upload.UploadSchemaType;
 import org.sagebionetworks.bridge.models.upload.UploadStatus;
 import org.sagebionetworks.bridge.s3.S3Helper;
+import org.sagebionetworks.bridge.services.AccountService;
 import org.sagebionetworks.bridge.services.HealthDataService;
 import org.sagebionetworks.bridge.services.StudyService;
 import org.sagebionetworks.bridge.services.SurveyService;
@@ -283,14 +283,14 @@ public class UploadHandlersEndToEndTest {
         account.setSharingScope(SharingScope.SPONSORS_AND_PARTNERS);
         account.setAccountSubstudies(ImmutableSet.of(acctSubstudy));
 
-        AccountDao mockAccountDao = mock(AccountDao.class);
-        when(mockAccountDao.getAccount(any())).thenReturn(account);
+        AccountService mockAccountService = mock(AccountService.class);
+        when(mockAccountService.getAccount(any())).thenReturn(account);
 
         ParticipantService mockParticipantService = mock(ParticipantService.class);
         when(mockParticipantService.getStudyStartTime(any())).thenReturn(STUDY_START_TIME);
 
         TranscribeConsentHandler transcribeConsentHandler = new TranscribeConsentHandler();
-        transcribeConsentHandler.setAccountDao(mockAccountDao);
+        transcribeConsentHandler.setAccountService(mockAccountService);
         transcribeConsentHandler.setParticipantService(mockParticipantService);
 
         // Set up UploadRawZipHandler.


### PR DESCRIPTION
In this first step, an AccountService is introduced that forwards everything from the existing AccountDao. This changes a bunch of references from the DAO to the service in a mechanical way that should make review easier... the actual refactor will come in a second PR.