### PR TITLE
Update objects saved/retrieved from Redis cache

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/cache/CacheProvider.java
+++ b/src/main/java/org/sagebionetworks/bridge/cache/CacheProvider.java
@@ -144,7 +144,6 @@ public class CacheProvider {
             }
             return null;
         } catch (Throwable e) {
-            e.printStackTrace();
             promptToStartRedisIfLocal(e);
             throw new BridgeServiceException(e);
         }
@@ -167,12 +166,13 @@ public class CacheProvider {
         }
     }
 
-    // During a transition period away from StudyIdentifier, we will need special handling to 
-    // ensure persisted sessions are retrieved correctly. This can be removed after a couple
-    // of days.
+    /**
+     * During a transition period away from StudyIdentifier, we will need special handling to
+     * ensure persisted sessions, subpopulations, are retrieved correctly. We can clear the 
+     * cache and then remove this code after a day (once all sessions have been refreshed or
+     * will be refreshed).
+     */
     private JsonNode adjustJsonWithStudyIdentifier(String ser) throws Exception {
-        // This is also verified by newUserSessionDeserializes(), but this focuses only on 
-        // the study identifier
         JsonNode node = BridgeObjectMapper.get().readTree(ser);
         if (node.isArray()) {
             for (int i=0; i < node.size(); i++) {
@@ -287,7 +287,6 @@ public class CacheProvider {
     public <T> T getObject(CacheKey cacheKey, Class<T> clazz, int expireInSeconds) {
         checkNotNull(cacheKey);
         checkNotNull(clazz);
-        
         try {
             String ser = jedisOps.get(cacheKey.toString());
             if (ser != null) {

--- a/src/main/java/org/sagebionetworks/bridge/cache/ViewCache.java
+++ b/src/main/java/org/sagebionetworks/bridge/cache/ViewCache.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.cache;
 
-import org.sagebionetworks.bridge.cache.CacheKey;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulation.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulation.java
@@ -35,7 +35,7 @@ public final class DynamoSubpopulation implements Subpopulation {
 
     private static final String DOCS_HOST = BridgeConfigFactory.getConfig().getHostnameWithPostfix("docs");
 
-    private String studyIdentifier;
+    private String appId;
     private String guid;
     private String name;
     private String description;
@@ -56,13 +56,13 @@ public final class DynamoSubpopulation implements Subpopulation {
     }
     
     @Override
-    @DynamoDBHashKey
-    public String getStudyIdentifier() {
-        return studyIdentifier;
+    @DynamoDBHashKey(attributeName = "studyIdentifier")
+    public String getAppId() {
+        return appId;
     }
     @Override
-    public void setStudyIdentifier(String studyIdentifier) {
-        this.studyIdentifier = studyIdentifier;
+    public void setAppId(String appId) {
+        this.appId = appId;
     }
     @Override
     @DynamoDBRangeKey(attributeName="guid")
@@ -204,7 +204,7 @@ public final class DynamoSubpopulation implements Subpopulation {
     
     @Override
     public int hashCode() {
-        return Objects.hash(name, description, required, deleted, defaultGroup, guid, studyIdentifier,
+        return Objects.hash(name, description, required, deleted, defaultGroup, guid, appId,
                 publishedConsentCreatedOn, version, criteria, autoSendConsentSuppressed, dataGroupsAssignedWhileConsented,
                 substudyIdsAssignedOnConsent);
     }
@@ -217,7 +217,7 @@ public final class DynamoSubpopulation implements Subpopulation {
         DynamoSubpopulation other = (DynamoSubpopulation) obj;
         return Objects.equals(name, other.name) && Objects.equals(description, other.description)
                 && Objects.equals(guid, other.guid) && Objects.equals(required, other.required)
-                && Objects.equals(deleted, other.deleted) && Objects.equals(studyIdentifier, other.studyIdentifier)
+                && Objects.equals(deleted, other.deleted) && Objects.equals(appId, other.appId)
                 && Objects.equals(publishedConsentCreatedOn, other.publishedConsentCreatedOn)
                 && Objects.equals(version, other.version) && Objects.equals(defaultGroup, other.defaultGroup)
                 && Objects.equals(criteria, other.criteria)
@@ -227,11 +227,12 @@ public final class DynamoSubpopulation implements Subpopulation {
     }
     @Override
     public String toString() {
-        return "DynamoSubpopulation [studyIdentifier=" + studyIdentifier + ", guid=" + guid + ", name=" + name
-                + ", description=" + description + ", required=" + required + ", deleted=" + deleted + ", criteria="
-                + criteria + ", publishedConsentCreatedOn=" + publishedConsentCreatedOn + ", version=" + version
+        return "DynamoSubpopulation [appId=" + appId + ", guid=" + guid + ", name=" + name + ", description="
+                + description + ", required=" + required + ", deleted=" + deleted + ", criteria=" + criteria
+                + ", publishedConsentCreatedOn=" + publishedConsentCreatedOn + ", version=" + version
                 + ", autoSendConsentSuppressed=" + autoSendConsentSuppressed + ", dataGroupsAssignedWhileConsented="
-                + dataGroupsAssignedWhileConsented + ", substudyIdsAssignedOnConsent=" + substudyIdsAssignedOnConsent + "]";
+                + dataGroupsAssignedWhileConsented + ", substudyIdsAssignedOnConsent=" + substudyIdsAssignedOnConsent
+                + "]";
     }
 
 }

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDao.java
@@ -50,7 +50,7 @@ public class DynamoSubpopulationDao implements SubpopulationDao {
     @Override
     public Subpopulation createSubpopulation(Subpopulation subpop) {
         checkNotNull(subpop);
-        checkNotNull(subpop.getStudyIdentifier());
+        checkNotNull(subpop.getAppId());
         
         subpop.setGuidString(generateGuid());
         subpop.setDeleted(false); 
@@ -68,13 +68,13 @@ public class DynamoSubpopulationDao implements SubpopulationDao {
     @Override
     public Subpopulation updateSubpopulation(Subpopulation subpop) {
         checkNotNull(subpop);
-        checkNotNull(subpop.getStudyIdentifier());
+        checkNotNull(subpop.getAppId());
         
         // These have to be supplied by the user so if they don't exist, we want a 400-level exception,
         if (subpop.getVersion() == null || subpop.getGuidString() == null) {
             throw new BadRequestException("Subpopulation appears to be a new object (no guid or version).");
         }
-        Subpopulation existing = getSubpopulation(subpop.getStudyIdentifier(), subpop.getGuid());
+        Subpopulation existing = getSubpopulation(subpop.getAppId(), subpop.getGuid());
         if (existing.isDeleted() && subpop.isDeleted()) {
             throw new EntityNotFoundException(Subpopulation.class);
         }
@@ -93,7 +93,7 @@ public class DynamoSubpopulationDao implements SubpopulationDao {
     @Override
     public List<Subpopulation> getSubpopulations(String studyId, boolean createDefault, boolean includeDeleted) {
         DynamoSubpopulation hashKey = new DynamoSubpopulation();
-        hashKey.setStudyIdentifier(studyId);
+        hashKey.setAppId(studyId);
         
         DynamoDBQueryExpression<DynamoSubpopulation> query = 
                 new DynamoDBQueryExpression<DynamoSubpopulation>().withHashKeyValues(hashKey);
@@ -120,7 +120,7 @@ public class DynamoSubpopulationDao implements SubpopulationDao {
     @Override
     public Subpopulation createDefaultSubpopulation(String studyId) {
         DynamoSubpopulation subpop = new DynamoSubpopulation();
-        subpop.setStudyIdentifier(studyId);
+        subpop.setAppId(studyId);
         subpop.setGuidString(studyId);
         subpop.setName("Default Consent Group");
         subpop.setDefaultGroup(true);
@@ -142,7 +142,7 @@ public class DynamoSubpopulationDao implements SubpopulationDao {
     @Override
     public Subpopulation getSubpopulation(String studyId, SubpopulationGuid subpopGuid) {
         DynamoSubpopulation hashKey = new DynamoSubpopulation();
-        hashKey.setStudyIdentifier(studyId);
+        hashKey.setAppId(studyId);
         hashKey.setGuidString(subpopGuid.getGuid());
         
         Subpopulation subpop = mapper.load(hashKey);

--- a/src/main/java/org/sagebionetworks/bridge/models/RequestInfo.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/RequestInfo.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -56,7 +57,8 @@ public final class RequestInfo {
     private DateTime uploadedOn;
     @Convert(converter = DateTimeZoneAttributeConverter.class)
     private DateTimeZone timeZone;
-    private String studyIdentifier;
+    @Column(name = "studyIdentifier")
+    private String appId;
 
     // Hibernate needs a default constructor; the easiest thing to do is to remove the 
     // existing constructor and allow the builder to set private fields directly.
@@ -101,14 +103,14 @@ public final class RequestInfo {
         return timeZone;
     }
     
-    public String getStudyIdentifier() {
-        return studyIdentifier;
+    public String getAppId() {
+        return appId;
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(getActivitiesAccessedOn(), clientInfo, userAgent, languages, getSignedInOn(),
-                userDataGroups, userSubstudyIds, userId, timeZone, uploadedOn, studyIdentifier);
+                userDataGroups, userSubstudyIds, userId, timeZone, uploadedOn, appId);
     }
 
     @Override
@@ -128,7 +130,7 @@ public final class RequestInfo {
                Objects.equals(userSubstudyIds, other.userSubstudyIds) && 
                Objects.equals(userId, other.userId) && 
                Objects.equals(timeZone, other.timeZone) && 
-               Objects.equals(studyIdentifier, other.studyIdentifier);
+               Objects.equals(appId, other.appId);
     }
     
     @Override
@@ -136,8 +138,8 @@ public final class RequestInfo {
         return "RequestInfo [userId=" + userId + ", userAgent=" + userAgent + ", languages=" + languages
                 + ", userDataGroups=" + userDataGroups + ", userSubstudyIds=" + userSubstudyIds 
                 + ", activitiesAccessedOn=" + getActivitiesAccessedOn() + ", signedInOn=" + getSignedInOn() 
-                + ", uploadedOn=" + getUploadedOn() + ", timeZone=" + timeZone + ", studyIdentifier=" 
-                + studyIdentifier + "]";
+                + ", uploadedOn=" + getUploadedOn() + ", timeZone=" + timeZone + ", appId=" 
+                + appId + "]";
     }
 
     public static class Builder {
@@ -151,7 +153,7 @@ public final class RequestInfo {
         private DateTime signedInOn;
         private DateTime uploadedOn;
         private DateTimeZone timeZone = DateTimeZone.UTC;
-        private String studyIdentifier;
+        private String appId;
 
         public Builder copyOf(RequestInfo requestInfo) {
             if (requestInfo != null) {
@@ -165,7 +167,7 @@ public final class RequestInfo {
                 withSignedInOn(requestInfo.getSignedInOn());
                 withUploadedOn(requestInfo.getUploadedOn());
                 withTimeZone(requestInfo.getTimeZone());
-                withStudyIdentifier(requestInfo.getStudyIdentifier());
+                withAppId(requestInfo.getAppId());
             }
             return this;
         }
@@ -229,9 +231,9 @@ public final class RequestInfo {
             }
             return this;
         }
-        public Builder withStudyIdentifier(String studyIdentifier) {
-            if (studyIdentifier != null) {
-                this.studyIdentifier = studyIdentifier;
+        public Builder withAppId(String appId) {
+            if (appId != null) {
+                this.appId = appId;    
             }
             return this;
         }
@@ -248,7 +250,7 @@ public final class RequestInfo {
             info.signedInOn = signedInOn;
             info.uploadedOn = uploadedOn;
             info.timeZone = timeZone;
-            info.studyIdentifier = studyIdentifier;
+            info.appId = appId;
             return info;
         }
     }

--- a/src/main/java/org/sagebionetworks/bridge/models/RequestInfo.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/RequestInfo.java
@@ -18,10 +18,15 @@ import org.sagebionetworks.bridge.hibernate.DateTimeToLongAttributeConverter;
 import org.sagebionetworks.bridge.hibernate.DateTimeZoneAttributeConverter;
 import org.sagebionetworks.bridge.hibernate.StringListConverter;
 import org.sagebionetworks.bridge.hibernate.StringSetConverter;
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.json.DateTimeSerializer;
 
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
 /**
  * Information about the criteria and access times of requests from a specific user. Useful for 
@@ -31,7 +36,11 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 @Entity
 @Table(name = "RequestInfos")
 @JsonDeserialize(builder = RequestInfo.Builder.class)
+@JsonFilter("filter")
 public final class RequestInfo {
+    public static final ObjectWriter REQUEST_INFO_WRITER = new BridgeObjectMapper().writer(
+            new SimpleFilterProvider().addFilter("filter",
+                    SimpleBeanPropertyFilter.serializeAllExcept("appId")));
     
     // By putting Hibernate annotations on the fields, we do not need to provide setter methods and
     // can continue using our Builder pattern.

--- a/src/main/java/org/sagebionetworks/bridge/models/accounts/UserSession.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/accounts/UserSession.java
@@ -23,7 +23,7 @@ public class UserSession {
     private String sessionToken;
     private String internalSessionToken;
     private String reauthToken;
-    private String studyIdentifier;
+    private String appId;
     private StudyParticipant participant;
     private Map<SubpopulationGuid,ConsentStatus> consentStatuses = ImmutableMap.of();
 
@@ -83,11 +83,11 @@ public class UserSession {
     public void setEnvironment(Environment environment) {
         this.environment = environment;
     }
-    public String getStudyIdentifier() {
-        return studyIdentifier;
+    public String getAppId() {
+        return appId;
     }
-    public void setStudyIdentifier(String studyIdentifier) {
-        this.studyIdentifier = studyIdentifier;
+    public void setAppId(String appId) {
+        this.appId = appId;
     }
     public boolean doesConsent() {
         return ConsentStatus.isUserConsented(consentStatuses);

--- a/src/main/java/org/sagebionetworks/bridge/models/accounts/VerificationData.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/accounts/VerificationData.java
@@ -1,0 +1,70 @@
+package org.sagebionetworks.bridge.models.accounts;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import org.sagebionetworks.bridge.services.AuthenticationService.ChannelType;
+
+@JsonDeserialize(builder = VerificationData.Builder.class)
+public class VerificationData {
+    private final String appId;
+    private final String userId;
+    private final ChannelType type;
+    private final long expiresOn;
+    
+    private VerificationData(String appId, ChannelType type, String userId, long expiresOn) {
+        checkArgument(isNotBlank(appId));
+        checkArgument(isNotBlank(userId));
+        this.appId = appId;
+        this.userId = userId;
+        this.type = type;
+        this.expiresOn = expiresOn;
+    }
+    public String getAppId() {
+        return appId;
+    }
+    public String getUserId() {
+        return userId;
+    }
+    public ChannelType getType() {
+        return type;
+    }
+    public long getExpiresOn() {
+        return expiresOn;
+    }
+    
+    // The builder pattern deals cleanly with deserializing studyId 
+    // and/or appId to the appId property
+    public static class Builder {
+        private String appId;
+        private String userId;
+        private ChannelType type;
+        private long expiresOn;
+        
+        public Builder withStudyId(String studyId) {
+            this.appId = studyId;
+            return this;
+        }
+        public Builder withAppId(String appId) {
+            this.appId = appId;
+            return this;
+        }
+        public Builder withUserId(String userId) {
+            this.userId = userId;
+            return this;
+        }
+        public Builder withType(ChannelType type) {
+            this.type = type;
+            return this;
+        }
+        public Builder withExpiresOn(long expiresOn) {
+            this.expiresOn = expiresOn;
+            return this;
+        }
+        public VerificationData build() {
+            return new VerificationData(appId, type, userId, expiresOn);
+        }
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/models/itp/IntentToParticipate.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/itp/IntentToParticipate.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(builder = IntentToParticipate.Builder.class)
 public class IntentToParticipate implements BridgeEntity {
-    private final String studyId;
+    private final String appId;
     private final Phone phone;
     private final String email;
     private final String subpopGuid;
@@ -18,9 +18,9 @@ public class IntentToParticipate implements BridgeEntity {
     private final String osName;
     private final ConsentSignature consentSignature;
     
-    private IntentToParticipate(String studyId, Phone phone, String email, String subpopGuid, SharingScope scope,
+    private IntentToParticipate(String appId, Phone phone, String email, String subpopGuid, SharingScope scope,
             String osName, ConsentSignature consentSignature) {
-        this.studyId = studyId;
+        this.appId = appId;
         this.phone = phone;
         this.email = email;
         this.subpopGuid = subpopGuid;
@@ -29,8 +29,8 @@ public class IntentToParticipate implements BridgeEntity {
         this.consentSignature = consentSignature;
     }
 
-    public String getStudyId() {
-        return studyId;
+    public String getAppId() {
+        return appId;
     }
     public Phone getPhone() {
         return phone;
@@ -52,7 +52,7 @@ public class IntentToParticipate implements BridgeEntity {
     }
     
     public static class Builder {
-        private String studyId;
+        private String appId;
         private Phone phone;
         private String email;
         private String subpopGuid;
@@ -61,7 +61,7 @@ public class IntentToParticipate implements BridgeEntity {
         private ConsentSignature consentSignature;
         
         public Builder copyOf(IntentToParticipate intent) {
-            this.studyId = intent.studyId;
+            this.appId = intent.appId;
             this.phone = intent.phone;
             this.email = intent.email;
             this.subpopGuid = intent.subpopGuid;
@@ -70,8 +70,14 @@ public class IntentToParticipate implements BridgeEntity {
             this.consentSignature = intent.consentSignature;
             return this;
         }
-        public Builder withStudyId(String studyId) {
-            this.studyId = studyId;
+        public Builder withAppId(String appId) {
+            this.appId = appId;
+            return this;
+        }
+        // To support existing submissions with studyId through the API, we 
+        // deserialize this to appId.
+        public Builder withStudyId(String appId) {
+            this.appId = appId;
             return this;
         }
         public Builder withPhone(Phone phone) {
@@ -103,7 +109,7 @@ public class IntentToParticipate implements BridgeEntity {
             if (OperatingSystem.SYNONYMS.containsKey(osName)) {
                 osName = OperatingSystem.SYNONYMS.get(osName);
             }
-            return new IntentToParticipate(studyId, phone, email, subpopGuid, scope, osName, consentSignature);
+            return new IntentToParticipate(appId, phone, email, subpopGuid, scope, osName, consentSignature);
         }
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/models/subpopulations/Subpopulation.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/subpopulations/Subpopulation.java
@@ -17,14 +17,14 @@ import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 public interface Subpopulation extends BridgeEntity, HasCriteria {
     ObjectWriter SUBPOP_WRITER = new BridgeObjectMapper().writer(
             new SimpleFilterProvider().addFilter("filter",
-            SimpleBeanPropertyFilter.serializeAllExcept("studyIdentifier")));
+            SimpleBeanPropertyFilter.serializeAllExcept("appId")));
 
     static Subpopulation create() {
         return new DynamoSubpopulation();
     }
     
-    void setStudyIdentifier(String studyIdentifier);
-    String getStudyIdentifier();
+    void setAppId(String appId);
+    String getAppId();
 
     void setGuidString(String guid);
     String getGuidString();

--- a/src/main/java/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -241,7 +241,7 @@ public class AuthenticationService {
 
     public void signOut(final UserSession session) {
         if (session != null) {
-            AccountId accountId = AccountId.forId(session.getStudyIdentifier(), session.getId());
+            AccountId accountId = AccountId.forId(session.getAppId(), session.getId());
             accountService.deleteReauthToken(accountId);
             // session does not have the reauth token so the reauthToken-->sessionToken Redis entry cannot be 
             // removed, but once the reauth token is removed from the user table, the reauth token will no 
@@ -478,7 +478,7 @@ public class AuthenticationService {
         session.setAuthenticated(true);
         session.setEnvironment(config.getEnvironment());
         session.setIpAddress(reqContext.getCallerIpAddress());
-        session.setStudyIdentifier(study.getIdentifier());
+        session.setAppId(study.getIdentifier());
         session.setReauthToken(account.getReauthToken());
         
         CriteriaContext newContext = updateContextFromSession(context, session);

--- a/src/main/java/org/sagebionetworks/bridge/services/IntentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/IntentService.java
@@ -107,9 +107,9 @@ public class IntentService {
         // If the account exists, do nothing.
         AccountId accountId = null;
         if (intent.getPhone() != null) {
-            accountId = AccountId.forPhone(intent.getStudyId(), intent.getPhone());
+            accountId = AccountId.forPhone(intent.getAppId(), intent.getPhone());
         } else {
-            accountId = AccountId.forEmail(intent.getStudyId(), intent.getEmail());
+            accountId = AccountId.forEmail(intent.getAppId(), intent.getEmail());
         }
         Account account = accountService.getAccount(accountId);
         if (account != null) {
@@ -117,7 +117,7 @@ public class IntentService {
         }
         
         // validate study exists
-        Study study = studyService.getStudy(intent.getStudyId());
+        Study study = studyService.getStudy(intent.getAppId());
 
         // validate subpopulation exists
         SubpopulationGuid guid = SubpopulationGuid.create(intent.getSubpopGuid());

--- a/src/main/java/org/sagebionetworks/bridge/services/SessionUpdateService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/SessionUpdateService.java
@@ -48,7 +48,7 @@ public class SessionUpdateService {
     }
     
     public void updateStudy(UserSession session, String studyId) {
-        session.setStudyIdentifier(studyId);
+        session.setAppId(studyId);
         cacheProvider.setUserSession(session);
     }
 

--- a/src/main/java/org/sagebionetworks/bridge/services/SubpopulationService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/SubpopulationService.java
@@ -84,7 +84,7 @@ public class SubpopulationService {
         checkNotNull(subpop);
 
         subpop.setGuidString(BridgeUtils.generateGuid());
-        subpop.setStudyIdentifier(study.getIdentifier());
+        subpop.setAppId(study.getIdentifier());
 
         Set<String> substudyIds = substudyService.getSubstudyIds(study.getIdentifier());
         
@@ -130,7 +130,7 @@ public class SubpopulationService {
         checkNotNull(study);
         checkNotNull(subpop);
         
-        subpop.setStudyIdentifier(study.getIdentifier());
+        subpop.setAppId(study.getIdentifier());
 
         // Verify this subpopulation is part of the study. Existing code also doesn't submit
         // this publication timestamp back to the server, so set if it doesn't exist.

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ActivityEventController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ActivityEventController.java
@@ -40,7 +40,7 @@ public class ActivityEventController extends BaseController {
         UserSession session = getAuthenticatedAndConsentedSession();
         CustomActivityEventRequest activityEvent = parseJson(CustomActivityEventRequest.class);
 
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         activityEventService.publishCustomEvent(study, session.getHealthCode(),
                 activityEvent.getEventKey(), activityEvent.getTimestamp());
         
@@ -51,7 +51,7 @@ public class ActivityEventController extends BaseController {
     public String getSelfActivityEvents() throws Exception {
         UserSession session = getAuthenticatedAndConsentedSession();
         
-        List<ActivityEvent> activityEvents = activityEventService.getActivityEventList(session.getStudyIdentifier(),
+        List<ActivityEvent> activityEvents = activityEventService.getActivityEventList(session.getAppId(),
                 session.getHealthCode());
         
         // I do not like the fact we are serializing in the controller, but that's the only way to access

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AppConfigController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AppConfigController.java
@@ -80,7 +80,7 @@ public class AppConfigController extends BaseController {
         
         boolean includeDeletedFlag = Boolean.valueOf(includeDeleted);
 
-        List<AppConfig> results = appConfigService.getAppConfigs(session.getStudyIdentifier(), includeDeletedFlag);
+        List<AppConfig> results = appConfigService.getAppConfigs(session.getAppId(), includeDeletedFlag);
 
         return new ResourceList<>(results).withRequestParam(INCLUDE_DELETED_PARAM, includeDeletedFlag);
     }
@@ -92,8 +92,8 @@ public class AppConfigController extends BaseController {
         
         AppConfig appConfig = parseJson(AppConfig.class);
         
-        AppConfig created = appConfigService.createAppConfig(session.getStudyIdentifier(), appConfig);
-        cacheProvider.removeSetOfCacheKeys(CacheKey.appConfigList(session.getStudyIdentifier()));
+        AppConfig created = appConfigService.createAppConfig(session.getAppId(), appConfig);
+        cacheProvider.removeSetOfCacheKeys(CacheKey.appConfigList(session.getAppId()));
         
         return new GuidVersionHolder(created.getGuid(), created.getVersion());
     }
@@ -102,7 +102,7 @@ public class AppConfigController extends BaseController {
     public AppConfig getAppConfig(@PathVariable String guid) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         
-        return appConfigService.getAppConfig(session.getStudyIdentifier(), guid);
+        return appConfigService.getAppConfig(session.getAppId(), guid);
     }
 
     @PostMapping("/v3/appconfigs/{guid}")
@@ -112,8 +112,8 @@ public class AppConfigController extends BaseController {
         AppConfig appConfig = parseJson(AppConfig.class);
         appConfig.setGuid(guid);
         
-        AppConfig updated = appConfigService.updateAppConfig(session.getStudyIdentifier(), appConfig);
-        cacheProvider.removeSetOfCacheKeys(CacheKey.appConfigList(session.getStudyIdentifier()));
+        AppConfig updated = appConfigService.updateAppConfig(session.getAppId(), appConfig);
+        cacheProvider.removeSetOfCacheKeys(CacheKey.appConfigList(session.getAppId()));
 
         return new GuidVersionHolder(updated.getGuid(), updated.getVersion());
     }
@@ -123,11 +123,11 @@ public class AppConfigController extends BaseController {
         UserSession session = getAuthenticatedSession(DEVELOPER, ADMIN);
         
         if ("true".equals(physical) && session.isInRole(ADMIN)) {
-            appConfigService.deleteAppConfigPermanently(session.getStudyIdentifier(), guid);
+            appConfigService.deleteAppConfigPermanently(session.getAppId(), guid);
         } else {
-            appConfigService.deleteAppConfig(session.getStudyIdentifier(), guid);
+            appConfigService.deleteAppConfig(session.getAppId(), guid);
         }
-        cacheProvider.removeSetOfCacheKeys(CacheKey.appConfigList(session.getStudyIdentifier()));
+        cacheProvider.removeSetOfCacheKeys(CacheKey.appConfigList(session.getAppId()));
         return new StatusMessage("App config deleted.");
     }
 

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AppConfigElementsController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AppConfigElementsController.java
@@ -43,7 +43,7 @@ public class AppConfigElementsController extends BaseController {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         boolean includeDeletedFlag = Boolean.valueOf(includeDeleted);
         
-        List<AppConfigElement> elements = service.getMostRecentElements(session.getStudyIdentifier(),
+        List<AppConfigElement> elements = service.getMostRecentElements(session.getAppId(),
                 includeDeletedFlag);
         
         return new ResourceList<AppConfigElement>(elements)
@@ -56,10 +56,10 @@ public class AppConfigElementsController extends BaseController {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         AppConfigElement element = parseJson(AppConfigElement.class);
         
-        VersionHolder version = service.createElement(session.getStudyIdentifier(), element);
+        VersionHolder version = service.createElement(session.getAppId(), element);
 
         // App config elements are included in the app configs, so allow cache to update
-        cacheProvider.removeSetOfCacheKeys(CacheKey.appConfigList(session.getStudyIdentifier()));
+        cacheProvider.removeSetOfCacheKeys(CacheKey.appConfigList(session.getAppId()));
         return version;
     }
     
@@ -68,7 +68,7 @@ public class AppConfigElementsController extends BaseController {
             @RequestParam String includeDeleted) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         boolean includeDeletedFlag = Boolean.valueOf(includeDeleted);
-        List<AppConfigElement> elements = service.getElementRevisions(session.getStudyIdentifier(), id,
+        List<AppConfigElement> elements = service.getElementRevisions(session.getAppId(), id,
                 includeDeletedFlag);
         
         return new ResourceList<AppConfigElement>(elements)
@@ -79,7 +79,7 @@ public class AppConfigElementsController extends BaseController {
     public AppConfigElement getMostRecentElement(@PathVariable String id) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         
-        return service.getMostRecentElement(session.getStudyIdentifier(), id);
+        return service.getMostRecentElement(session.getAppId(), id);
     }
 
     @GetMapping("/v3/appconfigs/elements/{id}/revisions/{revision}")
@@ -89,7 +89,7 @@ public class AppConfigElementsController extends BaseController {
         if (revisionLong == null) {
             throw new BadRequestException("Revision is not a valid revision number");
         }
-        return service.getElementRevision(session.getStudyIdentifier(), id, revisionLong);
+        return service.getElementRevision(session.getAppId(), id, revisionLong);
     }
     
     @PostMapping("/v3/appconfigs/elements/{id}/revisions/{revision}")
@@ -104,10 +104,10 @@ public class AppConfigElementsController extends BaseController {
         element.setId(id);
         element.setRevision(revisionLong);
         
-        VersionHolder holder = service.updateElementRevision(session.getStudyIdentifier(), element);
+        VersionHolder holder = service.updateElementRevision(session.getAppId(), element);
 
         // App config elements are included in the app configs, so allow cache to update
-        cacheProvider.removeSetOfCacheKeys(CacheKey.appConfigList(session.getStudyIdentifier()));
+        cacheProvider.removeSetOfCacheKeys(CacheKey.appConfigList(session.getAppId()));
         return holder;
     }
 
@@ -116,12 +116,12 @@ public class AppConfigElementsController extends BaseController {
         UserSession session = getAuthenticatedSession(DEVELOPER, ADMIN);
         
         if ("true".equals(physical) && session.isInRole(ADMIN)) {
-            service.deleteElementAllRevisionsPermanently(session.getStudyIdentifier(), id);
+            service.deleteElementAllRevisionsPermanently(session.getAppId(), id);
         } else {
-            service.deleteElementAllRevisions(session.getStudyIdentifier(), id);
+            service.deleteElementAllRevisions(session.getAppId(), id);
         }
         // App config elements are included in the app configs, so allow cache to update
-        cacheProvider.removeSetOfCacheKeys(CacheKey.appConfigList(session.getStudyIdentifier()));
+        cacheProvider.removeSetOfCacheKeys(CacheKey.appConfigList(session.getAppId()));
         return new StatusMessage("App config element deleted.");
     }
 
@@ -136,12 +136,12 @@ public class AppConfigElementsController extends BaseController {
         }
         
         if ("true".equals(physical) && session.isInRole(ADMIN)) {
-            service.deleteElementRevisionPermanently(session.getStudyIdentifier(), id, revisionLong);
+            service.deleteElementRevisionPermanently(session.getAppId(), id, revisionLong);
         } else {
-            service.deleteElementRevision(session.getStudyIdentifier(), id, revisionLong);
+            service.deleteElementRevision(session.getAppId(), id, revisionLong);
         }
         // App config elements are included in the app configs, so allow cache to update
-        cacheProvider.removeSetOfCacheKeys(CacheKey.appConfigList(session.getStudyIdentifier()));
+        cacheProvider.removeSetOfCacheKeys(CacheKey.appConfigList(session.getAppId()));
         return new StatusMessage("App config element revision deleted.");
     }
     

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AssessmentConfigController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AssessmentConfigController.java
@@ -35,7 +35,7 @@ public class AssessmentConfigController extends BaseController {
     @GetMapping("/v1/assessments/{guid}/config")
     public AssessmentConfig getAssessmentConfig(@PathVariable String guid) {
         UserSession session = getAuthenticatedSession();
-        String appId = session.getStudyIdentifier();
+        String appId = session.getAppId();
         
         return service.getAssessmentConfig(appId, guid);
     }
@@ -43,7 +43,7 @@ public class AssessmentConfigController extends BaseController {
     @PostMapping("/v1/assessments/{guid}/config")
     public AssessmentConfig updateAssessmentConfig(@PathVariable String guid) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String appId = session.getStudyIdentifier();
+        String appId = session.getAppId();
         
         if (SHARED_APP_ID.equals(appId)) {
             throw new UnauthorizedException(SHARED_ASSESSMENTS_ERROR);
@@ -56,7 +56,7 @@ public class AssessmentConfigController extends BaseController {
     @PostMapping("/v1/assessments/{guid}/config/customize")
     public AssessmentConfig customizeAssessmentConfig(@PathVariable String guid) throws Exception {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String appId = session.getStudyIdentifier();
+        String appId = session.getAppId();
         
         if (SHARED_APP_ID.equals(appId)) {
             throw new UnauthorizedException(SHARED_ASSESSMENTS_ERROR);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AssessmentController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AssessmentController.java
@@ -47,7 +47,7 @@ public class AssessmentController extends BaseController {
             @RequestParam(required = false) String includeDeleted) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         
-        String appId = session.getStudyIdentifier();
+        String appId = session.getAppId();
         if (SHARED_APP_ID.equals(appId)) {
             throw new UnauthorizedException(SHARED_ASSESSMENTS_ERROR);
         }
@@ -64,7 +64,7 @@ public class AssessmentController extends BaseController {
     public Assessment createAssessment() {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         
-        String appId = session.getStudyIdentifier();
+        String appId = session.getAppId();
         if (SHARED_APP_ID.equals(appId)) {
             throw new UnauthorizedException(SHARED_ASSESSMENTS_ERROR);
         }
@@ -77,7 +77,7 @@ public class AssessmentController extends BaseController {
     public Assessment getAssessmentByGuid(@PathVariable String guid) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
 
-        String appId = session.getStudyIdentifier();
+        String appId = session.getAppId();
         if (SHARED_APP_ID.equals(appId)) {
             throw new UnauthorizedException(SHARED_ASSESSMENTS_ERROR);
         }
@@ -88,7 +88,7 @@ public class AssessmentController extends BaseController {
     public Assessment updateAssessmentByGuid(@PathVariable String guid) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
 
-        String appId = session.getStudyIdentifier();
+        String appId = session.getAppId();
         if (SHARED_APP_ID.equals(appId)) {
             throw new UnauthorizedException(SHARED_ASSESSMENTS_ERROR);
         }
@@ -104,7 +104,7 @@ public class AssessmentController extends BaseController {
             @RequestParam(required = false) String includeDeleted) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
 
-        String appId = session.getStudyIdentifier();
+        String appId = session.getAppId();
         if (SHARED_APP_ID.equals(appId)) {
             throw new UnauthorizedException(SHARED_ASSESSMENTS_ERROR);
         }
@@ -122,7 +122,7 @@ public class AssessmentController extends BaseController {
     public Assessment createAssessmentRevision(@PathVariable String guid) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
 
-        String appId = session.getStudyIdentifier();
+        String appId = session.getAppId();
         if (SHARED_APP_ID.equals(appId)) {
             throw new UnauthorizedException(SHARED_ASSESSMENTS_ERROR);
         }
@@ -143,7 +143,7 @@ public class AssessmentController extends BaseController {
             @RequestParam(required = false) String newIdentifier) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
 
-        String appId = session.getStudyIdentifier();
+        String appId = session.getAppId();
         if (SHARED_APP_ID.equals(appId)) {
             throw new UnauthorizedException(SHARED_ASSESSMENTS_ERROR);
         }
@@ -155,7 +155,7 @@ public class AssessmentController extends BaseController {
     public StatusMessage deleteAssessment(@PathVariable String guid, @RequestParam(required = false) String physical) {
         UserSession session = getAuthenticatedSession(DEVELOPER, ADMIN);
 
-        String appId = session.getStudyIdentifier();
+        String appId = session.getAppId();
         if (SHARED_APP_ID.equals(appId)) {
             throw new UnauthorizedException(SHARED_ASSESSMENTS_ERROR);
         }
@@ -174,7 +174,7 @@ public class AssessmentController extends BaseController {
     public Assessment getLatestAssessment(@PathVariable String identifier) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
 
-        String appId = session.getStudyIdentifier();
+        String appId = session.getAppId();
         if (SHARED_APP_ID.equals(appId)) {
             throw new UnauthorizedException(SHARED_ASSESSMENTS_ERROR);
         }
@@ -188,7 +188,7 @@ public class AssessmentController extends BaseController {
             @RequestParam(required = false) String includeDeleted) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
 
-        String appId = session.getStudyIdentifier();
+        String appId = session.getAppId();
         if (SHARED_APP_ID.equals(appId)) {
             throw new UnauthorizedException(SHARED_ASSESSMENTS_ERROR);
         }
@@ -205,7 +205,7 @@ public class AssessmentController extends BaseController {
     public Assessment getAssessmentById(@PathVariable String identifier, @PathVariable String revision) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
 
-        String appId = session.getStudyIdentifier();
+        String appId = session.getAppId();
         if (SHARED_APP_ID.equals(appId)) {
             throw new UnauthorizedException(SHARED_ASSESSMENTS_ERROR);
         }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AssessmentResourceController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AssessmentResourceController.java
@@ -53,7 +53,7 @@ public class AssessmentResourceController extends BaseController {
             @RequestParam(required = false) String maxRevision,
             @RequestParam(required = false) String includeDeleted) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String appId = session.getStudyIdentifier();
+        String appId = session.getAppId();
         
         if (SHARED_APP_ID.equals(appId)) {
             throw new UnauthorizedException(SHARED_ASSESSMENTS_ERROR);
@@ -80,7 +80,7 @@ public class AssessmentResourceController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     public AssessmentResource createAssessmentResource(@PathVariable String assessmentId) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String appId = session.getStudyIdentifier();
+        String appId = session.getAppId();
 
         if (SHARED_APP_ID.equals(appId)) {
             throw new UnauthorizedException(SHARED_ASSESSMENTS_ERROR);
@@ -93,7 +93,7 @@ public class AssessmentResourceController extends BaseController {
     @GetMapping("/v1/assessments/identifier:{assessmentId}/resources/{guid}")
     public AssessmentResource getAssessmentResource(@PathVariable String assessmentId, @PathVariable String guid) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String appId = session.getStudyIdentifier();
+        String appId = session.getAppId();
         
         if (SHARED_APP_ID.equals(appId)) {
             throw new UnauthorizedException(SHARED_ASSESSMENTS_ERROR);
@@ -105,7 +105,7 @@ public class AssessmentResourceController extends BaseController {
     @PostMapping("/v1/assessments/identifier:{assessmentId}/resources/{guid}")
     public AssessmentResource updateAssessmentResource(@PathVariable String assessmentId, @PathVariable String guid) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String appId = session.getStudyIdentifier();
+        String appId = session.getAppId();
         
         if (SHARED_APP_ID.equals(appId)) {
             throw new UnauthorizedException(SHARED_ASSESSMENTS_ERROR);
@@ -121,7 +121,7 @@ public class AssessmentResourceController extends BaseController {
     public StatusMessage deleteAssessmentResource(@PathVariable String assessmentId, @PathVariable String guid,
             @RequestParam(required = false) String physical) {
         UserSession session = getAuthenticatedSession(DEVELOPER, ADMIN);
-        String appId = session.getStudyIdentifier();
+        String appId = session.getAppId();
         
         if (SHARED_APP_ID.equals(appId)) {
             throw new UnauthorizedException(SHARED_ASSESSMENTS_ERROR);
@@ -138,7 +138,7 @@ public class AssessmentResourceController extends BaseController {
     @PostMapping("/v1/assessments/identifier:{assessmentId}/resources/publish")
     public ResourceList<AssessmentResource> publishAssessmentResource(@PathVariable String assessmentId) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String appId = session.getStudyIdentifier();
+        String appId = session.getAppId();
 
         if (SHARED_APP_ID.equals(appId)) {
             throw new UnauthorizedException(SHARED_ASSESSMENTS_ERROR);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/BaseController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/BaseController.java
@@ -179,7 +179,7 @@ public abstract class BaseController {
         RequestContext.Builder builder = BridgeUtils.getRequestContext().toBuilder();
         // If the user has already persisted languages, we'll use that instead of the Accept-Language header
         builder.withCallerLanguages(getLanguages(session));
-        builder.withCallerStudyId(session.getStudyIdentifier());
+        builder.withCallerStudyId(session.getAppId());
         builder.withCallerSubstudies(session.getParticipant().getSubstudyIds());
         builder.withCallerRoles(session.getParticipant().getRoles());
         builder.withCallerUserId(session.getParticipant().getId());
@@ -188,7 +188,7 @@ public abstract class BaseController {
         
         // Sessions are locked to an IP address if (a) it is enabled in the study for unprivileged participant accounts
         // or (b) always for privileged accounts.
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         Set<Roles> userRoles = session.getParticipant().getRoles();
         boolean userHasRoles = !userRoles.isEmpty();
         if (study.isParticipantIpLockingEnabled() || userHasRoles) {
@@ -271,7 +271,7 @@ public abstract class BaseController {
         RequestContext reqContext = BridgeUtils.getRequestContext();
         List<String> languages = reqContext.getCallerLanguages();
         if (!languages.isEmpty()) {
-            accountService.editAccount(session.getStudyIdentifier(), session.getHealthCode(),
+            accountService.editAccount(session.getAppId(), session.getHealthCode(),
                     account -> account.setLanguages(languages));
 
             CriteriaContext newContext = new CriteriaContext.Builder()
@@ -281,7 +281,7 @@ public abstract class BaseController {
                 .withUserId(session.getId())
                 .withUserDataGroups(session.getParticipant().getDataGroups())
                 .withUserSubstudyIds(session.getParticipant().getSubstudyIds())
-                .withStudyIdentifier(session.getStudyIdentifier())
+                .withStudyIdentifier(session.getAppId())
                 .build();
 
             sessionUpdateService.updateLanguage(session, newContext);
@@ -309,7 +309,7 @@ public abstract class BaseController {
             .withUserId(session.getId())
             .withUserDataGroups(session.getParticipant().getDataGroups())
             .withUserSubstudyIds(session.getParticipant().getSubstudyIds())
-            .withStudyIdentifier(session.getStudyIdentifier())
+            .withStudyIdentifier(session.getAppId())
             .build();
     }
     
@@ -346,7 +346,7 @@ public abstract class BaseController {
         if (metrics != null && session != null) {
             metrics.setSessionId(session.getInternalSessionToken());
             metrics.setUserId(session.getId());
-            metrics.setStudy(session.getStudyIdentifier());
+            metrics.setStudy(session.getAppId());
         }
     }
     
@@ -386,7 +386,7 @@ public abstract class BaseController {
         builder.withUserDataGroups(session.getParticipant().getDataGroups());
         builder.withUserSubstudyIds(session.getParticipant().getSubstudyIds());
         builder.withTimeZone(session.getParticipant().getTimeZone());
-        builder.withStudyIdentifier(session.getStudyIdentifier());
+        builder.withAppId(session.getAppId());
         return builder;
     }
     

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/CompoundActivityDefinitionController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/CompoundActivityDefinitionController.java
@@ -45,7 +45,7 @@ public class CompoundActivityDefinitionController extends BaseController {
 
         CompoundActivityDefinition requestDef = parseJson(CompoundActivityDefinition.class);
         CompoundActivityDefinition createdDef = compoundActivityDefService.createCompoundActivityDefinition(
-                session.getStudyIdentifier(), requestDef);
+                session.getAppId(), requestDef);
         return PUBLIC_DEFINITION_WRITER.writeValueAsString(createdDef);
     }
 
@@ -54,7 +54,7 @@ public class CompoundActivityDefinitionController extends BaseController {
     public StatusMessage deleteCompoundActivityDefinition(@PathVariable String taskId) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
 
-        compoundActivityDefService.deleteCompoundActivityDefinition(session.getStudyIdentifier(), taskId);
+        compoundActivityDefService.deleteCompoundActivityDefinition(session.getAppId(), taskId);
         return new StatusMessage("Compound activity definition has been deleted.");
     }
 
@@ -64,7 +64,7 @@ public class CompoundActivityDefinitionController extends BaseController {
         UserSession session = getAuthenticatedSession(DEVELOPER);
 
         List<CompoundActivityDefinition> defList = compoundActivityDefService.getAllCompoundActivityDefinitionsInStudy(
-                session.getStudyIdentifier());
+                session.getAppId());
         ResourceList<CompoundActivityDefinition> defResourceList = new ResourceList<>(defList);
         return PUBLIC_DEFINITION_WRITER.writeValueAsString(defResourceList);
     }
@@ -75,7 +75,7 @@ public class CompoundActivityDefinitionController extends BaseController {
         UserSession session = getAuthenticatedSession(DEVELOPER);
 
         CompoundActivityDefinition def = compoundActivityDefService.getCompoundActivityDefinition(
-                session.getStudyIdentifier(), taskId);
+                session.getAppId(), taskId);
         return PUBLIC_DEFINITION_WRITER.writeValueAsString(def);
     }
 
@@ -86,7 +86,7 @@ public class CompoundActivityDefinitionController extends BaseController {
 
         CompoundActivityDefinition requestDef = parseJson(CompoundActivityDefinition.class);
         CompoundActivityDefinition updatedDef = compoundActivityDefService.updateCompoundActivityDefinition(
-                session.getStudyIdentifier(), taskId, requestDef);
+                session.getAppId(), taskId, requestDef);
         return PUBLIC_DEFINITION_WRITER.writeValueAsString(updatedDef);
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ConsentController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ConsentController.java
@@ -49,7 +49,7 @@ public class ConsentController extends BaseController {
             APPLICATION_JSON_UTF8_VALUE })
     public String getConsentSignature() throws Exception {
         UserSession session = getAuthenticatedAndConsentedSession();
-        return getConsentSignatureV2(session.getStudyIdentifier());
+        return getConsentSignatureV2(session.getAppId());
     }
 
     @Deprecated
@@ -57,7 +57,7 @@ public class ConsentController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     public JsonNode giveV1() {
         UserSession session = getAuthenticatedSession();
-        return giveConsentForVersion(1, SubpopulationGuid.create(session.getStudyIdentifier()));
+        return giveConsentForVersion(1, SubpopulationGuid.create(session.getAppId()));
     }
 
     @Deprecated
@@ -65,7 +65,7 @@ public class ConsentController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     public JsonNode giveV2() {
         UserSession session = getAuthenticatedSession();
-        return giveConsentForVersion(2, SubpopulationGuid.create(session.getStudyIdentifier()));
+        return giveConsentForVersion(2, SubpopulationGuid.create(session.getAppId()));
     }
 
     @Deprecated
@@ -73,7 +73,7 @@ public class ConsentController extends BaseController {
     public StatusMessage emailCopy() {
         UserSession session = getAuthenticatedAndConsentedSession();
         
-        return resendConsentAgreement(session.getStudyIdentifier());
+        return resendConsentAgreement(session.getAppId());
     }
 
     @Deprecated
@@ -100,7 +100,7 @@ public class ConsentController extends BaseController {
     @PostMapping("/v3/consents/signature/withdraw")
     public JsonNode withdrawConsent() {
         UserSession session = getAuthenticatedSession();
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         
         return withdrawConsentV2(study.getIdentifier());
     }
@@ -110,7 +110,7 @@ public class ConsentController extends BaseController {
     @GetMapping(path="/v3/subpopulations/{guid}/consents/signature", produces={APPLICATION_JSON_UTF8_VALUE})
     public String getConsentSignatureV2(@PathVariable String guid) throws Exception {
         UserSession session = getAuthenticatedAndConsentedSession();
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
 
         ConsentSignature sig = consentService.getConsentSignature(study, SubpopulationGuid.create(guid), session.getId());
         return ConsentSignature.SIGNATURE_WRITER.writeValueAsString(sig);
@@ -126,7 +126,7 @@ public class ConsentController extends BaseController {
     public JsonNode withdrawConsentV2(@PathVariable String guid) {
         UserSession session = getAuthenticatedSession();
         Withdrawal withdrawal = parseJson(Withdrawal.class);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         long withdrewOn = DateTime.now().getMillis();
         SubpopulationGuid subpopGuid = SubpopulationGuid.create(guid);
 
@@ -144,7 +144,7 @@ public class ConsentController extends BaseController {
     public StatusMessage withdrawFromStudy() {
         UserSession session = getAuthenticatedSession();
         Withdrawal withdrawal = parseJson(Withdrawal.class);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         long withdrewOn = DateTime.now().getMillis();
         
         consentService.withdrawFromStudy(study, session.getParticipant(), withdrawal, withdrewOn);
@@ -161,7 +161,7 @@ public class ConsentController extends BaseController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public StatusMessage resendConsentAgreement(@PathVariable String guid) {
         UserSession session = getAuthenticatedAndConsentedSession();
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
 
         consentService.resendConsentAgreement(study, SubpopulationGuid.create(guid), session.getParticipant());
         return new StatusMessage("Signed consent agreement resent.");
@@ -170,7 +170,7 @@ public class ConsentController extends BaseController {
     private JsonNode changeSharingScope(SharingScope sharingScope, String message) {
         UserSession session = getAuthenticatedAndConsentedSession();
         
-        accountService.editAccount(session.getStudyIdentifier(), session.getHealthCode(),
+        accountService.editAccount(session.getAppId(), session.getHealthCode(),
                 account -> account.setSharingScope(sharingScope));
 
         sessionUpdateService.updateSharingScope(session, sharingScope);
@@ -180,7 +180,7 @@ public class ConsentController extends BaseController {
     
     private JsonNode giveConsentForVersion(int version, SubpopulationGuid subpopGuid) {
         UserSession session = getAuthenticatedSession();
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
 
         JsonNode node = parseJson(JsonNode.class);
         ConsentSignature consentSignature = ConsentSignature.fromJSON(node);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ExportController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ExportController.java
@@ -31,7 +31,7 @@ public class ExportController extends BaseController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public StatusMessage startOnDemandExport() throws JsonProcessingException {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        exportService.startOnDemandExport(session.getStudyIdentifier());
+        exportService.startOnDemandExport(session.getAppId());
         return new StatusMessage("Request submitted.");
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ExternalIdControllerV4.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ExternalIdControllerV4.java
@@ -71,7 +71,7 @@ public class ExternalIdControllerV4 extends BaseController {
     @DeleteMapping("/v4/externalids/{externalId}")
     public StatusMessage deleteExternalIdentifier(@PathVariable String externalId) {
         UserSession session = getAuthenticatedSession(ADMIN);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         
         ExternalIdentifier externalIdentifier = ExternalIdentifier.create(study.getIdentifier(), externalId);
         externalIdService.deleteExternalIdPermanently(study, externalIdentifier);
@@ -86,7 +86,7 @@ public class ExternalIdControllerV4 extends BaseController {
         
         Boolean createAccountBool = Boolean.valueOf(createAccount);
         
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         return authenticationService.generatePassword(study, externalId, createAccountBool);
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/FPHSController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/FPHSController.java
@@ -56,7 +56,7 @@ public class FPHSController extends BaseController {
         UserSession session = getAuthenticatedSession();
         
         ExternalIdentifier externalId = parseJson(ExternalIdentifier.class);
-        fphsService.registerExternalIdentifier(session.getStudyIdentifier(), session.getHealthCode(), externalId);
+        fphsService.registerExternalIdentifier(session.getAppId(), session.getHealthCode(), externalId);
 
         // The service saves the external identifier and saves this as an option. We also need 
         // to update the user's session.
@@ -78,7 +78,7 @@ public class FPHSController extends BaseController {
     public StatusMessage addExternalIdentifiers() {
         UserSession session = getAuthenticatedSession(ADMIN);
         
-        if (!FPHS_ID.equals(session.getStudyIdentifier())) {
+        if (!FPHS_ID.equals(session.getAppId())) {
             throw new UnauthorizedException("Cannot create identifiers in FPHS study.");
         }
         

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/FileController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/FileController.java
@@ -49,7 +49,7 @@ public class FileController extends BaseController {
         int pageSizeInt = BridgeUtils.getIntOrDefault(pageSize, API_DEFAULT_PAGE_SIZE);
         boolean includeDeletedBool = Boolean.valueOf(includeDeleted);
         
-        return fileService.getFiles(session.getStudyIdentifier(), offsetInt, pageSizeInt, includeDeletedBool);
+        return fileService.getFiles(session.getAppId(), offsetInt, pageSizeInt, includeDeletedBool);
     }
     
     @PostMapping("/v3/files")
@@ -58,7 +58,7 @@ public class FileController extends BaseController {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         
         FileMetadata file = parseJson(FileMetadata.class);
-        FileMetadata updated = fileService.createFile(session.getStudyIdentifier(), file);
+        FileMetadata updated = fileService.createFile(session.getAppId(), file);
         
         return new GuidVersionHolder(updated.getGuid(), Long.valueOf(updated.getVersion()));
     }
@@ -67,7 +67,7 @@ public class FileController extends BaseController {
     public FileMetadata getFile(@PathVariable String guid) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         
-        return fileService.getFile(session.getStudyIdentifier(), guid);
+        return fileService.getFile(session.getAppId(), guid);
     }
     
     @PostMapping("/v3/files/{guid}")
@@ -76,7 +76,7 @@ public class FileController extends BaseController {
         
         FileMetadata file = parseJson(FileMetadata.class);
         file.setGuid(guid);
-        FileMetadata updated = fileService.updateFile(session.getStudyIdentifier(), file);
+        FileMetadata updated = fileService.updateFile(session.getAppId(), file);
         
         return new GuidVersionHolder(updated.getGuid(), Long.valueOf(updated.getVersion()));
     }
@@ -87,9 +87,9 @@ public class FileController extends BaseController {
         UserSession session = getAuthenticatedSession(DEVELOPER, ADMIN);
         
         if ("true".equals(physical) && session.isInRole(ADMIN)) {
-            fileService.deleteFilePermanently(session.getStudyIdentifier(), guid);
+            fileService.deleteFilePermanently(session.getAppId(), guid);
         } else {
-            fileService.deleteFile(session.getStudyIdentifier(), guid);
+            fileService.deleteFile(session.getAppId(), guid);
         }
         return DELETE_MSG;
     }
@@ -102,7 +102,7 @@ public class FileController extends BaseController {
         int offsetInt = BridgeUtils.getIntOrDefault(offsetBy, 0);
         int pageSizeInt = BridgeUtils.getIntOrDefault(pageSize, API_DEFAULT_PAGE_SIZE);
 
-        return fileService.getFileRevisions(session.getStudyIdentifier(), guid, offsetInt, pageSizeInt);
+        return fileService.getFileRevisions(session.getAppId(), guid, offsetInt, pageSizeInt);
     }
     
     @PostMapping("/v3/files/{guid}/revisions")
@@ -114,7 +114,7 @@ public class FileController extends BaseController {
         FileRevision revision = parseJson(FileRevision.class);
         revision.setFileGuid(guid);
         
-        return fileService.createFileRevision(session.getStudyIdentifier(), revision);
+        return fileService.createFileRevision(session.getAppId(), revision);
     }
     
     @PostMapping("/v3/files/{guid}/revisions/{createdOn}")
@@ -123,7 +123,7 @@ public class FileController extends BaseController {
         
         DateTime createdOn = DateTime.parse(createdOnStr);
         
-        fileService.finishFileRevision(session.getStudyIdentifier(), guid, createdOn);
+        fileService.finishFileRevision(session.getAppId(), guid, createdOn);
         return UPLOAD_FINISHED_MSG;
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/HealthDataController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/HealthDataController.java
@@ -87,7 +87,7 @@ public class HealthDataController extends BaseController {
         // Submit health data.
         UserSession session = getAuthenticatedAndConsentedSession();
         HealthDataSubmission healthDataSubmission = parseJson(HealthDataSubmission.class);
-        HealthDataRecord savedRecord = healthDataService.submitHealthData(session.getStudyIdentifier(),
+        HealthDataRecord savedRecord = healthDataService.submitHealthData(session.getAppId(),
                 session.getParticipant(), healthDataSubmission);
 
         // Write record ID into the metrics, for logging and diagnostics.
@@ -110,7 +110,7 @@ public class HealthDataController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     public String submitHealthDataForParticipant(@PathVariable String userId) throws IOException, UploadValidationException {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
 
         // Get participant.
         StudyParticipant participant = participantService.getParticipant(study, userId, false);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/NotificationRegistrationController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/NotificationRegistrationController.java
@@ -59,7 +59,7 @@ public class NotificationRegistrationController extends BaseController {
         NotificationRegistration registration = parseJson(NotificationRegistration.class);
         registration.setHealthCode(session.getHealthCode());
         
-        NotificationRegistration result = notificationsService.createRegistration(session.getStudyIdentifier(),
+        NotificationRegistration result = notificationsService.createRegistration(session.getAppId(),
                 getCriteriaContext(session), registration);
         
         return new GuidHolder(result.getGuid());
@@ -73,7 +73,7 @@ public class NotificationRegistrationController extends BaseController {
         registration.setHealthCode(session.getHealthCode());
         registration.setGuid(guid);
         
-        NotificationRegistration result = notificationsService.updateRegistration(session.getStudyIdentifier(),
+        NotificationRegistration result = notificationsService.updateRegistration(session.getAppId(),
                 registration);
         
         return new GuidHolder(result.getGuid());
@@ -89,7 +89,7 @@ public class NotificationRegistrationController extends BaseController {
     @DeleteMapping("/v3/notifications/{guid}")
     public StatusMessage deleteRegistration(@PathVariable String guid) {
         UserSession session = getAuthenticatedAndConsentedSession();
-        notificationsService.deleteRegistration(session.getStudyIdentifier(), session.getHealthCode(), guid);
+        notificationsService.deleteRegistration(session.getAppId(), session.getHealthCode(), guid);
         return DELETED_MSG;
     }
 
@@ -97,7 +97,7 @@ public class NotificationRegistrationController extends BaseController {
     public ResourceList<SubscriptionStatus> getSubscriptionStatuses(@PathVariable String guid) {
         UserSession session = getAuthenticatedAndConsentedSession();
         
-        List<SubscriptionStatus> statuses = topicService.currentSubscriptionStatuses(session.getStudyIdentifier(),
+        List<SubscriptionStatus> statuses = topicService.currentSubscriptionStatuses(session.getAppId(),
                 session.getHealthCode(), guid);
         return new ResourceList<>(statuses);
     }
@@ -108,7 +108,7 @@ public class NotificationRegistrationController extends BaseController {
         
         SubscriptionRequest request = parseJson(SubscriptionRequest.class);
         
-        List<SubscriptionStatus> statuses = topicService.subscribe(session.getStudyIdentifier(),
+        List<SubscriptionStatus> statuses = topicService.subscribe(session.getAppId(),
                 session.getHealthCode(), guid, request.getTopicGuids());
         return new ResourceList<>(statuses);
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/NotificationTopicController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/NotificationTopicController.java
@@ -41,7 +41,7 @@ public class NotificationTopicController extends BaseController {
     public ResourceList<NotificationTopic> getAllTopics(@RequestParam(defaultValue = "false") boolean includeDeleted) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
 
-        List<NotificationTopic> list = topicService.listTopics(session.getStudyIdentifier(), includeDeleted);
+        List<NotificationTopic> list = topicService.listTopics(session.getAppId(), includeDeleted);
 
         return new ResourceList<>(list);
     }
@@ -52,7 +52,7 @@ public class NotificationTopicController extends BaseController {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         
         NotificationTopic topic = parseJson(NotificationTopic.class);
-        topic.setStudyId(session.getStudyIdentifier());
+        topic.setStudyId(session.getAppId());
         
         NotificationTopic saved = topicService.createTopic(topic);
         
@@ -63,7 +63,7 @@ public class NotificationTopicController extends BaseController {
     public NotificationTopic getTopic(@PathVariable String guid) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
 
-        return topicService.getTopic(session.getStudyIdentifier(), guid);
+        return topicService.getTopic(session.getAppId(), guid);
     }
     
     @PostMapping("/v3/topics/{guid}")
@@ -71,7 +71,7 @@ public class NotificationTopicController extends BaseController {
         UserSession session = getAuthenticatedSession(DEVELOPER);
 
         NotificationTopic topic = parseJson(NotificationTopic.class);
-        topic.setStudyId(session.getStudyIdentifier());
+        topic.setStudyId(session.getAppId());
         topic.setGuid(guid);
         
         NotificationTopic updated = topicService.updateTopic(topic);
@@ -85,9 +85,9 @@ public class NotificationTopicController extends BaseController {
         UserSession session = getAuthenticatedSession(DEVELOPER, ADMIN);
 
         if (physical && session.isInRole(ADMIN)) {
-            topicService.deleteTopicPermanently(session.getStudyIdentifier(), guid);
+            topicService.deleteTopicPermanently(session.getAppId(), guid);
         } else {
-            topicService.deleteTopic(session.getStudyIdentifier(), guid);
+            topicService.deleteTopic(session.getAppId(), guid);
         }
         return DELETE_STATUS_MSG;
     }
@@ -99,7 +99,7 @@ public class NotificationTopicController extends BaseController {
         
         NotificationMessage message = parseJson(NotificationMessage.class);
         
-        topicService.sendNotification(session.getStudyIdentifier(), guid, message);
+        topicService.sendNotification(session.getAppId(), guid, message);
         
         return SEND_STATUS_MSG;
     }}

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/OAuthController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/OAuthController.java
@@ -41,7 +41,7 @@ public class OAuthController extends BaseController {
         String token = node.has(AUTH_TOKEN) ? node.get(AUTH_TOKEN).textValue() : null;
         OAuthAuthorizationToken authToken = new OAuthAuthorizationToken(null, vendorId, token, null);
         
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         
         return service.requestAccessToken(study, session.getHealthCode(), authToken);
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
@@ -6,6 +6,7 @@ import static org.sagebionetworks.bridge.BridgeUtils.getIntOrDefault;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.WORKER;
+import static org.sagebionetworks.bridge.models.RequestInfo.REQUEST_INFO_WRITER;
 import static org.sagebionetworks.bridge.models.ResourceList.END_DATE;
 import static org.sagebionetworks.bridge.models.ResourceList.END_TIME;
 import static org.sagebionetworks.bridge.models.ResourceList.OFFSET_BY;
@@ -17,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -314,8 +316,10 @@ public class ParticipantController extends BaseController {
         return writer.writeValueAsString(participant);
     }
     
-    @GetMapping(path="/v3/studies/{studyId}/participants/{userId}/requestInfo")
-    public RequestInfo getRequestInfoForWorker(@PathVariable String studyId, @PathVariable String userId) {
+    @GetMapping(path = "/v3/studies/{studyId}/participants/{userId}/requestInfo", produces = {
+            APPLICATION_JSON_UTF8_VALUE })
+    public String getRequestInfoForWorker(@PathVariable String studyId, @PathVariable String userId)
+            throws JsonProcessingException {
         getAuthenticatedSession(WORKER);
 
         // Verify it's in the same study as the researcher.
@@ -325,11 +329,12 @@ public class ParticipantController extends BaseController {
         } else if (!studyId.equals(requestInfo.getAppId())) {
             throw new EntityNotFoundException(StudyParticipant.class);
         }
-        return requestInfo;
+        return REQUEST_INFO_WRITER.writeValueAsString(requestInfo);
     }
 
-    @GetMapping("/v3/participants/{userId}/requestInfo")
-    public RequestInfo getRequestInfo(@PathVariable String userId) {
+    @GetMapping(path = "/v3/participants/{userId}/requestInfo", produces = {
+            APPLICATION_JSON_UTF8_VALUE })
+    public String getRequestInfo(@PathVariable String userId) throws JsonProcessingException {
         UserSession session = getAuthenticatedSession(RESEARCHER);
         Study study = studyService.getStudy(session.getAppId());
 
@@ -340,7 +345,7 @@ public class ParticipantController extends BaseController {
         } else if (!study.getIdentifier().equals(requestInfo.getAppId())) {
             throw new EntityNotFoundException(StudyParticipant.class);
         }
-        return requestInfo;
+        return REQUEST_INFO_WRITER.writeValueAsString(requestInfo);
     }
     
     @PostMapping("/v3/participants/{userId}")

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
@@ -94,7 +94,7 @@ public class ParticipantController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     public StatusMessage createSmsRegistration(@PathVariable String userId) {
         UserSession session = getAuthenticatedSession(RESEARCHER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
 
         participantService.createSmsRegistration(study, userId);
         return new StatusMessage("SMS notification registration created");
@@ -103,7 +103,7 @@ public class ParticipantController extends BaseController {
     @GetMapping(path="/v3/participants/self", produces={APPLICATION_JSON_UTF8_VALUE})
     public String getSelfParticipant(@RequestParam(defaultValue = "true") boolean consents) throws Exception {
         UserSession session = getAuthenticatedSession();
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         
         CriteriaContext context = getCriteriaContext(session);
         StudyParticipant participant = participantService.getSelfParticipant(study, context, consents);
@@ -114,7 +114,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/self")
     public JsonNode updateSelfParticipant() {
         UserSession session = getAuthenticatedSession();
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         
         // By copying only values that were included in the JSON onto the existing StudyParticipant,
         // we allow clients to only send back partial JSON to update the user. This has been the 
@@ -152,7 +152,7 @@ public class ParticipantController extends BaseController {
                 .withUserId(session.getId())
                 .withUserDataGroups(updatedParticipant.getDataGroups())
                 .withUserSubstudyIds(updatedParticipant.getSubstudyIds())
-                .withStudyIdentifier(session.getStudyIdentifier())
+                .withStudyIdentifier(session.getAppId())
                 .build();
         
         sessionUpdateService.updateParticipant(session, context, updatedParticipant);
@@ -163,7 +163,7 @@ public class ParticipantController extends BaseController {
     @DeleteMapping("/v3/participants/{userId}")
     public StatusMessage deleteTestParticipant(@PathVariable String userId) {
         UserSession session = getAuthenticatedSession(Roles.RESEARCHER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         
         StudyParticipant participant = participantService.getParticipant(study, userId, false);
         if (!participant.getDataGroups().contains(BridgeConstants.TEST_USER_GROUP)) {
@@ -215,7 +215,7 @@ public class ParticipantController extends BaseController {
         UserSession session = getAuthenticatedSession();
         
         IdentifierUpdate update = parseJson(IdentifierUpdate.class);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
 
         CriteriaContext context = getCriteriaContext(session);
         
@@ -233,7 +233,7 @@ public class ParticipantController extends BaseController {
             @RequestParam(required = false) String endDate, @RequestParam(required = false) String startTime,
             @RequestParam(required = false) String endTime) {
         UserSession session = getAuthenticatedSession(RESEARCHER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         
         return getParticipantsInternal(study, offsetBy, pageSize, emailFilter, phoneFilter, startDate,
                 endDate, startTime, endTime);
@@ -242,7 +242,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/search")
     public PagedResourceList<AccountSummary> searchForAccountSummaries() {
         UserSession session = getAuthenticatedSession(RESEARCHER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         
         AccountSummarySearch search = parseJson(AccountSummarySearch.class);
         return participantService.getPagedAccountSummaries(study, search);
@@ -275,7 +275,7 @@ public class ParticipantController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     public IdentifierHolder createParticipant() {
         UserSession session = getAuthenticatedSession(RESEARCHER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         
         StudyParticipant participant = parseJson(StudyParticipant.class);
         return participantService.createParticipant(study, participant, true);
@@ -285,7 +285,7 @@ public class ParticipantController extends BaseController {
     public String getParticipant(@PathVariable String userId, @RequestParam(defaultValue = "true") boolean consents)
             throws Exception {
         UserSession session = getAuthenticatedSession(RESEARCHER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
 
         // Do not allow lookup by health code if health code access is disabled. Allow it however
         // if the user is an administrator.
@@ -322,7 +322,7 @@ public class ParticipantController extends BaseController {
         RequestInfo requestInfo = requestInfoService.getRequestInfo(userId);
         if (requestInfo == null) {
             requestInfo = new RequestInfo.Builder().build();
-        } else if (!studyId.equals(requestInfo.getStudyIdentifier())) {
+        } else if (!studyId.equals(requestInfo.getAppId())) {
             throw new EntityNotFoundException(StudyParticipant.class);
         }
         return requestInfo;
@@ -331,13 +331,13 @@ public class ParticipantController extends BaseController {
     @GetMapping("/v3/participants/{userId}/requestInfo")
     public RequestInfo getRequestInfo(@PathVariable String userId) {
         UserSession session = getAuthenticatedSession(RESEARCHER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
 
         // Verify it's in the same study as the researcher.
         RequestInfo requestInfo = requestInfoService.getRequestInfo(userId);
         if (requestInfo == null) {
             requestInfo = new RequestInfo.Builder().build();
-        } else if (!study.getIdentifier().equals(requestInfo.getStudyIdentifier())) {
+        } else if (!study.getIdentifier().equals(requestInfo.getAppId())) {
             throw new EntityNotFoundException(StudyParticipant.class);
         }
         return requestInfo;
@@ -346,7 +346,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}")
     public StatusMessage updateParticipant(@PathVariable String userId) {
         UserSession session = getAuthenticatedSession(RESEARCHER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
 
         StudyParticipant participant = parseJson(StudyParticipant.class);
  
@@ -361,7 +361,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/signOut")
     public StatusMessage signOut(@PathVariable String userId, @RequestParam(required = false) boolean deleteReauthToken) {
         UserSession session = getAuthenticatedSession(RESEARCHER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
 
         participantService.signUserOut(study, userId, deleteReauthToken);
 
@@ -371,7 +371,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/requestResetPassword")
     public StatusMessage requestResetPassword(@PathVariable String userId) {
         UserSession session = getAuthenticatedSession(RESEARCHER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
 
         participantService.requestResetPassword(study, userId);
         
@@ -385,7 +385,7 @@ public class ParticipantController extends BaseController {
             @RequestParam(required = false) String offsetKey, @RequestParam(required = false) String pageSize)
             throws Exception {
         UserSession session = getAuthenticatedSession(RESEARCHER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         
         return getActivityHistoryInternalV2(study, userId, activityGuid, scheduledOnStart,
             scheduledOnEnd, offsetBy, offsetKey, pageSize);
@@ -397,7 +397,7 @@ public class ParticipantController extends BaseController {
             @RequestParam(required = false) String scheduledOnEnd, @RequestParam(required = false) String offsetKey,
             @RequestParam(required = false) String pageSize) throws Exception {
         UserSession session = getAuthenticatedSession(RESEARCHER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         
         return getActivityHistoryV3Internal(study, userId, activityType, referentGuid, scheduledOnStart,
                 scheduledOnEnd, offsetKey, pageSize);
@@ -406,7 +406,7 @@ public class ParticipantController extends BaseController {
     @DeleteMapping("/v3/participants/{userId}/activities")
     public StatusMessage deleteActivities(@PathVariable String userId) {
         UserSession session = getAuthenticatedSession(RESEARCHER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
 
         participantService.deleteActivities(study, userId);
         
@@ -416,7 +416,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/resendEmailVerification")
     public StatusMessage resendEmailVerification(@PathVariable String userId) {
         UserSession session = getAuthenticatedSession(RESEARCHER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
 
         participantService.resendVerification(study, ChannelType.EMAIL, userId);
         
@@ -426,7 +426,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/resendPhoneVerification")
     public StatusMessage resendPhoneVerification(@PathVariable String userId) {
         UserSession session = getAuthenticatedSession(RESEARCHER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
 
         participantService.resendVerification(study, ChannelType.PHONE, userId);
         
@@ -436,7 +436,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/consents/{guid}/resendConsent")
     public StatusMessage resendConsentAgreement(@PathVariable String userId, @PathVariable String guid) {
         UserSession session = getAuthenticatedSession(RESEARCHER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         
         SubpopulationGuid subpopGuid = SubpopulationGuid.create(guid);
         participantService.resendConsentAgreement(study, subpopGuid, userId);
@@ -447,7 +447,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/consents/withdraw")
     public StatusMessage withdrawFromStudy(@PathVariable String userId) {
         UserSession session = getAuthenticatedSession(RESEARCHER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         
         Withdrawal withdrawal = parseJson(Withdrawal.class);
         long withdrewOn = DateTime.now().getMillis();
@@ -460,7 +460,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/consents/{guid}/withdraw")
     public StatusMessage withdrawConsent(@PathVariable String userId, @PathVariable String guid) {
         UserSession session = getAuthenticatedSession(RESEARCHER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         
         Withdrawal withdrawal = parseJson(Withdrawal.class);
         long withdrewOn = DateTime.now().getMillis();
@@ -476,7 +476,7 @@ public class ParticipantController extends BaseController {
             @RequestParam(required = false) String startTime, @RequestParam(required = false) String endTime,
             @RequestParam(required = false) Integer pageSize, @RequestParam(required = false) String offsetKey) {
         UserSession session = getAuthenticatedSession(RESEARCHER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         
         DateTime startTimeDate = getDateTimeOrDefault(startTime, null);
         DateTime endTimeDate = getDateTimeOrDefault(endTime, null);
@@ -487,7 +487,7 @@ public class ParticipantController extends BaseController {
     @GetMapping("/v3/participants/{userId}/notifications")
     public ResourceList<NotificationRegistration> getNotificationRegistrations(@PathVariable String userId) {
         UserSession session = getAuthenticatedSession(RESEARCHER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         
         List<NotificationRegistration> registrations = participantService.listRegistrations(study, userId);
         
@@ -498,7 +498,7 @@ public class ParticipantController extends BaseController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public StatusMessage sendNotification(@PathVariable String userId) {
         UserSession session = getAuthenticatedSession(RESEARCHER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         
         NotificationMessage message = parseJson(NotificationMessage.class);
         
@@ -514,7 +514,7 @@ public class ParticipantController extends BaseController {
     @GetMapping("/v3/participants/{userId}/activityEvents")
     public ResourceList<ActivityEvent> getActivityEvents(@PathVariable String userId) {
         UserSession researcherSession = getAuthenticatedSession(Roles.RESEARCHER);
-        Study study = studyService.getStudy(researcherSession.getStudyIdentifier());
+        Study study = studyService.getStudy(researcherSession.getAppId());
 
         return new ResourceList<>(participantService.getActivityEvents(study, userId));
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportController.java
@@ -69,7 +69,7 @@ public class ParticipantReportController extends BaseController {
         LocalDate localStartDate = getLocalDateOrDefault(startDate, null);
         LocalDate localEndDate = getLocalDateOrDefault(endDate, null);
         
-        return reportService.getParticipantReport(session.getStudyIdentifier(), identifier, session.getHealthCode(),
+        return reportService.getParticipantReport(session.getAppId(), identifier, session.getHealthCode(),
                 localStartDate, localEndDate);
     }
 
@@ -83,7 +83,7 @@ public class ParticipantReportController extends BaseController {
         DateTime endTimeObj = getDateTimeOrDefault(endTime, null);
         int pageSizeInt = getIntOrDefault(pageSize, API_DEFAULT_PAGE_SIZE);
         
-        return reportService.getParticipantReportV4(session.getStudyIdentifier(), identifier, session.getHealthCode(),
+        return reportService.getParticipantReportV4(session.getAppId(), identifier, session.getHealthCode(),
                 startTimeObj, endTimeObj, offsetKey, pageSizeInt);
     }
 
@@ -95,7 +95,7 @@ public class ParticipantReportController extends BaseController {
         ReportData reportData = parseJson(ReportData.class);
         reportData.setKey(null); // set in service, but just so no future use depends on it
         
-        reportService.saveParticipantReport(session.getStudyIdentifier(), identifier, 
+        reportService.saveParticipantReport(session.getAppId(), identifier, 
                 session.getHealthCode(), reportData);
         
         return new StatusMessage("Report data saved.");
@@ -108,7 +108,7 @@ public class ParticipantReportController extends BaseController {
     public ReportTypeResourceList<? extends ReportIndex> listParticipantReportIndices() {
         UserSession session = getAuthenticatedSession();
         
-        return reportService.getReportIndices(session.getStudyIdentifier(), ReportType.PARTICIPANT);
+        return reportService.getReportIndices(session.getAppId(), ReportType.PARTICIPANT);
     }
     
     @GetMapping("/v3/participants/reports/{identifier}/index")
@@ -117,7 +117,7 @@ public class ParticipantReportController extends BaseController {
         ReportDataKey key = new ReportDataKey.Builder()
                 .withIdentifier(identifier)
                 .withReportType(ReportType.PARTICIPANT)
-                .withStudyIdentifier(session.getStudyIdentifier()).build();
+                .withStudyIdentifier(session.getAppId()).build();
         
         return reportService.getReportIndex(key);
     }
@@ -128,7 +128,7 @@ public class ParticipantReportController extends BaseController {
             @PathVariable String identifier, @RequestParam(required = false) String startDate,
             @RequestParam(required = false) String endDate) {
         UserSession session = getAuthenticatedSession(RESEARCHER);
-        return getParticipantReportInternal(session.getStudyIdentifier(), userId, identifier, startDate,
+        return getParticipantReportInternal(session.getAppId(), userId, identifier, startDate,
                 endDate);
     }
 
@@ -161,7 +161,7 @@ public class ParticipantReportController extends BaseController {
             @RequestParam(required = false) String endTime, @RequestParam(required = false) String offsetKey,
             @RequestParam(required = false) String pageSize) {
         UserSession session = getAuthenticatedSession(RESEARCHER);
-        return getParticipantReportInternalV4(session.getStudyIdentifier(), userId, identifier, startTime,
+        return getParticipantReportInternalV4(session.getAppId(), userId, identifier, startTime,
                 endTime, offsetKey, pageSize);
     }
 
@@ -199,7 +199,7 @@ public class ParticipantReportController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     public StatusMessage saveParticipantReport(@PathVariable String userId, @PathVariable String identifier) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         
         Account account = accountService.getAccount(AccountId.forId(study.getIdentifier(), userId));
         if (account == null) {
@@ -208,7 +208,7 @@ public class ParticipantReportController extends BaseController {
         ReportData reportData = parseJson(ReportData.class);
         reportData.setKey(null); // set in service, but just so no future use depends on it
         
-        reportService.saveParticipantReport(session.getStudyIdentifier(), identifier, 
+        reportService.saveParticipantReport(session.getAppId(), identifier, 
                 account.getHealthCode(), reportData);
         
         return new StatusMessage("Report data saved.");
@@ -232,7 +232,7 @@ public class ParticipantReportController extends BaseController {
         ReportData reportData = parseJson(node, ReportData.class);
         reportData.setKey(null); // set in service, but just so no future use depends on it
         
-        reportService.saveParticipantReport(session.getStudyIdentifier(), identifier, 
+        reportService.saveParticipantReport(session.getAppId(), identifier, 
                 healthCode, reportData);
         
         return new StatusMessage("Report data saved.");
@@ -247,13 +247,13 @@ public class ParticipantReportController extends BaseController {
             "/v3/participants/{userId}/reports/{identifier}" })
     public StatusMessage deleteParticipantReport(@PathVariable String userId, @PathVariable String identifier) {
         UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         
         Account account = accountService.getAccount(AccountId.forId(study.getIdentifier(), userId));
         if (account == null) {
             throw new EntityNotFoundException(Account.class);    
         }
-        reportService.deleteParticipantReport(session.getStudyIdentifier(), identifier, account.getHealthCode());
+        reportService.deleteParticipantReport(session.getAppId(), identifier, account.getHealthCode());
         
         return new StatusMessage("Report deleted.");
     }
@@ -265,13 +265,13 @@ public class ParticipantReportController extends BaseController {
     public StatusMessage deleteParticipantReportRecord(@PathVariable String userId, @PathVariable String identifier,
             @PathVariable String date) {
         UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         
         Account account = accountService.getAccount(AccountId.forId(study.getIdentifier(), userId));
         if (account == null) {
             throw new EntityNotFoundException(Account.class);
         }
-        reportService.deleteParticipantReportRecord(session.getStudyIdentifier(), identifier, date, account.getHealthCode());
+        reportService.deleteParticipantReportRecord(session.getAppId(), identifier, date, account.getHealthCode());
         
         return new StatusMessage("Report record deleted.");
     }
@@ -280,7 +280,7 @@ public class ParticipantReportController extends BaseController {
     public StatusMessage deleteParticipantReportIndex(@PathVariable String identifier) {
         UserSession session = getAuthenticatedSession(ADMIN);
         
-        reportService.deleteParticipantReportIndex(session.getStudyIdentifier(), identifier);
+        reportService.deleteParticipantReportIndex(session.getAppId(), identifier);
         
         return new StatusMessage("Report index deleted.");
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ScheduleController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ScheduleController.java
@@ -72,7 +72,7 @@ public class ScheduleController extends BaseController {
     
     private List<Schedule> getSchedulesInternal() {
         UserSession session = getAuthenticatedAndConsentedSession();
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
         
         ClientInfo clientInfo = BridgeUtils.getRequestContext().getCallerClientInfo();
 

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/SchedulePlanController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/SchedulePlanController.java
@@ -56,7 +56,7 @@ public class SchedulePlanController extends BaseController {
     @GetMapping("/v3/scheduleplans")
     public ResourceList<SchedulePlan> getSchedulePlans(@RequestParam(defaultValue = "false") boolean includeDeleted) {
         UserSession session = getAuthenticatedSession(DEVELOPER, RESEARCHER);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
 
         // We don't filter plans when we return a list of all of them for developers.
         List<SchedulePlan> plans = schedulePlanService.getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, studyId,
@@ -68,7 +68,7 @@ public class SchedulePlanController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     public GuidVersionHolder createSchedulePlan() {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
 
         DynamoSchedulePlan planForm = DynamoSchedulePlan.fromJson(parseJson(JsonNode.class));
         SchedulePlan plan = schedulePlanService.createSchedulePlan(study, planForm);
@@ -78,7 +78,7 @@ public class SchedulePlanController extends BaseController {
     @GetMapping("/v3/scheduleplans/{guid}")
     public SchedulePlan getSchedulePlan(@PathVariable String guid) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
         
         return schedulePlanService.getSchedulePlan(studyId, guid);
     }
@@ -86,7 +86,7 @@ public class SchedulePlanController extends BaseController {
     @PostMapping("/v3/scheduleplans/{guid}")
     public GuidVersionHolder updateSchedulePlan(@PathVariable String guid) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
 
         DynamoSchedulePlan planForm = DynamoSchedulePlan.fromJson(parseJson(JsonNode.class));
         planForm.setGuid(guid);
@@ -99,7 +99,7 @@ public class SchedulePlanController extends BaseController {
     public StatusMessage deleteSchedulePlan(@PathVariable String guid,
             @RequestParam(defaultValue = "false") boolean physical) {
         UserSession session = getAuthenticatedSession(DEVELOPER, ADMIN);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
         
         if (physical && session.isInRole(ADMIN)) {
             schedulePlanService.deleteSchedulePlanPermanently(studyId, guid);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ScheduledActivityController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ScheduledActivityController.java
@@ -133,7 +133,7 @@ public class ScheduledActivityController extends BaseController {
     public String getScheduledActivitiesByDateRange(@RequestParam String startTime, @RequestParam String endTime)
             throws Exception {
         UserSession session = getAuthenticatedAndConsentedSession();
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         
         DateTime startsOnObj = BridgeUtils.getDateTimeOrDefault(startTime, null);
         DateTime endsOnObj = BridgeUtils.getDateTimeOrDefault(endTime, null);
@@ -198,7 +198,7 @@ public class ScheduledActivityController extends BaseController {
     private List<ScheduledActivity> getScheduledActivitiesInternalV3(String untilString, String offset,
             String daysAhead, String minimumPerScheduleString) {
         UserSession session = getAuthenticatedAndConsentedSession();
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         
         DateTime endsOn = null;
         DateTimeZone requestTimeZone = null;
@@ -244,7 +244,7 @@ public class ScheduledActivityController extends BaseController {
         builder.withUserSubstudyIds(session.getParticipant().getSubstudyIds());
         builder.withHealthCode(session.getHealthCode());
         builder.withUserId(session.getId());
-        builder.withStudyIdentifier(session.getStudyIdentifier());
+        builder.withStudyIdentifier(session.getAppId());
         builder.withAccountCreatedOn(session.getParticipant().getCreatedOn());
         builder.withLanguages(getLanguages(session));
         builder.withClientInfo(reqContext.getCallerClientInfo());
@@ -261,7 +261,7 @@ public class ScheduledActivityController extends BaseController {
     }
 
     DateTimeZone persistTimeZone(UserSession session, DateTimeZone timeZone) {
-        accountService.editAccount(session.getStudyIdentifier(), session.getHealthCode(),
+        accountService.editAccount(session.getAppId(), session.getHealthCode(),
                 account -> account.setTimeZone(timeZone));
         sessionUpdateService.updateTimeZone(session, timeZone);
         return timeZone;

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/SharedAssessmentController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/SharedAssessmentController.java
@@ -43,7 +43,7 @@ public class SharedAssessmentController extends BaseController {
     public Assessment importAssessment(@PathVariable String guid, @RequestParam(required = false) String ownerId,
             @RequestParam(required = false) String newIdentifier) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String appId = session.getStudyIdentifier();
+        String appId = session.getAppId();
         
         return service.importAssessment(appId, ownerId, newIdentifier, guid);
     }
@@ -115,7 +115,7 @@ public class SharedAssessmentController extends BaseController {
     @PostMapping("/v1/sharedassessments/{guid}")
     public Assessment updateSharedAssessment(@PathVariable String guid) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String appId = session.getStudyIdentifier();
+        String appId = session.getAppId();
         
         Assessment assessment = parseJson(Assessment.class);
         assessment.setGuid(guid);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/SharedAssessmentResourceController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/SharedAssessmentResourceController.java
@@ -73,7 +73,7 @@ public class SharedAssessmentResourceController extends BaseController {
     @PostMapping("/v1/sharedassessments/identifier:{assessmentId}/resources/{guid}")
     public AssessmentResource updateAssessmentResource(@PathVariable String assessmentId, @PathVariable String guid) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String appId = session.getStudyIdentifier();
+        String appId = session.getAppId();
         
         AssessmentResource resource = parseJson(AssessmentResource.class);
         resource.setGuid(guid);
@@ -97,7 +97,7 @@ public class SharedAssessmentResourceController extends BaseController {
     @PostMapping("/v1/sharedassessments/identifier:{assessmentId}/resources/import")
     public ResourceList<AssessmentResource> importAssessmentResources(@PathVariable String assessmentId) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String appId = session.getStudyIdentifier();
+        String appId = session.getAppId();
 
         Set<String> resourceGuids = parseJson(STRING_SET_TYPEREF);
         

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/SharedModuleController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/SharedModuleController.java
@@ -29,7 +29,7 @@ public class SharedModuleController extends BaseController {
     public SharedModuleImportStatus importModuleByIdAndVersion(@PathVariable String moduleId,
             @PathVariable int moduleVersion) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
 
         return moduleService.importModuleByIdAndVersion(studyId, moduleId, moduleVersion);
     }
@@ -38,7 +38,7 @@ public class SharedModuleController extends BaseController {
     @PostMapping("/v3/sharedmodules/{moduleId}/import")
     public SharedModuleImportStatus importModuleByIdLatestPublishedVersion(@PathVariable String moduleId) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
 
         return moduleService.importModuleByIdLatestPublishedVersion(studyId, moduleId);
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/SharedModuleMetadataController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/SharedModuleMetadataController.java
@@ -171,7 +171,7 @@ public class SharedModuleMetadataController extends BaseController {
     // study (the study for the Shared Module Library).
     private UserSession verifySharedDeveloperAccess() {
         UserSession session = getAuthenticatedSession(Roles.DEVELOPER);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
         if (!SHARED_APP_ID.equals(studyId)) {
             throw new UnauthorizedException();
         }
@@ -180,7 +180,7 @@ public class SharedModuleMetadataController extends BaseController {
     
     private UserSession verifySharedDeveloperOrAdminAccess() {
         UserSession session = getAuthenticatedSession(Roles.DEVELOPER, Roles.ADMIN);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
         if (!SHARED_APP_ID.equals(studyId)) {
             throw new UnauthorizedException();
         }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/SmsController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/SmsController.java
@@ -38,7 +38,7 @@ public class SmsController extends BaseController {
     @GetMapping("/v3/participants/{userId}/sms/recent")
     public SmsMessage getMostRecentMessage(@PathVariable String userId) {
         UserSession session = getAuthenticatedSession(ADMIN);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
 
         // Get phone number for participant.
         StudyParticipant participant = participantService.getParticipant(study, userId, false);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyConsentController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyConsentController.java
@@ -50,28 +50,28 @@ public class StudyConsentController extends BaseController {
     public ResourceList<StudyConsent> getAllConsents() {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         
-        return getAllConsentsV2(session.getStudyIdentifier());
+        return getAllConsentsV2(session.getAppId());
     }
 
     @Deprecated
     @GetMapping("/v3/consents/published")
     public StudyConsentView getActiveConsent() {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        return getActiveConsentV2(session.getStudyIdentifier());
+        return getActiveConsentV2(session.getAppId());
     }
     
     @Deprecated
     @GetMapping("/v3/consents/recent")
     public StudyConsentView getMostRecentConsent() {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        return getMostRecentConsentV2(session.getStudyIdentifier());
+        return getMostRecentConsentV2(session.getAppId());
     }
 
     @Deprecated
     @GetMapping("/v3/consents/{createdOn}")
     public StudyConsentView getConsent(@PathVariable String createdOn) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        return getConsentV2(session.getStudyIdentifier(), createdOn);
+        return getConsentV2(session.getAppId(), createdOn);
     }
     
     @Deprecated
@@ -79,14 +79,14 @@ public class StudyConsentController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     public StudyConsentView addConsent() {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        return addConsentV2(session.getStudyIdentifier());
+        return addConsentV2(session.getAppId());
     }
 
     @Deprecated
     @PostMapping("/v3/consents/{createdOn}/publish")
     public StatusMessage publishConsent(@PathVariable String createdOn) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        return publishConsentV2(session.getStudyIdentifier(), createdOn);
+        return publishConsentV2(session.getAppId(), createdOn);
     }
     
     // V2: consents associated to a subpopulation
@@ -94,7 +94,7 @@ public class StudyConsentController extends BaseController {
     @GetMapping("/v3/subpopulations/{guid}/consents")
     public ResourceList<StudyConsent> getAllConsentsV2(@PathVariable String guid) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
         SubpopulationGuid subpopGuid = SubpopulationGuid.create(guid);
         
         // Throws 404 exception if this subpopulation is not part of the caller's study
@@ -107,7 +107,7 @@ public class StudyConsentController extends BaseController {
     @GetMapping("/v3/subpopulations/{guid}/consents/published")
     public StudyConsentView getActiveConsentV2(@PathVariable String guid) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
         SubpopulationGuid subpopGuid = SubpopulationGuid.create(guid);
         
         // Throws 404 exception if this subpopulation is not part of the caller's study
@@ -119,7 +119,7 @@ public class StudyConsentController extends BaseController {
     @GetMapping("/v3/subpopulations/{guid}/consents/recent")
     public StudyConsentView getMostRecentConsentV2(@PathVariable String guid) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
         SubpopulationGuid subpopGuid = SubpopulationGuid.create(guid);
         
         // Throws 404 exception if this subpopulation is not part of the caller's study
@@ -131,7 +131,7 @@ public class StudyConsentController extends BaseController {
     @GetMapping("/v3/subpopulations/{guid}/consents/{createdOn}")
     public StudyConsentView getConsentV2(@PathVariable String guid, @PathVariable String createdOn) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
         SubpopulationGuid subpopGuid = SubpopulationGuid.create(guid);
         
         // Throws 404 exception if this subpopulation is not part of the caller's study
@@ -145,7 +145,7 @@ public class StudyConsentController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     public StudyConsentView addConsentV2(@PathVariable String guid) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
         SubpopulationGuid subpopGuid = SubpopulationGuid.create(guid);
         
         // Throws 404 exception if this subpopulation is not part of the caller's study
@@ -158,7 +158,7 @@ public class StudyConsentController extends BaseController {
     @PostMapping("/v3/subpopulations/{guid}/consents/{createdOn}/publish")
     public StatusMessage publishConsentV2(@PathVariable String guid, @PathVariable String createdOn) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         SubpopulationGuid subpopGuid = SubpopulationGuid.create(guid);
         
         // Throws 404 exception if this subpopulation is not part of the caller's study

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyController.java
@@ -106,7 +106,7 @@ public class StudyController extends BaseController {
     public Study getCurrentStudy() {
         UserSession session = getAuthenticatedSession(DEVELOPER, RESEARCHER, ADMIN);
         
-        return studyService.getStudy(session.getStudyIdentifier());
+        return studyService.getStudy(session.getAppId());
     }
     
     @PostMapping("/v3/studies/self")
@@ -114,7 +114,7 @@ public class StudyController extends BaseController {
         UserSession session = getAuthenticatedSession(DEVELOPER, ADMIN);
 
         Study studyUpdate = parseJson(Study.class);
-        studyUpdate.setIdentifier(session.getStudyIdentifier());
+        studyUpdate.setIdentifier(session.getAppId());
         studyUpdate = studyService.updateStudy(studyUpdate, session.isInRole(ADMIN));
         return new VersionHolder(studyUpdate.getVersion());
     }
@@ -212,7 +212,7 @@ public class StudyController extends BaseController {
     public SynapseProjectIdTeamIdHolder createSynapse() throws SynapseException {
         // first get current study
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
 
         // then create project and team and grant admin permission to current user and exporter
         List<String> userIds = Arrays.asList(parseJson(String[].class));
@@ -230,7 +230,7 @@ public class StudyController extends BaseController {
         // Finally, you cannot delete your own study because it locks this user out of their session.
         // This is true of *all* users in the study, btw. There is an action in the BSM that iterates 
         // through all the participants in a study and signs them out one-by-one.
-        if (session.getStudyIdentifier().equals(identifier)) {
+        if (session.getAppId().equals(identifier)) {
             throw new UnauthorizedException("Admin cannot delete the study they are associated with.");
         }
         if (getStudyWhitelist().contains(identifier)) {
@@ -246,7 +246,7 @@ public class StudyController extends BaseController {
     public CmsPublicKey getStudyPublicKeyAsPem() {
         UserSession session = getAuthenticatedSession(DEVELOPER);
 
-        String pem = uploadCertificateService.getPublicKeyAsPem(session.getStudyIdentifier());
+        String pem = uploadCertificateService.getPublicKeyAsPem(session.getAppId());
 
         return new CmsPublicKey(pem);
     }
@@ -254,7 +254,7 @@ public class StudyController extends BaseController {
     @GetMapping("/v3/studies/self/emailStatus")
     public EmailVerificationStatusHolder getEmailStatus() {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
 
         EmailVerificationStatus status = emailVerificationService.getEmailStatus(study.getSupportEmail());
         return new EmailVerificationStatusHolder(status);
@@ -265,7 +265,7 @@ public class StudyController extends BaseController {
     public StatusMessage resendVerifyEmail(@RequestParam(required = false) String type) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         StudyEmailType parsedType = parseEmailType(type);
-        studyService.sendVerifyEmail(session.getStudyIdentifier(), parsedType);
+        studyService.sendVerifyEmail(session.getAppId(), parsedType);
         return RESEND_EMAIL_MSG;
     }
 
@@ -298,7 +298,7 @@ public class StudyController extends BaseController {
     @PostMapping("/v3/studies/self/verifyEmail")
     public EmailVerificationStatusHolder verifySenderEmail() {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
 
         EmailVerificationStatus status = emailVerificationService.verifyEmailAddress(study.getSupportEmail());
         return new EmailVerificationStatusHolder(status);
@@ -313,7 +313,7 @@ public class StudyController extends BaseController {
         DateTime startTimeObj = BridgeUtils.getDateTimeOrDefault(startTime, null);
         DateTime endTimeObj = BridgeUtils.getDateTimeOrDefault(endTime, null);
 
-        return uploadService.getStudyUploads(session.getStudyIdentifier(), startTimeObj, endTimeObj, pageSize,
+        return uploadService.getStudyUploads(session.getAppId(), startTimeObj, endTimeObj, pageSize,
                 offsetKey);
     }
 

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyReportController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyReportController.java
@@ -71,7 +71,7 @@ public class StudyReportController extends BaseController {
         UserSession session = getAuthenticatedSession();
         ReportType reportType = ("participant".equalsIgnoreCase(type)) ? PARTICIPANT : STUDY;
         
-        return reportService.getReportIndices(session.getStudyIdentifier(), reportType);
+        return reportService.getReportIndices(session.getAppId(), reportType);
     }
     
     /**
@@ -86,7 +86,7 @@ public class StudyReportController extends BaseController {
         LocalDate startDateObj = getLocalDateOrDefault(startDate, null);
         LocalDate endDateObj = getLocalDateOrDefault(endDate, null);
         
-        return reportService.getStudyReport(session.getStudyIdentifier(), identifier, startDateObj, endDateObj);
+        return reportService.getStudyReport(session.getAppId(), identifier, startDateObj, endDateObj);
     }
     
     /**
@@ -122,7 +122,7 @@ public class StudyReportController extends BaseController {
         DateTime endTimeObj = getDateTimeOrDefault(endTime, null);
         int pageSizeInt = getIntOrDefault(pageSize, API_DEFAULT_PAGE_SIZE);
         
-        return reportService.getStudyReportV4(session.getStudyIdentifier(), identifier, startTimeObj, endTimeObj,
+        return reportService.getStudyReportV4(session.getAppId(), identifier, startTimeObj, endTimeObj,
                 offsetKey, pageSizeInt);
     }
     
@@ -137,7 +137,7 @@ public class StudyReportController extends BaseController {
         ReportData reportData = parseJson(ReportData.class);
         reportData.setKey(null); // set in service, but just so no future use depends on it
         
-        reportService.saveStudyReport(session.getStudyIdentifier(), identifier, reportData);
+        reportService.saveStudyReport(session.getAppId(), identifier, reportData);
         
         return SAVED_MSG;
     }
@@ -166,7 +166,7 @@ public class StudyReportController extends BaseController {
     public StatusMessage deleteStudyReport(@PathVariable String identifier) {
         UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
         
-        reportService.deleteStudyReport(session.getStudyIdentifier(), identifier);
+        reportService.deleteStudyReport(session.getAppId(), identifier);
         
         return DELETED_MSG;
     }
@@ -178,7 +178,7 @@ public class StudyReportController extends BaseController {
     public StatusMessage deleteStudyReportRecord(@PathVariable String identifier, @PathVariable String date) {
         UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
         
-        reportService.deleteStudyReportRecord(session.getStudyIdentifier(), identifier, date);
+        reportService.deleteStudyReportRecord(session.getAppId(), identifier, date);
         
         return DELETED_DATA_MSG;
     }
@@ -192,7 +192,7 @@ public class StudyReportController extends BaseController {
         ReportDataKey key = new ReportDataKey.Builder()
                 .withIdentifier(identifier)
                 .withReportType(STUDY)
-                .withStudyIdentifier(session.getStudyIdentifier()).build();
+                .withStudyIdentifier(session.getAppId()).build();
         
         return reportService.getReportIndex(key);
     }
@@ -209,11 +209,11 @@ public class StudyReportController extends BaseController {
                 .withHealthCode(session.getHealthCode())
                 .withReportType(STUDY)
                 .withIdentifier(identifier)
-                .withStudyIdentifier(session.getStudyIdentifier()).build();
+                .withStudyIdentifier(session.getAppId()).build();
         index.setKey(key.getIndexKeyString());
         index.setIdentifier(identifier);
         
-        reportService.updateReportIndex(session.getStudyIdentifier(), STUDY, index);
+        reportService.updateReportIndex(session.getAppId(), STUDY, index);
         
         return UPDATED_MSG;
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/SubpopulationController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/SubpopulationController.java
@@ -44,7 +44,7 @@ public class SubpopulationController extends BaseController {
     public String getAllSubpopulations(@RequestParam(defaultValue = "false") boolean includeDeleted) throws Exception {
         UserSession session = getAuthenticatedSession(DEVELOPER);
 
-        List<Subpopulation> subpopulations = subpopService.getSubpopulations(session.getStudyIdentifier(),
+        List<Subpopulation> subpopulations = subpopService.getSubpopulations(session.getAppId(),
                 includeDeleted);
 
         return Subpopulation.SUBPOP_WRITER.writeValueAsString(new ResourceList<Subpopulation>(subpopulations));
@@ -54,7 +54,7 @@ public class SubpopulationController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     public GuidVersionHolder createSubpopulation() {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
 
         Subpopulation subpop = parseJson(Subpopulation.class);
         subpop = subpopService.createSubpopulation(study, subpop);
@@ -65,7 +65,7 @@ public class SubpopulationController extends BaseController {
     @PostMapping("/v3/subpopulations/{guid}")
     public GuidVersionHolder updateSubpopulation(@PathVariable String guid) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
 
         Subpopulation subpop = parseJson(Subpopulation.class);
         subpop.setGuidString(guid);
@@ -80,7 +80,7 @@ public class SubpopulationController extends BaseController {
         UserSession session = getAuthenticatedSession(DEVELOPER, RESEARCHER);
         SubpopulationGuid subpopGuid = SubpopulationGuid.create(guid);
 
-        Subpopulation subpop = subpopService.getSubpopulation(session.getStudyIdentifier(), subpopGuid);
+        Subpopulation subpop = subpopService.getSubpopulation(session.getAppId(), subpopGuid);
 
         return Subpopulation.SUBPOP_WRITER.writeValueAsString(subpop);
     }
@@ -92,9 +92,9 @@ public class SubpopulationController extends BaseController {
 
         SubpopulationGuid subpopGuid = SubpopulationGuid.create(guid);
         if (physical && session.isInRole(ADMIN)) {
-            subpopService.deleteSubpopulationPermanently(session.getStudyIdentifier(), subpopGuid);
+            subpopService.deleteSubpopulationPermanently(session.getAppId(), subpopGuid);
         } else {
-            subpopService.deleteSubpopulation(session.getStudyIdentifier(), subpopGuid);
+            subpopService.deleteSubpopulation(session.getAppId(), subpopGuid);
         }
         return DELETED_MSG;
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/SubstudyController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/SubstudyController.java
@@ -42,7 +42,7 @@ public class SubstudyController extends BaseController {
     public ResourceList<Substudy> getSubstudies(@RequestParam(defaultValue = "false") boolean includeDeleted) {
         UserSession session = getAuthenticatedSession(DEVELOPER, RESEARCHER, ADMIN);
 
-        List<Substudy> substudies = service.getSubstudies(session.getStudyIdentifier(), includeDeleted);
+        List<Substudy> substudies = service.getSubstudies(session.getAppId(), includeDeleted);
 
         return new ResourceList<>(substudies).withRequestParam(INCLUDE_DELETED, includeDeleted);
     }
@@ -53,14 +53,14 @@ public class SubstudyController extends BaseController {
         UserSession session = getAuthenticatedSession(SUPERADMIN);
 
         Substudy substudy = parseJson(Substudy.class);
-        return service.createSubstudy(session.getStudyIdentifier(), substudy);
+        return service.createSubstudy(session.getAppId(), substudy);
     }
 
     @GetMapping("/v3/substudies/{id}")
     public Substudy getSubstudy(@PathVariable String id) {
         UserSession session = getAuthenticatedSession(SUPERADMIN);
 
-        return service.getSubstudy(session.getStudyIdentifier(), id, true);
+        return service.getSubstudy(session.getAppId(), id, true);
     }
 
     @PostMapping("/v3/substudies/{id}")
@@ -68,7 +68,7 @@ public class SubstudyController extends BaseController {
         UserSession session = getAuthenticatedSession(SUPERADMIN);
 
         Substudy substudy = parseJson(Substudy.class);
-        return service.updateSubstudy(session.getStudyIdentifier(), substudy);
+        return service.updateSubstudy(session.getAppId(), substudy);
     }
 
     @DeleteMapping("/v3/substudies/{id}")
@@ -77,9 +77,9 @@ public class SubstudyController extends BaseController {
         UserSession session = getAuthenticatedSession(SUPERADMIN);
 
         if (physical) {
-            service.deleteSubstudyPermanently(session.getStudyIdentifier(), id);
+            service.deleteSubstudyPermanently(session.getAppId(), id);
         } else {
-            service.deleteSubstudy(session.getStudyIdentifier(), id);
+            service.deleteSubstudy(session.getAppId(), id);
         }
         return DELETED_MSG;
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/SurveyController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/SurveyController.java
@@ -62,7 +62,7 @@ public class SurveyController extends BaseController {
     public ResourceList<Survey> getAllSurveysMostRecentVersion(
             @RequestParam(defaultValue = "false") boolean includeDeleted) {
         UserSession session = getAuthenticatedSession(DEVELOPER, RESEARCHER);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
 
         List<Survey> surveys = surveyService.getAllSurveysMostRecentVersion(studyId, includeDeleted);
         return new ResourceList<>(surveys);
@@ -72,7 +72,7 @@ public class SurveyController extends BaseController {
     public ResourceList<Survey> getAllSurveysMostRecentlyPublishedVersion(
             @RequestParam(defaultValue = "false") boolean includeDeleted) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
 
         List<Survey> surveys = surveyService.getAllSurveysMostRecentlyPublishedVersion(studyId, includeDeleted);
         return new ResourceList<>(surveys);
@@ -148,7 +148,7 @@ public class SurveyController extends BaseController {
     @GetMapping(path="/v3/surveys/{surveyGuid}/revisions/recent", produces={APPLICATION_JSON_UTF8_VALUE})
     public String getSurveyMostRecentVersion(@PathVariable String surveyGuid) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
 
         CacheKey cacheKey = viewCache.getCacheKey(Survey.class, surveyGuid, MOSTRECENT_KEY, studyId);
 
@@ -178,7 +178,7 @@ public class SurveyController extends BaseController {
     public StatusMessage deleteSurvey(@PathVariable String surveyGuid, @PathVariable String createdOn,
             @RequestParam(defaultValue = "false") boolean physical) {
         UserSession session = getAuthenticatedSession(DEVELOPER, ADMIN);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
 
         long createdOnLong = DateUtils.convertToMillisFromEpoch(createdOn);
         GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(surveyGuid, createdOnLong);
@@ -201,7 +201,7 @@ public class SurveyController extends BaseController {
     public ResourceList<Survey> getSurveyAllVersions(@PathVariable String surveyGuid,
             @RequestParam(defaultValue = "false") boolean includeDeleted) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
 
         List<Survey> surveys = surveyService.getSurveyAllVersions(studyId, surveyGuid, includeDeleted);
         return new ResourceList<>(surveys);
@@ -211,7 +211,7 @@ public class SurveyController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     public GuidCreatedOnVersionHolder createSurvey() {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
 
         Survey survey = parseJson(Survey.class);
         survey.setStudyIdentifier(studyId);
@@ -224,12 +224,12 @@ public class SurveyController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     public GuidCreatedOnVersionHolder versionSurvey(@PathVariable String surveyGuid, @PathVariable String createdOn) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
 
         long createdOnLong = DateUtils.convertToMillisFromEpoch(createdOn);
         GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(surveyGuid, createdOnLong);
 
-        Survey survey = surveyService.versionSurvey(session.getStudyIdentifier(), keys);
+        Survey survey = surveyService.versionSurvey(session.getAppId(), keys);
         expireCache(surveyGuid, createdOn, studyId);
 
         return new GuidCreatedOnVersionHolderImpl(survey);
@@ -238,7 +238,7 @@ public class SurveyController extends BaseController {
     @PostMapping("/v3/surveys/{surveyGuid}/revisions/{createdOn}")
     public GuidCreatedOnVersionHolder updateSurvey(@PathVariable String surveyGuid, @PathVariable String createdOn) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
 
         // The parameters in the URL take precedence over anything declared in
         // the object itself.
@@ -247,7 +247,7 @@ public class SurveyController extends BaseController {
         survey.setCreatedOn(DateUtils.convertToMillisFromEpoch(createdOn));
         survey.setStudyIdentifier(studyId);
 
-        survey = surveyService.updateSurvey(session.getStudyIdentifier(), survey);
+        survey = surveyService.updateSurvey(session.getAppId(), survey);
         expireCache(surveyGuid, createdOn, studyId);
 
         return new GuidCreatedOnVersionHolderImpl(survey);
@@ -257,7 +257,7 @@ public class SurveyController extends BaseController {
     public GuidCreatedOnVersionHolder publishSurvey(@PathVariable String surveyGuid, @PathVariable String createdOn,
             @RequestParam(defaultValue = "false") boolean newSchemaRev) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
 
         long createdOnLong = DateUtils.convertToMillisFromEpoch(createdOn);
         GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(surveyGuid, createdOnLong);
@@ -273,19 +273,19 @@ public class SurveyController extends BaseController {
         GuidCreatedOnVersionHolder keys = new GuidCreatedOnVersionHolderImpl(surveyGuid, createdOn);
 
         CacheKey cacheKey = viewCache.getCacheKey(Survey.class, surveyGuid, createdOnString,
-                session.getStudyIdentifier());
+                session.getAppId());
 
         return getView(cacheKey, session, () -> {
-            return surveyService.getSurvey(session.getStudyIdentifier(), keys, true, true);
+            return surveyService.getSurvey(session.getAppId(), keys, true, true);
         });
     }
 
     private String getCachedSurveyMostRecentlyPublishedInternal(String surveyGuid, UserSession session) {
         CacheKey cacheKey = viewCache.getCacheKey(Survey.class, surveyGuid, PUBLISHED_KEY,
-                session.getStudyIdentifier());
+                session.getAppId());
 
         return getView(cacheKey, session, () -> {
-            return surveyService.getSurveyMostRecentlyPublishedVersion(session.getStudyIdentifier(), surveyGuid, true);
+            return surveyService.getSurveyMostRecentlyPublishedVersion(session.getAppId(), surveyGuid, true);
         });
     }
 

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/TemplateController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/TemplateController.java
@@ -57,7 +57,7 @@ public class TemplateController extends BaseController {
         Integer pageSizeInt = BridgeUtils.getIntOrDefault(pageSize, API_DEFAULT_PAGE_SIZE);
         Boolean includeDeletedFlag = Boolean.valueOf(includeDeleted);
         
-        return templateService.getTemplatesForType(session.getStudyIdentifier(), type, offsetInt, pageSizeInt,
+        return templateService.getTemplatesForType(session.getAppId(), type, offsetInt, pageSizeInt,
                 includeDeletedFlag);
     }
     
@@ -65,7 +65,7 @@ public class TemplateController extends BaseController {
     @ResponseStatus(CREATED)
     public GuidVersionHolder createTemplate() {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         
         Template template = parseJson(Template.class);
         
@@ -76,7 +76,7 @@ public class TemplateController extends BaseController {
     public Template getTemplate(@PathVariable String guid) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         
-        return templateService.getTemplate(session.getStudyIdentifier(), guid);
+        return templateService.getTemplate(session.getAppId(), guid);
     }
 
     @PostMapping("/v3/templates/{guid}")
@@ -86,7 +86,7 @@ public class TemplateController extends BaseController {
         Template template = parseJson(Template.class);
         template.setGuid(guid);
         
-        return templateService.updateTemplate(session.getStudyIdentifier(), template);
+        return templateService.updateTemplate(session.getAppId(), template);
     }
     
     @DeleteMapping("/v3/templates/{guid}")
@@ -94,9 +94,9 @@ public class TemplateController extends BaseController {
         UserSession session = getAuthenticatedSession(DEVELOPER, ADMIN);
         
         if ("true".equals(physical) && session.isInRole(ADMIN)) {
-            templateService.deleteTemplatePermanently(session.getStudyIdentifier(), guid);
+            templateService.deleteTemplatePermanently(session.getAppId(), guid);
         } else {
-            templateService.deleteTemplate(session.getStudyIdentifier(), guid);
+            templateService.deleteTemplate(session.getAppId(), guid);
         }
         return new StatusMessage("Template deleted.");
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/TemplateRevisionController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/TemplateRevisionController.java
@@ -44,7 +44,7 @@ public class TemplateRevisionController extends BaseController {
         int offsetInt = getIntOrDefault(offsetBy, 0);
         int pageSizeInt = getIntOrDefault(pageSize, API_DEFAULT_PAGE_SIZE);
         
-        return templateRevisionService.getTemplateRevisions(session.getStudyIdentifier(), guid, offsetInt, pageSizeInt);
+        return templateRevisionService.getTemplateRevisions(session.getAppId(), guid, offsetInt, pageSizeInt);
     }
     
     @PostMapping("/v3/templates/{guid}/revisions")
@@ -54,7 +54,7 @@ public class TemplateRevisionController extends BaseController {
         
         TemplateRevision revision = parseJson(TemplateRevision.class);
         
-        return templateRevisionService.createTemplateRevision(session.getStudyIdentifier(), guid, revision);
+        return templateRevisionService.createTemplateRevision(session.getAppId(), guid, revision);
     }
     
     @GetMapping("/v3/templates/{guid}/revisions/{createdOn}")
@@ -63,7 +63,7 @@ public class TemplateRevisionController extends BaseController {
         
         DateTime createdOnDate = getDateTimeOrDefault(createdOn, null);
         
-        return templateRevisionService.getTemplateRevision(session.getStudyIdentifier(), guid, createdOnDate);
+        return templateRevisionService.getTemplateRevision(session.getAppId(), guid, createdOnDate);
     }
     
     @PostMapping("/v3/templates/{guid}/revisions/{createdOn}/publish")
@@ -72,7 +72,7 @@ public class TemplateRevisionController extends BaseController {
         
         DateTime createdOnDate = getDateTimeOrDefault(createdOn, null);
         
-        templateRevisionService.publishTemplateRevision(session.getStudyIdentifier(), guid, createdOnDate);
+        templateRevisionService.publishTemplateRevision(session.getAppId(), guid, createdOnDate);
         
         return PUBLISHED_MSG;
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/UploadController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/UploadController.java
@@ -85,7 +85,7 @@ public class UploadController extends BaseController {
     public UploadSession upload() {
         UserSession session = getAuthenticatedAndConsentedSession();
         UploadRequest uploadRequest = UploadRequest.fromJson(parseJson(JsonNode.class));
-        UploadSession uploadSession = uploadService.createUpload(session.getStudyIdentifier(), session.getParticipant(),
+        UploadSession uploadSession = uploadService.createUpload(session.getAppId(), session.getParticipant(),
                 uploadRequest);
         final Metrics metrics = getMetrics();
         if (metrics != null) {
@@ -147,7 +147,7 @@ public class UploadController extends BaseController {
                 throw new UnauthorizedException();
             }
 
-            studyId = session.getStudyIdentifier();
+            studyId = session.getAppId();
             uploadCompletionClient = UploadCompletionClient.APP;
         }
         uploadService.uploadComplete(studyId, uploadCompletionClient, upload, redrive);
@@ -179,7 +179,7 @@ public class UploadController extends BaseController {
             }
             
             if (!session.isInRole(EnumSet.of(SUPERADMIN, WORKER)) &&
-                !session.getStudyIdentifier().equals(record.getStudyId())) {
+                !session.getAppId().equals(record.getStudyId())) {
                 throw new UnauthorizedException("Study admin cannot retrieve upload in another study.");
             }
             uploadId = record.getUploadId();

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/UploadSchemaController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/UploadSchemaController.java
@@ -52,7 +52,7 @@ public class UploadSchemaController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     public String createSchemaRevisionV4() throws Exception {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
 
         UploadSchema uploadSchema = parseJson(UploadSchema.class);
         UploadSchema createdSchema = uploadSchemaService.createSchemaRevisionV4(studyId, uploadSchema);
@@ -69,7 +69,7 @@ public class UploadSchemaController extends BaseController {
     @PostMapping(path="/v3/uploadschemas", produces={APPLICATION_JSON_UTF8_VALUE})
     public String createOrUpdateUploadSchema() throws JsonProcessingException, IOException {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
         
         UploadSchema uploadSchema = parseJson(UploadSchema.class);
         UploadSchema createdSchema = uploadSchemaService.createOrUpdateUploadSchema(studyId, uploadSchema);
@@ -82,9 +82,9 @@ public class UploadSchemaController extends BaseController {
         UserSession session = getAuthenticatedSession(DEVELOPER, ADMIN);
         
         if (physical && session.isInRole(ADMIN)) {
-            uploadSchemaService.deleteUploadSchemaByIdPermanently(session.getStudyIdentifier(), schemaId);
+            uploadSchemaService.deleteUploadSchemaByIdPermanently(session.getAppId(), schemaId);
         } else {
-            uploadSchemaService.deleteUploadSchemaById(session.getStudyIdentifier(), schemaId);    
+            uploadSchemaService.deleteUploadSchemaById(session.getAppId(), schemaId);    
         }
         return DELETED_MSG;
     }
@@ -95,9 +95,9 @@ public class UploadSchemaController extends BaseController {
         UserSession session = getAuthenticatedSession(DEVELOPER, ADMIN);
         
         if (physical && session.isInRole(ADMIN)) {
-            uploadSchemaService.deleteUploadSchemaByIdAndRevisionPermanently(session.getStudyIdentifier(), schemaId, revision);
+            uploadSchemaService.deleteUploadSchemaByIdAndRevisionPermanently(session.getAppId(), schemaId, revision);
         } else {
-            uploadSchemaService.deleteUploadSchemaByIdAndRevision(session.getStudyIdentifier(), schemaId, revision);
+            uploadSchemaService.deleteUploadSchemaByIdAndRevision(session.getAppId(), schemaId, revision);
         }
         return DELETED_REVISION_MSG;
     }
@@ -114,7 +114,7 @@ public class UploadSchemaController extends BaseController {
     @GetMapping(path="/v3/uploadschemas/{schemaId}/recent", produces={APPLICATION_JSON_UTF8_VALUE})
     public String getUploadSchema(@PathVariable String schemaId) throws JsonProcessingException, IOException {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
         
         UploadSchema uploadSchema = uploadSchemaService.getUploadSchema(studyId, schemaId);
         return PUBLIC_SCHEMA_WRITER.writeValueAsString(uploadSchema);
@@ -133,7 +133,7 @@ public class UploadSchemaController extends BaseController {
     public String getUploadSchemaAllRevisions(@PathVariable String schemaId,
             @RequestParam(defaultValue = "false") boolean includeDeleted) throws JsonProcessingException, IOException {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
         
         List<UploadSchema> uploadSchemas = uploadSchemaService.getUploadSchemaAllRevisions(studyId, schemaId,
                 Boolean.valueOf(includeDeleted));
@@ -155,7 +155,7 @@ public class UploadSchemaController extends BaseController {
     public String getUploadSchemaByIdAndRev(@PathVariable String schemaId, @PathVariable int revision)
             throws JsonProcessingException, IOException {
         UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
 
         UploadSchema uploadSchema = uploadSchemaService.getUploadSchemaByIdAndRev(studyId, schemaId, revision);
         return PUBLIC_SCHEMA_WRITER.writeValueAsString(uploadSchema);
@@ -189,7 +189,7 @@ public class UploadSchemaController extends BaseController {
     public String getUploadSchemasForStudy(@RequestParam(defaultValue = "false") boolean includeDeleted)
             throws Exception {
         UserSession session = getAuthenticatedSession(DEVELOPER, RESEARCHER);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
 
         List<UploadSchema> schemaList = uploadSchemaService.getUploadSchemasForStudy(studyId, Boolean.valueOf(includeDeleted));
         ResourceList<UploadSchema> schemaResourceList = new ResourceList<>(schemaList);
@@ -210,7 +210,7 @@ public class UploadSchemaController extends BaseController {
     public String updateSchemaRevisionV4(@PathVariable String schemaId, @PathVariable int revision)
             throws JsonProcessingException, IOException {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String studyId = session.getStudyIdentifier();
+        String studyId = session.getAppId();
 
         UploadSchema uploadSchema = parseJson(UploadSchema.class);
         UploadSchema updatedSchema = uploadSchemaService.updateSchemaRevisionV4(studyId, schemaId, revision,

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/UserDataDownloadController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/UserDataDownloadController.java
@@ -36,7 +36,7 @@ public class UserDataDownloadController extends BaseController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public StatusMessage requestUserData() throws JsonProcessingException {
         UserSession session = getAuthenticatedAndConsentedSession();
-        String studyIdentifier = session.getStudyIdentifier();
+        String studyIdentifier = session.getAppId();
         
         // At least for now, if the user does not have a verified email address, do not allow this service.
         StudyParticipant participant = session.getParticipant();

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/UserManagementController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/UserManagementController.java
@@ -93,7 +93,7 @@ public class UserManagementController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     public JsonNode createUser() {
         UserSession session = getAuthenticatedSession(ADMIN);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
 
         JsonNode node = parseJson(JsonNode.class);
         StudyParticipant participant = parseJson(node, StudyParticipant.class);
@@ -130,7 +130,7 @@ public class UserManagementController extends BaseController {
     @DeleteMapping("/v3/users/{userId}")
     public StatusMessage deleteUser(@PathVariable String userId) {
         UserSession session = getAuthenticatedSession(ADMIN);
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         
         userAdminService.deleteUser(study, userId);
         

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/UserProfileController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/UserProfileController.java
@@ -65,7 +65,7 @@ public class UserProfileController extends BaseController {
     @GetMapping(path={"/v3/users/self", "/api/v1/profile"}, produces={APPLICATION_JSON_UTF8_VALUE})
     public String getUserProfile() {
         UserSession session = getAuthenticatedSession();
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         String userId = session.getId();
         
         CacheKey cacheKey = viewCache.getCacheKey(ObjectNode.class, userId, study.getIdentifier());
@@ -95,7 +95,7 @@ public class UserProfileController extends BaseController {
     @PostMapping({"/v3/users/self", "/api/v1/profile"})
     public JsonNode updateUserProfile() {
         UserSession session = getAuthenticatedSession();
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         String userId = session.getId();
         
         JsonNode node = parseJson(JsonNode.class);
@@ -131,7 +131,7 @@ public class UserProfileController extends BaseController {
     public JsonNode getDataGroups() {
         UserSession session = getAuthenticatedSession();
         
-        AccountId accountId = AccountId.forHealthCode(session.getStudyIdentifier(), session.getHealthCode());
+        AccountId accountId = AccountId.forHealthCode(session.getAppId(), session.getHealthCode());
         Account account = accountService.getAccount(accountId);
         if (account == null) {
             throw new EntityNotFoundException(Account.class);
@@ -152,7 +152,7 @@ public class UserProfileController extends BaseController {
     @PostMapping("/v3/users/self/dataGroups")
     public JsonNode updateDataGroups() {
         UserSession session = getAuthenticatedSession();
-        Study study = studyService.getStudy(session.getStudyIdentifier());
+        Study study = studyService.getStudy(session.getAppId());
         
         StudyParticipant participant = participantService.getParticipant(study, session.getId(), false);
         
@@ -173,7 +173,7 @@ public class UserProfileController extends BaseController {
                 .withUserId(session.getId())
                 .withUserDataGroups(updated.getDataGroups())
                 .withUserSubstudyIds(updated.getSubstudyIds())
-                .withStudyIdentifier(session.getStudyIdentifier())
+                .withStudyIdentifier(session.getAppId())
                 .build();
         
         sessionUpdateService.updateDataGroups(session, context);

--- a/src/main/java/org/sagebionetworks/bridge/validators/IntentToParticipateValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/IntentToParticipateValidator.java
@@ -24,8 +24,8 @@ public class IntentToParticipateValidator implements Validator {
     public void validate(Object object, Errors errors) {
         IntentToParticipate intent = (IntentToParticipate)object;
         
-        if (isBlank(intent.getStudyId())) {
-            errors.rejectValue("studyId", "is required");
+        if (isBlank(intent.getAppId())) {
+            errors.rejectValue("appId", "is required");
         }
         if (isBlank(intent.getSubpopGuid())) {
             errors.rejectValue("subpopGuid", "is required");

--- a/src/main/java/org/sagebionetworks/bridge/validators/SubpopulationValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/SubpopulationValidator.java
@@ -30,8 +30,8 @@ public class SubpopulationValidator implements Validator {
     public void validate(Object object, Errors errors) {
         Subpopulation subpop = (Subpopulation)object;
         
-        if (subpop.getStudyIdentifier() == null) {
-            errors.rejectValue("studyIdentifier", "is required");
+        if (subpop.getAppId() == null) {
+            errors.rejectValue("appId", "is required");
         }
         if (isBlank(subpop.getName())) {
             errors.rejectValue("name", "is required");

--- a/src/test/java/org/sagebionetworks/bridge/DefaultStudyBootstrapperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/DefaultStudyBootstrapperTest.java
@@ -8,7 +8,6 @@ import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
-import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 

--- a/src/test/java/org/sagebionetworks/bridge/TestUtils.java
+++ b/src/test/java/org/sagebionetworks/bridge/TestUtils.java
@@ -370,7 +370,7 @@ public class TestUtils {
                 .withImageData("image-data")
                 .withImageMimeType("image/png").build();
         return new IntentToParticipate.Builder()
-                .withStudyId(TEST_APP_ID)
+                .withAppId(TEST_APP_ID)
                 .withScope(SharingScope.SPONSORS_AND_PARTNERS)
                 .withPhone(TestConstants.PHONE)
                 .withSubpopGuid("subpopGuid")

--- a/src/test/java/org/sagebionetworks/bridge/cache/CacheProviderMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/cache/CacheProviderMockTest.java
@@ -32,7 +32,6 @@ import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.Roles;
-import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.config.Environment;
@@ -131,7 +130,7 @@ public class CacheProviderMockTest {
         assertEquals(session.getSessionToken(), DECRYPTED_SESSION_TOKEN);
         assertEquals(session.getInternalSessionToken(), "4f0937a5-6ebf-451b-84bc-fbf649b9e93c");
         assertEquals(session.getId(), "6gq4jGXLmAxVbLLmVifKN4");
-        assertEquals(session.getStudyIdentifier(), TEST_APP_ID);
+        assertEquals(session.getAppId(), TEST_APP_ID);
         
         StudyParticipant participant = session.getParticipant();
         assertEquals(participant.getFirstName(), "Bridge");
@@ -223,16 +222,6 @@ public class CacheProviderMockTest {
         verify(jedisOps).get(REQUEST_INFO_KEY);
     }
     
-    @Test
-    public void getRequestInfoWithStudyIdentifier() throws Exception {
-        String json = TestUtils.createJson("{'userId':'userId','timeZone':'UTC',"+
-                "'studyIdentifier':{'identifier':'"+TEST_APP_ID+"'},'type':'RequestInfo'}");
-        when(jedisOps.get(REQUEST_INFO_KEY)).thenReturn(json);
-        
-        RequestInfo returned = cacheProvider.getRequestInfo(USER_ID);
-        assertEquals(returned.getStudyIdentifier(), TEST_APP_ID);
-    }
-
     @Test
     public void emptySetDoesNotDelete() {
         doReturn(Sets.newHashSet()).when(jedisOps).smembers(CACHE_KEY.toString());

--- a/src/test/java/org/sagebionetworks/bridge/cache/CacheProviderStudyMigrationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/cache/CacheProviderStudyMigrationTest.java
@@ -1,0 +1,158 @@
+package org.sagebionetworks.bridge.cache;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.List;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.models.RequestInfo;
+import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.itp.IntentToParticipate;
+import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
+import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
+import org.sagebionetworks.bridge.redis.JedisOps;
+
+public class CacheProviderStudyMigrationTest extends Mockito {
+    private static final TypeReference<List<Subpopulation>> SURVEY_LIST_REF = new TypeReference<List<Subpopulation>>() {};
+    
+    @Mock
+    JedisOps mockJedisOps;
+    
+    @InjectMocks
+    CacheProvider provider;
+    
+    @BeforeMethod
+    public void beforeMethod() {
+        MockitoAnnotations.initMocks(this);
+        provider.setSessionExpireInSeconds(10);
+    }
+
+    @Test
+    public void requestInfoConvertedWithAppId() throws Exception {
+        String json = TestUtils.createJson("{'userId':'userId','timeZone':'UTC',"+
+                "'appId':'"+TEST_APP_ID+"'}");
+        CacheKey key = CacheKey.requestInfo("userId");
+        when(mockJedisOps.get(key.toString())).thenReturn(json);
+        
+        RequestInfo info = provider.getRequestInfo("userId");
+        
+        assertEquals(info.getAppId(), TEST_APP_ID);
+    }
+
+    @Test
+    public void requestInfoConvertedWithStudyIdentifier() throws Exception {
+        String json = TestUtils.createJson("{'userId':'userId','timeZone':'UTC',"+
+                "'studyIdentifier':'"+TEST_APP_ID+"'}");
+        CacheKey key = CacheKey.requestInfo("userId");
+        when(mockJedisOps.get(key.toString())).thenReturn(json);
+        
+        RequestInfo info = provider.getRequestInfo("userId");
+        
+        assertEquals(info.getAppId(), TEST_APP_ID);
+    }
+    
+    @Test
+    public void userSesssionWithStudyIdentifier() { 
+        String json = TestUtils.createJson(
+                "{'studyIdentifier':'"+TEST_APP_ID+"','sessionToken':'aToken'}");
+
+        doReturn("aUser").when(mockJedisOps).get("aToken:session2");
+        doReturn(json).when(mockJedisOps).get("aUser:session2:user");
+        
+        UserSession session = provider.getUserSession("aToken");
+        assertEquals(session.getAppId(), TEST_APP_ID);
+    }
+    
+    @Test
+    public void userSessionWithAppId() {
+        String json = TestUtils.createJson(
+                "{'appId':'"+TEST_APP_ID+"','sessionToken':'aToken'}");
+
+        doReturn("aUser").when(mockJedisOps).get("aToken:session2");
+        doReturn(json).when(mockJedisOps).get("aUser:session2:user");
+        
+        UserSession session = provider.getUserSession("aToken");
+        assertEquals(session.getAppId(), TEST_APP_ID);
+    }
+    
+    @Test
+    public void intentToParticipanteWithStudyId() throws Exception {
+        String json = TestUtils.createJson("{'studyId':'"+TEST_APP_ID+
+                "','email':'email@email.com','subpopGuid':'subpopGuid',"+
+                "'scope':'all_qualified_researchers',"+
+                "'type':'IntentToParticipate'}");
+        
+        CacheKey key = CacheKey.itp(SubpopulationGuid.create("subpopGuid"), 
+                TEST_APP_ID, "email@email.com");
+        when(mockJedisOps.get(key.toString())).thenReturn(json);
+        
+        IntentToParticipate itp = provider.getObject(key, IntentToParticipate.class);
+        assertEquals(itp.getAppId(), TEST_APP_ID);
+    }
+    
+    @Test
+    public void intentToParticipanteWithAppId() throws Exception {
+        String json = TestUtils.createJson("{'appId':'"+TEST_APP_ID+
+                "','email':'email@email.com','subpopGuid':'subpopGuid',"+
+                "'scope':'all_qualified_researchers',"+
+                "'type':'IntentToParticipate'}");
+        
+        CacheKey key = CacheKey.itp(SubpopulationGuid.create("subpopGuid"), 
+                TEST_APP_ID, "email@email.com");
+        when(mockJedisOps.get(key.toString())).thenReturn(json);
+        
+        IntentToParticipate itp = provider.getObject(key, IntentToParticipate.class);
+        assertEquals(itp.getAppId(), TEST_APP_ID);
+    }
+    
+    @Test
+    public void subpopulationWithStudyIdentifier() throws Exception {
+        String json = TestUtils.createJson("{'studyIdentifier':'"+TEST_APP_ID+"','type':'Subpopulation'}");
+        CacheKey key = CacheKey.subpop(SubpopulationGuid.create("subpopGuid"), TEST_APP_ID);
+        when(mockJedisOps.get(key.toString())).thenReturn(json);
+        
+        Subpopulation subpop = provider.getObject(key, Subpopulation.class);
+        assertEquals(subpop.getAppId(), TEST_APP_ID);
+    }
+    
+    @Test
+    public void subpopulationWithAppId() throws Exception {
+        String json = TestUtils.createJson("{'appId':'"+TEST_APP_ID+"','type':'Subpopulation'}");
+        CacheKey key = CacheKey.subpop(SubpopulationGuid.create("subpopGuid"), TEST_APP_ID);
+        when(mockJedisOps.get(key.toString())).thenReturn(json);
+        
+        Subpopulation subpop = provider.getObject(key, Subpopulation.class);
+        assertEquals(subpop.getAppId(), TEST_APP_ID);
+    }
+    
+    @Test
+    public void subpopulationListWithStudyId() {
+        String json = TestUtils.createJson("[{'studyIdentifier':'"+TEST_APP_ID+"','type':'Subpopulation'}]");
+        CacheKey key = CacheKey.subpopList(TEST_APP_ID);
+        when(mockJedisOps.get(key.toString())).thenReturn(json);
+        
+        List<Subpopulation> subpops = provider.getObject(key, SURVEY_LIST_REF);
+        assertEquals(subpops.get(0).getAppId(), TEST_APP_ID);
+    }
+    
+    @Test
+    public void subpopulationListWithAppId() {
+        String json = TestUtils.createJson("[{'appId':'"+TEST_APP_ID+"','type':'Subpopulation'}]");
+        CacheKey key = CacheKey.subpopList(TEST_APP_ID);
+        when(mockJedisOps.get(key.toString())).thenReturn(json);
+        
+        List<Subpopulation> subpops = provider.getObject(key, SURVEY_LIST_REF);
+        assertEquals(subpops.get(0).getAppId(), TEST_APP_ID);
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDaoMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDaoMockTest.java
@@ -181,7 +181,7 @@ public class DynamoSubpopulationDaoMockTest {
     @Test
     public void updateSubpopulationUpdatesCriteriaFromObject() {
         Subpopulation subpopWithCritObject = Subpopulation.create();
-        subpopWithCritObject.setStudyIdentifier(TEST_APP_ID);
+        subpopWithCritObject.setAppId(TEST_APP_ID);
         subpopWithCritObject.setGuidString(BridgeUtils.generateGuid());
         subpopWithCritObject.setVersion(1L);
         subpopWithCritObject.setCriteria(CRITERIA);
@@ -204,7 +204,7 @@ public class DynamoSubpopulationDaoMockTest {
         
         Subpopulation subpop = Subpopulation.create();
         subpop.setDeleted(false);
-        subpop.setStudyIdentifier(TEST_APP_ID);
+        subpop.setAppId(TEST_APP_ID);
         subpop.setGuidString(BridgeUtils.generateGuid());
         subpop.setVersion(1L);
         
@@ -221,7 +221,7 @@ public class DynamoSubpopulationDaoMockTest {
         
         Subpopulation subpop = Subpopulation.create();
         subpop.setDeleted(true);
-        subpop.setStudyIdentifier(TEST_APP_ID);
+        subpop.setAppId(TEST_APP_ID);
         subpop.setGuidString(BridgeUtils.generateGuid());
         subpop.setVersion(1L);
         
@@ -238,7 +238,7 @@ public class DynamoSubpopulationDaoMockTest {
         
         Subpopulation subpop = Subpopulation.create();
         subpop.setDeleted(true);
-        subpop.setStudyIdentifier(TEST_APP_ID);
+        subpop.setAppId(TEST_APP_ID);
         subpop.setGuidString(BridgeUtils.generateGuid());
         subpop.setVersion(1L);
         
@@ -292,7 +292,7 @@ public class DynamoSubpopulationDaoMockTest {
         
         Subpopulation subpop = Subpopulation.create();
         subpop.setGuid(SUBPOP_GUID);
-        subpop.setStudyIdentifier(TEST_APP_ID);
+        subpop.setAppId(TEST_APP_ID);
         subpop.setCriteria(criteria);
         return subpop;
     }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationDaoTest.java
@@ -78,7 +78,7 @@ public class DynamoSubpopulationDaoTest extends Mockito {
         subpop.setDefaultGroup(true);
         subpop.setVersion(1L);
         subpop.setPublishedConsentCreatedOn(100L);
-        subpop.setStudyIdentifier(TEST_APP_ID);
+        subpop.setAppId(TEST_APP_ID);
         
         dao.createSubpopulation(subpop);
         
@@ -103,7 +103,7 @@ public class DynamoSubpopulationDaoTest extends Mockito {
         
         verify(mockMapper).save(subpopCaptor.capture());
         Subpopulation subpop = subpopCaptor.getValue();
-        assertEquals(subpop.getStudyIdentifier(), TEST_APP_ID);
+        assertEquals(subpop.getAppId(), TEST_APP_ID);
         assertEquals(subpop.getGuidString(), TEST_APP_ID);
         assertEquals(subpop.getName(), "Default Consent Group");
         assertTrue(subpop.isDefaultGroup());
@@ -135,7 +135,7 @@ public class DynamoSubpopulationDaoTest extends Mockito {
         assertEquals(result.size(), 2);
         
         verify(mockMapper).query(eq(DynamoSubpopulation.class), queryCaptor.capture());
-        assertEquals(queryCaptor.getValue().getHashKeyValues().getStudyIdentifier(), TEST_APP_ID);        
+        assertEquals(queryCaptor.getValue().getHashKeyValues().getAppId(), TEST_APP_ID);        
     }
 
     @Test
@@ -215,7 +215,7 @@ public class DynamoSubpopulationDaoTest extends Mockito {
         when(mockMapper.load(any())).thenReturn(saved);
         
         Subpopulation subpop = Subpopulation.create();
-        subpop.setStudyIdentifier(TEST_APP_ID);
+        subpop.setAppId(TEST_APP_ID);
         subpop.setGuid(SUBPOP_GUID);
         subpop.setVersion(2L);
         subpop.setDefaultGroup(false);
@@ -232,7 +232,7 @@ public class DynamoSubpopulationDaoTest extends Mockito {
     @Test(expectedExceptions = BadRequestException.class)
     public void updateSubpopulationNoVersion() {
         Subpopulation subpop = Subpopulation.create();
-        subpop.setStudyIdentifier(TEST_APP_ID);
+        subpop.setAppId(TEST_APP_ID);
         subpop.setGuid(SUBPOP_GUID);
         
         dao.updateSubpopulation(subpop);
@@ -241,7 +241,7 @@ public class DynamoSubpopulationDaoTest extends Mockito {
     @Test(expectedExceptions = BadRequestException.class)
     public void updateSubpopulationNoGuid() {
         Subpopulation subpop = Subpopulation.create();
-        subpop.setStudyIdentifier(TEST_APP_ID);
+        subpop.setAppId(TEST_APP_ID);
         subpop.setVersion(2L);
         
         dao.updateSubpopulation(subpop);
@@ -254,7 +254,7 @@ public class DynamoSubpopulationDaoTest extends Mockito {
         when(mockMapper.load(any())).thenReturn(saved);
         
         Subpopulation subpop = Subpopulation.create();
-        subpop.setStudyIdentifier(TEST_APP_ID);
+        subpop.setAppId(TEST_APP_ID);
         subpop.setGuid(SUBPOP_GUID);
         subpop.setVersion(2L);
         // not deleted
@@ -273,7 +273,7 @@ public class DynamoSubpopulationDaoTest extends Mockito {
         when(mockMapper.load(any())).thenReturn(saved);
         
         Subpopulation subpop = Subpopulation.create();
-        subpop.setStudyIdentifier(TEST_APP_ID);
+        subpop.setAppId(TEST_APP_ID);
         subpop.setGuid(SUBPOP_GUID);
         subpop.setVersion(2L);
         subpop.setDeleted(true);
@@ -292,7 +292,7 @@ public class DynamoSubpopulationDaoTest extends Mockito {
         when(mockMapper.load(any())).thenReturn(saved);
         
         Subpopulation subpop = Subpopulation.create();
-        subpop.setStudyIdentifier(TEST_APP_ID);
+        subpop.setAppId(TEST_APP_ID);
         subpop.setGuid(SUBPOP_GUID);
         subpop.setVersion(2L);
         subpop.setDeleted(true);
@@ -307,7 +307,7 @@ public class DynamoSubpopulationDaoTest extends Mockito {
         when(mockMapper.load(any())).thenReturn(saved);
         
         Subpopulation subpop = Subpopulation.create();
-        subpop.setStudyIdentifier(TEST_APP_ID);
+        subpop.setAppId(TEST_APP_ID);
         subpop.setGuid(SUBPOP_GUID);
         subpop.setVersion(2L);
         subpop.setDeleted(true);

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoSubpopulationTest.java
@@ -58,7 +58,7 @@ public class DynamoSubpopulationTest {
         assertTrue(node.get("defaultGroup").booleanValue());
         assertTrue(node.get("autoSendConsentSuppressed").booleanValue());
         assertTrue(node.get("deleted").booleanValue()); // users do not see this flag, they never get deleted items
-        assertEquals(node.get("studyIdentifier").textValue(), "study-key");
+        assertEquals(node.get("appId").textValue(), "study-key");
         assertTrue(node.get("deleted").booleanValue());
         assertEquals(node.get("version").longValue(), 3L);
         
@@ -79,7 +79,7 @@ public class DynamoSubpopulationTest {
         
         Subpopulation newSubpop = BridgeObjectMapper.get().treeToValue(node, Subpopulation.class);
         // Not serialized, these values have to be added back to have equal objects 
-        newSubpop.setStudyIdentifier("study-key");
+        newSubpop.setAppId("study-key");
         
         assertEquals(newSubpop, subpop);
         
@@ -105,7 +105,7 @@ public class DynamoSubpopulationTest {
         subpop.setName("Name");
         subpop.setDescription("Description");
         subpop.setGuidString("guid");
-        subpop.setStudyIdentifier("study-key");
+        subpop.setAppId("study-key");
         subpop.setRequired(true);
         subpop.setDefaultGroup(true);
         subpop.setPublishedConsentCreatedOn(PUBLISHED_CONSENT_TIMESTAMP.getMillis());

--- a/src/test/java/org/sagebionetworks/bridge/models/RequestInfoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/RequestInfoTest.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.models;
 
+import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.USER_DATA_GROUPS;
 import static org.sagebionetworks.bridge.TestConstants.USER_SUBSTUDY_IDS;
 import static org.testng.Assert.assertEquals;
@@ -22,7 +23,6 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class RequestInfoTest {
 
-    private static final String STUDY_ID = "test-study";
     private static final String USER_ID = "userId";
     private static final ClientInfo CLIENT_INFO = ClientInfo.parseUserAgentString("app/20");
     private static final String USER_AGENT_STRING = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.116 Safari/537.36";
@@ -64,7 +64,7 @@ public class RequestInfoTest {
         assertEquals(node.get("timeZone").textValue(), "+03:00");
         assertEquals(node.get("type").textValue(), "RequestInfo");
         assertEquals(node.get("userAgent").textValue(), USER_AGENT_STRING);
-        assertEquals(node.get("studyIdentifier").textValue(), "test-study");
+        assertEquals(node.get("appId").textValue(), TEST_APP_ID);
         assertEquals(node.size(), 12);
         
         JsonNode clientInfoNode = node.get("clientInfo");
@@ -94,7 +94,7 @@ public class RequestInfoTest {
         RequestInfo requestInfo = createRequestInfo();
         
         RequestInfo copy = new RequestInfo.Builder().copyOf(requestInfo).build();
-        assertEquals(copy.getStudyIdentifier(), STUDY_ID);
+        assertEquals(copy.getAppId(), TEST_APP_ID);
         assertEquals(copy.getClientInfo(), CLIENT_INFO);
         assertEquals(copy.getUserAgent(), USER_AGENT_STRING);
         assertEquals(copy.getUserDataGroups(), USER_DATA_GROUPS);
@@ -109,7 +109,7 @@ public class RequestInfoTest {
 
     private RequestInfo createRequestInfo() {
         RequestInfo requestInfo = new RequestInfo.Builder()
-                .withStudyIdentifier(STUDY_ID)
+                .withAppId(TEST_APP_ID)
                 .withClientInfo(CLIENT_INFO)
                 .withUserAgent(USER_AGENT_STRING)
                 .withUserDataGroups(USER_DATA_GROUPS)

--- a/src/test/java/org/sagebionetworks/bridge/models/RequestInfoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/RequestInfoTest.java
@@ -45,6 +45,7 @@ public class RequestInfoTest {
         JsonNode node = BridgeObjectMapper.get().valueToTree(requestInfo);
 
         assertEquals(node.get("userId").textValue(), "userId");
+        assertEquals(node.get("appId").textValue(), TEST_APP_ID);
         assertEquals(node.get("activitiesAccessedOn").textValue(), ACTIVITIES_REQUESTED_ON.withZone(MST).toString());
         assertEquals(node.get("uploadedOn").textValue(), UPLOADED_ON.withZone(MST).toString());
         assertEquals(node.get("languages").get(0).textValue(), "en");

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/AccountSummaryTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/AccountSummaryTest.java
@@ -50,6 +50,7 @@ public class AccountSummaryTest {
         assertEquals(node.get("status").textValue(), "unverified");
         assertEquals(node.get("studyId").textValue(), TEST_APP_ID);
         assertEquals(node.get("studyIdentifier").get("identifier").textValue(), TEST_APP_ID);
+        assertEquals(node.get("studyIdentifier").get("type").textValue(), "StudyIdentifier");
         assertEquals(node.get("substudyIds").get(0).textValue(), "sub1");
         assertEquals(node.get("substudyIds").get(1).textValue(), "sub2");
         assertEquals(node.get("externalId").textValue(), "externalId");

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/UserSessionInfoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/UserSessionInfoTest.java
@@ -52,7 +52,7 @@ public class UserSessionInfoTest {
         session.setInternalSessionToken("internal");
         session.setSessionToken("external");
         session.setReauthToken("reauthToken");
-        session.setStudyIdentifier("study-identifier");
+        session.setAppId("study-identifier");
         
         JsonNode node = UserSessionInfo.toJSON(session);
         assertEquals(node.get("firstName").textValue(), "first name");

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/UserSessionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/UserSessionTest.java
@@ -60,7 +60,7 @@ public class UserSessionTest {
         session.setAuthenticated(true);
         session.setEnvironment(PROD);
         session.setIpAddress("ip address");
-        session.setStudyIdentifier("study-key");
+        session.setAppId("study-key");
         session.setReauthToken("reauthToken");
         session.setConsentStatuses(statuses);
         
@@ -73,7 +73,7 @@ public class UserSessionTest {
         assertEquals(newSession.getInternalSessionToken(), session.getInternalSessionToken());
         assertEquals(newSession.getEnvironment(), session.getEnvironment());
         assertEquals(newSession.getIpAddress(), session.getIpAddress());
-        assertEquals(newSession.getStudyIdentifier(), session.getStudyIdentifier());
+        assertEquals(newSession.getAppId(), session.getAppId());
         assertEquals(newSession.getParticipant(), session.getParticipant());
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/VerificationDataTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/VerificationDataTest.java
@@ -1,0 +1,51 @@
+package org.sagebionetworks.bridge.models.accounts;
+
+import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
+import static org.sagebionetworks.bridge.TestConstants.TIMESTAMP;
+import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.services.AuthenticationService.ChannelType;
+
+public class VerificationDataTest {
+    @Test
+    public void serializeVerificationData() throws Exception { 
+        VerificationData data = new VerificationData.Builder()
+                .withAppId(TEST_APP_ID)
+                .withType(ChannelType.PHONE)
+                .withUserId(USER_ID)
+                .withExpiresOn(TIMESTAMP.getMillis()).build();
+        
+        JsonNode node = BridgeObjectMapper.get().valueToTree(data);
+        assertEquals(node.get("appId").textValue(), TEST_APP_ID);
+        assertEquals(node.get("type").textValue(), "phone");
+        assertEquals(node.get("userId").textValue(), USER_ID);
+        assertEquals(node.get("expiresOn").longValue(), TIMESTAMP.getMillis());
+        
+        VerificationData deser = BridgeObjectMapper.get().readValue(node.toString(),
+                VerificationData.class);
+        assertEquals(deser.getAppId(), TEST_APP_ID);
+        assertEquals(deser.getType(), ChannelType.PHONE);
+        assertEquals(deser.getUserId(), USER_ID);
+        assertEquals(deser.getExpiresOn(), TIMESTAMP.getMillis());
+    }
+    
+    @Test
+    public void restoreVerificationDataWithStudyId() throws Exception {
+        String json = TestUtils.createJson("{'studyId':'"+TEST_APP_ID+"','type':'email','userId':'"+
+                USER_ID+"',"+"'expiresOn':1422319112486}");
+        VerificationData deser = BridgeObjectMapper.get().readValue(json,
+                VerificationData.class);
+        assertEquals(deser.getAppId(), TEST_APP_ID);
+        assertEquals(deser.getType(), ChannelType.EMAIL);
+        assertEquals(deser.getUserId(), USER_ID);
+        assertEquals(deser.getExpiresOn(), TIMESTAMP.getMillis());
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/models/itp/IntentToParticipateTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/itp/IntentToParticipateTest.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.models.itp;
 
 import static org.sagebionetworks.bridge.TestConstants.EMAIL;
 import static org.sagebionetworks.bridge.TestConstants.PHONE;
+import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 
@@ -27,12 +28,12 @@ public class IntentToParticipateTest {
                 .withBirthdate("1980-10-10").withImageData("image-data").withImageMimeType("image/png")
                 .withSignedOn(TIMESTAMP.getMillis()).withConsentCreatedOn(TIMESTAMP.getMillis()).build();
         
-        IntentToParticipate itp = new IntentToParticipate.Builder().withStudyId("studyId").withPhone(PHONE)
+        IntentToParticipate itp = new IntentToParticipate.Builder().withAppId(TEST_APP_ID).withPhone(PHONE)
                 .withEmail(EMAIL).withSubpopGuid("subpopGuid").withScope(SharingScope.ALL_QUALIFIED_RESEARCHERS)
                 .withOsName("iOS").withConsentSignature(consentSignature).build();
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(itp);
-        assertEquals(node.get("studyId").textValue(), "studyId");
+        assertEquals(node.get("appId").textValue(), TEST_APP_ID);
         assertEquals(node.get("email").textValue(), EMAIL);
         assertEquals(node.get("subpopGuid").textValue(), "subpopGuid");
         assertEquals(node.get("scope").textValue(), "all_qualified_researchers");
@@ -58,7 +59,7 @@ public class IntentToParticipateTest {
         assertEquals(consentNode.size(), 7);
         
         IntentToParticipate deser = BridgeObjectMapper.get().readValue(node.toString(), IntentToParticipate.class);
-        assertEquals(deser.getStudyId(), "studyId");
+        assertEquals(deser.getAppId(), TEST_APP_ID);
         assertEquals(deser.getPhone().getNationalFormat(), PHONE.getNationalFormat());
         assertEquals(deser.getEmail(), EMAIL);
         assertEquals(deser.getSubpopGuid(), "subpopGuid");
@@ -85,12 +86,12 @@ public class IntentToParticipateTest {
                 .withBirthdate("1980-10-10").withImageData("image-data").withImageMimeType("image/png")
                 .withSignedOn(TIMESTAMP.getMillis()).withConsentCreatedOn(TIMESTAMP.getMillis()).build();
         
-        IntentToParticipate itp = new IntentToParticipate.Builder().withStudyId("studyId").withPhone(PHONE)
+        IntentToParticipate itp = new IntentToParticipate.Builder().withAppId(TEST_APP_ID).withPhone(PHONE)
                 .withEmail(EMAIL).withSubpopGuid("subpopGuid").withScope(SharingScope.ALL_QUALIFIED_RESEARCHERS)
                 .withOsName("iOS").withConsentSignature(consentSignature).build();
 
         IntentToParticipate copy = new IntentToParticipate.Builder().copyOf(itp).build();
-        assertEquals(copy.getStudyId(), itp.getStudyId());
+        assertEquals(copy.getAppId(), itp.getAppId());
         assertEquals(copy.getPhone().getNumber(), itp.getPhone().getNumber());
         assertEquals(copy.getEmail(), itp.getEmail());
         assertEquals(copy.getSubpopGuid(), itp.getSubpopGuid());
@@ -105,7 +106,7 @@ public class IntentToParticipateTest {
                 .withBirthdate("1980-10-10").withImageData("image-data").withImageMimeType("image/png")
                 .withSignedOn(TIMESTAMP.getMillis()).withConsentCreatedOn(TIMESTAMP.getMillis()).build();
         
-        IntentToParticipate itp = new IntentToParticipate.Builder().withStudyId("studyId").withPhone(PHONE)
+        IntentToParticipate itp = new IntentToParticipate.Builder().withAppId(TEST_APP_ID).withPhone(PHONE)
                 .withSubpopGuid("subpopGuid").withScope(SharingScope.ALL_QUALIFIED_RESEARCHERS).withOsName("iOS")
                 .withConsentSignature(consentSignature).build();
         

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
@@ -1338,35 +1338,5 @@ public class AccountWorkflowServiceTest extends Mockito {
 
         verify(mockSmsService, times(2)).sendSmsMessage(any(), any());
     }
-    
-    @Test
-    public void serializeVerificationData() throws Exception { 
-        AccountWorkflowService.VerificationData data = new AccountWorkflowService.VerificationData(
-                TEST_APP_ID, null, ChannelType.PHONE, USER_ID, TIMESTAMP.getMillis());
-        
-        JsonNode node = BridgeObjectMapper.get().valueToTree(data);
-        assertEquals(node.get("appId").textValue(), TEST_APP_ID);
-        assertEquals(node.get("type").textValue(), "phone");
-        assertEquals(node.get("userId").textValue(), USER_ID);
-        assertEquals(node.get("expiresOn").longValue(), TIMESTAMP.getMillis());
-        
-        AccountWorkflowService.VerificationData deser = BridgeObjectMapper.get().readValue(node.toString(),
-                AccountWorkflowService.VerificationData.class);
-        assertEquals(deser.getAppId(), TEST_APP_ID);
-        assertEquals(deser.getType(), ChannelType.PHONE);
-        assertEquals(deser.getUserId(), USER_ID);
-        assertEquals(deser.getExpiresOn(), TIMESTAMP.getMillis());
-    }
-    
-    @Test
-    public void restoreVerificationDataWithStudyId() throws Exception {
-        String json = TestUtils.createJson("{'studyId':'"+TEST_APP_ID+"','type':'email','userId':'"+
-                USER_ID+"',"+"'expiresOn':1422319112486}");
-        AccountWorkflowService.VerificationData deser = BridgeObjectMapper.get().readValue(json,
-                AccountWorkflowService.VerificationData.class);
-        assertEquals(deser.getAppId(), TEST_APP_ID);
-        assertEquals(deser.getType(), ChannelType.EMAIL);
-        assertEquals(deser.getUserId(), USER_ID);
-        assertEquals(deser.getExpiresOn(), TIMESTAMP.getMillis());
-    }
+
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountWorkflowServiceTest.java
@@ -236,7 +236,7 @@ public class AccountWorkflowServiceTest extends Mockito {
         
         String string = stringCaptor.getValue();
         JsonNode node = BridgeObjectMapper.get().readTree(string);
-        assertEquals(node.get("studyId").textValue(), TEST_APP_ID);
+        assertEquals(node.get("appId").textValue(), TEST_APP_ID);
         assertEquals(node.get("userId").textValue(), "userId");
         assertEquals(node.get("type").textValue(), "email");
         assertEquals(node.get("expiresOn").longValue(),
@@ -293,7 +293,7 @@ public class AccountWorkflowServiceTest extends Mockito {
         
         String string = stringCaptor.getValue();
         JsonNode node = BridgeObjectMapper.get().readTree(string);
-        assertEquals(node.get("studyId").textValue(), TEST_APP_ID);
+        assertEquals(node.get("appId").textValue(), TEST_APP_ID);
         assertEquals(node.get("userId").textValue(), "userId");
         assertEquals(node.get("type").textValue(), "phone");
         assertEquals(node.get("expiresOn").longValue(),
@@ -1342,18 +1342,30 @@ public class AccountWorkflowServiceTest extends Mockito {
     @Test
     public void serializeVerificationData() throws Exception { 
         AccountWorkflowService.VerificationData data = new AccountWorkflowService.VerificationData(
-                TEST_APP_ID, ChannelType.PHONE, USER_ID, TIMESTAMP.getMillis());
+                TEST_APP_ID, null, ChannelType.PHONE, USER_ID, TIMESTAMP.getMillis());
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(data);
-        assertEquals(node.get("studyId").textValue(), TEST_APP_ID);
+        assertEquals(node.get("appId").textValue(), TEST_APP_ID);
         assertEquals(node.get("type").textValue(), "phone");
         assertEquals(node.get("userId").textValue(), USER_ID);
         assertEquals(node.get("expiresOn").longValue(), TIMESTAMP.getMillis());
         
         AccountWorkflowService.VerificationData deser = BridgeObjectMapper.get().readValue(node.toString(),
                 AccountWorkflowService.VerificationData.class);
-        assertEquals(deser.getStudyId(), TEST_APP_ID);
+        assertEquals(deser.getAppId(), TEST_APP_ID);
         assertEquals(deser.getType(), ChannelType.PHONE);
+        assertEquals(deser.getUserId(), USER_ID);
+        assertEquals(deser.getExpiresOn(), TIMESTAMP.getMillis());
+    }
+    
+    @Test
+    public void restoreVerificationDataWithStudyId() throws Exception {
+        String json = TestUtils.createJson("{'studyId':'"+TEST_APP_ID+"','type':'email','userId':'"+
+                USER_ID+"',"+"'expiresOn':1422319112486}");
+        AccountWorkflowService.VerificationData deser = BridgeObjectMapper.get().readValue(json,
+                AccountWorkflowService.VerificationData.class);
+        assertEquals(deser.getAppId(), TEST_APP_ID);
+        assertEquals(deser.getType(), ChannelType.EMAIL);
         assertEquals(deser.getUserId(), USER_ID);
         assertEquals(deser.getExpiresOn(), TIMESTAMP.getMillis());
     }

--- a/src/test/java/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AuthenticationServiceMockTest.java
@@ -248,7 +248,7 @@ public class AuthenticationServiceMockTest {
         assertEquals(session.getInternalSessionToken(), SESSION_TOKEN);
         assertEquals(session.getReauthToken(), REAUTH_TOKEN);
         assertEquals(session.getEnvironment(), Environment.PROD);
-        assertEquals(session.getStudyIdentifier(), TEST_APP_ID);
+        assertEquals(session.getAppId(), TEST_APP_ID);
 
         // updated context
         CriteriaContext updatedContext = contextCaptor.getValue();
@@ -328,7 +328,7 @@ public class AuthenticationServiceMockTest {
         assertEquals(session.getInternalSessionToken(), SESSION_TOKEN);
         assertEquals(session.getReauthToken(), REAUTH_TOKEN);
         assertEquals(session.getEnvironment(), Environment.PROD);
-        assertEquals(session.getStudyIdentifier(), TEST_APP_ID);
+        assertEquals(session.getAppId(), TEST_APP_ID);
 
         // updated context
         CriteriaContext updatedContext = contextCaptor.getValue();
@@ -424,7 +424,7 @@ public class AuthenticationServiceMockTest {
     @Test
     public void signOut() {
         UserSession session = new UserSession();
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setReauthToken(TOKEN);
         session.setParticipant(new StudyParticipant.Builder().withEmail("email@email.com").withId(USER_ID).build());
         service.signOut(session);
@@ -1279,7 +1279,7 @@ public class AuthenticationServiceMockTest {
         assertTrue(session.isAuthenticated());
         assertEquals(session.getEnvironment(), Environment.LOCAL);
         assertEquals(session.getIpAddress(), IP_ADDRESS);
-        assertEquals(session.getStudyIdentifier(), TEST_APP_ID);
+        assertEquals(session.getAppId(), TEST_APP_ID);
         assertEquals(session.getReauthToken(), REAUTH_TOKEN);
         assertEquals(session.getConsentStatuses(), CONSENTED_STATUS_MAP);
         

--- a/src/test/java/org/sagebionetworks/bridge/services/IntentServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/IntentServiceTest.java
@@ -117,7 +117,7 @@ public class IntentServiceTest {
         
         when(mockStudy.getIdentifier()).thenReturn(TEST_APP_ID);
         when(mockStudy.getInstallLinks()).thenReturn(installLinks);
-        when(mockStudyService.getStudy(intent.getStudyId())).thenReturn(mockStudy);
+        when(mockStudyService.getStudy(intent.getAppId())).thenReturn(mockStudy);
         
         TemplateRevision revision = TemplateRevision.create();
         revision.setDocumentContent("this-is-a-link");
@@ -155,7 +155,7 @@ public class IntentServiceTest {
         
         when(mockStudy.getIdentifier()).thenReturn(TEST_APP_ID);
         when(mockStudy.getInstallLinks()).thenReturn(installLinks);
-        when(mockStudyService.getStudy(intent.getStudyId())).thenReturn(mockStudy);
+        when(mockStudyService.getStudy(intent.getAppId())).thenReturn(mockStudy);
         
         TemplateRevision revision = TemplateRevision.create();
         revision.setDocumentContent("this-is-a-link");
@@ -193,7 +193,7 @@ public class IntentServiceTest {
         
         when(mockStudy.getIdentifier()).thenReturn(TEST_APP_ID);
         when(mockStudy.getInstallLinks()).thenReturn(installLinks);
-        when(mockStudyService.getStudy(intent.getStudyId())).thenReturn(mockStudy);
+        when(mockStudyService.getStudy(intent.getAppId())).thenReturn(mockStudy);
         
         TemplateRevision revision = TemplateRevision.create();
         revision.setSubject("subject");
@@ -248,7 +248,7 @@ public class IntentServiceTest {
                 TestConstants.PHONE);
         
         when(mockStudy.getIdentifier()).thenReturn("testStudy");
-        when(mockStudyService.getStudy(intent.getStudyId())).thenReturn(mockStudy);
+        when(mockStudyService.getStudy(intent.getAppId())).thenReturn(mockStudy);
         when(mockCacheProvider.getObject(cacheKey, IntentToParticipate.class))
                 .thenReturn(intent);
 
@@ -291,7 +291,7 @@ public class IntentServiceTest {
                 .withOsName("Android")
                 .withPhone(TestConstants.PHONE)
                 .withScope(SharingScope.NO_SHARING)
-                .withStudyId(TEST_APP_ID)
+                .withAppId(TEST_APP_ID)
                 .withSubpopGuid("BBB")
                 .withConsentSignature(new ConsentSignature.Builder()
                         .withName("Test Name")
@@ -328,7 +328,7 @@ public class IntentServiceTest {
                 .withOsName("Android")
                 .withEmail(TestConstants.EMAIL)
                 .withScope(SharingScope.NO_SHARING)
-                .withStudyId(TEST_APP_ID)
+                .withAppId(TEST_APP_ID)
                 .withSubpopGuid("BBB")
                 .withConsentSignature(new ConsentSignature.Builder()
                         .withName("Test Name")
@@ -365,7 +365,7 @@ public class IntentServiceTest {
                 .withOsName("Android")
                 .withPhone(TestConstants.PHONE)
                 .withScope(SharingScope.NO_SHARING)
-                .withStudyId(TEST_APP_ID)
+                .withAppId(TEST_APP_ID)
                 .withSubpopGuid("AAA")
                 .withConsentSignature(new ConsentSignature.Builder()
                         .withName("Test Name")
@@ -377,7 +377,7 @@ public class IntentServiceTest {
                 .withOsName("Android")
                 .withPhone(TestConstants.PHONE)
                 .withScope(SharingScope.NO_SHARING)
-                .withStudyId(TEST_APP_ID)
+                .withAppId(TEST_APP_ID)
                 .withSubpopGuid("BBB")
                 .withConsentSignature(new ConsentSignature.Builder()
                         .withName("Test Name")
@@ -453,7 +453,7 @@ public class IntentServiceTest {
         IntentToParticipate intent = TestUtils.getIntentToParticipate(TIMESTAMP).build();
         
         when(mockStudy.getIdentifier()).thenReturn(TEST_APP_ID);
-        when(mockStudyService.getStudy(intent.getStudyId())).thenReturn(mockStudy);
+        when(mockStudyService.getStudy(intent.getAppId())).thenReturn(mockStudy);
         
         CacheKey cacheKey = CacheKey.itp(SubpopulationGuid.create("subpopGuid"), TEST_APP_ID, PHONE);
         

--- a/src/test/java/org/sagebionetworks/bridge/services/SessionUpdateServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/SessionUpdateServiceTest.java
@@ -191,12 +191,12 @@ public class SessionUpdateServiceTest {
     @Test
     public void updateStudy() {
         UserSession session = new UserSession();
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         
         service.updateStudy(session, "new-study");
         
         verify(mockCacheProvider).setUserSession(session);
-        assertEquals(session.getStudyIdentifier(), "new-study");
+        assertEquals(session.getAppId(), "new-study");
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/SubpopulationServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/SubpopulationServiceTest.java
@@ -143,7 +143,7 @@ public class SubpopulationServiceTest {
         Subpopulation subpop = Subpopulation.create();
         subpop.setName("Name");
         subpop.setDescription("Description");
-        subpop.setStudyIdentifier("junk-you-cannot-set");
+        subpop.setAppId("junk-you-cannot-set");
         subpop.setGuidString("cannot-set-guid");
         subpop.setDefaultGroup(false);
         
@@ -154,7 +154,7 @@ public class SubpopulationServiceTest {
         assertNotNull(result.getGuidString());
         assertNotEquals(result.getGuidString(), "cannot-set-guid");
         assertFalse(result.isDeleted());
-        assertEquals(result.getStudyIdentifier(), TEST_APP_ID);
+        assertEquals(result.getAppId(), TEST_APP_ID);
         
         verify(subpopDao).createSubpopulation(subpop);
         verify(studyConsentService).addConsent(eq(result.getGuid()), any());
@@ -210,7 +210,7 @@ public class SubpopulationServiceTest {
         Subpopulation subpop = Subpopulation.create();
         subpop.setName("Name");
         subpop.setDescription("Description");
-        subpop.setStudyIdentifier("junk-you-cannot-set");
+        subpop.setAppId("junk-you-cannot-set");
         subpop.setGuidString("guid");
         subpop.setDefaultGroup(false);
         subpop.setDeleted(true);
@@ -221,7 +221,7 @@ public class SubpopulationServiceTest {
         Subpopulation result = service.updateSubpopulation(study, subpop);
         assertEquals(result.getName(), "Name");
         assertEquals(result.getGuidString(), "guid");
-        assertEquals(result.getStudyIdentifier(), TEST_APP_ID);
+        assertEquals(result.getAppId(), TEST_APP_ID);
         
         verify(subpopDao).updateSubpopulation(subpop);
         verify(substudyService).getSubstudyIds(TEST_APP_ID);
@@ -438,7 +438,7 @@ public class SubpopulationServiceTest {
     
     private Subpopulation createSubpop(String name, Integer min, Integer max, String group) {
         DynamoSubpopulation subpop = new DynamoSubpopulation();
-        subpop.setStudyIdentifier(TEST_APP_ID);
+        subpop.setAppId(TEST_APP_ID);
         subpop.setName(name);
         subpop.setGuidString(BridgeUtils.generateGuid());
         

--- a/src/test/java/org/sagebionetworks/bridge/services/SubstudyServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/SubstudyServiceTest.java
@@ -23,7 +23,6 @@ import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dao.SubstudyDao;
 import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ActivityEventControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ActivityEventControllerTest.java
@@ -63,7 +63,7 @@ public class ActivityEventControllerTest extends Mockito {
         MockitoAnnotations.initMocks(this);
         
         UserSession session = new UserSession();
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setParticipant(new StudyParticipant.Builder().withHealthCode(HEALTH_CODE).build());
         
         doReturn(session).when(controller).getAuthenticatedAndConsentedSession();

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AppConfigControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AppConfigControllerTest.java
@@ -111,7 +111,7 @@ public class AppConfigControllerTest extends Mockito {
         study.setIdentifier(TEST_APP_ID);
         
         session = new UserSession();
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setParticipant(new StudyParticipant.Builder()
                 .withDataGroups(TestConstants.USER_DATA_GROUPS)
                 .withLanguages(TestConstants.LANGUAGES)

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AppConfigElementsControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AppConfigElementsControllerTest.java
@@ -76,7 +76,7 @@ public class AppConfigElementsControllerTest {
         MockitoAnnotations.initMocks(this);
 
         session = new UserSession(new StudyParticipant.Builder().build());
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         
         doReturn(mockRequest).when(controller).request();
         doReturn(session).when(controller).getAuthenticatedSession(Roles.DEVELOPER, Roles.ADMIN);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AssessmentConfigControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AssessmentConfigControllerTest.java
@@ -64,7 +64,7 @@ public class AssessmentConfigControllerTest extends Mockito {
         MockitoAnnotations.initMocks(this);
         
         session = new UserSession();
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         doReturn(mockRequest).when(controller).request();
     }
     
@@ -111,7 +111,7 @@ public class AssessmentConfigControllerTest extends Mockito {
             expectedExceptionsMessageRegExp = SHARED_ASSESSMENTS_ERROR)
     public void updateAssessmentConfigRejectsSharedStudy() throws Exception {
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
-        session.setStudyIdentifier(SHARED_APP_ID);
+        session.setAppId(SHARED_APP_ID);
         
         AssessmentConfig config = new AssessmentConfig();
         config.setConfig(TestUtils.getClientData());
@@ -145,7 +145,7 @@ public class AssessmentConfigControllerTest extends Mockito {
             expectedExceptionsMessageRegExp = SHARED_ASSESSMENTS_ERROR)
     public void customizeAssessmentConfigRejectsSharedStudy() throws Exception {
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
-        session.setStudyIdentifier(SHARED_APP_ID);
+        session.setAppId(SHARED_APP_ID);
         
         Map<String, Map<String, JsonNode>> updates = new HashMap<>();
         updates.put("guid", ImmutableMap.of("objGuid", TestUtils.getClientData()));

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AssessmentControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AssessmentControllerTest.java
@@ -85,7 +85,7 @@ public class AssessmentControllerTest extends Mockito {
         doReturn(mockResponse).when(controller).response();
         
         session = new UserSession();
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
     }
 
     @AfterMethod
@@ -146,7 +146,7 @@ public class AssessmentControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class, 
             expectedExceptionsMessageRegExp = SHARED_ASSESSMENTS_ERROR)
     public void getAssessmentsRejectsSharedAppContext() {
-        session.setStudyIdentifier(SHARED_APP_ID);
+        session.setAppId(SHARED_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         
         controller.getAssessments(null, null, null, null);
@@ -189,7 +189,7 @@ public class AssessmentControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class, 
             expectedExceptionsMessageRegExp = SHARED_ASSESSMENTS_ERROR)
     public void createAssessmentRejectsSharedAppContext() {
-        session.setStudyIdentifier(SHARED_APP_ID);
+        session.setAppId(SHARED_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         
         controller.createAssessment();
@@ -219,7 +219,7 @@ public class AssessmentControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class, 
             expectedExceptionsMessageRegExp = SHARED_ASSESSMENTS_ERROR)
     public void updateAssessmentRejectsSharedAppContext() {
-        session.setStudyIdentifier(SHARED_APP_ID);
+        session.setAppId(SHARED_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         
         controller.updateAssessmentByGuid(GUID);
@@ -254,7 +254,7 @@ public class AssessmentControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class, 
             expectedExceptionsMessageRegExp = SHARED_ASSESSMENTS_ERROR)
     public void getAssessmentByGuidRejectsSharedAppContext() {
-        session.setStudyIdentifier(SHARED_APP_ID);
+        session.setAppId(SHARED_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         
         controller.getAssessmentByGuid(GUID);
@@ -308,7 +308,7 @@ public class AssessmentControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class, 
             expectedExceptionsMessageRegExp = SHARED_ASSESSMENTS_ERROR)
     public void getAssessmentByIdRejectsSharedAppContext() {
-        session.setStudyIdentifier(SHARED_APP_ID);
+        session.setAppId(SHARED_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         
         controller.getAssessmentById(IDENTIFIER, "3");
@@ -327,7 +327,7 @@ public class AssessmentControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class, 
             expectedExceptionsMessageRegExp = SHARED_ASSESSMENTS_ERROR)
     public void getLatestAssessmentRejectsSharedAppContext() {
-        session.setStudyIdentifier(SHARED_APP_ID);
+        session.setAppId(SHARED_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         
         controller.getLatestAssessment(IDENTIFIER);
@@ -360,7 +360,7 @@ public class AssessmentControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class, 
             expectedExceptionsMessageRegExp = SHARED_ASSESSMENTS_ERROR)
     public void getAssessmentRevisionsByIdRejectsSharedAppContext() {
-        session.setStudyIdentifier(SHARED_APP_ID);
+        session.setAppId(SHARED_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         
         controller.getAssessmentRevisionsById(IDENTIFIER, null, null, null);
@@ -393,7 +393,7 @@ public class AssessmentControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class, 
             expectedExceptionsMessageRegExp = SHARED_ASSESSMENTS_ERROR)
     public void getAssessmentRevisionsByGuidRejectsSharedAppContext() {
-        session.setStudyIdentifier(SHARED_APP_ID);
+        session.setAppId(SHARED_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         
         controller.getAssessmentRevisionsByGuid(GUID, null, null, null);
@@ -437,7 +437,7 @@ public class AssessmentControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class, 
             expectedExceptionsMessageRegExp = SHARED_ASSESSMENTS_ERROR)
     public void createAssessmentRevisionRejectsSharedAppContext() {
-        session.setStudyIdentifier(SHARED_APP_ID);
+        session.setAppId(SHARED_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         
         controller.createAssessmentRevision(GUID);
@@ -466,7 +466,7 @@ public class AssessmentControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class, 
             expectedExceptionsMessageRegExp = SHARED_ASSESSMENTS_ERROR)
     public void publishAssessmentRejectsSharedAppContext() {
-        session.setStudyIdentifier(SHARED_APP_ID);
+        session.setAppId(SHARED_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         
         controller.publishAssessment(GUID, null);
@@ -511,7 +511,7 @@ public class AssessmentControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class, 
             expectedExceptionsMessageRegExp = SHARED_ASSESSMENTS_ERROR)
     public void deleteAssessmentRejectsSharedAppContext() {
-        session.setStudyIdentifier(SHARED_APP_ID);
+        session.setAppId(SHARED_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
         
         controller.deleteAssessment(GUID, null);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AssessmentResourceControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AssessmentResourceControllerTest.java
@@ -73,7 +73,7 @@ public class AssessmentResourceControllerTest extends Mockito {
         doReturn(mockResponse).when(controller).response();
         
         session = new UserSession();
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
     }
     
     @Test
@@ -210,7 +210,7 @@ public class AssessmentResourceControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class, 
             expectedExceptionsMessageRegExp = SHARED_ASSESSMENTS_ERROR)
     public void getAssessmentResourcesRejectsSharedAppContext() {
-        session.setStudyIdentifier(SHARED_APP_ID);
+        session.setAppId(SHARED_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         
         controller.getAssessmentResources(ASSESSMENT_ID, null, null, null, null, null, null);
@@ -219,7 +219,7 @@ public class AssessmentResourceControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class, 
             expectedExceptionsMessageRegExp = SHARED_ASSESSMENTS_ERROR)
     public void createAssessmentResourceRejectsSharedAppContext() {
-        session.setStudyIdentifier(SHARED_APP_ID);
+        session.setAppId(SHARED_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         
         controller.createAssessmentResource(ASSESSMENT_ID);
@@ -228,7 +228,7 @@ public class AssessmentResourceControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class, 
             expectedExceptionsMessageRegExp = SHARED_ASSESSMENTS_ERROR)
     public void getAssessmentResourceRejectsSharedAppContext() {
-        session.setStudyIdentifier(SHARED_APP_ID);
+        session.setAppId(SHARED_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         
         controller.getAssessmentResource(ASSESSMENT_ID, GUID);
@@ -237,7 +237,7 @@ public class AssessmentResourceControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class, 
             expectedExceptionsMessageRegExp = SHARED_ASSESSMENTS_ERROR)
     public void updateAssessmentResourceRejectsSharedAppContext() {
-        session.setStudyIdentifier(SHARED_APP_ID);
+        session.setAppId(SHARED_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         
         controller.updateAssessmentResource(ASSESSMENT_ID, GUID);
@@ -246,7 +246,7 @@ public class AssessmentResourceControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class, 
             expectedExceptionsMessageRegExp = SHARED_ASSESSMENTS_ERROR)
     public void deleteAssessmentResourceRejectsSharedAppContext() {
-        session.setStudyIdentifier(SHARED_APP_ID);
+        session.setAppId(SHARED_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
         
         controller.deleteAssessmentResource(ASSESSMENT_ID, GUID, null);
@@ -267,7 +267,7 @@ public class AssessmentResourceControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class, 
             expectedExceptionsMessageRegExp = SHARED_ASSESSMENTS_ERROR)
     public void publishAssessmentResourceRejectsSharedAppContext() throws Exception {
-        session.setStudyIdentifier(SHARED_APP_ID);
+        session.setAppId(SHARED_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         
         controller.publishAssessmentResource(ASSESSMENT_ID);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationControllerTest.java
@@ -186,7 +186,7 @@ public class AuthenticationControllerTest extends Mockito {
         userSession.setSessionToken(TEST_SESSION_TOKEN);
         userSession.setParticipant(new StudyParticipant.Builder().withId(TEST_ACCOUNT_ID).build());
         userSession.setInternalSessionToken(TEST_INTERNAL_SESSION_ID);
-        userSession.setStudyIdentifier(TEST_STUDY_ID_STRING);
+        userSession.setAppId(TEST_STUDY_ID_STRING);
         
         study = new DynamoStudy();
         study.setIdentifier(TEST_STUDY_ID_STRING);
@@ -532,7 +532,7 @@ public class AuthenticationControllerTest extends Mockito {
         verify(mockRequestInfoService).updateRequestInfo(requestInfoCaptor.capture());
         RequestInfo requestInfo = requestInfoCaptor.getValue();
         assertEquals("spId", requestInfo.getUserId());
-        assertEquals(TEST_STUDY_ID_STRING, requestInfo.getStudyIdentifier());
+        assertEquals(TEST_STUDY_ID_STRING, requestInfo.getAppId());
         assertTrue(requestInfo.getSignedInOn() != null);
         assertEquals(TestConstants.USER_DATA_GROUPS, requestInfo.getUserDataGroups());
         assertNotNull(requestInfo.getSignedInOn());
@@ -1334,7 +1334,7 @@ public class AuthenticationControllerTest extends Mockito {
         session.setAuthenticated(true);
         session.setInternalSessionToken(TEST_INTERNAL_SESSION_ID);
         session.setSessionToken(TEST_SESSION_TOKEN);
-        session.setStudyIdentifier(TEST_STUDY_ID_STRING);
+        session.setAppId(TEST_STUDY_ID_STRING);
         if (status != null){
             session.setConsentStatuses(ImmutableMap.of(
                 SubpopulationGuid.create(status.getSubpopulationGuid()), status));    

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/BaseControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/BaseControllerTest.java
@@ -165,7 +165,7 @@ public class BaseControllerTest extends Mockito {
 
     @Test
     public void getSessionIfItExists() {
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
         when(mockRequest.getHeader(X_REQUEST_ID_HEADER)).thenReturn(REQUEST_ID);
 
@@ -178,7 +178,7 @@ public class BaseControllerTest extends Mockito {
     @Test
     public void getAuthenticatedAndConsentedSession() {
         session.setAuthenticated(true);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setConsentStatuses(CONSENTED_STATUS_MAP);
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
         when(mockRequest.getHeader(X_REQUEST_ID_HEADER)).thenReturn(REQUEST_ID);
@@ -198,7 +198,7 @@ public class BaseControllerTest extends Mockito {
     @Test(expectedExceptions = ConsentRequiredException.class)
     public void getAuthenticatedAndConsentedSessionNotConsented() {
         session.setAuthenticated(true);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setConsentStatuses(UNCONSENTED_STATUS_MAP);
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
         when(mockRequest.getHeader(X_REQUEST_ID_HEADER)).thenReturn(REQUEST_ID);
@@ -212,7 +212,7 @@ public class BaseControllerTest extends Mockito {
     @Test
     public void getAuthenticatedSessionRolesSucceeds() {
         session.setAuthenticated(true);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.DEVELOPER)).build());
         session.setConsentStatuses(CONSENTED_STATUS_MAP);
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
@@ -228,7 +228,7 @@ public class BaseControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class)
     public void getAuthenticatedSessionRolesFailsRolesMismatched() {
         session.setAuthenticated(true);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.ADMIN)).build());
         session.setConsentStatuses(CONSENTED_STATUS_MAP);
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
@@ -243,7 +243,7 @@ public class BaseControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class)
     public void getAuthenticatedSessionRolesFailsNoCallerRole() {
         session.setAuthenticated(true);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setConsentStatuses(CONSENTED_STATUS_MAP);
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
         when(mockRequest.getHeader(X_REQUEST_ID_HEADER)).thenReturn(REQUEST_ID);
@@ -263,7 +263,7 @@ public class BaseControllerTest extends Mockito {
     public void getAuthenticationNotAuthenticated() {
         study.setParticipantIpLockingEnabled(false);
         session.setAuthenticated(true);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setConsentStatuses(CONSENTED_STATUS_MAP);
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
         when(mockRequest.getHeader(X_REQUEST_ID_HEADER)).thenReturn(REQUEST_ID);
@@ -278,7 +278,7 @@ public class BaseControllerTest extends Mockito {
     @Test
     public void getSessionEitherConsentedOrInRoleSucceedsOnRole() {
         session.setAuthenticated(true);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.DEVELOPER)).build());
         session.setConsentStatuses(UNCONSENTED_STATUS_MAP);
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
@@ -294,7 +294,7 @@ public class BaseControllerTest extends Mockito {
     @Test
     public void getSessionEitherConsentedOrInRoleSucceedsOnConsent() {
         session.setAuthenticated(true);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setConsentStatuses(CONSENTED_STATUS_MAP);
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
         when(mockRequest.getHeader(X_REQUEST_ID_HEADER)).thenReturn(REQUEST_ID);
@@ -309,7 +309,7 @@ public class BaseControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class)
     public void getSessionEitherConsentedOrInRoleFails() {
         session.setAuthenticated(true);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.RESEARCHER)).build());
         session.setConsentStatuses(UNCONSENTED_STATUS_MAP);
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
@@ -347,7 +347,7 @@ public class BaseControllerTest extends Mockito {
 
     @Test
     public void getLanguagesInits() {
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setParticipant(new StudyParticipant.Builder().withHealthCode(HEALTH_CODE).build());
         when(mockRequest.getHeader(ACCEPT_LANGUAGE))
                 .thenReturn("fr-fr;q=0.4,fr;q=0.2,en-ca,en;q=0.8,en-us;q=0.6");
@@ -363,7 +363,7 @@ public class BaseControllerTest extends Mockito {
     
     @Test
     public void getLanguagesDoesNotOverwrite() {
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setParticipant(new StudyParticipant.Builder().withLanguages(ImmutableList.of("fr"))
                 .withHealthCode(HEALTH_CODE).build());
         when(mockRequest.getHeader(ACCEPT_LANGUAGE))
@@ -395,7 +395,7 @@ public class BaseControllerTest extends Mockito {
     public void getCriteriaContextWithSession() {
         when(mockRequest.getHeader(USER_AGENT)).thenReturn(UA);
         
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setIpAddress(IP_ADDRESS);
         session.setParticipant(new StudyParticipant.Builder()
                 .withDataGroups(USER_DATA_GROUPS).withSubstudyIds(USER_SUBSTUDY_IDS)
@@ -478,7 +478,7 @@ public class BaseControllerTest extends Mockito {
         
         session.setInternalSessionToken("internalSessionToken");
         session.setParticipant(new StudyParticipant.Builder().withId(USER_ID).build());
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         
         controller.writeSessionInfoToMetrics(session);
         
@@ -510,7 +510,7 @@ public class BaseControllerTest extends Mockito {
     @Test
     public void setCookieAndRecordMetrics() {
         session.setSessionToken(SESSION_TOKEN);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         when(mockBridgeConfig.getEnvironment()).thenReturn(Environment.LOCAL);
         
         controller.setCookieAndRecordMetrics(session);
@@ -534,7 +534,7 @@ public class BaseControllerTest extends Mockito {
     @Test
     public void setCookieAndRecordMetricsNoCookieOutsideLocal() throws Exception {
         session.setSessionToken(SESSION_TOKEN);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         when(mockBridgeConfig.getEnvironment()).thenReturn(Environment.UAT);
         when(mockBridgeConfig.get("domain")).thenReturn("domain-value");
         
@@ -553,7 +553,7 @@ public class BaseControllerTest extends Mockito {
         when(requestInfoService.getRequestInfo(USER_ID)).thenReturn(existingInfo);
         when(mockRequest.getHeader(USER_AGENT)).thenReturn(UA);
         
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setParticipant(new StudyParticipant.Builder().withId(USER_ID).withLanguages(LANGUAGES)
                 .withDataGroups(USER_DATA_GROUPS).withSubstudyIds(USER_SUBSTUDY_IDS)
                 .withTimeZone(TIMEZONE_MSK).build());
@@ -567,7 +567,7 @@ public class BaseControllerTest extends Mockito {
         assertEquals(info.getUserDataGroups(), USER_DATA_GROUPS);
         assertEquals(info.getUserSubstudyIds(), USER_SUBSTUDY_IDS);
         assertEquals(info.getTimeZone(), TIMEZONE_MSK);
-        assertEquals(info.getStudyIdentifier(), TEST_APP_ID);
+        assertEquals(info.getAppId(), TEST_APP_ID);
     }
 
 
@@ -625,7 +625,7 @@ public class BaseControllerTest extends Mockito {
         
         session.setAuthenticated(true);
         session.setParticipant(participant);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         doReturn(session).when(controller).getSessionIfItExists();
 
         // Mock study.
@@ -685,7 +685,7 @@ public class BaseControllerTest extends Mockito {
         session.setParticipant(new StudyParticipant.Builder().withHealthCode(HEALTH_CODE)
                 .withLanguages(ImmutableList.of()).build());
         session.setSessionToken(SESSION_TOKEN);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         
         // Verify as well that the values retrieved from the header have been saved in session and ParticipantOptions table.
         List<String> languages = controller.getLanguages(session);
@@ -710,7 +710,7 @@ public class BaseControllerTest extends Mockito {
                 .withHealthCode(HEALTH_CODE)
                 .withLanguages(Lists.newArrayList()).build();
         session.setParticipant(participant);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
 
         // Execute test.
         List<String> languages = controller.getLanguages(session);
@@ -739,7 +739,7 @@ public class BaseControllerTest extends Mockito {
         session.setAuthenticated(true);
         session.setIpAddress("original address");
         session.setParticipant(participant);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
 
         study.setParticipantIpLockingEnabled(false);
 
@@ -757,7 +757,7 @@ public class BaseControllerTest extends Mockito {
         // Setup test
         session.setAuthenticated(true);
         session.setIpAddress("original address");
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
 
         study.setParticipantIpLockingEnabled(true);
 
@@ -775,7 +775,7 @@ public class BaseControllerTest extends Mockito {
         // Setup test
         session.setAuthenticated(true);
         session.setIpAddress("original address");
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
 
         study.setParticipantIpLockingEnabled(false);
 
@@ -797,7 +797,7 @@ public class BaseControllerTest extends Mockito {
         session.setAuthenticated(true);
         session.setIpAddress("same address");
         session.setParticipant(participant);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
 
         study.setParticipantIpLockingEnabled(false);
 
@@ -823,7 +823,7 @@ public class BaseControllerTest extends Mockito {
                 .withRoles(roles).withId(USER_ID).build();
         session.setParticipant(participant);
         session.setAuthenticated(true);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         
         doReturn(session).when(controller).getSessionIfItExists();
         when(mockStudyService.getStudy(TEST_APP_ID)).thenReturn(study);
@@ -845,7 +845,7 @@ public class BaseControllerTest extends Mockito {
                 .build();
         session.setAuthenticated(true);
         session.setParticipant(participant);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         
         doReturn(session).when(controller).getSessionIfItExists();
         when(mockStudyService.getStudy(TEST_APP_ID)).thenReturn(study);
@@ -858,7 +858,7 @@ public class BaseControllerTest extends Mockito {
     @Test(expectedExceptions = ConsentRequiredException.class)
     public void getSessionWithNoRolesConsentedOrRoleFails() {
         session.setAuthenticated(true);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         
         doReturn(session).when(controller).getSessionIfItExists();
         when(mockStudyService.getStudy(TEST_APP_ID)).thenReturn(study);
@@ -873,7 +873,7 @@ public class BaseControllerTest extends Mockito {
                 .build();
         session.setAuthenticated(true);
         session.setParticipant(participant);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
 
         doReturn(session).when(controller).getSessionIfItExists();
         when(mockStudyService.getStudy(TEST_APP_ID)).thenReturn(study);
@@ -888,7 +888,7 @@ public class BaseControllerTest extends Mockito {
         session.setAuthenticated(true);
         session.setConsentStatuses(CONSENTED_STATUS_MAP);
         session.setParticipant(participant);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
 
         doReturn(session).when(controller).getSessionIfItExists();
         when(mockStudyService.getStudy(TEST_APP_ID)).thenReturn(study);
@@ -904,7 +904,7 @@ public class BaseControllerTest extends Mockito {
         session.setAuthenticated(true);
         session.setConsentStatuses(CONSENTED_STATUS_MAP);
         session.setParticipant(participant);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
 
         doReturn(session).when(controller).getSessionIfItExists();
         when(mockStudyService.getStudy(TEST_APP_ID)).thenReturn(study);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/CacheAdminControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/CacheAdminControllerTest.java
@@ -80,7 +80,7 @@ public class CacheAdminControllerTest extends Mockito {
     
     @Test
     public void listItems() throws Exception {
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(Account.create());
         
         Set<String> items = ImmutableSet.of("A", "B", "C");
@@ -107,7 +107,7 @@ public class CacheAdminControllerTest extends Mockito {
     
     @Test
     public void removeItem() throws Exception {
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(Account.create());
         
         StatusMessage result = controller.removeItem("cacheKey");

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/CompoundActivityDefinitionControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/CompoundActivityDefinitionControllerTest.java
@@ -45,7 +45,7 @@ public class CompoundActivityDefinitionControllerTest extends Mockito {
     public void setup() {
         // mock session
         UserSession mockSession = new UserSession();
-        mockSession.setStudyIdentifier(TEST_APP_ID);
+        mockSession.setAppId(TEST_APP_ID);
 
         // mock study service
         studyService = mock(StudyService.class);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ConsentControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ConsentControllerTest.java
@@ -118,7 +118,7 @@ public class ConsentControllerTest extends Mockito {
         StudyParticipant participant = new StudyParticipant.Builder()
                 .withHealthCode(HEALTH_CODE).withId(USER_ID).build();
         session = new UserSession(participant);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setSessionToken(ORIGINAL_SESSION_TOKEN);
         
         // The session token is just a marker to verify that we have retrieved an updated session.
@@ -217,7 +217,7 @@ public class ConsentControllerTest extends Mockito {
         String studyId = TestConstants.REQUIRED_UNSIGNED.getSubpopulationGuid();
         
         // Need to adjust the study session to match the subpopulation in the unconsented status map
-        session.setStudyIdentifier(studyId);
+        session.setAppId(studyId);
         when(mockAuthService.getSession(any(), any())).thenReturn(updatedSession);
         doReturn(session).when(controller).getAuthenticatedSession();
         when(mockConsentService.getConsentStatuses(any())).thenReturn(TestConstants.UNCONSENTED_STATUS_MAP);
@@ -244,7 +244,7 @@ public class ConsentControllerTest extends Mockito {
         String studyId = TestConstants.REQUIRED_UNSIGNED.getSubpopulationGuid();
         
         // Need to adjust the study session to match the subpopulation in the unconsented status map
-        session.setStudyIdentifier(studyId);
+        session.setAppId(studyId);
         when(mockAuthService.getSession(any(), any())).thenReturn(updatedSession);
         doReturn(session).when(controller).getAuthenticatedSession();
         when(mockConsentService.getConsentStatuses(any())).thenReturn(TestConstants.UNCONSENTED_STATUS_MAP);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ExportControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ExportControllerTest.java
@@ -22,7 +22,7 @@ public class ExportControllerTest extends Mockito {
 
         // mock session
         UserSession mockSession = new UserSession();
-        mockSession.setStudyIdentifier(TEST_APP_ID);
+        mockSession.setAppId(TEST_APP_ID);
         doReturn(mockSession).when(controller).getAuthenticatedSession(any());
 
         // mock service

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ExternalIdControllerV4Test.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ExternalIdControllerV4Test.java
@@ -89,7 +89,7 @@ public class ExternalIdControllerV4Test extends Mockito {
         study.setIdentifier(TEST_APP_ID);
 
         session = new UserSession();
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, RESEARCHER);
         doReturn(mockRequest).when(controller).request();
         doReturn(mockResponse).when(controller).response();

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/FPHSControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/FPHSControllerTest.java
@@ -109,7 +109,7 @@ public class FPHSControllerTest extends Mockito {
         StudyParticipant participant = new StudyParticipant.Builder().withId(USER_ID).withHealthCode("BBB").build();
         
         UserSession session = new UserSession(participant);
-        session.setStudyIdentifier(FPHS_ID);
+        session.setAppId(FPHS_ID);
         session.setAuthenticated(true);
         
         doReturn(session).when(controller).getSessionIfItExists();
@@ -228,7 +228,7 @@ public class FPHSControllerTest extends Mockito {
         when(mockStudyService.getStudy(TEST_APP_ID)).thenReturn(Study.create());
         
         UserSession session = setUserSession();
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         // Now when we have an admin user, we get back results
         session.setParticipant(new StudyParticipant.Builder().copyOf(session.getParticipant())
                 .withRoles(ImmutableSet.of(ADMIN)).build());

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/FileControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/FileControllerTest.java
@@ -77,7 +77,7 @@ public class FileControllerTest extends Mockito {
         MockitoAnnotations.initMocks(this);
         
         session = new UserSession();
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         doReturn(mockRequest).when(controller).request();
         doReturn(mockResponse).when(controller).response();

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/HealthDataControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/HealthDataControllerTest.java
@@ -133,7 +133,7 @@ public class HealthDataControllerTest extends Mockito {
 
         // mock session
         UserSession mockSession = new UserSession();
-        mockSession.setStudyIdentifier(TEST_APP_ID);
+        mockSession.setAppId(TEST_APP_ID);
         mockSession.setParticipant(PARTICIPANT);
         doReturn(mockSession).when(controller).getAuthenticatedAndConsentedSession();
         doReturn(mockSession).when(controller).getAuthenticatedSession(any());

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/IntentControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/IntentControllerTest.java
@@ -103,7 +103,7 @@ public class IntentControllerTest extends Mockito {
                 .withImageData("image-data")
                 .withImageMimeType("image/png").build();
         return new IntentToParticipate.Builder()
-                .withStudyId(TEST_APP_ID)
+                .withAppId(TEST_APP_ID)
                 .withScope(SPONSORS_AND_PARTNERS)
                 .withPhone(PHONE)
                 .withSubpopGuid("subpopGuid")

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/MasterSchedulerControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/MasterSchedulerControllerTest.java
@@ -88,7 +88,7 @@ public class MasterSchedulerControllerTest extends Mockito {
         MockitoAnnotations.initMocks(this);
         
         mockSession = new UserSession();
-        mockSession.setStudyIdentifier(TEST_APP_ID);
+        mockSession.setAppId(TEST_APP_ID);
         mockSession.setAuthenticated(true);
         mockSession.setParticipant(new StudyParticipant.Builder().withId(USER_ID).build());
         doReturn(mockSession).when(controller).getAuthenticatedSession(SUPERADMIN);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/NotificationRegistrationControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/NotificationRegistrationControllerTest.java
@@ -89,7 +89,7 @@ public class NotificationRegistrationControllerTest extends Mockito {
         
         when(mockSession.getHealthCode()).thenReturn(HEALTH_CODE);
         when(mockSession.getParticipant()).thenReturn(PARTICIPANT);
-        when(mockSession.getStudyIdentifier()).thenReturn(TEST_APP_ID);
+        when(mockSession.getAppId()).thenReturn(TEST_APP_ID);
         
         doReturn(mockSession).when(controller).getAuthenticatedAndConsentedSession();
         doReturn(mockRequest).when(controller).request();

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/NotificationTopicControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/NotificationTopicControllerTest.java
@@ -82,7 +82,7 @@ public class NotificationTopicControllerTest extends Mockito {
         MockitoAnnotations.initMocks(this);
         
         doReturn(Environment.UAT).when(mockBridgeConfig).getEnvironment();
-        doReturn(TEST_APP_ID).when(mockUserSession).getStudyIdentifier();
+        doReturn(TEST_APP_ID).when(mockUserSession).getAppId();
         
         doReturn(mockRequest).when(controller).request();
         doReturn(mockResponse).when(controller).response();

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/OAuthControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/OAuthControllerTest.java
@@ -88,7 +88,7 @@ public class OAuthControllerTest extends Mockito {
         MockitoAnnotations.initMocks(this);
         
         session = new UserSession();
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setParticipant(new StudyParticipant.Builder().withHealthCode(HEALTH_CODE).build());
         
         when(mockStudyService.getStudy(TEST_APP_ID)).thenReturn(mockStudy);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
@@ -249,7 +249,7 @@ public class ParticipantControllerTest extends Mockito {
 
         session = new UserSession(participant);
         session.setAuthenticated(true);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setParticipant(participant);
 
         doReturn(session).when(controller).getSessionIfItExists();
@@ -539,7 +539,7 @@ public class ParticipantControllerTest extends Mockito {
     @Test
     public void getParticipantRequestInfo() throws Exception {
         RequestInfo requestInfo = new RequestInfo.Builder().withUserAgent("app/20")
-                .withTimeZone(DateTimeZone.forOffsetHours(-7)).withStudyIdentifier(TEST_APP_ID).build();
+                .withTimeZone(DateTimeZone.forOffsetHours(-7)).withAppId(TEST_APP_ID).build();
 
         doReturn(requestInfo).when(mockRequestInfoService).getRequestInfo("userId");
         RequestInfo result = controller.getRequestInfo("userId");
@@ -560,7 +560,7 @@ public class ParticipantControllerTest extends Mockito {
     public void getParticipantRequestInfoOnlyReturnsCurrentStudyInfo() throws Exception {
         RequestInfo requestInfo = new RequestInfo.Builder().withUserAgent("app/20")
                 .withTimeZone(DateTimeZone.forOffsetHours(-7))
-                .withStudyIdentifier("some-other-study").build();
+                .withAppId("some-other-study").build();
 
         doReturn(requestInfo).when(mockRequestInfoService).getRequestInfo("userId");
         controller.getRequestInfo("userId");
@@ -577,7 +577,7 @@ public class ParticipantControllerTest extends Mockito {
         session.setParticipant(participant);
         
         RequestInfo requestInfo = new RequestInfo.Builder().withUserAgent("app/20")
-                .withTimeZone(DateTimeZone.forOffsetHours(-7)).withStudyIdentifier(TEST_APP_ID).build();
+                .withTimeZone(DateTimeZone.forOffsetHours(-7)).withAppId(TEST_APP_ID).build();
 
         doReturn(requestInfo).when(mockRequestInfoService).getRequestInfo("userId");
         RequestInfo result = controller.getRequestInfoForWorker(study.getIdentifier(), "userId");
@@ -602,7 +602,7 @@ public class ParticipantControllerTest extends Mockito {
         
         RequestInfo requestInfo = new RequestInfo.Builder().withUserAgent("app/20")
                 .withTimeZone(DateTimeZone.forOffsetHours(-7))
-                .withStudyIdentifier("some-other-study").build();
+                .withAppId("some-other-study").build();
 
         doReturn(requestInfo).when(mockRequestInfoService).getRequestInfo("userId");
         controller.getRequestInfoForWorker(study.getIdentifier(), "userId");

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
@@ -542,17 +542,20 @@ public class ParticipantControllerTest extends Mockito {
                 .withTimeZone(DateTimeZone.forOffsetHours(-7)).withAppId(TEST_APP_ID).build();
 
         doReturn(requestInfo).when(mockRequestInfoService).getRequestInfo("userId");
-        RequestInfo result = controller.getRequestInfo("userId");
+        String resultStr = controller.getRequestInfo("userId");
 
         // serialization was tested separately... just validate the object is there
-        assertEquals(result, requestInfo);
+        RequestInfo result = BridgeObjectMapper.get().readValue(resultStr, RequestInfo.class);
+        assertEquals(result.getClientInfo(), requestInfo.getClientInfo());
+        assertNull(result.getAppId());
     }
 
     @Test
     public void getParticipantRequestInfoIsNullsafe() throws Exception {
         // There is no request info.
-        RequestInfo result = controller.getRequestInfo("userId");
+        String resultStr = controller.getRequestInfo("userId");
 
+        RequestInfo result = BridgeObjectMapper.get().readValue(resultStr, RequestInfo.class);
         assertNotNull(result); // values are all null, but object is returned
     }
 
@@ -580,9 +583,11 @@ public class ParticipantControllerTest extends Mockito {
                 .withTimeZone(DateTimeZone.forOffsetHours(-7)).withAppId(TEST_APP_ID).build();
 
         doReturn(requestInfo).when(mockRequestInfoService).getRequestInfo("userId");
-        RequestInfo result = controller.getRequestInfoForWorker(study.getIdentifier(), "userId");
+        String resultStr = controller.getRequestInfoForWorker(study.getIdentifier(), "userId");
 
-        assertEquals(result, requestInfo);
+        RequestInfo result = BridgeObjectMapper.get().readValue(resultStr, RequestInfo.class);
+        assertEquals(result.getClientInfo(), requestInfo.getClientInfo());
+        assertNull(result.getAppId());
     }
     
     @Test
@@ -590,8 +595,9 @@ public class ParticipantControllerTest extends Mockito {
         participant = new StudyParticipant.Builder().copyOf(participant).withRoles(ImmutableSet.of(WORKER)).build();
         session.setParticipant(participant);
         // There is no request info.
-        RequestInfo result = controller.getRequestInfoForWorker(study.getIdentifier(), "userId");
+        String resultStr = controller.getRequestInfoForWorker(study.getIdentifier(), "userId");
 
+        RequestInfo result = BridgeObjectMapper.get().readValue(resultStr, RequestInfo.class);
         assertNotNull(result); // values are all null, but object is returned
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportControllerTest.java
@@ -134,7 +134,7 @@ public class ParticipantReportControllerTest extends Mockito {
         statuses.put(SubpopulationGuid.create(status.getSubpopulationGuid()), status);
         
         session = new UserSession(participant);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setAuthenticated(true);
         session.setConsentStatuses(statuses);
         
@@ -180,7 +180,7 @@ public class ParticipantReportControllerTest extends Mockito {
     
     @Test
     public void getParticipantReportDataForSelf() throws Exception {
-        doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getParticipantReport(session.getStudyIdentifier(),
+        doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getParticipantReport(session.getAppId(),
                 REPORT_ID, HEALTH_CODE, START_DATE, END_DATE);
         
         DateRangeResourceList<? extends ReportData> result = controller.getParticipantReportForSelf(REPORT_ID, START_DATE.toString(), END_DATE.toString());
@@ -190,7 +190,7 @@ public class ParticipantReportControllerTest extends Mockito {
     @Test
     public void getParticipantReportDataForSelfV4() throws Exception {
         doReturn(makePagedResults(START_TIME, END_TIME, OFFSET_KEY, PAGE_SIZE_INT)).when(mockReportService)
-                .getParticipantReportV4(session.getStudyIdentifier(), REPORT_ID, HEALTH_CODE, START_TIME, END_TIME,
+                .getParticipantReportV4(session.getAppId(), REPORT_ID, HEALTH_CODE, START_TIME, END_TIME,
                         OFFSET_KEY, Integer.parseInt(PAGE_SIZE));
         
         ForwardCursorPagedResourceList<ReportData> result = controller.getParticipantReportForSelfV4(REPORT_ID, START_TIME.toString(), END_TIME.toString(),
@@ -207,7 +207,7 @@ public class ParticipantReportControllerTest extends Mockito {
         StatusMessage result = controller.saveParticipantReportForSelf(REPORT_ID);
         assertEquals(result.getMessage(), "Report data saved.");
         
-        verify(mockReportService).saveParticipantReport(eq(session.getStudyIdentifier()), eq(REPORT_ID),
+        verify(mockReportService).saveParticipantReport(eq(session.getAppId()), eq(REPORT_ID),
                 eq(HEALTH_CODE), reportDataCaptor.capture());
         
         ReportData reportData = reportDataCaptor.getValue();
@@ -219,7 +219,7 @@ public class ParticipantReportControllerTest extends Mockito {
     
     @Test
     public void getParticipantReportDataNoDatesForSelf() throws Exception {
-        doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getParticipantReport(session.getStudyIdentifier(),
+        doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getParticipantReport(session.getAppId(),
                 REPORT_ID, HEALTH_CODE, null, null);
         
         DateRangeResourceList<? extends ReportData> result = controller.getParticipantReportForSelf(REPORT_ID, null, null);
@@ -236,7 +236,7 @@ public class ParticipantReportControllerTest extends Mockito {
         doReturn(mockAccount).when(mockAccountService).getAccount(OTHER_ACCOUNT_ID);
         
         doReturn(makePagedResults(START_TIME, END_TIME, OFFSET_KEY, PAGE_SIZE_INT)).when(mockReportService)
-                .getParticipantReportV4(session.getStudyIdentifier(), REPORT_ID, HEALTH_CODE, START_TIME, END_TIME,
+                .getParticipantReportV4(session.getAppId(), REPORT_ID, HEALTH_CODE, START_TIME, END_TIME,
                         OFFSET_KEY, Integer.parseInt(PAGE_SIZE));
         
         ForwardCursorPagedResourceList<ReportData> result = controller.getParticipantReportV4(OTHER_PARTICIPANT_ID,
@@ -298,7 +298,7 @@ public class ParticipantReportControllerTest extends Mockito {
         
         doReturn(mockAccount).when(mockAccountService).getAccount(OTHER_ACCOUNT_ID);
         
-        doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getParticipantReport(session.getStudyIdentifier(),
+        doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getParticipantReport(session.getAppId(),
                 REPORT_ID, HEALTH_CODE, START_DATE, END_DATE);
         
         DateRangeResourceList<? extends ReportData> result = controller.getParticipantReport(OTHER_PARTICIPANT_ID,
@@ -446,7 +446,7 @@ public class ParticipantReportControllerTest extends Mockito {
         StatusMessage result = controller.deleteParticipantReport(OTHER_PARTICIPANT_ID, REPORT_ID);
         assertEquals(result.getMessage(), "Report deleted.");
         
-        verify(mockReportService).deleteParticipantReport(session.getStudyIdentifier(), REPORT_ID, OTHER_PARTICIPANT_HEALTH_CODE);
+        verify(mockReportService).deleteParticipantReport(session.getAppId(), REPORT_ID, OTHER_PARTICIPANT_HEALTH_CODE);
     }
     
     @Test
@@ -454,7 +454,7 @@ public class ParticipantReportControllerTest extends Mockito {
         StatusMessage result = controller.deleteParticipantReportRecord(OTHER_PARTICIPANT_ID, REPORT_ID, "2014-05-10");
         assertEquals(result.getMessage(), "Report record deleted.");
         
-        verify(mockReportService).deleteParticipantReportRecord(session.getStudyIdentifier(), REPORT_ID,
+        verify(mockReportService).deleteParticipantReportRecord(session.getAppId(), REPORT_ID,
                 "2014-05-10", OTHER_PARTICIPANT_HEALTH_CODE);
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ScheduleControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ScheduleControllerTest.java
@@ -91,7 +91,7 @@ public class ScheduleControllerTest extends Mockito {
         when(mockSchedulePlanService.getSchedulePlans(clientInfo, studyId, false)).thenReturn(plans);
         
         UserSession session = new UserSession();
-        session.setStudyIdentifier(studyId);
+        session.setAppId(studyId);
         
         doReturn(session).when(controller).getAuthenticatedAndConsentedSession();
         BridgeUtils.setRequestContext(new RequestContext.Builder().withCallerClientInfo(clientInfo).build());

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/SchedulePlanControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/SchedulePlanControllerTest.java
@@ -86,7 +86,7 @@ public class SchedulePlanControllerTest extends Mockito {
         when(mockStudyService.getStudy(study.getIdentifier())).thenReturn(study);
         when(mockStudyService.getStudy(study.getIdentifier())).thenReturn(study);
         
-        when(mockUserSession.getStudyIdentifier()).thenReturn(TEST_APP_ID);
+        when(mockUserSession.getAppId()).thenReturn(TEST_APP_ID);
         doReturn(mockUserSession).when(controller).getAuthenticatedSession(DEVELOPER);
         doReturn(mockUserSession).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
         

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ScheduledActivityControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ScheduledActivityControllerTest.java
@@ -185,7 +185,7 @@ public class ScheduledActivityControllerTest extends Mockito {
                 .withCreatedOn(ACCOUNT_CREATED_ON)
                 .withId(ID).build();
         session = new UserSession(participant);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         
         when(mockScheduledActivityService.getScheduledActivities(eq(STUDY), any(ScheduleContext.class))).thenReturn(list);
 
@@ -289,7 +289,7 @@ public class ScheduledActivityControllerTest extends Mockito {
         assertEquals(requestInfo.getLanguages(), LANGUAGES);
         assertEquals(requestInfo.getUserDataGroups(), USER_DATA_GROUPS);
         assertEquals(requestInfo.getUserSubstudyIds(), USER_SUBSTUDY_IDS);
-        assertEquals(requestInfo.getStudyIdentifier(), TEST_APP_ID);
+        assertEquals(requestInfo.getAppId(), TEST_APP_ID);
         assertEquals(requestInfo.getUserAgent(), USER_AGENT);
         assertEquals(requestInfo.getClientInfo(), CLIENT_INFO);
         assertNotNull(requestInfo.getActivitiesAccessedOn());
@@ -545,7 +545,7 @@ public class ScheduledActivityControllerTest extends Mockito {
         assertEquals(requestInfo.getUserSubstudyIds(), USER_SUBSTUDY_IDS);
         assertTrue(requestInfo.getActivitiesAccessedOn().isAfter(startsOn));
         assertNull(requestInfo.getSignedInOn());
-        assertEquals(requestInfo.getStudyIdentifier(), TEST_APP_ID);
+        assertEquals(requestInfo.getAppId(), TEST_APP_ID);
         
         ScheduleContext context = contextCaptor.getValue();
         assertEquals(context.getInitialTimeZone(), startsOn.getZone());

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/SharedAssessmentControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/SharedAssessmentControllerTest.java
@@ -66,7 +66,7 @@ public class SharedAssessmentControllerTest extends Mockito {
     @Test
     public void importAssessment() {
         UserSession session = new UserSession();
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
 
         Assessment assessment = AssessmentTest.createAssessment();
@@ -81,7 +81,7 @@ public class SharedAssessmentControllerTest extends Mockito {
     @Test
     public void importAssessmentWithNewId() {
         UserSession session = new UserSession();
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
 
         Assessment assessment = AssessmentTest.createAssessment();
@@ -192,7 +192,7 @@ public class SharedAssessmentControllerTest extends Mockito {
     public void updateSharedAssessment() throws Exception {
         // You do need a session for this call
         UserSession session = new UserSession();
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
 
         Assessment assessment = AssessmentTest.createAssessment();

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/SharedAssessmentResourceControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/SharedAssessmentResourceControllerTest.java
@@ -71,7 +71,7 @@ public class SharedAssessmentResourceControllerTest extends Mockito {
         doReturn(mockResponse).when(controller).response();
         
         session = new UserSession();
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setParticipant(new StudyParticipant.Builder()
                 .withRoles(ImmutableSet.of(DEVELOPER)).build());
     }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/SharedModuleControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/SharedModuleControllerTest.java
@@ -33,7 +33,7 @@ public class SharedModuleControllerTest extends Mockito {
 
         // mock session
         UserSession mockSession = new UserSession();
-        mockSession.setStudyIdentifier(TEST_APP_ID);
+        mockSession.setAppId(TEST_APP_ID);
         doReturn(mockSession).when(controller).getAuthenticatedSession(Roles.DEVELOPER);
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/SharedModuleMetadataControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/SharedModuleMetadataControllerTest.java
@@ -70,7 +70,7 @@ public class SharedModuleMetadataControllerTest extends Mockito {
 
         // mock controller with session with shared study
         mockSession = new UserSession();
-        mockSession.setStudyIdentifier(SHARED_APP_ID);
+        mockSession.setAppId(SHARED_APP_ID);
         doReturn(mockSession).when(controller).getAuthenticatedSession(Roles.DEVELOPER);
         
         mockRequest = mock(HttpServletRequest.class);
@@ -369,7 +369,7 @@ public class SharedModuleMetadataControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class)
     public void nonSharedStudyCantCreate() throws Exception {
         // Set session to return API study instead. This will cause the server to throw an 403 Unauthorized.
-        mockSession.setStudyIdentifier(TEST_APP_ID);
+        mockSession.setAppId(TEST_APP_ID);
         controller.createMetadata();
     }
 
@@ -378,7 +378,7 @@ public class SharedModuleMetadataControllerTest extends Mockito {
         doReturn(mockSession).when(controller).getAuthenticatedSession(Roles.DEVELOPER, Roles.ADMIN);
         
         // Set session to return API study instead. This will cause the server to throw an 403 Unauthorized.
-        mockSession.setStudyIdentifier(TEST_APP_ID);
+        mockSession.setAppId(TEST_APP_ID);
         controller.deleteMetadataByIdAllVersions(MODULE_ID, false);
     }
 
@@ -386,14 +386,14 @@ public class SharedModuleMetadataControllerTest extends Mockito {
     public void nonSharedStudyCantDeleteByIdAndVersion() throws Exception {
         doReturn(mockSession).when(controller).getAuthenticatedSession(Roles.DEVELOPER, Roles.ADMIN);
         // Set session to return API study instead. This will cause the server to throw an 403 Unauthorized.
-        mockSession.setStudyIdentifier(TEST_APP_ID);
+        mockSession.setAppId(TEST_APP_ID);
         controller.deleteMetadataByIdAndVersion(MODULE_ID, MODULE_VERSION, false);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
     public void nonSharedStudyUpdate() throws Exception {
         // Set session to return API study instead. This will cause the server to throw an 403 Unauthorized.
-        mockSession.setStudyIdentifier(TEST_APP_ID);
+        mockSession.setAppId(TEST_APP_ID);
         controller.updateMetadata(MODULE_ID, MODULE_VERSION);
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/SmsControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/SmsControllerTest.java
@@ -57,7 +57,7 @@ public class SmsControllerTest extends Mockito {
 
         // Mock get session.
         UserSession session = new UserSession();
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(ADMIN);
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyConsentControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyConsentControllerTest.java
@@ -71,7 +71,7 @@ public class StudyConsentControllerTest extends Mockito {
         MockitoAnnotations.initMocks(this);
         
         session = new UserSession();
-        session.setStudyIdentifier(STUDY_ID);
+        session.setAppId(STUDY_ID);
         session.setAuthenticated(true);
         
         when(mockSubpopService.getSubpopulation(STUDY_ID, SubpopulationGuid.create(GUID)))

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyControllerTest.java
@@ -147,7 +147,7 @@ public class StudyControllerTest extends Mockito {
         MockitoAnnotations.initMocks(this);
         
         // mock session with study identifier
-        when(mockSession.getStudyIdentifier()).thenReturn(TEST_APP_ID);
+        when(mockSession.getAppId()).thenReturn(TEST_APP_ID);
         when(mockSession.getId()).thenReturn(USER_ID);
         
         study = new DynamoStudy();
@@ -194,7 +194,7 @@ public class StudyControllerTest extends Mockito {
         StudyParticipant participant = new StudyParticipant.Builder()
                 .withHealthCode(HEALTH_CODE).build();
         UserSession session = new UserSession(participant);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setAuthenticated(true);
         
         doReturn(session).when(controller).getSessionIfItExists();
@@ -207,7 +207,7 @@ public class StudyControllerTest extends Mockito {
         StudyParticipant participant = new StudyParticipant.Builder()
                 .withHealthCode(HEALTH_CODE).build();
         UserSession session = new UserSession(participant);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setAuthenticated(true);
 
         DateTime startTime = DateTime.parse("2010-01-01T00:00:00.000Z");
@@ -593,7 +593,7 @@ public class StudyControllerTest extends Mockito {
 
     @Test
     public void updateStudy() throws Exception {
-        when(mockSession.getStudyIdentifier()).thenReturn(TEST_APP_ID);
+        when(mockSession.getAppId()).thenReturn(TEST_APP_ID);
         doReturn(mockSession).when(controller).getAuthenticatedSession(SUPERADMIN);
         
         Study created = Study.create();
@@ -783,7 +783,7 @@ public class StudyControllerTest extends Mockito {
             expectedExceptionsMessageRegExp = ".*Admin cannot delete the study they are associated with.*")
     public void deleteStudyRejectsCallerInStudy() throws Exception {
         // API is protected by the whitelist so this test must target some other study
-        when(mockSession.getStudyIdentifier()).thenReturn("other-study");
+        when(mockSession.getAppId()).thenReturn("other-study");
         doReturn(mockSession).when(controller).getAuthenticatedSession(SUPERADMIN);
         
         controller.deleteStudy("other-study", true);
@@ -896,7 +896,7 @@ public class StudyControllerTest extends Mockito {
         }
         UserSession session = new UserSession(builder.build());
         session.setAuthenticated(true);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         doReturn(session).when(controller).getSessionIfItExists();
         
         Study result = controller.getCurrentStudy();

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyReportControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyReportControllerTest.java
@@ -126,7 +126,7 @@ public class StudyReportControllerTest extends Mockito {
                 .withRoles(ImmutableSet.of(DEVELOPER)).build();
         
         session = new UserSession(participant);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setAuthenticated(true);
         session.setConsentStatuses(CONSENTED_STATUS_MAP);
         
@@ -209,7 +209,7 @@ public class StudyReportControllerTest extends Mockito {
     @Test
     public void getStudyReportData() throws Exception {
         mockRequestBody(mockRequest, "{}");
-        doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getStudyReport(session.getStudyIdentifier(),
+        doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getStudyReport(session.getAppId(),
                 REPORT_ID, START_DATE, END_DATE);
         
         DateRangeResourceList<? extends ReportData> result = controller.getStudyReport(REPORT_ID, START_DATE.toString(), END_DATE.toString());
@@ -219,7 +219,7 @@ public class StudyReportControllerTest extends Mockito {
     @Test
     public void getStudyReportDataWithNoDates() throws Exception {
         mockRequestBody(mockRequest, "{}");
-        doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getStudyReport(session.getStudyIdentifier(),
+        doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getStudyReport(session.getAppId(),
                 REPORT_ID, null, null);
         
         DateRangeResourceList<? extends ReportData>result = controller.getStudyReport(REPORT_ID, null, null);
@@ -247,7 +247,7 @@ public class StudyReportControllerTest extends Mockito {
         StatusMessage result = controller.deleteStudyReport(REPORT_ID);
         assertEquals(result, StudyReportController.DELETED_MSG);
         
-        verify(mockReportService).deleteStudyReport(session.getStudyIdentifier(), REPORT_ID);
+        verify(mockReportService).deleteStudyReport(session.getAppId(), REPORT_ID);
     }
     
     @Test
@@ -255,7 +255,7 @@ public class StudyReportControllerTest extends Mockito {
         StatusMessage result = controller.deleteStudyReportRecord(REPORT_ID, "2014-05-10");
         assertEquals(result, StudyReportController.DELETED_DATA_MSG);
         
-        verify(mockReportService).deleteStudyReportRecord(session.getStudyIdentifier(), REPORT_ID, "2014-05-10");
+        verify(mockReportService).deleteStudyReportRecord(session.getAppId(), REPORT_ID, "2014-05-10");
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -291,7 +291,7 @@ public class StudyReportControllerTest extends Mockito {
         index.setIdentifier(REPORT_ID);
         doReturn(index).when(mockReportService).getReportIndex(key);
         
-        doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getStudyReport(session.getStudyIdentifier(),
+        doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getStudyReport(session.getAppId(),
                 REPORT_ID, START_DATE, END_DATE);
         
         DateRangeResourceList<? extends ReportData>result = controller.getPublicStudyReport(
@@ -334,7 +334,7 @@ public class StudyReportControllerTest extends Mockito {
         index.setKey(key.getIndexKeyString());
         index.setIdentifier(REPORT_ID);
         
-        doReturn(page).when(mockReportService).getStudyReportV4(session.getStudyIdentifier(), REPORT_ID, START_TIME,
+        doReturn(page).when(mockReportService).getStudyReportV4(session.getAppId(), REPORT_ID, START_TIME,
                 END_TIME, OFFSET_KEY, Integer.parseInt(PAGE_SIZE));
         
         ForwardCursorPagedResourceList<ReportData> result = controller.getStudyReportV4(REPORT_ID,

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/SubpopulationControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/SubpopulationControllerTest.java
@@ -87,7 +87,7 @@ public class SubpopulationControllerTest extends Mockito {
 
         participant = new StudyParticipant.Builder().withRoles(ImmutableSet.of(DEVELOPER)).build();
         session = new UserSession(participant);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setAuthenticated(true);
 
         when(mockStudy.getIdentifier()).thenReturn(TEST_APP_ID);
@@ -235,7 +235,7 @@ public class SubpopulationControllerTest extends Mockito {
     public void deleteSubpopulationPhysically() throws Exception {
         participant = new StudyParticipant.Builder().withRoles(ImmutableSet.of(ADMIN)).build();
         session = new UserSession(participant);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setAuthenticated(true);
         doReturn(session).when(controller).getSessionIfItExists();
 

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/SubstudyControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/SubstudyControllerTest.java
@@ -70,7 +70,7 @@ public class SubstudyControllerTest extends Mockito {
         MockitoAnnotations.initMocks(this);
         session = new UserSession();
         session.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(ADMIN)).build());
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
 
         controller.setSubstudyService(service);
 

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/SurveyControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/SurveyControllerTest.java
@@ -154,7 +154,7 @@ public class SurveyControllerTest extends Mockito {
 
         // Set up a session that is returned as if the user is already signed in.
         session = new UserSession(participant);
-        session.setStudyIdentifier(studyId);
+        session.setAppId(studyId);
         session.setAuthenticated(true);
         
         // ... and setup session to report user consented, if needed.

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/TagControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/TagControllerTest.java
@@ -68,7 +68,7 @@ public class TagControllerTest extends Mockito {
         doReturn(mockResponse).when(controller).response();
         
         session = new UserSession();
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/TemplateControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/TemplateControllerTest.java
@@ -76,7 +76,7 @@ public class TemplateControllerTest extends Mockito {
         doReturn(mockResponse).when(controller).response();
         
         session = new UserSession();
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
         

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/TemplateRevisionControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/TemplateRevisionControllerTest.java
@@ -72,7 +72,7 @@ public class TemplateRevisionControllerTest extends Mockito {
         doReturn(response).when(controller).response();
         
         UserSession session = new UserSession(new StudyParticipant.Builder().withRoles(ImmutableSet.of(DEVELOPER)).build());
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/UploadControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/UploadControllerTest.java
@@ -144,7 +144,7 @@ public class UploadControllerTest extends Mockito {
         doReturn(true).when(mockWorkerSession).isInRole(Roles.WORKER);
         
         doReturn("consented-user-health-code").when(mockConsentedUserSession).getHealthCode();
-        doReturn("consented-user-study-id").when(mockConsentedUserSession).getStudyIdentifier();
+        doReturn("consented-user-study-id").when(mockConsentedUserSession).getAppId();
         doReturn("userId").when(mockConsentedUserSession).getId();
         doReturn(new StudyParticipant.Builder().build()).when(mockConsentedUserSession).getParticipant();
         
@@ -332,7 +332,7 @@ public class UploadControllerTest extends Mockito {
     @Test
     public void getUploadByRecordId() throws Exception {
         doReturn(USER_ID).when(mockResearcherSession).getId();
-        doReturn(TEST_APP_ID).when(mockResearcherSession).getStudyIdentifier();
+        doReturn(TEST_APP_ID).when(mockResearcherSession).getAppId();
         doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(ADMIN, WORKER);
         
         HealthDataRecord record = HealthDataRecord.create();
@@ -361,7 +361,7 @@ public class UploadControllerTest extends Mockito {
     public void getUploadByRecordIdRejectsStudyAdmin() throws Exception {
         doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(ADMIN, WORKER);
         doReturn(USER_ID).when(mockResearcherSession).getId();
-        when(mockResearcherSession.getStudyIdentifier()).thenReturn("researcher-study-id");
+        when(mockResearcherSession.getAppId()).thenReturn("researcher-study-id");
 
         HealthDataRecord record = HealthDataRecord.create();
         record.setStudyId(TEST_APP_ID);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/UploadSchemaControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/UploadSchemaControllerTest.java
@@ -324,7 +324,7 @@ public class UploadSchemaControllerTest extends Mockito {
     private static UploadSchemaController setupControllerWithServiceWithoutSecondRole(UploadSchemaService svc, Roles role1, Roles role2) throws Exception {
         // mock session
         UserSession mockSession = new UserSession();
-        mockSession.setStudyIdentifier(TEST_APP_ID);
+        mockSession.setAppId(TEST_APP_ID);
         mockSession.setParticipant(new StudyParticipant.Builder().withRoles(Sets.newHashSet(role1)).build());
 
         // spy controller
@@ -343,7 +343,7 @@ public class UploadSchemaControllerTest extends Mockito {
     private static UploadSchemaController setupControllerWithService(UploadSchemaService svc, Roles role1, Roles role2) throws Exception {
         // mock session
         UserSession mockSession = new UserSession();
-        mockSession.setStudyIdentifier(TEST_APP_ID);
+        mockSession.setAppId(TEST_APP_ID);
         mockSession.setParticipant(new StudyParticipant.Builder().withRoles(Sets.newHashSet(role1, role2)).build());
 
         // spy controller
@@ -362,7 +362,7 @@ public class UploadSchemaControllerTest extends Mockito {
     private static UploadSchemaController setupControllerWithService(UploadSchemaService svc, Roles role1) throws Exception {
         // mock session
         UserSession mockSession = new UserSession();
-        mockSession.setStudyIdentifier(TEST_APP_ID);
+        mockSession.setAppId(TEST_APP_ID);
         mockSession.setParticipant(new StudyParticipant.Builder().withRoles(Sets.newHashSet(role1)).build());
 
         // spy controller

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserDataDownloadControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserDataDownloadControllerTest.java
@@ -54,7 +54,7 @@ public class UserDataDownloadControllerTest extends Mockito {
         MockitoAnnotations.initMocks(this);
         
         doReturn(mockSession).when(controller).getAuthenticatedAndConsentedSession();
-        doReturn(STUDY_ID).when(mockSession).getStudyIdentifier();
+        doReturn(STUDY_ID).when(mockSession).getAppId();
         doReturn(mockRequest).when(controller).request();
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserManagementControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserManagementControllerTest.java
@@ -112,7 +112,7 @@ public class UserManagementControllerTest extends Mockito {
                 .withId(USER_ID).withRoles(ImmutableSet.of(SUPERADMIN)).withEmail(EMAIL).build();
 
         session = new UserSession(participant);
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         session.setAuthenticated(true);
 
         sessionUpdateService = new SessionUpdateService();
@@ -160,7 +160,7 @@ public class UserManagementControllerTest extends Mockito {
         assertEquals(result.get("email").textValue(), EMAIL); // it's the session
 
         // This isn't in the session that is returned to the user, but verify it has been changed
-        assertEquals(session.getStudyIdentifier(), "originalStudy");
+        assertEquals(session.getAppId(), "originalStudy");
         assertEquals(signInCaptor.getValue().getStudyId(), API_APP_ID);
 
         verify(mockResponse).addCookie(cookieCaptor.capture());
@@ -212,7 +212,7 @@ public class UserManagementControllerTest extends Mockito {
         when(mockStudyService.getStudy("nextStudy")).thenReturn(nextStudy);
 
         controller.changeStudyForAdmin();
-        assertEquals(session.getStudyIdentifier(), "nextStudy");
+        assertEquals(session.getAppId(), "nextStudy");
         verify(mockCacheProvider).setUserSession(session);
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserProfileControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserProfileControllerTest.java
@@ -154,7 +154,7 @@ public class UserProfileControllerTest extends Mockito {
                 .withHealthCode(HEALTH_CODE)
                 .withId(USER_ID)
                 .build());
-        session.setStudyIdentifier(TEST_APP_ID);
+        session.setAppId(TEST_APP_ID);
         
         doReturn(session).when(controller).getAuthenticatedSession();
         doReturn(mockRequest).when(controller).request();

--- a/src/test/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandlerTest.java
@@ -106,7 +106,7 @@ public class BridgeExceptionHandlerTest extends Mockito {
         session.setInternalSessionToken("internalToken");
         session.setSessionToken("sessionToken");
         session.setReauthToken("reauthToken");
-        session.setStudyIdentifier("test");
+        session.setAppId("test");
         session.setConsentStatuses(Maps.newHashMap());
         
         ConsentRequiredException exception = new ConsentRequiredException(session);

--- a/src/test/java/org/sagebionetworks/bridge/validators/IntentToParticipateValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/IntentToParticipateValidatorTest.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.validators;
 
+import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 import static org.sagebionetworks.bridge.validators.IntentToParticipateValidator.INSTANCE;
 
@@ -13,7 +14,6 @@ import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 
 public class IntentToParticipateValidatorTest {
 
-    private static final String STUDY = "studyId";
     private static final String SUBPOP_GUID = "subpopGuid";
     private static final String OS_NAME = "Android";
     private static final SharingScope SCOPE = SharingScope.SPONSORS_AND_PARTNERS;
@@ -24,7 +24,7 @@ public class IntentToParticipateValidatorTest {
     
     private IntentToParticipate.Builder builder() {
         return new IntentToParticipate.Builder()
-                .withStudyId(STUDY)
+                .withAppId(TEST_APP_ID)
                 .withPhone(TestConstants.PHONE)
                 .withSubpopGuid(SUBPOP_GUID)
                 .withScope(SCOPE)
@@ -46,8 +46,8 @@ public class IntentToParticipateValidatorTest {
     
     @Test
     public void studyRequired() {
-        IntentToParticipate intent = builder().withStudyId(null).build();
-        assertValidatorMessage(INSTANCE, intent, "studyId", "is required");
+        IntentToParticipate intent = builder().withAppId(null).build();
+        assertValidatorMessage(INSTANCE, intent, "appId", "is required");
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/validators/SubpopulationValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/SubpopulationValidatorTest.java
@@ -33,7 +33,7 @@ public class SubpopulationValidatorTest {
         subpop.setDescription("Description");
         subpop.setDefaultGroup(true);
         subpop.setRequired(true);
-        subpop.setStudyIdentifier("test-study");
+        subpop.setAppId("test-study");
         subpop.setVersion(3L);
         subpop.setGuidString("AAA");
         subpop.setDataGroupsAssignedWhileConsented(TestConstants.USER_DATA_GROUPS);
@@ -64,7 +64,7 @@ public class SubpopulationValidatorTest {
         } catch(InvalidEntityException e) {
             assertMessage(e, "minAppVersions.iphone_os", " cannot be negative");
             assertMessage(e, "maxAppVersions.iphone_os", " cannot be negative");
-            assertMessage(e, "studyIdentifier", " is required");
+            assertMessage(e, "appId", " is required");
             assertMessage(e, "name", " is required");
             assertMessage(e, "guid", " is required");
             assertMessage(e, "noneOfGroups", " 'wrongGroup' is not in enumeration");
@@ -78,7 +78,7 @@ public class SubpopulationValidatorTest {
     @Test
     public void emptyListsOK() {
         Subpopulation subpop = Subpopulation.create();
-        subpop.setStudyIdentifier("test-study");
+        subpop.setAppId("test-study");
         subpop.setGuidString("AAA");
         subpop.setName("Name");
         subpop.setDataGroupsAssignedWhileConsented(ImmutableSet.of());
@@ -92,7 +92,7 @@ public class SubpopulationValidatorTest {
     @Test
     public void nullListsOK() {
         Subpopulation subpop = Subpopulation.create();
-        subpop.setStudyIdentifier("test-study");
+        subpop.setAppId("test-study");
         subpop.setGuidString("AAA");
         subpop.setName("Name");
         subpop.setDataGroupsAssignedWhileConsented(null);


### PR DESCRIPTION
Changing the objects that are persisted in Redis as JSON: user session, subpopulation, request info, intent to participate, and verification data. Now use appId where appropriate.

Although RequestInfo is exposed through the API, I could not find any use of the StudyIdentifier in requestInfo in any of our projects that use our SDK, and so I am removing it here, rather than converting it to appId. In general we rarely expose this value and that has turned out to be a good idea.

No effect on integration tests. RequestInfo in the SDK would start returning null with this change. The alternative is to create a temporary StudyIdentifier property, similar to AccountSummary.