### PR TITLE
Make the osName field more flexible: fix common aliases and allow for a 'both/universal' option.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/models/OperatingSystem.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/OperatingSystem.java
@@ -27,4 +27,7 @@ public class OperatingSystem {
     
     public static final Set<String> ALL_OS_SYSTEMS = new ImmutableSet.Builder<String>()
             .add(IOS).add(ANDROID).build();
+    // This matix would explode if there were more mobile operating systems, but there aren't.
+    public static final Set<String> ALL_OS_SUPPORT_OPTIONS = new ImmutableSet.Builder<String>()
+            .add(IOS).add(ANDROID).add(UNIVERSAL).build();
 }

--- a/src/main/java/org/sagebionetworks/bridge/services/AssessmentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AssessmentService.java
@@ -11,6 +11,7 @@ import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.PAGE_SIZE_ERROR;
 import static org.sagebionetworks.bridge.BridgeConstants.SHARED_STUDY_ID_STRING;
 import static org.sagebionetworks.bridge.BridgeUtils.sanitizeHTML;
+import static org.sagebionetworks.bridge.models.OperatingSystem.SYNONYMS;
 import static org.sagebionetworks.bridge.models.ResourceList.GUID;
 import static org.sagebionetworks.bridge.models.ResourceList.IDENTIFIER;
 import static org.sagebionetworks.bridge.models.ResourceList.INCLUDE_DELETED;
