### PR TITLE
Fix for BRIDGE-2658

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
@@ -51,14 +51,13 @@ public abstract class ActivityScheduler {
             // Start time is event time, with added delay if it's present.
             DateTime startTime = oneEventTime;
             if (schedule.getDelay() != null) {
-                startTime = oneEventTime.withZone(context.getRequestTimeZone()).plus(schedule.getDelay());
+                startTime = startTime.plus(schedule.getDelay());
             }
-
             // End time is only present if a sequence period is specified.
             // Sequence period is measured from the first timestamp plus the delay, to the end of the period.
             DateTime endTime = null;
             if (schedule.getSequencePeriod() != null) {
-                endTime = startTime.withZone(context.getRequestTimeZone()).plus(schedule.getSequencePeriod());
+                endTime = startTime.plus(schedule.getSequencePeriod());
             }
 
             // Construct the range tuple.

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules/ActivityScheduler.java
@@ -51,14 +51,14 @@ public abstract class ActivityScheduler {
             // Start time is event time, with added delay if it's present.
             DateTime startTime = oneEventTime;
             if (schedule.getDelay() != null) {
-                startTime = oneEventTime.plus(schedule.getDelay());
+                startTime = oneEventTime.withZone(context.getRequestTimeZone()).plus(schedule.getDelay());
             }
 
             // End time is only present if a sequence period is specified.
             // Sequence period is measured from the first timestamp plus the delay, to the end of the period.
             DateTime endTime = null;
             if (schedule.getSequencePeriod() != null) {
-                endTime = startTime.plus(schedule.getSequencePeriod());
+                endTime = startTime.withZone(context.getRequestTimeZone()).plus(schedule.getSequencePeriod());
             }
 
             // Construct the range tuple.
@@ -162,7 +162,7 @@ public abstract class ActivityScheduler {
             Iterable<String> eventIds = Schedule.EVENT_ID_SPLITTER.split(eventIdsString.trim());
             for (String thisEventId : eventIds) {
                 if (context.getEvent(thisEventId) != null) {
-                    eventDateTimeList.add(context.getEvent(thisEventId));
+                    eventDateTimeList.add(context.getEvent(thisEventId).withZone(context.getRequestTimeZone()));
 
                     if (!getAll) {
                         // We only wanted one event, and we found it, so break.

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules/ScheduleContext.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules/ScheduleContext.java
@@ -85,6 +85,10 @@ public final class ScheduleContext {
         return startsOn;
     }
     
+    public DateTimeZone getRequestTimeZone() { 
+        return startsOn.getZone();
+    }
+    
     public int getMinimumPerSchedule() {
         return minimumPerSchedule;
     }

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
@@ -12,7 +12,6 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules/ActivitySchedulerTest.java
@@ -469,7 +469,7 @@ public class ActivitySchedulerTest {
         ScheduleContext context = new ScheduleContext.Builder()
                 .withStudyIdentifier(TEST_STUDY)
                 // not the enrollment time zone, and not the request timezone
-                .withInitialTimeZone(DateTimeZone.forOffsetHours(-4)) 
+                .withInitialTimeZone(DateTimeZone.forOffsetHours(-4))
                 .withStartsOn(DateTime.parse("2015-03-26T14:40:00+05:30"))
                 .withEndsOn(DateTime.parse("2015-03-26T14:40:00+05:30"))
                 .withEvents(events).build();
@@ -481,12 +481,42 @@ public class ActivitySchedulerTest {
         // Need a recurring schedule with a sequence to generate an end time and multiple windows
         schedule.setSequencePeriod("P1W");
         schedule.setScheduleType(RECURRING);
+        schedule.setDelay("P2D");
         
-        List<RangeTuple<DateTime>> tuple = new IntervalActivityScheduler(schedule).getScheduleWindowsBasedOnEvents(context);
-        assertEquals(tuple.get(0).getStart().getZone(), IST);
-        assertEquals(tuple.get(0).getEnd().getZone(), IST);
-        assertEquals(tuple.get(1).getStart().getZone(), IST);
-        assertEquals(tuple.get(1).getEnd().getZone(), IST);
+        List<RangeTuple<DateTime>> tuples = new IntervalActivityScheduler(schedule).getScheduleWindowsBasedOnEvents(context);
+        assertEquals(tuples.get(0).getStart().getZone(), IST);
+        assertEquals(tuples.get(0).getEnd().getZone(), IST);
+        assertEquals(tuples.get(1).getStart().getZone(), IST);
+        assertEquals(tuples.get(1).getEnd().getZone(), IST);
+    }
+    
+    @Test
+    public void getEventDateTimesAdjustsTimeZones() {
+        Map<String,DateTime> events = ImmutableMap.of(
+                "enrollment", NOW, 
+                "enrollment2", NOW.plusWeeks(2).withZone(DateTimeZone.UTC)); // -07:00 and UTC timezones, not IST
+        
+        ScheduleContext context = new ScheduleContext.Builder()
+                .withStudyIdentifier(TEST_STUDY)
+                // not the enrollment time zone, and not the request timezone
+                .withInitialTimeZone(DateTimeZone.forOffsetHours(-4))
+                .withStartsOn(DateTime.parse("2015-03-26T14:40:00+05:30"))
+                .withEndsOn(DateTime.parse("2015-03-26T14:40:00+05:30"))
+                .withEvents(events).build();
+        
+        assertEquals(context.getRequestTimeZone(), IST);
+        
+        Schedule schedule = new Schedule();
+        schedule.setEventId("enrollment,enrollment2");
+        // Need a recurring schedule with a sequence to generate an end time and multiple windows
+        schedule.setSequencePeriod("P1W");
+        schedule.setScheduleType(RECURRING);
+        schedule.setDelay("P2D");
+        
+        List<DateTime> dates = new IntervalActivityScheduler(schedule).getEventDateTimes(context,
+                "enrollment,enrollment2", true);
+        assertEquals(dates.get(0).getZone(), IST);
+        assertEquals(dates.get(1).getZone(), IST);
     }
     
     private ScheduleContext getContext(DateTime endsOn) {

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules/IntervalActivitySchedulerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules/IntervalActivitySchedulerTest.java
@@ -53,6 +53,36 @@ public class IntervalActivitySchedulerTest {
     }
     
     @Test
+    public void recurringScheduleBugInIndianTimeZone() {
+        Schedule schedule = new Schedule();
+        schedule.setScheduleType(RECURRING);
+        schedule.setInterval("P1D");
+        schedule.setExpires("P1D");
+        schedule.addTimes("08:00");
+        schedule.addActivity(TestUtils.getActivity3());
+
+        DateTime now = DateTime.parse("2019-12-18T23:52:33.462+05:30");
+        DateTimeUtils.setCurrentMillisFixed(now.getMillis());
+
+        events.put("enrollment", DateTime.parse("2019-11-28T22:31:41.270-07:00"));
+
+        ScheduleContext context = new ScheduleContext.Builder()
+            .withStudyIdentifier(TEST_STUDY)
+            .withInitialTimeZone(DateTimeZone.forOffsetHours(-7))
+            .withStartsOn(DateTime.parse("2019-12-18T00:00:00.000+05:30"))
+            .withEndsOn(DateTime.parse("2019-12-19T00:00:00.000+05:30"))
+            .withEvents(events).build();
+        scheduledActivities = schedule.getScheduler().getScheduledActivities(plan, context);
+
+        assertEquals(scheduledActivities.size(), 2);
+        assertEquals(scheduledActivities.get(0).getScheduledOn().toString(), "2019-12-17T08:00:00.000+05:30");
+        assertEquals(scheduledActivities.get(0).getExpiresOn().toString(), "2019-12-18T08:00:00.000+05:30");
+        assertEquals(scheduledActivities.get(1).getScheduledOn().toString(), "2019-12-18T08:00:00.000+05:30");
+        assertEquals(scheduledActivities.get(1).getExpiresOn().toString(), "2019-12-19T08:00:00.000+05:30");
+        DateTimeUtils.setCurrentMillisSystem();
+    }
+    
+    @Test
     public void canSpecifyASequence() {
         Schedule schedule = new Schedule();
         schedule.setScheduleType(RECURRING);

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules/IntervalActivitySchedulerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules/IntervalActivitySchedulerTest.java
@@ -79,7 +79,6 @@ public class IntervalActivitySchedulerTest {
         assertEquals(scheduledActivities.get(0).getExpiresOn().toString(), "2019-12-18T08:00:00.000+05:30");
         assertEquals(scheduledActivities.get(1).getScheduledOn().toString(), "2019-12-18T08:00:00.000+05:30");
         assertEquals(scheduledActivities.get(1).getExpiresOn().toString(), "2019-12-19T08:00:00.000+05:30");
-        DateTimeUtils.setCurrentMillisSystem();
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules/ScheduleContextTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules/ScheduleContextTest.java
@@ -146,4 +146,21 @@ public class ScheduleContextTest {
         assertEquals(context2.getAccountCreatedOn().toString(), "2010-10-10T07:10:10.010Z");
     }
     
+    @Test
+    public void getRequestTimeZoneFromStartsOn() {
+        ScheduleContext context = new ScheduleContext.Builder()
+                .withStartsOn(DateTime.parse("2010-10-10T10:10:10.010+03:00"))
+                .withStudyIdentifier(TEST_STUDY).build();
+        assertEquals(context.getRequestTimeZone().toString(), "+03:00");
+    }
+
+    @Test
+    public void getRequestTimeZoneNull() {
+        // The startsOn field will be set by the builder, so it's never entirely null. In this
+        // case it matches the initial time zone of the user
+        ScheduleContext context = new ScheduleContext.Builder().withStudyIdentifier(TEST_STUDY)
+            .withInitialTimeZone(DateTimeZone.forOffsetHoursMinutes(5, 30)).build();
+
+        assertEquals(context.getRequestTimeZone().toString(), "+05:30");
+    }
 }


### PR DESCRIPTION
On investigation, the getScheduleWindowsBasedOnEvents(...) method was returning a start and end date time that are not in the timezone of the current request, which is then used to truncate scheduled activities in ways that are not in the user's timezone.