### PR TITLE
fix log errors

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
@@ -30,6 +30,7 @@ import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.AccountSecretDao;
 import org.sagebionetworks.bridge.exceptions.AccountDisabledException;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
@@ -72,11 +73,11 @@ public class AccountService {
     /**
      * Search for all accounts across studies that have the same Synapse user ID in common, 
      * and return a list of the study IDs where these accounts are found.
-     * @param synapseUserId
-     * @return list of study identifiers
      */
     public List<String> getStudyIdsForUser(String synapseUserId) {
-        checkNotNull(synapseUserId);
+        if (StringUtils.isBlank(synapseUserId)) {
+            throw new BadRequestException("Account does not have a Synapse user");
+        }
         return accountDao.getStudyIdsForUser(synapseUserId);
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
@@ -53,6 +53,7 @@ import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.AccountSecretDao;
 import org.sagebionetworks.bridge.exceptions.AccountDisabledException;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.PagedResourceList;
@@ -137,6 +138,24 @@ public class AccountServiceTest extends Mockito {
         List<String> returnVal = service.getStudyIdsForUser(SYNAPSE_USER_ID);
         assertEquals(returnVal, studies);
         verify(mockAccountDao).getStudyIdsForUser(SYNAPSE_USER_ID);
+    }
+
+    @Test(expectedExceptions = BadRequestException.class, expectedExceptionsMessageRegExp =
+            "Account does not have a Synapse user")
+    public void getStudyIdsForUser_NullSynapseUserId() {
+        service.getStudyIdsForUser(null);
+    }
+
+    @Test(expectedExceptions = BadRequestException.class, expectedExceptionsMessageRegExp =
+            "Account does not have a Synapse user")
+    public void getStudyIdsForUser_EmptySynapseUserId() {
+        service.getStudyIdsForUser("");
+    }
+
+    @Test(expectedExceptions = BadRequestException.class, expectedExceptionsMessageRegExp =
+            "Account does not have a Synapse user")
+    public void getStudyIdsForUser_BlankSynapseUserId() {
+        service.getStudyIdsForUser("   ");
     }
 
     @Test


### PR DESCRIPTION
We have a few log errors accumulating. This fixes a few that I saw recently.

1. It's possible for an account without a Synapse User ID to call getStudyMemberships(). If this happens, the old code would throw a NullPointerException. Now we throw a BadRequestException.

2. AWS exceptions were being reported with the correct status code, but were still being logged as errors. Now, if the the AWS exception is a 4XX (and not a throttling exception), we log it as a warning (and keep the stack trace).