### PR TITLE
MasterScheduleConfig scan should use consistent read

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoMasterSchedulerConfigDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoMasterSchedulerConfigDao.java
@@ -47,7 +47,7 @@ public class DynamoMasterSchedulerConfigDao implements MasterSchedulerConfigDao 
 
     @Override
     public List<MasterSchedulerConfig> getAllSchedulerConfig() {
-        DynamoDBScanExpression scan = new DynamoDBScanExpression();
+        DynamoDBScanExpression scan = new DynamoDBScanExpression().withConsistentRead(true);
         
         List<DynamoMasterSchedulerConfig> mappings = mapper.scan(DynamoMasterSchedulerConfig.class, scan);
         

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoMasterSchedulerConfigDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoMasterSchedulerConfigDaoTest.java
@@ -45,9 +45,6 @@ public class DynamoMasterSchedulerConfigDaoTest extends Mockito {
     private ArgumentCaptor<DynamoMasterSchedulerConfig> configCaptor;
     
     @Captor
-    ArgumentCaptor<DynamoMasterSchedulerConfig> scanCaptor;
-    
-    @Captor
     private ArgumentCaptor<DynamoDBSaveExpression> saveExpressionCaptor;
     
     @InjectMocks
@@ -73,7 +70,10 @@ public class DynamoMasterSchedulerConfigDaoTest extends Mockito {
         assertEquals(result.size(), 2);
         assertEquals(result, configList);
 
-        verify(mockMapper).scan(eq(DynamoMasterSchedulerConfig.class), any(DynamoDBScanExpression.class));
+        ArgumentCaptor<DynamoDBScanExpression> scanCaptor = ArgumentCaptor.forClass(DynamoDBScanExpression.class);
+        verify(mockMapper).scan(eq(DynamoMasterSchedulerConfig.class), scanCaptor.capture());
+        DynamoDBScanExpression scan = scanCaptor.getValue();
+        assertTrue(scan.isConsistentRead());
     }
     
     @Test


### PR DESCRIPTION
By default, scan is eventually consistent (https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html). Make this use consistent read.