### PR TITLE
MD5s of files sent to Synapse need to be hex encoded

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/upload/UploadFileHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/upload/UploadFileHelper.java
@@ -12,7 +12,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.base.Charsets;
-import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -242,29 +242,29 @@ public class UploadFileHelper {
 
     /** Upload bytes to the attachment bucket and apply the correct metadata. */
     public void uploadBytesAsAttachment(String filename, byte[] bytes) throws IOException {
-        // Calculate MD5 (base64-encoded).
+        // Calculate MD5 (hex-encoded).
         byte[] md5 = md5DigestUtils.digest(bytes);
-        String md5Base64Encoded = Base64.encodeBase64String(md5);
+        String md5HexEncoded = Hex.encodeHexString(md5);
 
         // S3 Metadata must include encryption and MD5. Note that for some reason setContentMD5() doesn't work, so we
         // have to use addUserMetadata().
         ObjectMetadata metadata = new ObjectMetadata();
-        metadata.addUserMetadata(KEY_CUSTOM_CONTENT_MD5, md5Base64Encoded);
+        metadata.addUserMetadata(KEY_CUSTOM_CONTENT_MD5, md5HexEncoded);
         metadata.setSSEAlgorithm(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
         s3Helper.writeBytesToS3(ATTACHMENT_BUCKET, filename, bytes, metadata);
     }
 
     /** Upload a file to the attachment bucket and apply the correct metadata. */
     public void uploadFileAsAttachment(String filename, File file) throws IOException {
-        // Calculate MD5 (base64-encoded).
+        // Calculate MD5 (hex-encoded).
         byte[] md5 = md5DigestUtils.digest(file);
-        String md5Base64Encoded = Base64.encodeBase64String(md5);
+        String md5HexEncoded = Hex.encodeHexString(md5);
 
         // S3 Metadata must include encryption and MD5. Note that for some reason setContentMD5() doesn't work, so we
         // have to use addUserMetadata().
         ObjectMetadata metadata = new ObjectMetadata();
-        LOG.info("Writing MD5 for attachment " + filename + ": " + md5Base64Encoded);
-        metadata.addUserMetadata(KEY_CUSTOM_CONTENT_MD5, md5Base64Encoded);
+        LOG.info("Writing MD5 for attachment " + filename + ": " + md5HexEncoded);
+        metadata.addUserMetadata(KEY_CUSTOM_CONTENT_MD5, md5HexEncoded);
         metadata.setSSEAlgorithm(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
         s3Helper.writeFileToS3(ATTACHMENT_BUCKET, filename, file, metadata);
     }

--- a/src/test/java/org/sagebionetworks/bridge/TestConstants.java
+++ b/src/test/java/org/sagebionetworks/bridge/TestConstants.java
@@ -45,8 +45,8 @@ public class TestConstants {
     
     public static final String DUMMY_IMAGE_DATA = "VGhpcyBpc24ndCBhIHJlYWwgaW1hZ2Uu";
 
-    public static final byte[] MOCK_MD5 = { 29, -23, 101, -93, -27, -88, -82, 87, 126 };
-    public static final String MOCK_MD5_BASE64_ENCODED = "Hello+World+";
+    public static final byte[] MOCK_MD5 = { -104, 10, -30, -37, 25, -113, 92, -9, 69, -118, -46, -87, 11, -14, 38, -61 };
+    public static final String MOCK_MD5_HEX_ENCODED = "980ae2db198f5cf7458ad2a90bf226c3";
 
     public static final String TEST_STUDY_IDENTIFIER = "api";
     public static final StudyIdentifier TEST_STUDY = new StudyIdentifierImpl(TEST_STUDY_IDENTIFIER);

--- a/src/test/java/org/sagebionetworks/bridge/upload/UploadFileHelperFindValueTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/UploadFileHelperFindValueTest.java
@@ -85,7 +85,7 @@ public class UploadFileHelperFindValueTest {
 
         ObjectMetadata metadata = metadataCaptor.getValue();
         assertEquals(metadata.getUserMetaDataOf(UploadFileHelper.KEY_CUSTOM_CONTENT_MD5),
-                TestConstants.MOCK_MD5_BASE64_ENCODED);
+                TestConstants.MOCK_MD5_HEX_ENCODED);
         assertEquals(metadata.getSSEAlgorithm(), ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
     }
 
@@ -189,7 +189,7 @@ public class UploadFileHelperFindValueTest {
                 eq("\"record-value\"".getBytes(Charsets.UTF_8)), metadataCaptor.capture());
 
         ObjectMetadata metadata = metadataCaptor.getValue();
-        assertEquals(TestConstants.MOCK_MD5_BASE64_ENCODED, metadata.getUserMetaDataOf(
+        assertEquals(TestConstants.MOCK_MD5_HEX_ENCODED, metadata.getUserMetaDataOf(
                 UploadFileHelper.KEY_CUSTOM_CONTENT_MD5));
         assertEquals(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION, metadata.getSSEAlgorithm());
     }

--- a/src/test/java/org/sagebionetworks/bridge/upload/UploadFileHelperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/UploadFileHelperTest.java
@@ -1,0 +1,76 @@
+package org.sagebionetworks.bridge.upload;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import java.io.File;
+
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.TestConstants;
+import org.sagebionetworks.bridge.s3.S3Helper;
+
+public class UploadFileHelperTest {
+    private static final byte[] CONTENT = "Hello world!".getBytes();
+    private static final String FILENAME = "file.txt";
+
+    @Mock
+    DigestUtils mockMd5DigestUtils;
+
+    @Mock
+    S3Helper mockS3Helper;
+
+    @InjectMocks
+    UploadFileHelper helper;
+
+    @BeforeMethod
+    public void before() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        when(mockMd5DigestUtils.digest(any(File.class))).thenReturn(TestConstants.MOCK_MD5);
+        when(mockMd5DigestUtils.digest(any(byte[].class))).thenReturn(TestConstants.MOCK_MD5);
+    }
+
+    @Test
+    public void uploadBytesAsAttachment() throws Exception {
+        // Execute.
+        helper.uploadBytesAsAttachment(FILENAME, CONTENT);
+
+        // Verify.
+        ArgumentCaptor<ObjectMetadata> metadataCaptor = ArgumentCaptor.forClass(ObjectMetadata.class);
+        verify(mockS3Helper).writeBytesToS3(eq(UploadFileHelper.ATTACHMENT_BUCKET), eq(FILENAME), eq(CONTENT),
+                metadataCaptor.capture());
+        ObjectMetadata metadata = metadataCaptor.getValue();
+        assertEquals(metadata.getUserMetaDataOf(UploadFileHelper.KEY_CUSTOM_CONTENT_MD5),
+                TestConstants.MOCK_MD5_HEX_ENCODED);
+        assertEquals(metadata.getSSEAlgorithm(), ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
+    }
+
+    @Test
+    public void uploadFileAsAttachment() throws Exception {
+        // Execute.
+        File mockFile = mock(File.class);
+        helper.uploadFileAsAttachment(FILENAME, mockFile);
+
+        // Verify.
+        ArgumentCaptor<ObjectMetadata> metadataCaptor = ArgumentCaptor.forClass(ObjectMetadata.class);
+        verify(mockS3Helper).writeFileToS3(eq(UploadFileHelper.ATTACHMENT_BUCKET), eq(FILENAME), same(mockFile),
+                metadataCaptor.capture());
+        ObjectMetadata metadata = metadataCaptor.getValue();
+        assertEquals(metadata.getUserMetaDataOf(UploadFileHelper.KEY_CUSTOM_CONTENT_MD5),
+                TestConstants.MOCK_MD5_HEX_ENCODED);
+        assertEquals(metadata.getSSEAlgorithm(), ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
+    }
+}


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-2662

Testing done: Ran unit tests and integ tests. Manually tested health data submission and verified MD5s in S3.