### PR TITLE
More compact random identifiers.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
@@ -16,13 +16,13 @@ import java.net.URLEncoder;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
@@ -93,6 +93,7 @@ public class BridgeUtils {
     private static final int ONE_DAY = 60*60*24;
     private static final int ONE_MINUTE = 60;
     
+    private static final Base64.Encoder ENCODER = Base64.getUrlEncoder().withoutPadding();
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
     private static final SubstudyAssociations NO_ASSOCIATIONS = new SubstudyAssociations(ImmutableSet.of(),
             ImmutableMap.of());
@@ -316,9 +317,13 @@ public class BridgeUtils {
         }
         return template;
     }
-    
+
     public static String generateGuid() {
-        return UUID.randomUUID().toString();
+        // Increases size from 16 to 18 bytes over UUID.randomUUID() while 
+        // still being shorter than the prior implementation. 
+        byte[] buffer = new byte[18];
+        SECURE_RANDOM.nextBytes(buffer);
+        return ENCODER.encodeToString(buffer);
     }
     
     /** Generate a random 16-byte salt, using a {@link SecureRandom}. */

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules/ABTestScheduleStrategy.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules/ABTestScheduleStrategy.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.bridge.models.schedules;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.UUID;
 
 import org.sagebionetworks.bridge.validators.ScheduleValidator;
 import org.springframework.validation.Errors;
@@ -32,8 +31,10 @@ public final class ABTestScheduleStrategy implements ScheduleStrategy {
         }
         // Randomly assign to a group, weighted based on the percentage representation of the group.
         ABTestGroup group = null;
-        long seed = UUID.fromString(plan.getGuid()).getLeastSignificantBits()
-                + UUID.fromString(context.getCriteriaContext().getHealthCode()).getLeastSignificantBits();        
+        
+        // A random(ish) number that is stable for a given user against a given schedule plan.
+        long seed = Math.abs(plan.getGuid().hashCode() + 
+                context.getCriteriaContext().getHealthCode().hashCode());
         
         int i = 0;
         int perc = (int)(seed % 100.0) + 1;

--- a/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -18,6 +18,7 @@ import static org.testng.Assert.assertTrue;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +59,18 @@ public class BridgeUtilsTest {
     @AfterMethod
     public void after() {
         BridgeUtils.setRequestContext(RequestContext.NULL_INSTANCE);
+    }
+    
+    @Test
+    public void generateUUID() {
+        // create 20 UUIDs, they should all be unique.
+        Set<String> uuids = new HashSet<>();
+        for (int i=0; i < 20; i++) {
+            String uuid = BridgeUtils.generateGuid();
+            assertEquals(uuid.length(), 24);
+            uuids.add( uuid );
+        }
+        assertEquals(uuids.size(), 20);
     }
     
     @Test


### PR DESCRIPTION
As with the current implementation, these are entirely random, but also 2 bytes larger than a standard UUID.