### PR TITLE
Worker should be able to get uploads by record ID

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/UploadController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/UploadController.java
@@ -6,6 +6,7 @@ import static org.sagebionetworks.bridge.Roles.WORKER;
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
 
 import java.io.IOException;
+import java.util.EnumSet;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -179,7 +180,7 @@ public class UploadController extends BaseController {
                 throw new EntityNotFoundException(HealthDataRecord.class);
             }
             
-            if (!session.isInRole(SUPERADMIN) && 
+            if (!session.isInRole(EnumSet.of(SUPERADMIN, WORKER)) &&
                 !session.getStudyIdentifier().getIdentifier().equals(record.getStudyId())) {
                 throw new UnauthorizedException("Study admin cannot retrieve upload in another study.");
             }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/UploadControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/UploadControllerTest.java
@@ -15,6 +15,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.fail;
 
 import java.net.URL;
+import java.util.EnumSet;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -383,7 +384,7 @@ public class UploadControllerTest extends Mockito {
     @Test
     public void getUploadByRecordIdWorksForFullAdmin() throws Exception {
         doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(ADMIN, WORKER);
-        doReturn(true).when(mockResearcherSession).isInRole(Roles.SUPERADMIN);
+        doReturn(true).when(mockResearcherSession).isInRole(EnumSet.of(Roles.SUPERADMIN, Roles.WORKER));
         
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(Account.create());
 


### PR DESCRIPTION
It looks like when we converted to Superadmins, we accidentally broke workers. This is needed for redriving uploads by record ID.

Note that there's a similar bug where study admins can get uploads by upload ID for any study. This is a more in-depth change. Filed https://sagebionetworks.jira.com/browse/BRIDGE-2795