@@ -181,7 +182,11 @@ public class AssessmentService {
         DateTime timestamp = getModifiedOn();
         assessment.setModifiedOn(timestamp);
         sanitizeAssessment(assessment);
-        
+
+        String osName = assessment.getOsName();
+        if (SYNONYMS.get(osName) != null) {
+            assessment.setOsName(SYNONYMS.get(osName));
+        }
         AssessmentValidator validator = new AssessmentValidator(substudyService, appId);
         Validate.entityThrowingException(validator, assessment);
 
@@ -376,6 +381,10 @@ public class AssessmentService {
         assessment.setDeleted(false);
         sanitizeAssessment(assessment);
 
+        String osName = assessment.getOsName();
+        if (SYNONYMS.get(osName) != null) {
+            assessment.setOsName(SYNONYMS.get(osName));
+        }
         AssessmentValidator validator = new AssessmentValidator(substudyService, appId);
         Validate.entityThrowingException(validator, assessment);
         

--- a/src/main/java/org/sagebionetworks/bridge/validators/AssessmentValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/AssessmentValidator.java
@@ -40,9 +40,10 @@ public class AssessmentValidator implements Validator {
         if (isBlank(assessment.getTitle())) {
             errors.rejectValue("title", CANNOT_BE_BLANK);   
         }
+        String osName = assessment.getOsName();
         if (isBlank(assessment.getOsName())) {
             errors.rejectValue("osName", CANNOT_BE_BLANK);   
-        } else if (!OperatingSystem.ALL_OS_SYSTEMS.contains(assessment.getOsName())) {
+        } else if (!OperatingSystem.ALL_OS_SUPPORT_OPTIONS.contains(osName)) {
             errors.rejectValue("osName", "is not a supported platform");
         }
         if (isBlank(assessment.getIdentifier())) {

--- a/src/test/java/org/sagebionetworks/bridge/services/AssessmentServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AssessmentServiceTest.java
@@ -10,6 +10,7 @@ import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
 import static org.sagebionetworks.bridge.TestConstants.OWNER_ID;
 import static org.sagebionetworks.bridge.TestConstants.STRING_TAGS;
 import static org.sagebionetworks.bridge.models.OperatingSystem.ANDROID;
+import static org.sagebionetworks.bridge.models.OperatingSystem.UNIVERSAL;
 import static org.sagebionetworks.bridge.services.AssessmentService.CALLER_NOT_MEMBER;
 import static org.sagebionetworks.bridge.services.AssessmentService.IDENTIFIER_REQUIRED;
 import static org.sagebionetworks.bridge.services.AssessmentService.OFFSET_BY_CANNOT_BE_NEGATIVE;
@@ -147,6 +148,21 @@ public class AssessmentServiceTest extends Mockito {
         assertEquals(assessment.getCreatedOn(), CREATED_ON);
         assertEquals(assessment.getModifiedOn(), CREATED_ON);
         assertFalse(assessment.isDeleted());
+    }
+    
+    @Test
+    public void createAssessmentAdjustsOsNameAlias() {
+        when(mockSubstudyService.getSubstudy(APP_AS_STUDY_ID, OWNER_ID, false))
+            .thenReturn(mockSubstudy);
+        when(mockDao.getAssessmentRevisions(any(), any(), anyInt(), anyInt(), anyBoolean()))
+            .thenReturn(EMPTY_LIST);
+        
+        Assessment assessment = AssessmentTest.createAssessment();
+        assessment.setOsName("Both");
+        
+        service.createAssessment(APP_ID_VALUE, assessment);
+        
+        assertEquals(assessment.getOsName(), UNIVERSAL);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -306,6 +322,23 @@ public class AssessmentServiceTest extends Mockito {
     }
     
     @Test
+    public void updateAssessmentAdjustsOsNameAlias() {
+        when(mockSubstudyService.getSubstudy(APP_AS_STUDY_ID, OWNER_ID, false)).thenReturn(mockSubstudy);
+        
+        Assessment assessment = AssessmentTest.createAssessment();
+        assessment.setOsName("Both");
+        when(mockDao.saveAssessment(APP_ID_VALUE, assessment)).thenReturn(assessment);
+        
+        Assessment existing = AssessmentTest.createAssessment();
+        existing.setDeleted(false);
+        when(mockDao.getAssessment(APP_ID_VALUE, GUID)).thenReturn(Optional.of(existing));
+        
+        service.updateAssessment(APP_ID_VALUE, assessment);
+        
+        assertEquals(assessment.getOsName(), UNIVERSAL);
+    }    
+
+    @Test
     public void updateAssessmentSomeFieldsImmutable() {
         when(mockSubstudyService.getSubstudy(APP_AS_STUDY_ID, OWNER_ID, false)).thenReturn(mockSubstudy);
         
@@ -439,6 +472,28 @@ public class AssessmentServiceTest extends Mockito {
         assertEquals(assessment.getOriginGuid(), "unusualGuid");
         assertEquals(assessment.getCreatedOn(), CREATED_ON);
         assertEquals(assessment.getModifiedOn(), MODIFIED_ON);
+    }
+    
+    @Test
+    public void updateSharedAssessmentAdjustsOsNameAlias() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerStudyId(APP_AS_STUDY_ID)
+                .withCallerSubstudies(ImmutableSet.of(OWNER_ID)).build());
+        
+        when(mockSubstudyService.getSubstudy(APP_AS_STUDY_ID, OWNER_ID, false))
+            .thenReturn(Substudy.create());
+        
+        Assessment existing = AssessmentTest.createAssessment();
+        existing.setDeleted(false);
+        existing.setOwnerId(APP_ID_VALUE + ":" + OWNER_ID);
+        when(mockDao.getAssessment(SHARED_STUDY_ID_STRING, GUID))
+            .thenReturn(Optional.of(existing));
+        
+        Assessment assessment = AssessmentTest.createAssessment();
+        assessment.setOsName("Both");
+        service.updateSharedAssessment(APP_ID_VALUE, assessment);
+        
+        assertEquals(assessment.getOsName(), UNIVERSAL);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/validators/AssessmentValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/AssessmentValidatorTest.java
@@ -103,6 +103,14 @@ public class AssessmentValidatorTest extends Mockito {
         assertValidatorMessage(validator, assessment, "osName", "is not a supported platform");
     }
     @Test
+    public void osNameUniversalIsValid() {
+        when(mockSubstudyService.getSubstudy(TEST_STUDY, assessment.getOwnerId(), false))
+            .thenReturn(Substudy.create());
+        
+        assessment.setOsName("Universal");
+        Validate.entityThrowingException(validator, assessment);
+    }
+    @Test
     public void identifierNull() {
         assessment.setIdentifier(null);
         assertValidatorMessage(validator, assessment, "identifier", CANNOT_BE_BLANK);


### PR DESCRIPTION
In writing tests it became apparent the validation was too stringent; we expect most assessments to work cross-platform I believe. So allow for that.