### PR TITLE
Fixed BRIDGE-2471 and some NPE cases that would also return 500

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/AccountWorkflowService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AccountWorkflowService.java
@@ -327,7 +327,7 @@ public class AccountWorkflowService {
 
         Account account = accountService.getAccount(accountId);
         if (account == null) {
-            throw new EntityNotFoundException(Account.class);
+            return;
         }
         boolean verifiedEmail = account.getEmail() != null && Boolean.TRUE.equals(account.getEmailVerified());
         boolean verifiedPhone = account.getPhone() != null && Boolean.TRUE.equals(account.getPhoneVerified());

--- a/src/main/java/org/sagebionetworks/bridge/services/AccountWorkflowService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AccountWorkflowService.java
@@ -326,7 +326,9 @@ public class AccountWorkflowService {
         checkNotNull(accountId);
 
         Account account = accountService.getAccount(accountId);
-        
+        if (account == null) {
+            throw new EntityNotFoundException(Account.class);
+        }
         boolean verifiedEmail = account.getEmail() != null && Boolean.TRUE.equals(account.getEmailVerified());
         boolean verifiedPhone = account.getPhone() != null && Boolean.TRUE.equals(account.getPhoneVerified());
         boolean sendEmail = study.isEmailVerificationEnabled() && !study.isAutoVerificationEmailSuppressed();

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportController.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
+import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.DateRangeResourceList;
 import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
 import org.sagebionetworks.bridge.models.ReportTypeResourceList;
@@ -136,8 +137,8 @@ public class ParticipantReportController extends BaseController {
     /** Worker API to get reports for the given user in the given study by date. */
     @GetMapping("/v3/studies/{studyId}/participants/{userId}/reports/{reportId}")
     public DateRangeResourceList<? extends ReportData> getParticipantReportForWorker(@PathVariable String studyId,
-            @PathVariable String userId, @PathVariable String reportId, @RequestParam(required = true) String startDate,
-            @RequestParam(required = true) String endDate) {
+            @PathVariable String userId, @PathVariable String reportId, @RequestParam(required = false) String startDate,
+            @RequestParam(required = false) String endDate) {
         getAuthenticatedSession(WORKER);
         return getParticipantReportInternal(new StudyIdentifierImpl(studyId), userId, reportId, startDate,
                 endDate);
@@ -149,7 +150,9 @@ public class ParticipantReportController extends BaseController {
         LocalDate endDate = getLocalDateOrDefault(endDateString, null);
 
         Account account = accountService.getAccount(AccountId.forId(studyId.getIdentifier(), userId));
-
+        if (account == null) {
+            throw new EntityNotFoundException(Account.class);
+        }
         return reportService.getParticipantReport(studyId, reportId, account.getHealthCode(), startDate, endDate);
     }
 
@@ -183,7 +186,9 @@ public class ParticipantReportController extends BaseController {
         int pageSize = getIntOrDefault(pageSizeString, API_DEFAULT_PAGE_SIZE);
 
         Account account = accountService.getAccount(AccountId.forId(studyId.getIdentifier(), userId));
-
+        if (account == null) {
+            throw new EntityNotFoundException(Account.class);    
+        }
         return reportService.getParticipantReportV4(studyId, reportId, account.getHealthCode(), startTime, endTime,
                 offsetKey, pageSize);
     }
@@ -199,7 +204,9 @@ public class ParticipantReportController extends BaseController {
         Study study = studyService.getStudy(session.getStudyIdentifier());
         
         Account account = accountService.getAccount(AccountId.forId(study.getIdentifier(), userId));
-        
+        if (account == null) {
+            throw new EntityNotFoundException(Account.class);    
+        }
         ReportData reportData = parseJson(ReportData.class);
         reportData.setKey(null); // set in service, but just so no future use depends on it
         
@@ -245,7 +252,9 @@ public class ParticipantReportController extends BaseController {
         Study study = studyService.getStudy(session.getStudyIdentifier());
         
         Account account = accountService.getAccount(AccountId.forId(study.getIdentifier(), userId));
-        
+        if (account == null) {
+            throw new EntityNotFoundException(Account.class);    
+        }
         reportService.deleteParticipantReport(session.getStudyIdentifier(), identifier, account.getHealthCode());
         
         return new StatusMessage("Report deleted.");
@@ -261,7 +270,9 @@ public class ParticipantReportController extends BaseController {
         Study study = studyService.getStudy(session.getStudyIdentifier());
         
         Account account = accountService.getAccount(AccountId.forId(study.getIdentifier(), userId));
-        
+        if (account == null) {
+            throw new EntityNotFoundException(Account.class);    
+        }
         reportService.deleteParticipantReportRecord(session.getStudyIdentifier(), identifier, date, account.getHealthCode());
         
         return new StatusMessage("Report record deleted.");

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyReportController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyReportController.java
@@ -117,8 +117,8 @@ public class StudyReportController extends BaseController {
      */
     @GetMapping("/v4/reports/{identifier}")
     public ForwardCursorPagedResourceList<ReportData> getStudyReportV4(@PathVariable String identifier,
-            @RequestParam(required = true) String startTime, @RequestParam(required = true) String endTime,
-            @RequestParam(required = true) String offsetKey, @RequestParam(required = true) String pageSize) {
+            @RequestParam(required = false) String startTime, @RequestParam(required = false) String endTime,
+            @RequestParam(required = false) String offsetKey, @RequestParam(required = false) String pageSize) {
         UserSession session = getAuthenticatedSession();
         
         DateTime startTimeObj = getDateTimeOrDefault(startTime, null);
@@ -128,26 +128,6 @@ public class StudyReportController extends BaseController {
         return reportService.getStudyReportV4(session.getStudyIdentifier(), identifier, startTimeObj, endTimeObj,
                 offsetKey, pageSizeInt);
     }
-    
-    /**
-     * Get a study report *if* it is marked public, as this call does not require the user to be authenticated.
-     */
-    /* Not referenced in the BridgePF routes file
-    public ForwardCursorPagedResourceList<ReportData> getPublicStudyReportV4(String studyIdString, String identifier, String startTimeString,
-            String endTimeString, String offsetKey, String pageSizeString) {
-        StudyIdentifier studyId = new StudyIdentifierImpl(studyIdString);
-
-        verifyIndexIsPublic(studyId, identifier);
-        // We do not want to inherit a user's session information, if a session token is being 
-        // passed to this method.
-        setRequestContext(NULL_INSTANCE);
-
-        DateTime startTime = getDateTimeOrDefault(startTimeString, null);
-        DateTime endTime = getDateTimeOrDefault(endTimeString, null);
-        int pageSize = getIntOrDefault(pageSizeString, API_DEFAULT_PAGE_SIZE);
-        
-        return reportService.getStudyReportV4(studyId, identifier, startTime, endTime, offsetKey, pageSize);
-    }*/   
     
     /**
      * Report study data can be saved by developers or by worker processes.

--- a/src/main/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandler.java
@@ -29,7 +29,6 @@ import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.exceptions.NoStackTraceException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.accounts.UserSessionInfo;
-import org.sagebionetworks.bridge.spring.util.HttpUtil;
 
 /** Exception handler to convert exceptions into JSON instead of a generic HTML error page. */
 @ControllerAdvice
@@ -87,7 +86,7 @@ public class BridgeExceptionHandler {
         node.remove(UNEXPOSED_FIELD_NAMES);
         
         return ResponseEntity.status(status)
-                .header(HttpUtil.CONTENT_TYPE_HEADER, HttpUtil.CONTENT_TYPE_JSON)
+                .header(CONTENT_TYPE_HEADER, CONTENT_TYPE_JSON)
                 .body(node.toString());
     }
     

--- a/src/main/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandler.java
@@ -1,6 +1,9 @@
 package org.sagebionetworks.bridge.spring.handlers;
 
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.sagebionetworks.bridge.BridgeConstants.X_REQUEST_ID_HEADER;
+import static org.sagebionetworks.bridge.spring.util.HttpUtil.CONTENT_TYPE_HEADER;
+import static org.sagebionetworks.bridge.spring.util.HttpUtil.CONTENT_TYPE_JSON;
 
 import java.util.Set;
 
@@ -17,6 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -41,6 +45,7 @@ public class BridgeExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<String> handleException(HttpServletRequest request, Exception ex) throws JsonProcessingException {
         logException(request, ex);
+        
         return getResult(ex);
     }
 
@@ -62,8 +67,14 @@ public class BridgeExceptionHandler {
             
             JsonNode info = UserSessionInfo.toJSON(cre.getUserSession());
             return ResponseEntity.status(cre.getStatusCode())
-                    .header(HttpUtil.CONTENT_TYPE_HEADER, HttpUtil.CONTENT_TYPE_JSON)
+                    .header(CONTENT_TYPE_HEADER, CONTENT_TYPE_JSON)
                     .body(info.toString());
+        } else if (throwable instanceof MissingServletRequestParameterException) {
+            // This otherwise returns a 500 exception, which we don't consider to be correct
+            String paramName = ((MissingServletRequestParameterException)throwable).getParameterName();
+            String payload = String.format("{\"statusCode\":400,\"message\":\"Required request parameter "+
+                    "'%s' is missing\",\"type\":\"BadRequestException\"}", paramName);
+            return ResponseEntity.status(SC_BAD_REQUEST).header(CONTENT_TYPE_HEADER, CONTENT_TYPE_JSON).body(payload);
         }
         ObjectNode node = BridgeObjectMapper.get().valueToTree(throwable);
         final int status = getStatusCode(throwable);

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.services;
 
 import static java.lang.Boolean.TRUE;
 import static org.sagebionetworks.bridge.RequestContext.NULL_INSTANCE;
+import static org.sagebionetworks.bridge.TestConstants.ACCOUNT_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
 import static org.sagebionetworks.bridge.TestConstants.TIMESTAMP;
 import static org.sagebionetworks.bridge.TestUtils.createJson;
@@ -895,6 +896,12 @@ public class AccountWorkflowServiceTest extends Mockito {
         // We never send email nor SMS.
         verify(mockSendMailService, never()).sendEmail(any());
         verify(mockSmsService, never()).sendSmsMessage(any(), any());
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class,
+            expectedExceptionsMessageRegExp = ".*Account not found.*")
+    public void notifyAccountExistsNotFound() {
+        service.notifyAccountExists(study, ACCOUNT_ID);
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
@@ -898,10 +898,13 @@ public class AccountWorkflowServiceTest extends Mockito {
         verify(mockSmsService, never()).sendSmsMessage(any(), any());
     }
     
-    @Test(expectedExceptions = EntityNotFoundException.class,
-            expectedExceptionsMessageRegExp = ".*Account not found.*")
+    @Test
     public void notifyAccountExistsNotFound() {
         service.notifyAccountExists(study, ACCOUNT_ID);
+        
+        verify(mockTemplateService, never()).getRevisionForUser(any(), any());
+        verify(mockSendMailService, never()).sendEmail(any());
+        verify(mockSmsService, never()).sendSmsMessage(any(), any());
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportControllerTest.java
@@ -1,7 +1,11 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
+import static org.sagebionetworks.bridge.Roles.DEVELOPER;
+import static org.sagebionetworks.bridge.Roles.RESEARCHER;
+import static org.sagebionetworks.bridge.Roles.WORKER;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_IDENTIFIER;
+import static org.sagebionetworks.bridge.TestConstants.USER_ID;
 import static org.sagebionetworks.bridge.TestConstants.USER_SUBSTUDY_IDS;
 import static org.sagebionetworks.bridge.TestUtils.assertCreate;
 import static org.sagebionetworks.bridge.TestUtils.assertCrossOrigin;
@@ -43,6 +47,7 @@ import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoStudy;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
+import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.DateRangeResourceList;
 import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
@@ -474,6 +479,46 @@ public class ParticipantReportControllerTest extends Mockito {
 
         // Execute and validate.
         controller.deleteParticipantReportIndex(REPORT_ID);
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class, 
+            expectedExceptionsMessageRegExp=".*Account not found.*")
+    public void getParticipantReportAccountNotFound() {
+        doReturn(session).when(controller).getAuthenticatedSession(RESEARCHER);
+        reset(mockAccountService);
+        controller.getParticipantReport(USER_ID, REPORT_ID, null, null);
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class, 
+            expectedExceptionsMessageRegExp=".*Account not found.*")
+    public void getParticipantReportForWorkerAccountNotFound() {
+        doReturn(session).when(controller).getAuthenticatedSession(WORKER);
+        reset(mockAccountService);
+        controller.getParticipantReportForWorker(TEST_STUDY_IDENTIFIER, USER_ID, REPORT_ID, null, null);
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class, 
+            expectedExceptionsMessageRegExp=".*Account not found.*")
+    public void saveParticipantReportAccountNotFound() {
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
+        reset(mockAccountService);
+        controller.saveParticipantReport(USER_ID, REPORT_ID);
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class, 
+            expectedExceptionsMessageRegExp=".*Account not found.*")
+    public void deleteParticipantReportAccountNotFound() {
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, WORKER);
+        reset(mockAccountService);
+        controller.deleteParticipantReport(USER_ID, REPORT_ID);
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class, 
+            expectedExceptionsMessageRegExp=".*Account not found.*")
+    public void deleteParticipantReportRecordAccountNotFound() {
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, WORKER);
+        reset(mockAccountService);
+        controller.deleteParticipantReportRecord(USER_ID, REPORT_ID, null);
     }
     
     private void assertResultContent(LocalDate expectedStartDate, LocalDate expectedEndDate,

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportControllerTest.java
@@ -521,6 +521,22 @@ public class ParticipantReportControllerTest extends Mockito {
         controller.deleteParticipantReportRecord(USER_ID, REPORT_ID, null);
     }
     
+    @Test(expectedExceptions = EntityNotFoundException.class, 
+            expectedExceptionsMessageRegExp=".*Account not found.*")
+    public void getParticipantReportV4AccountNotFound() {
+        doReturn(session).when(controller).getAuthenticatedSession(RESEARCHER);
+        reset(mockAccountService);
+        controller.getParticipantReportV4(USER_ID, REPORT_ID, null, null, null, null);
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class, 
+            expectedExceptionsMessageRegExp=".*Account not found.*")
+    public void getParticipantReportForWorkerV4AccountNotFound() {
+        doReturn(session).when(controller).getAuthenticatedSession(WORKER);
+        reset(mockAccountService);
+        controller.getParticipantReportForWorkerV4(TEST_STUDY_IDENTIFIER, USER_ID, REPORT_ID, null, null, null, null);
+    }
+    
     private void assertResultContent(LocalDate expectedStartDate, LocalDate expectedEndDate,
             DateRangeResourceList<? extends ReportData> result) throws Exception {
 

--- a/src/test/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandlerTest.java
@@ -28,6 +28,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -207,5 +208,17 @@ public class BridgeExceptionHandlerTest extends Mockito {
             assertEquals(response.getStatusCodeValue(), 400);
             assertEquals(node.get("statusCode").intValue(), 400);
         }
+    }
+    
+    @Test
+    public void convertsMissingServletRequestParameterException() throws Throwable {
+        MissingServletRequestParameterException ex = new MissingServletRequestParameterException("myParam", "String");
+        
+        ResponseEntity<String> response = handler.handleException(mockRequest, ex);
+        JsonNode node = new ObjectMapper().readTree(response.getBody());
+        
+        assertEquals(node.get("statusCode").intValue(), 400);
+        assertEquals(node.get("message").textValue(), "Required request parameter 'myParam' is missing");
+        assertEquals(node.get("type").textValue(), "BadRequestException");
     }
 }


### PR DESCRIPTION
Converted some required request parameters to be optional (when required, and not present, Spring is returning a 500 error). In the course of working on that, found a number of cases where accounts were being retrieved and used without checking for null and returning an appropriate 404, even though the userId is sometimes in the URL and can easily be wrong. Fixed all of those, added tests.