### PR TITLE
[BRIDGE-2452] redirect http to https

### DIFF
--- a/ebextensions/alb.config
+++ b/ebextensions/alb.config
@@ -1,0 +1,32 @@
+option_settings:
+    - Namespace: 'aws:elbv2:loadbalancer'
+      OptionName: AccessLogsS3Bucket
+      Value: !Ref LoadBalancerAccessLogsBucket
+    - Namespace: 'aws:elbv2:loadbalancer'
+      OptionName: AccessLogsS3Enabled
+      Value: 'true'
+    - Namespace: 'aws:elbv2:listener:default'
+      OptionName: Protocol
+      Value: HTTP
+    - Namespace: 'aws:elbv2:listener:443'
+      OptionName: Protocol
+      Value: HTTPS
+    - Namespace: 'aws:elbv2:listener:443'
+      OptionName: SSLCertificateArns
+      Value: !ImportValue us-east-1-bridgeserver2-common-SSLCertificate
+Resources:
+    AlbHttpsRedirectListener:
+       Type: "AWS::ElasticLoadBalancingV2::Listener"
+       Properties:
+         DefaultActions:
+           - Type: "redirect"
+             RedirectConfig:
+               Protocol: "HTTPS"
+               Port: "443"
+               Host: "#{host}"
+               Path: "/#{path}"
+               Query: "#{query}"
+               StatusCode: "HTTP_301"
+         LoadBalancerArn: !Ref AWSEBV2LoadBalancer
+         Port: 80
+         Protocol: "HTTP"


### PR DESCRIPTION
Attempt to setup http to https redirect. This is unlikely to work
since beanstalk does not provide a reference to the ALB.
This also moves all ALB configs from the cloudformation
template to ebextensions.