### PR TITLE
Refactor RequestContext to use callerAppId

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/DefaultStudyBootstrapper.java
+++ b/src/main/java/org/sagebionetworks/bridge/DefaultStudyBootstrapper.java
@@ -70,7 +70,7 @@ public class DefaultStudyBootstrapper  implements ApplicationListener<ContextRef
 
         BridgeConfig config = BridgeConfigFactory.getConfig();
         
-        BridgeUtils.setRequestContext(new RequestContext.Builder().withCallerStudyId(API_APP_ID)
+        BridgeUtils.setRequestContext(new RequestContext.Builder().withCallerAppId(API_APP_ID)
                 .withCallerRoles(ImmutableSet.of(ADMIN, SUPERADMIN, DEVELOPER, RESEARCHER))
                 .withCallerUserId("DefaultStudyBootstrapper").build());
 

--- a/src/main/java/org/sagebionetworks/bridge/RequestContext.java
+++ b/src/main/java/org/sagebionetworks/bridge/RequestContext.java
@@ -17,7 +17,7 @@ public class RequestContext {
             ImmutableSet.of(), null, UNKNOWN_CLIENT, ImmutableList.of(), null);
 
     private final String requestId;
-    private final String callerStudyId;
+    private final String callerAppId;
     private final Set<String> callerSubstudies;
     private final Set<Roles> callerRoles;
     private final String callerUserId;
@@ -26,11 +26,11 @@ public class RequestContext {
     private final Metrics metrics;
     private final String callerIpAddress;
     
-    private RequestContext(Metrics metrics, String requestId, String callerStudyId, Set<String> callerSubstudies,
+    private RequestContext(Metrics metrics, String requestId, String callerAppId, Set<String> callerSubstudies,
             Set<Roles> callerRoles, String callerUserId, ClientInfo callerClientInfo, List<String> callerLanguages,
             String callerIpAddress) {
         this.requestId = requestId;
-        this.callerStudyId = callerStudyId;
+        this.callerAppId = callerAppId;
         this.callerSubstudies = callerSubstudies;
         this.callerRoles = callerRoles;
         this.callerUserId = callerUserId;
@@ -46,8 +46,8 @@ public class RequestContext {
     public String getId() {
         return requestId;
     }
-    public String getCallerStudyId() {
-        return callerStudyId;
+    public String getCallerAppId() {
+        return callerAppId;
     }
     public Set<String> getCallerSubstudies() {
         return callerSubstudies;
@@ -82,7 +82,7 @@ public class RequestContext {
         return new RequestContext.Builder()
             .withRequestId(requestId)
             .withCallerClientInfo(callerClientInfo)
-            .withCallerStudyId(callerStudyId)
+            .withCallerAppId(callerAppId)
             .withCallerLanguages(callerLanguages)
             .withCallerRoles(callerRoles)
             .withCallerSubstudies(callerSubstudies)
@@ -93,7 +93,7 @@ public class RequestContext {
     
     public static class Builder {
         private Metrics metrics;
-        private String callerStudyId;
+        private String callerAppId;
         private Set<String> callerSubstudies;
         private Set<Roles> callerRoles;
         private String requestId;
@@ -106,8 +106,8 @@ public class RequestContext {
             this.metrics = metrics;
             return this;
         }
-        public Builder withCallerStudyId(String studyId) {
-            this.callerStudyId = studyId;
+        public Builder withCallerAppId(String appId) {
+            this.callerAppId = appId;
             return this;
         }
         public Builder withCallerSubstudies(Set<String> callerSubstudies) {
@@ -158,14 +158,14 @@ public class RequestContext {
             if (metrics == null) {
                 metrics = new Metrics(requestId);
             }
-            return new RequestContext(metrics, requestId, callerStudyId, callerSubstudies, callerRoles, callerUserId,
+            return new RequestContext(metrics, requestId, callerAppId, callerSubstudies, callerRoles, callerUserId,
                     callerClientInfo, callerLanguages, callerIpAddress);
         }
     }
 
     @Override
     public String toString() {
-        return "RequestContext [requestId=" + requestId + ", callerStudyId=" + callerStudyId + ", callerSubstudies="
+        return "RequestContext [requestId=" + requestId + ", callerAppId=" + callerAppId + ", callerSubstudies="
                 + callerSubstudies + ", callerRoles=" + callerRoles + ", callerUserId=" + callerUserId
                 + ", callerClientInfo=" + callerClientInfo + ", callerIpAddress=" + callerIpAddress
                 + ", callerLanguages=" + callerLanguages + ", metrics=" + metrics + "]";

--- a/src/main/java/org/sagebionetworks/bridge/services/ExternalIdService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ExternalIdService.java
@@ -72,15 +72,15 @@ public class ExternalIdService {
             throw new BadRequestException(PAGE_SIZE_ERROR);
         }
 
-        String studyId = BridgeUtils.getRequestContext().getCallerStudyId();
-        return externalIdDao.getExternalIds(studyId, offsetKey, pageSize, idFilter, assignmentFilter);
+        String appId = BridgeUtils.getRequestContext().getCallerAppId();
+        return externalIdDao.getExternalIds(appId, offsetKey, pageSize, idFilter, assignmentFilter);
     }
     
     public void createExternalId(ExternalIdentifier externalId, boolean isV3) {
         checkNotNull(externalId);
         
-        String studyId = BridgeUtils.getRequestContext().getCallerStudyId();
-        externalId.setStudyId(studyId);
+        String appId = BridgeUtils.getRequestContext().getCallerAppId();
+        externalId.setStudyId(appId);
         
         // In this one  case, we can default the value for the caller and avoid an error. Any other situation
         // is going to generate a validation error
@@ -95,7 +95,7 @@ public class ExternalIdService {
         // Note that this external ID must be unique across the whole study, not just a substudy, or else
         // it cannot be used to identify the substudy, and that's a significant purpose behind the 
         // association of the two
-        if (externalIdDao.getExternalId(studyId, externalId.getIdentifier()).isPresent()) {
+        if (externalIdDao.getExternalId(appId, externalId.getIdentifier()).isPresent()) {
             throw new EntityAlreadyExistsException(ExternalIdentifier.class, "identifier", externalId.getIdentifier());
         }
         externalIdDao.createExternalId(externalId);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/BaseController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/BaseController.java
@@ -179,7 +179,7 @@ public abstract class BaseController {
         RequestContext.Builder builder = BridgeUtils.getRequestContext().toBuilder();
         // If the user has already persisted languages, we'll use that instead of the Accept-Language header
         builder.withCallerLanguages(getLanguages(session));
-        builder.withCallerStudyId(session.getAppId());
+        builder.withCallerAppId(session.getAppId());
         builder.withCallerSubstudies(session.getParticipant().getSubstudyIds());
         builder.withCallerRoles(session.getParticipant().getRoles());
         builder.withCallerUserId(session.getParticipant().getId());

--- a/src/main/java/org/sagebionetworks/bridge/validators/ExternalIdValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/ExternalIdValidator.java
@@ -30,7 +30,7 @@ public class ExternalIdValidator implements Validator {
     public void validate(Object object, Errors errors) {
         ExternalIdentifier extId = (ExternalIdentifier)object;
 
-        String callerStudyId = BridgeUtils.getRequestContext().getCallerStudyId();
+        String callerAppId = BridgeUtils.getRequestContext().getCallerAppId();
         Set<String> callerSubstudies = BridgeUtils.getRequestContext().getCallerSubstudies();
         
         if (StringUtils.isBlank(extId.getIdentifier())) {
@@ -52,7 +52,7 @@ public class ExternalIdValidator implements Validator {
         }
         if (StringUtils.isBlank(extId.getStudyId())) {
             errors.rejectValue("studyId", "cannot be null or blank");
-        } else if (!extId.getStudyId().equals(callerStudyId)) {
+        } else if (!extId.getStudyId().equals(callerAppId)) {
             errors.rejectValue("studyId", "is not a valid study");
         }
     }

--- a/src/test/java/org/sagebionetworks/bridge/DefaultStudyBootstrapperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/DefaultStudyBootstrapperTest.java
@@ -114,7 +114,7 @@ public class DefaultStudyBootstrapperTest extends Mockito {
         verify(mockUserAdminService, times(3)).createUser(any(), participantCaptor.capture(),
                 subpopCaptor.capture(), eq(false), eq(false));
         
-        assertEquals(BridgeUtils.getRequestContext().getCallerStudyId(), API_APP_ID);
+        assertEquals(BridgeUtils.getRequestContext().getCallerAppId(), API_APP_ID);
         assertTrue(BridgeUtils.getRequestContext().isInRole(SUPERADMIN));
         assertEquals(BridgeUtils.getRequestContext().getCallerUserId(), "DefaultStudyBootstrapper");
         

--- a/src/test/java/org/sagebionetworks/bridge/RequestContextTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/RequestContextTest.java
@@ -37,14 +37,14 @@ public class RequestContextTest {
         // Verify that minimal construction of a context works and returns a valid, if 
         // empty and useless, request context. It's expected this will be augmented by other
         // code that executes.
-        RequestContext nullContext = new RequestContext.Builder().withRequestId(null).withCallerStudyId(null)
+        RequestContext nullContext = new RequestContext.Builder().withRequestId(null).withCallerAppId(null)
                 .withCallerSubstudies(null).withCallerRoles(null).withCallerUserId(null)
                 .withCallerLanguages(null).withCallerClientInfo(null).build();
         
         assertNotNull(nullContext.getId());
         assertTrue(nullContext.getCallerSubstudies().isEmpty());
         assertTrue(nullContext.getCallerRoles().isEmpty());
-        assertNull(nullContext.getCallerStudyId());
+        assertNull(nullContext.getCallerAppId());
         assertNull(nullContext.getCallerUserId());
         assertNotNull(nullContext.getMetrics());
         assertTrue(nullContext.getCallerLanguages().isEmpty());
@@ -64,7 +64,7 @@ public class RequestContextTest {
         assertNull(NULL_INSTANCE.getId());
         assertTrue(NULL_INSTANCE.getCallerSubstudies().isEmpty());
         assertTrue(NULL_INSTANCE.getCallerRoles().isEmpty());
-        assertNull(NULL_INSTANCE.getCallerStudyId());
+        assertNull(NULL_INSTANCE.getCallerAppId());
         assertNull(NULL_INSTANCE.getCallerUserId());
         assertNull(NULL_INSTANCE.getMetrics());
         assertTrue(NULL_INSTANCE.getCallerLanguages().isEmpty());
@@ -79,11 +79,11 @@ public class RequestContextTest {
         ClientInfo clientInfo = ClientInfo.fromUserAgentCache("Asthma/26 (Unknown iPhone; iPhone OS/9.1) BridgeSDK/4");
         
         RequestContext context = new RequestContext.Builder().withRequestId(REQUEST_ID).withCallerSubstudies(SUBSTUDIES)
-                .withCallerStudyId(TEST_APP_ID).withMetrics(metrics).withCallerRoles(ROLES)
+                .withCallerAppId(TEST_APP_ID).withMetrics(metrics).withCallerRoles(ROLES)
                 .withCallerUserId(USER_ID).withCallerLanguages(LANGUAGES).withCallerClientInfo(clientInfo).build();
 
         assertEquals(context.getId(), REQUEST_ID);
-        assertEquals(context.getCallerStudyId(), TEST_APP_ID);
+        assertEquals(context.getCallerAppId(), TEST_APP_ID);
         assertEquals(context.getCallerSubstudies(), SUBSTUDIES);
         assertEquals(context.getCallerRoles(), ROLES);
         assertEquals(context.getCallerUserId(), USER_ID);
@@ -100,14 +100,14 @@ public class RequestContextTest {
         ClientInfo clientInfo = ClientInfo.fromUserAgentCache("Asthma/26 (Unknown iPhone; iPhone OS/9.1) BridgeSDK/4");
         
         RequestContext context = new RequestContext.Builder().withRequestId(REQUEST_ID)
-                .withCallerStudyId(TEST_APP_ID).withCallerSubstudies(SUBSTUDIES).withMetrics(metrics)
+                .withCallerAppId(TEST_APP_ID).withCallerSubstudies(SUBSTUDIES).withMetrics(metrics)
                 .withCallerRoles(ROLES).withCallerUserId(USER_ID).withCallerLanguages(LANGUAGES)
                 .withCallerClientInfo(clientInfo).build();
         
         RequestContext copy = context.toBuilder().withRequestId("did-change-this").build();
         
         assertEquals(copy.getId(), "did-change-this");
-        assertEquals(copy.getCallerStudyId(), TEST_APP_ID);
+        assertEquals(copy.getCallerAppId(), TEST_APP_ID);
         assertEquals(copy.getCallerSubstudies(), SUBSTUDIES);
         assertEquals(copy.getCallerRoles(), ROLES);
         assertEquals(copy.getCallerUserId(), USER_ID);

--- a/src/test/java/org/sagebionetworks/bridge/services/AssessmentServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AssessmentServiceTest.java
@@ -11,6 +11,7 @@ import static org.sagebionetworks.bridge.TestConstants.INFO1;
 import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
 import static org.sagebionetworks.bridge.TestConstants.OWNER_ID;
 import static org.sagebionetworks.bridge.TestConstants.STRING_TAGS;
+import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.models.OperatingSystem.ANDROID;
 import static org.sagebionetworks.bridge.models.OperatingSystem.UNIVERSAL;
 import static org.sagebionetworks.bridge.services.AssessmentService.IDENTIFIER_REQUIRED;
@@ -61,7 +62,6 @@ import org.sagebionetworks.bridge.models.substudies.Substudy;
 
 public class AssessmentServiceTest extends Mockito {
     private static final String NEW_IDENTIFIER = "oneNewId";
-    private static final String APP_ID_VALUE = "appId";
     private static final int REVISION_VALUE = 3;
     private static final PagedResourceList<Assessment> EMPTY_LIST = new PagedResourceList<>(ImmutableList.of(), 0);
     private static final Assessment ASSESSMENT = new Assessment();
@@ -108,10 +108,10 @@ public class AssessmentServiceTest extends Mockito {
     @Test
     public void getAssessments() {
         PagedResourceList<Assessment> page = new PagedResourceList<>(ImmutableList.of(ASSESSMENT), 100);
-        when(mockDao.getAssessments(APP_ID_VALUE, 10, 26, STRING_TAGS, true)).thenReturn(page);
+        when(mockDao.getAssessments(TEST_APP_ID, 10, 26, STRING_TAGS, true)).thenReturn(page);
         
         PagedResourceList<Assessment> retValue = service.getAssessments(
-                APP_ID_VALUE, 10, 26, STRING_TAGS, true);
+                TEST_APP_ID, 10, 26, STRING_TAGS, true);
         
         assertEquals(retValue.getItems().get(0), ASSESSMENT);
         assertEquals(retValue.getTotal(), Integer.valueOf(100));
@@ -125,24 +125,24 @@ public class AssessmentServiceTest extends Mockito {
     @Test(expectedExceptions = BadRequestException.class, 
             expectedExceptionsMessageRegExp = "offsetBy cannot be negative")
     public void getAssessmentsNegativeOffsetBy() {
-        service.getAssessments(APP_ID_VALUE, -100, 25, null, false);
+        service.getAssessments(TEST_APP_ID, -100, 25, null, false);
     }
 
     @Test(expectedExceptions = BadRequestException.class, 
             expectedExceptionsMessageRegExp = PAGE_SIZE_ERROR)
     public void getAssessmentsPageSizeUnderMin() {
-        service.getAssessments(APP_ID_VALUE, 0, 1, null, false);
+        service.getAssessments(TEST_APP_ID, 0, 1, null, false);
     }
     
     @Test(expectedExceptions = BadRequestException.class, 
             expectedExceptionsMessageRegExp = PAGE_SIZE_ERROR)
     public void getAssessmentsPageSizeOverMax() {
-        service.getAssessments(APP_ID_VALUE, 0, 100000, null, false);
+        service.getAssessments(TEST_APP_ID, 0, 100000, null, false);
     }
     
     @Test
     public void createAssessment() {
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false))
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
                 .thenReturn(mockSubstudy);
         when(mockDao.getAssessmentRevisions(any(), any(), anyInt(), anyInt(), anyBoolean()))
             .thenReturn(EMPTY_LIST);
@@ -151,9 +151,9 @@ public class AssessmentServiceTest extends Mockito {
         assessment.setGuid(null);
         assessment.setDeleted(true); // can't do this, it's reset
         
-        service.createAssessment(APP_ID_VALUE, assessment);
+        service.createAssessment(TEST_APP_ID, assessment);
         
-        verify(mockDao).createAssessment(eq(APP_ID_VALUE), eq(assessment), configCaptor.capture());
+        verify(mockDao).createAssessment(eq(TEST_APP_ID), eq(assessment), configCaptor.capture());
         
         assertEquals(assessment.getGuid(), GUID);
         assertEquals(assessment.getOwnerId(), OWNER_ID);
@@ -170,7 +170,7 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void createAssessmentAdjustsOsNameAlias() {
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false))
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
             .thenReturn(mockSubstudy);
         when(mockDao.getAssessmentRevisions(any(), any(), anyInt(), anyInt(), anyBoolean()))
             .thenReturn(EMPTY_LIST);
@@ -178,7 +178,7 @@ public class AssessmentServiceTest extends Mockito {
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setOsName("Both");
         
-        service.createAssessment(APP_ID_VALUE, assessment);
+        service.createAssessment(TEST_APP_ID, assessment);
         
         assertEquals(assessment.getOsName(), UNIVERSAL);
     }
@@ -188,7 +188,7 @@ public class AssessmentServiceTest extends Mockito {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
                 .withCallerSubstudies(ImmutableSet.of("substudyD")).build());
         Assessment assessment = AssessmentTest.createAssessment();
-        service.createAssessment(APP_ID_VALUE, assessment);
+        service.createAssessment(TEST_APP_ID, assessment);
     }
     
     @Test(expectedExceptions = EntityAlreadyExistsException.class)
@@ -197,18 +197,18 @@ public class AssessmentServiceTest extends Mockito {
         assessment.setGuid(null);
         assessment.setDeleted(false);
         
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false))
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
             .thenReturn(mockSubstudy);
         when(mockDao.getAssessmentRevisions(any(), any(), anyInt(), anyInt(), anyBoolean()))
             .thenReturn(new PagedResourceList<>(ImmutableList.of(assessment), 1));
     
-        service.createAssessment(APP_ID_VALUE, assessment);
+        service.createAssessment(TEST_APP_ID, assessment);
     }
     
     @Test(expectedExceptions = InvalidEntityException.class,
             expectedExceptionsMessageRegExp = ".*identifier cannot be missing.*")
     public void createAssessmentInvalid() {
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false))
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
             .thenReturn(mockSubstudy);
         when(mockDao.getAssessmentRevisions(any(), any(), anyInt(), anyInt(), anyBoolean()))
             .thenReturn(EMPTY_LIST);
@@ -216,12 +216,12 @@ public class AssessmentServiceTest extends Mockito {
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setIdentifier(null);
         
-        service.createAssessment(APP_ID_VALUE, assessment);
+        service.createAssessment(TEST_APP_ID, assessment);
     }
     
     @Test
     public void createAssessmentScrubsMarkup() {
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false))
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
             .thenReturn(mockSubstudy);
         when(mockDao.getAssessmentRevisions(any(), any(), anyInt(), anyInt(), anyBoolean()))
             .thenReturn(EMPTY_LIST);
@@ -229,16 +229,16 @@ public class AssessmentServiceTest extends Mockito {
         Assessment assessment = AssessmentTest.createAssessment();
         addMarkupToSensitiveFields(assessment);
 
-        service.createAssessment(APP_ID_VALUE, assessment);
+        service.createAssessment(TEST_APP_ID, assessment);
         
         assertMarkupRemoved(assessment);
     }
 
     @Test
     public void createAssessmentRevision() {
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false))
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
                 .thenReturn(mockSubstudy);
-        when(mockDao.getAssessment(APP_ID_VALUE, GUID))
+        when(mockDao.getAssessment(TEST_APP_ID, GUID))
             .thenReturn(Optional.of(AssessmentTest.createAssessment()));
         
         Assessment assessment = AssessmentTest.createAssessment();
@@ -246,9 +246,9 @@ public class AssessmentServiceTest extends Mockito {
         assessment.setGuid(null);
         assessment.setDeleted(true); // can't do this, it's reset
         
-        service.createAssessmentRevision(APP_ID_VALUE, GUID, assessment);
+        service.createAssessmentRevision(TEST_APP_ID, GUID, assessment);
         
-        verify(mockDao).createAssessment(eq(APP_ID_VALUE), eq(assessment), configCaptor.capture());
+        verify(mockDao).createAssessment(eq(TEST_APP_ID), eq(assessment), configCaptor.capture());
         
         assertEquals(assessment.getGuid(), GUID);
         assertEquals(assessment.getIdentifier(), IDENTIFIER);
@@ -269,7 +269,7 @@ public class AssessmentServiceTest extends Mockito {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
                 .withCallerSubstudies(ImmutableSet.of("substudyD")).build());
         Assessment assessment = AssessmentTest.createAssessment();
-        service.createAssessmentRevision(APP_ID_VALUE, GUID, assessment);
+        service.createAssessmentRevision(TEST_APP_ID, GUID, assessment);
     }
 
     @Test(expectedExceptions = EntityNotFoundException.class)
@@ -278,47 +278,47 @@ public class AssessmentServiceTest extends Mockito {
         assessment.setGuid(null);
         assessment.setDeleted(false);
         
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false))
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
             .thenReturn(mockSubstudy);
         when(mockDao.getAssessmentRevisions(any(), any(), anyInt(), anyInt(), anyBoolean()))
             .thenReturn(new PagedResourceList<>(ImmutableList.of(), 0));
     
-        service.createAssessmentRevision(APP_ID_VALUE, GUID, assessment);
+        service.createAssessmentRevision(TEST_APP_ID, GUID, assessment);
     }
 
     @Test(expectedExceptions = InvalidEntityException.class,
             expectedExceptionsMessageRegExp = ".*identifier cannot be missing.*")
     public void createAssessmentRevisionInvalid() {
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false))
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
             .thenReturn(mockSubstudy);
-        when(mockDao.getAssessment(APP_ID_VALUE, GUID))
+        when(mockDao.getAssessment(TEST_APP_ID, GUID))
             .thenReturn(Optional.of(new Assessment()));
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setIdentifier(null);
         
-        service.createAssessmentRevision(APP_ID_VALUE, GUID, assessment);
+        service.createAssessmentRevision(TEST_APP_ID, GUID, assessment);
     }
 
     @Test
     public void createAssessmentRevisionScrubsMarkup() {
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false))
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
             .thenReturn(mockSubstudy);
         Assessment existing = AssessmentTest.createAssessment();
-        when(mockDao.getAssessment(APP_ID_VALUE, GUID))
+        when(mockDao.getAssessment(TEST_APP_ID, GUID))
             .thenReturn(Optional.of(existing));
         
         Assessment assessment = AssessmentTest.createAssessment();
         addMarkupToSensitiveFields(assessment);
 
-        service.createAssessmentRevision(APP_ID_VALUE, GUID, assessment);
+        service.createAssessmentRevision(TEST_APP_ID, GUID, assessment);
         
         assertMarkupRemoved(assessment);
     }
 
     @Test
     public void updateAssessment() {
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false)).thenReturn(mockSubstudy);
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false)).thenReturn(mockSubstudy);
         
         // Fill out only the fields needed to pass validation, leaving the rest to be
         // filled in by the existing assessment
@@ -326,13 +326,13 @@ public class AssessmentServiceTest extends Mockito {
         assessment.setGuid(GUID); // this always gets set in the controller
         assessment.setTitle("title");
         assessment.setOsName(ANDROID);
-        when(mockDao.updateAssessment(APP_ID_VALUE, assessment)).thenReturn(assessment);
+        when(mockDao.updateAssessment(TEST_APP_ID, assessment)).thenReturn(assessment);
         
         Assessment existing = AssessmentTest.createAssessment();
-        when(mockDao.getAssessment(APP_ID_VALUE, assessment.getGuid()))
+        when(mockDao.getAssessment(TEST_APP_ID, assessment.getGuid()))
             .thenReturn(Optional.of(existing));
         
-        Assessment retValue = service.updateAssessment(APP_ID_VALUE, assessment);
+        Assessment retValue = service.updateAssessment(TEST_APP_ID, assessment);
         assertSame(retValue, assessment);
         
         assertEquals(retValue.getIdentifier(), IDENTIFIER);
@@ -341,34 +341,34 @@ public class AssessmentServiceTest extends Mockito {
         assertEquals(retValue.getCreatedOn(), CREATED_ON);
         assertEquals(retValue.getModifiedOn(), MODIFIED_ON);
         
-        verify(mockDao).updateAssessment(APP_ID_VALUE, retValue);
+        verify(mockDao).updateAssessment(TEST_APP_ID, retValue);
     }
     
     @Test
     public void updateAssessmentAdjustsOsNameAlias() {
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false)).thenReturn(mockSubstudy);
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false)).thenReturn(mockSubstudy);
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setOsName("Both");
-        when(mockDao.updateAssessment(APP_ID_VALUE, assessment)).thenReturn(assessment);
+        when(mockDao.updateAssessment(TEST_APP_ID, assessment)).thenReturn(assessment);
         
         Assessment existing = AssessmentTest.createAssessment();
         existing.setDeleted(false);
-        when(mockDao.getAssessment(APP_ID_VALUE, GUID)).thenReturn(Optional.of(existing));
+        when(mockDao.getAssessment(TEST_APP_ID, GUID)).thenReturn(Optional.of(existing));
         
-        service.updateAssessment(APP_ID_VALUE, assessment);
+        service.updateAssessment(TEST_APP_ID, assessment);
         
         assertEquals(assessment.getOsName(), UNIVERSAL);
     }    
 
     @Test
     public void updateAssessmentSomeFieldsImmutable() {
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false)).thenReturn(mockSubstudy);
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false)).thenReturn(mockSubstudy);
         
         Assessment existing = AssessmentTest.createAssessment();
-        when(mockDao.getAssessment(APP_ID_VALUE, GUID))
+        when(mockDao.getAssessment(TEST_APP_ID, GUID))
             .thenReturn(Optional.of(existing));
-        when(mockDao.updateAssessment(eq(APP_ID_VALUE), any()))
+        when(mockDao.updateAssessment(eq(TEST_APP_ID), any()))
             .thenReturn(existing);
         
         Assessment assessment = AssessmentTest.createAssessment();
@@ -379,14 +379,14 @@ public class AssessmentServiceTest extends Mockito {
         assessment.setModifiedOn(MODIFIED_ON.minusDays(1));
         assessment.setDeleted(false);
         
-        Assessment retValue = service.updateAssessment(APP_ID_VALUE, assessment);
+        Assessment retValue = service.updateAssessment(TEST_APP_ID, assessment);
         assertEquals(retValue.getIdentifier(), IDENTIFIER);
         assertEquals(retValue.getOwnerId(), OWNER_ID);
         assertEquals(retValue.getOriginGuid(), "originGuid");
         assertEquals(retValue.getCreatedOn(), CREATED_ON);
         assertEquals(retValue.getModifiedOn(), MODIFIED_ON);
         
-        verify(mockDao).updateAssessment(eq(APP_ID_VALUE), assessmentCaptor.capture());
+        verify(mockDao).updateAssessment(eq(TEST_APP_ID), assessmentCaptor.capture());
         Assessment saved = assessmentCaptor.getValue();
         assertEquals(saved.getIdentifier(), IDENTIFIER);
         assertEquals(saved.getOwnerId(), OWNER_ID);
@@ -399,15 +399,15 @@ public class AssessmentServiceTest extends Mockito {
     public void updateAssessmentEntityNotFound() {
         Assessment assessment = new Assessment();
         
-        when(mockDao.getAssessment(APP_ID_VALUE, assessment.getGuid()))
+        when(mockDao.getAssessment(TEST_APP_ID, assessment.getGuid()))
             .thenReturn(Optional.empty());
         
-        service.updateAssessment(APP_ID_VALUE, assessment);
+        service.updateAssessment(TEST_APP_ID, assessment);
     }
     
     @Test
     public void updateAssessmentCanDelete() {
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false)).thenReturn(mockSubstudy);
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false)).thenReturn(mockSubstudy);
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setDeleted(true);
@@ -415,16 +415,16 @@ public class AssessmentServiceTest extends Mockito {
         Assessment existing = AssessmentTest.createAssessment();
         existing.setDeleted(false);
         
-        when(mockDao.getAssessment(APP_ID_VALUE, assessment.getGuid()))
+        when(mockDao.getAssessment(TEST_APP_ID, assessment.getGuid()))
             .thenReturn(Optional.of(existing));
         
-        service.updateAssessment(APP_ID_VALUE, assessment);
+        service.updateAssessment(TEST_APP_ID, assessment);
         assertTrue(assessment.isDeleted());
     }
 
     @Test
     public void updateAssessmentCanUndelete() {
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false)).thenReturn(mockSubstudy);
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false)).thenReturn(mockSubstudy);
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setDeleted(false);
@@ -432,10 +432,10 @@ public class AssessmentServiceTest extends Mockito {
         Assessment existing = AssessmentTest.createAssessment();
         existing.setDeleted(true);
         
-        when(mockDao.getAssessment(APP_ID_VALUE, assessment.getGuid()))
+        when(mockDao.getAssessment(TEST_APP_ID, assessment.getGuid()))
             .thenReturn(Optional.of(existing));
         
-        service.updateAssessment(APP_ID_VALUE, assessment);
+        service.updateAssessment(TEST_APP_ID, assessment);
         assertFalse(assessment.isDeleted());
     }
     
@@ -447,24 +447,24 @@ public class AssessmentServiceTest extends Mockito {
         Assessment existing = AssessmentTest.createAssessment();
         existing.setDeleted(true);
         
-        when(mockDao.getAssessment(APP_ID_VALUE, assessment.getGuid()))
+        when(mockDao.getAssessment(TEST_APP_ID, assessment.getGuid()))
             .thenReturn(Optional.of(existing));
         
-        service.updateAssessment(APP_ID_VALUE, assessment);
+        service.updateAssessment(TEST_APP_ID, assessment);
     }
     
     @Test
     public void updateAssessmentScrubsMarkup() {
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false)).thenReturn(mockSubstudy);
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false)).thenReturn(mockSubstudy);
 
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setDeleted(false);
         addMarkupToSensitiveFields(assessment);
 
-        when(mockDao.getAssessment(eq(APP_ID_VALUE), any()))
+        when(mockDao.getAssessment(eq(TEST_APP_ID), any()))
             .thenReturn(Optional.of(assessment));
         
-        service.updateAssessment(APP_ID_VALUE, assessment);
+        service.updateAssessment(TEST_APP_ID, assessment);
         
         assertMarkupRemoved(assessment);
     }
@@ -472,26 +472,26 @@ public class AssessmentServiceTest extends Mockito {
     @Test
     public void updateSharedAssessment() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerStudyId(APP_ID_VALUE)
+                .withCallerAppId(TEST_APP_ID)
                 .withCallerSubstudies(ImmutableSet.of(OWNER_ID)).build());
         
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false))
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
             .thenReturn(Substudy.create());
         
         Assessment existing = AssessmentTest.createAssessment();
         existing.setOriginGuid("unusualGuid");
         existing.setDeleted(false);
-        existing.setOwnerId(APP_ID_VALUE + ":" + OWNER_ID);
+        existing.setOwnerId(TEST_APP_ID + ":" + OWNER_ID);
         when(mockDao.getAssessment(SHARED_APP_ID, GUID))
             .thenReturn(Optional.of(existing));
         
         Assessment assessment = AssessmentTest.createAssessment();
-        service.updateSharedAssessment(APP_ID_VALUE, assessment);
+        service.updateSharedAssessment(TEST_APP_ID, assessment);
         
         verify(mockDao).updateAssessment(SHARED_APP_ID, assessment);
         
         assertEquals(assessment.getIdentifier(), IDENTIFIER);
-        assertEquals(APP_ID_VALUE + ":" + OWNER_ID, assessment.getOwnerId());
+        assertEquals(TEST_APP_ID + ":" + OWNER_ID, assessment.getOwnerId());
         assertEquals(assessment.getOriginGuid(), "unusualGuid");
         assertEquals(assessment.getCreatedOn(), CREATED_ON);
         assertEquals(assessment.getModifiedOn(), MODIFIED_ON);
@@ -500,34 +500,34 @@ public class AssessmentServiceTest extends Mockito {
     @Test
     public void updateSharedAssessmentAdjustsOsNameAlias() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerStudyId(APP_ID_VALUE)
+                .withCallerAppId(TEST_APP_ID)
                 .withCallerSubstudies(ImmutableSet.of(OWNER_ID)).build());
         
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false))
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
             .thenReturn(Substudy.create());
         
         Assessment existing = AssessmentTest.createAssessment();
         existing.setDeleted(false);
-        existing.setOwnerId(APP_ID_VALUE + ":" + OWNER_ID);
+        existing.setOwnerId(TEST_APP_ID + ":" + OWNER_ID);
         when(mockDao.getAssessment(SHARED_APP_ID, GUID))
             .thenReturn(Optional.of(existing));
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setOsName("Both");
-        service.updateSharedAssessment(APP_ID_VALUE, assessment);
+        service.updateSharedAssessment(TEST_APP_ID, assessment);
         
         assertEquals(assessment.getOsName(), UNIVERSAL);
     }
     
     @Test
     public void updateSharedAssessmentSomeFieldsImmutable() {
-        String ownerIdInShared = APP_ID_VALUE + ":" + OWNER_ID;
+        String ownerIdInShared = TEST_APP_ID + ":" + OWNER_ID;
         
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerStudyId(APP_ID_VALUE)
+                .withCallerAppId(TEST_APP_ID)
                 .withCallerSubstudies(ImmutableSet.of(OWNER_ID)).build());
         
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false))
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
             .thenReturn(Substudy.create());
         
         Assessment existing = AssessmentTest.createAssessment();
@@ -546,7 +546,7 @@ public class AssessmentServiceTest extends Mockito {
         assessment.setModifiedOn(MODIFIED_ON.minusDays(1));
         assessment.setDeleted(false);
         
-        Assessment retValue = service.updateSharedAssessment(APP_ID_VALUE, assessment);
+        Assessment retValue = service.updateSharedAssessment(TEST_APP_ID, assessment);
         assertEquals(retValue.getIdentifier(), IDENTIFIER);
         assertEquals(retValue.getOwnerId(), ownerIdInShared);
         assertEquals(retValue.getOriginGuid(), "originGuid");
@@ -565,7 +565,7 @@ public class AssessmentServiceTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class)
     public void updateSharedAssessmentUnauthorizedApp() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerStudyId(APP_ID_VALUE)
+                .withCallerAppId(TEST_APP_ID)
                 .withCallerSubstudies(ImmutableSet.of(OWNER_ID)).build());
         
         Assessment existing = AssessmentTest.createAssessment();
@@ -575,41 +575,41 @@ public class AssessmentServiceTest extends Mockito {
             .thenReturn(Optional.of(existing));
         
         Assessment assessment = AssessmentTest.createAssessment();
-        service.updateSharedAssessment(APP_ID_VALUE, assessment);
+        service.updateSharedAssessment(TEST_APP_ID, assessment);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
     public void updateSharedAssessmentUnauthorizedOrg() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerStudyId(APP_ID_VALUE)
+                .withCallerAppId(TEST_APP_ID)
                 .withCallerSubstudies(ImmutableSet.of(OWNER_ID)).build());
         
         Assessment existing = AssessmentTest.createAssessment();
         existing.setDeleted(false);
-        existing.setOwnerId(APP_ID_VALUE + ":wrong-org");
+        existing.setOwnerId(TEST_APP_ID + ":wrong-org");
         when(mockDao.getAssessment(SHARED_APP_ID, GUID))
             .thenReturn(Optional.of(existing));
         
         Assessment assessment = AssessmentTest.createAssessment();
-        service.updateSharedAssessment(APP_ID_VALUE, assessment);
+        service.updateSharedAssessment(TEST_APP_ID, assessment);
     }
     
     @Test
     public void updateSharedAssessmentSucceedsForGlobalUser() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerStudyId(APP_ID_VALUE)
+                .withCallerAppId(TEST_APP_ID)
                 .withCallerSubstudies(ImmutableSet.of()).build());
         when(mockSubstudyService.getSubstudy(
-                APP_ID_VALUE, OWNER_ID, false)).thenReturn(Substudy.create());
+                TEST_APP_ID, OWNER_ID, false)).thenReturn(Substudy.create());
         
         Assessment existing = AssessmentTest.createAssessment();
         existing.setDeleted(false);
-        existing.setOwnerId(APP_ID_VALUE + ":" + OWNER_ID);
+        existing.setOwnerId(TEST_APP_ID + ":" + OWNER_ID);
         when(mockDao.getAssessment(SHARED_APP_ID, GUID))
             .thenReturn(Optional.of(existing));
         
         Assessment assessment = AssessmentTest.createAssessment();
-        service.updateSharedAssessment(APP_ID_VALUE, assessment);
+        service.updateSharedAssessment(TEST_APP_ID, assessment);
         
         verify(mockDao).updateAssessment(SHARED_APP_ID, assessment);
     }
@@ -620,7 +620,7 @@ public class AssessmentServiceTest extends Mockito {
             .thenReturn(Optional.empty());
         
         Assessment assessment = AssessmentTest.createAssessment();
-        service.updateSharedAssessment(APP_ID_VALUE, assessment);
+        service.updateSharedAssessment(TEST_APP_ID, assessment);
     }
     
     @Test(expectedExceptions = EntityNotFoundException.class)
@@ -630,81 +630,81 @@ public class AssessmentServiceTest extends Mockito {
             .thenReturn(Optional.of(existing));
         
         Assessment assessment = AssessmentTest.createAssessment();
-        service.updateSharedAssessment(APP_ID_VALUE, assessment);
+        service.updateSharedAssessment(TEST_APP_ID, assessment);
     }
 
     @Test
     public void updateSharedAssessmentCanDelete() {
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false)).thenReturn(mockSubstudy);
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false)).thenReturn(mockSubstudy);
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setDeleted(true);
         
         Assessment existing = AssessmentTest.createAssessment();
-        existing.setOwnerId(APP_ID_VALUE + ":" + OWNER_ID);
+        existing.setOwnerId(TEST_APP_ID + ":" + OWNER_ID);
         existing.setDeleted(false);
         
         when(mockDao.getAssessment(SHARED_APP_ID, assessment.getGuid()))
             .thenReturn(Optional.of(existing));
-        when(mockDao.updateAssessment(APP_ID_VALUE, assessment)).thenReturn(assessment);
+        when(mockDao.updateAssessment(TEST_APP_ID, assessment)).thenReturn(assessment);
         
-        service.updateSharedAssessment(APP_ID_VALUE, assessment);
+        service.updateSharedAssessment(TEST_APP_ID, assessment);
         assertTrue(assessment.isDeleted());
     }
     
     @Test
     public void updateSharedAssessmentCanUndelete() {
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false)).thenReturn(mockSubstudy);
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false)).thenReturn(mockSubstudy);
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setDeleted(false);
         
         Assessment existing = AssessmentTest.createAssessment();
-        existing.setOwnerId(APP_ID_VALUE + ":" + OWNER_ID);
+        existing.setOwnerId(TEST_APP_ID + ":" + OWNER_ID);
         existing.setDeleted(true);
         
         when(mockDao.getAssessment(SHARED_APP_ID, assessment.getGuid()))
             .thenReturn(Optional.of(existing));
-        when(mockDao.updateAssessment(APP_ID_VALUE, assessment)).thenReturn(assessment);
+        when(mockDao.updateAssessment(TEST_APP_ID, assessment)).thenReturn(assessment);
         
-        service.updateSharedAssessment(APP_ID_VALUE, assessment);
+        service.updateSharedAssessment(TEST_APP_ID, assessment);
         assertFalse(assessment.isDeleted());
     }
     
     @Test
     public void getAssessmentByGuid() {
-        when(mockDao.getAssessment(APP_ID_VALUE, GUID))
+        when(mockDao.getAssessment(TEST_APP_ID, GUID))
             .thenReturn(Optional.of(ASSESSMENT));        
-        Assessment retValue = service.getAssessmentByGuid(APP_ID_VALUE, GUID);
+        Assessment retValue = service.getAssessmentByGuid(TEST_APP_ID, GUID);
         assertSame(retValue, ASSESSMENT);
     }
     
     @Test(expectedExceptions = EntityNotFoundException.class)
     public void getAssessmentByGuidEntityNotFound() {
-        when(mockDao.getAssessment(APP_ID_VALUE, GUID))
+        when(mockDao.getAssessment(TEST_APP_ID, GUID))
             .thenReturn(Optional.empty());        
-        service.getAssessmentByGuid(APP_ID_VALUE, GUID);
+        service.getAssessmentByGuid(TEST_APP_ID, GUID);
     }
         
     @Test
     public void getAssessmentByIdentifier() {
-        when(mockDao.getAssessment(APP_ID_VALUE, IDENTIFIER, REVISION_VALUE))
+        when(mockDao.getAssessment(TEST_APP_ID, IDENTIFIER, REVISION_VALUE))
             .thenReturn(Optional.of(ASSESSMENT));        
-        Assessment retValue = service.getAssessmentById(APP_ID_VALUE, IDENTIFIER, REVISION_VALUE);
+        Assessment retValue = service.getAssessmentById(TEST_APP_ID, IDENTIFIER, REVISION_VALUE);
         assertSame(retValue, ASSESSMENT);
     }
         
     @Test(expectedExceptions = EntityNotFoundException.class)
     public void getAssessmentByIdentifierEntityNotFound() {
-        when(mockDao.getAssessment(APP_ID_VALUE, IDENTIFIER, REVISION_VALUE))
+        when(mockDao.getAssessment(TEST_APP_ID, IDENTIFIER, REVISION_VALUE))
             .thenReturn(Optional.empty());        
-        service.getAssessmentById(APP_ID_VALUE, IDENTIFIER, REVISION_VALUE);
+        service.getAssessmentById(TEST_APP_ID, IDENTIFIER, REVISION_VALUE);
     }
     
     @Test(expectedExceptions = BadRequestException.class,
             expectedExceptionsMessageRegExp = "offsetBy must be positive integer")
     public void getAssessmentByIdentifierBadRevision() {
-        service.getAssessmentById(APP_ID_VALUE, IDENTIFIER, -2);
+        service.getAssessmentById(TEST_APP_ID, IDENTIFIER, -2);
     }
     
     @Test
@@ -713,17 +713,17 @@ public class AssessmentServiceTest extends Mockito {
         rev.setRevision(2);
         
         PagedResourceList<Assessment> page = new PagedResourceList<>(ImmutableList.of(rev), 2);
-        when(mockDao.getAssessmentRevisions(APP_ID_VALUE, IDENTIFIER, 0, 1, false)).thenReturn(page);
+        when(mockDao.getAssessmentRevisions(TEST_APP_ID, IDENTIFIER, 0, 1, false)).thenReturn(page);
         
-        Assessment retValue = service.getLatestAssessment(APP_ID_VALUE, IDENTIFIER);
+        Assessment retValue = service.getLatestAssessment(TEST_APP_ID, IDENTIFIER);
         assertSame(retValue, rev);
     }
         
     @Test(expectedExceptions = EntityNotFoundException.class)
     public void getLatestAssessmentEntityNotFound() {
-        when(mockDao.getAssessmentRevisions(APP_ID_VALUE, IDENTIFIER, 0, 1, false)).thenReturn(EMPTY_LIST);
+        when(mockDao.getAssessmentRevisions(TEST_APP_ID, IDENTIFIER, 0, 1, false)).thenReturn(EMPTY_LIST);
         
-        service.getLatestAssessment(APP_ID_VALUE, IDENTIFIER);
+        service.getLatestAssessment(TEST_APP_ID, IDENTIFIER);
     }
     
     @Test
@@ -733,10 +733,10 @@ public class AssessmentServiceTest extends Mockito {
         Assessment rev3 = AssessmentTest.createAssessment();
         
         PagedResourceList<Assessment> page = new PagedResourceList<>(ImmutableList.of(rev3, rev2, rev1), 10);
-        when(mockDao.getAssessmentRevisions(APP_ID_VALUE, IDENTIFIER, 10, 25, true)).thenReturn(page);
+        when(mockDao.getAssessmentRevisions(TEST_APP_ID, IDENTIFIER, 10, 25, true)).thenReturn(page);
         
         PagedResourceList<Assessment> retValue = service.getAssessmentRevisionsById(
-                APP_ID_VALUE, IDENTIFIER, 10, 25, true);
+                TEST_APP_ID, IDENTIFIER, 10, 25, true);
         
         assertEquals(retValue.getTotal(), Integer.valueOf(10));
         assertEquals(retValue.getItems().size(), 3);
@@ -748,33 +748,33 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test(expectedExceptions = EntityNotFoundException.class)
     public void getAssessmentRevisionsEntityNotFound() {
-        when(mockDao.getAssessmentRevisions(APP_ID_VALUE, IDENTIFIER, 10, 25, true)).thenReturn(EMPTY_LIST);
+        when(mockDao.getAssessmentRevisions(TEST_APP_ID, IDENTIFIER, 10, 25, true)).thenReturn(EMPTY_LIST);
         
-        service.getAssessmentRevisionsById(APP_ID_VALUE, IDENTIFIER, 10, 25, true);
+        service.getAssessmentRevisionsById(TEST_APP_ID, IDENTIFIER, 10, 25, true);
     }
     
     @Test(expectedExceptions = BadRequestException.class, 
             expectedExceptionsMessageRegExp = IDENTIFIER_REQUIRED)
     public void getAssessmentRevisionsNoIdentifier() {
-        service.getAssessmentRevisionsById(APP_ID_VALUE, null, 10, 25, true);
+        service.getAssessmentRevisionsById(TEST_APP_ID, null, 10, 25, true);
     }
     
     @Test(expectedExceptions = BadRequestException.class, 
             expectedExceptionsMessageRegExp = OFFSET_BY_CANNOT_BE_NEGATIVE)
     public void getAssessmentRevisionsNegativeOffsetBy() {
-        service.getAssessmentRevisionsById(APP_ID_VALUE, IDENTIFIER, -10, 25, true);
+        service.getAssessmentRevisionsById(TEST_APP_ID, IDENTIFIER, -10, 25, true);
     }
         
     @Test(expectedExceptions = BadRequestException.class, 
             expectedExceptionsMessageRegExp = PAGE_SIZE_ERROR)
     public void getAssessmentRevisionsPageSizeUnderMin() {
-        service.getAssessmentRevisionsById(APP_ID_VALUE, IDENTIFIER, 10, 1, true);
+        service.getAssessmentRevisionsById(TEST_APP_ID, IDENTIFIER, 10, 1, true);
     }
     
     @Test(expectedExceptions = BadRequestException.class, 
             expectedExceptionsMessageRegExp = PAGE_SIZE_ERROR)
     public void getAssessmentRevisionsPageSizeOverMax() {
-        service.getAssessmentRevisionsById(APP_ID_VALUE, IDENTIFIER, 10, 10000, true);
+        service.getAssessmentRevisionsById(TEST_APP_ID, IDENTIFIER, 10, 10000, true);
     }
 
     @Test
@@ -784,14 +784,14 @@ public class AssessmentServiceTest extends Mockito {
         Assessment rev3 = AssessmentTest.createAssessment();
         
         PagedResourceList<Assessment> page = new PagedResourceList<>(ImmutableList.of(rev3, rev2, rev1), 10);
-        when(mockDao.getAssessmentRevisions(APP_ID_VALUE, IDENTIFIER, 10, 25, true)).thenReturn(page);
+        when(mockDao.getAssessmentRevisions(TEST_APP_ID, IDENTIFIER, 10, 25, true)).thenReturn(page);
         
         Assessment assessment = AssessmentTest.createAssessment();
         // identifier is the correct identifier already
-        when(mockDao.getAssessment(APP_ID_VALUE, GUID)).thenReturn(Optional.of(assessment));
+        when(mockDao.getAssessment(TEST_APP_ID, GUID)).thenReturn(Optional.of(assessment));
         
         PagedResourceList<Assessment> retValue = service.getAssessmentRevisionsByGuid(
-                APP_ID_VALUE, GUID, 10, 25, true);
+                TEST_APP_ID, GUID, 10, 25, true);
         
         assertEquals(retValue.getTotal(), Integer.valueOf(10));
         assertEquals(retValue.getItems().size(), 3);
@@ -803,54 +803,54 @@ public class AssessmentServiceTest extends Mockito {
 
     @Test(expectedExceptions = EntityNotFoundException.class)
     public void getAssessmentRevisionsByGuidEntityNotFound() {
-        when(mockDao.getAssessment(APP_ID_VALUE, GUID)).thenReturn(Optional.empty());
+        when(mockDao.getAssessment(TEST_APP_ID, GUID)).thenReturn(Optional.empty());
         
-        service.getAssessmentRevisionsByGuid(APP_ID_VALUE, GUID, 10, 25, true);
+        service.getAssessmentRevisionsByGuid(TEST_APP_ID, GUID, 10, 25, true);
     }
     
     @Test(expectedExceptions = EntityNotFoundException.class)
     public void getAssessmentRevisionsByGuidRevisionsNotFound() {
         PagedResourceList<Assessment> page = new PagedResourceList<>(ImmutableList.of(), 0);
-        when(mockDao.getAssessmentRevisions(APP_ID_VALUE, IDENTIFIER, 10, 25, true)).thenReturn(page);
+        when(mockDao.getAssessmentRevisions(TEST_APP_ID, IDENTIFIER, 10, 25, true)).thenReturn(page);
 
         // This exists, but there are no revisions... this is pathological.
         Assessment assessment = AssessmentTest.createAssessment();
         // identifier is the correct identifier already
-        when(mockDao.getAssessment(APP_ID_VALUE, GUID)).thenReturn(Optional.of(assessment));
+        when(mockDao.getAssessment(TEST_APP_ID, GUID)).thenReturn(Optional.of(assessment));
         
-        service.getAssessmentRevisionsByGuid(APP_ID_VALUE, GUID, 10, 25, true);
+        service.getAssessmentRevisionsByGuid(TEST_APP_ID, GUID, 10, 25, true);
     }
     
     @Test(expectedExceptions = BadRequestException.class, 
             expectedExceptionsMessageRegExp = OFFSET_BY_CANNOT_BE_NEGATIVE)
     public void getAssessmentRevisionsByGuidNegativeOffsetBy() {
         Assessment assessment = AssessmentTest.createAssessment();
-        when(mockDao.getAssessment(APP_ID_VALUE, GUID)).thenReturn(Optional.of(assessment));
+        when(mockDao.getAssessment(TEST_APP_ID, GUID)).thenReturn(Optional.of(assessment));
         
-        service.getAssessmentRevisionsByGuid(APP_ID_VALUE, GUID, -10, 25, true);
+        service.getAssessmentRevisionsByGuid(TEST_APP_ID, GUID, -10, 25, true);
     }
 
     @Test(expectedExceptions = BadRequestException.class, 
             expectedExceptionsMessageRegExp = PAGE_SIZE_ERROR)
     public void getAssessmentRevisionsByGuidPageSizeUnderMin() {
         Assessment assessment = AssessmentTest.createAssessment();
-        when(mockDao.getAssessment(APP_ID_VALUE, GUID)).thenReturn(Optional.of(assessment));
+        when(mockDao.getAssessment(TEST_APP_ID, GUID)).thenReturn(Optional.of(assessment));
         
-        service.getAssessmentRevisionsByGuid(APP_ID_VALUE, GUID, 10, 1, true);
+        service.getAssessmentRevisionsByGuid(TEST_APP_ID, GUID, 10, 1, true);
     }
 
     @Test(expectedExceptions = BadRequestException.class, 
             expectedExceptionsMessageRegExp = PAGE_SIZE_ERROR)
     public void getAssessmentRevisionsByGuidPageSizeOverMax() {
         Assessment assessment = AssessmentTest.createAssessment();
-        when(mockDao.getAssessment(APP_ID_VALUE, GUID)).thenReturn(Optional.of(assessment));
+        when(mockDao.getAssessment(TEST_APP_ID, GUID)).thenReturn(Optional.of(assessment));
         
-        service.getAssessmentRevisionsByGuid(APP_ID_VALUE, GUID, 10, 10000, true);
+        service.getAssessmentRevisionsByGuid(TEST_APP_ID, GUID, 10, 10000, true);
     }
     
     @Test
     public void publishAssessment() {
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false))
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
             .thenReturn(mockSubstudy);
         
         Assessment existing =  AssessmentTest.createAssessment();
@@ -861,17 +861,17 @@ public class AssessmentServiceTest extends Mockito {
         existing.setOwnerId(OWNER_ID);
         existing.setVersion(-1L);        
         
-        when(mockDao.getAssessment(APP_ID_VALUE, "oldGuid")).thenReturn(Optional.of(existing));
+        when(mockDao.getAssessment(TEST_APP_ID, "oldGuid")).thenReturn(Optional.of(existing));
         when(mockDao.publishAssessment(any(), any(), any(), any())).thenReturn(ASSESSMENT);
         
         // Assume no published versions
         when(mockDao.getAssessmentRevisions(SHARED_APP_ID, IDENTIFIER, 0, 1, true)).thenReturn(EMPTY_LIST);
-        when(mockConfigService.getAssessmentConfig(APP_ID_VALUE, "oldGuid")).thenReturn(new AssessmentConfig());
+        when(mockConfigService.getAssessmentConfig(TEST_APP_ID, "oldGuid")).thenReturn(new AssessmentConfig());
         
-        Assessment retValue = service.publishAssessment(APP_ID_VALUE, null, "oldGuid");
+        Assessment retValue = service.publishAssessment(TEST_APP_ID, null, "oldGuid");
         assertSame(retValue, ASSESSMENT);
 
-        verify(mockDao).publishAssessment(eq(APP_ID_VALUE), assessmentCaptor.capture(), 
+        verify(mockDao).publishAssessment(eq(TEST_APP_ID), assessmentCaptor.capture(), 
                 assessmentCaptor.capture(), any(AssessmentConfig.class));
         
         Assessment original = assessmentCaptor.getAllValues().get(0);
@@ -882,7 +882,7 @@ public class AssessmentServiceTest extends Mockito {
         assertEquals(assessmentToPublish.getGuid(), GUID); // has been reset
         assertEquals(assessmentToPublish.getRevision(), 1);
         assertNull(assessmentToPublish.getOriginGuid());
-        assertEquals(assessmentToPublish.getOwnerId(), APP_ID_VALUE + ":" + OWNER_ID);
+        assertEquals(assessmentToPublish.getOwnerId(), TEST_APP_ID + ":" + OWNER_ID);
         assertEquals(assessmentToPublish.getVersion(), 0);
         // verify that a fuller copy also occurred
         assertEquals(assessmentToPublish.getTitle(), existing.getTitle());
@@ -891,20 +891,20 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void publishAssessmentWithNewIdentifier() { 
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false)).thenReturn(mockSubstudy);
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false)).thenReturn(mockSubstudy);
     
         Assessment existing =  AssessmentTest.createAssessment();
     
-        when(mockDao.getAssessment(APP_ID_VALUE, "oldGuid")).thenReturn(Optional.of(existing));
+        when(mockDao.getAssessment(TEST_APP_ID, "oldGuid")).thenReturn(Optional.of(existing));
         when(mockDao.publishAssessment(any(), any(), any(), any())).thenReturn(ASSESSMENT);
     
         // Assume no published versions
         when(mockDao.getAssessmentRevisions(SHARED_APP_ID, NEW_IDENTIFIER, 0, 1, true)).thenReturn(EMPTY_LIST);
     
-        Assessment retValue = service.publishAssessment(APP_ID_VALUE, NEW_IDENTIFIER, "oldGuid");
+        Assessment retValue = service.publishAssessment(TEST_APP_ID, NEW_IDENTIFIER, "oldGuid");
         assertSame(retValue, ASSESSMENT);
 
-        verify(mockDao).publishAssessment(eq(APP_ID_VALUE), assessmentCaptor.capture(), 
+        verify(mockDao).publishAssessment(eq(TEST_APP_ID), assessmentCaptor.capture(), 
                 assessmentCaptor.capture(), configCaptor.capture());
     
         Assessment assessmentToPublish = assessmentCaptor.getAllValues().get(1);
@@ -916,41 +916,41 @@ public class AssessmentServiceTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class)
     public void publishAssessmentCallerUnauthorized() {
         Assessment assessment = AssessmentTest.createAssessment();
-        when(mockDao.getAssessment(APP_ID_VALUE, GUID)).thenReturn(Optional.of(assessment));
+        when(mockDao.getAssessment(TEST_APP_ID, GUID)).thenReturn(Optional.of(assessment));
         
         BridgeUtils.setRequestContext(new RequestContext.Builder()
                 .withCallerSubstudies(ImmutableSet.of("notTheOwnerId")).build());
         
-        service.publishAssessment(APP_ID_VALUE, null, GUID);
+        service.publishAssessment(TEST_APP_ID, null, GUID);
     }
 
     @Test(expectedExceptions = EntityNotFoundException.class)
     public void publishAssessmentEntityNotFound() {
-        service.publishAssessment(APP_ID_VALUE, null, GUID);
+        service.publishAssessment(TEST_APP_ID, null, GUID);
     }
 
     @Test
     public void publishAssessmentPriorPublishedVersion() {
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false))
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
             .thenReturn(mockSubstudy);
         
         Assessment local = AssessmentTest.createAssessment();
-        when(mockDao.getAssessment(APP_ID_VALUE, GUID)).thenReturn(Optional.of(local));
+        when(mockDao.getAssessment(TEST_APP_ID, GUID)).thenReturn(Optional.of(local));
         
         AssessmentConfig localConfig = new AssessmentConfig();
-        when(mockConfigService.getAssessmentConfig(APP_ID_VALUE, GUID)).thenReturn(localConfig);
+        when(mockConfigService.getAssessmentConfig(TEST_APP_ID, GUID)).thenReturn(localConfig);
         
         // Same as the happy path version, but this time there is a revision in the
         // shared library
         Assessment revision = AssessmentTest.createAssessment();
         revision.setRevision(10);
-        revision.setOwnerId(APP_ID_VALUE + ":" + OWNER_ID);
+        revision.setOwnerId(TEST_APP_ID + ":" + OWNER_ID);
         PagedResourceList<Assessment> page = new PagedResourceList<>(ImmutableList.of(revision), 1);
         when(mockDao.getAssessmentRevisions(SHARED_APP_ID, IDENTIFIER, 0, 1, true)).thenReturn(page);        
         
-        service.publishAssessment(APP_ID_VALUE, null, GUID);
+        service.publishAssessment(TEST_APP_ID, null, GUID);
         
-        verify(mockDao).publishAssessment(eq(APP_ID_VALUE), assessmentCaptor.capture(), 
+        verify(mockDao).publishAssessment(eq(TEST_APP_ID), assessmentCaptor.capture(), 
                 assessmentCaptor.capture(), configCaptor.capture());
         
         Assessment assessmentToPublish = assessmentCaptor.getAllValues().get(1);
@@ -962,11 +962,11 @@ public class AssessmentServiceTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class, 
             expectedExceptionsMessageRegExp = ".*Assessment exists in shared library.*")
     public void publishAssessmentPriorPublishedVersionDifferentOwner() {
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false))
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
             .thenReturn(mockSubstudy);
         
         Assessment local = AssessmentTest.createAssessment();
-        when(mockDao.getAssessment(APP_ID_VALUE, GUID)).thenReturn(Optional.of(local));
+        when(mockDao.getAssessment(TEST_APP_ID, GUID)).thenReturn(Optional.of(local));
         
         // Same as the happy path version, but this time there is a revision in the
         // shared library
@@ -976,7 +976,7 @@ public class AssessmentServiceTest extends Mockito {
         PagedResourceList<Assessment> page = new PagedResourceList<>(ImmutableList.of(revision), 1);
         when(mockDao.getAssessmentRevisions(SHARED_APP_ID, IDENTIFIER, 0, 1, true)).thenReturn(page);        
         
-        service.publishAssessment(APP_ID_VALUE, null, GUID);
+        service.publishAssessment(TEST_APP_ID, null, GUID);
     }
 
     @Test
@@ -989,19 +989,19 @@ public class AssessmentServiceTest extends Mockito {
         when(mockConfigService.getSharedAssessmentConfig(SHARED_APP_ID, GUID)).thenReturn(sharedConfig);
         
         when(mockDao.getAssessment(SHARED_APP_ID, GUID)).thenReturn(Optional.of(sharedAssessment));
-        when(mockDao.getAssessmentRevisions(APP_ID_VALUE, IDENTIFIER, 0, 1, true))
+        when(mockDao.getAssessmentRevisions(TEST_APP_ID, IDENTIFIER, 0, 1, true))
             .thenReturn(new PagedResourceList<>(ImmutableList.of(), 0));
 
-        when(mockDao.importAssessment(APP_ID_VALUE, sharedAssessment, sharedConfig))
+        when(mockDao.importAssessment(TEST_APP_ID, sharedAssessment, sharedConfig))
             .thenReturn(sharedAssessment);
         
-        Assessment retValue = service.importAssessment(APP_ID_VALUE, OWNER_ID, null, GUID);
+        Assessment retValue = service.importAssessment(TEST_APP_ID, OWNER_ID, null, GUID);
         assertSame(retValue, sharedAssessment);
         assertEquals(retValue.getRevision(), 1);
         assertEquals(retValue.getOriginGuid(), "sharedGuid");
         assertEquals(retValue.getOwnerId(), OWNER_ID);
         
-        verify(mockDao).importAssessment(APP_ID_VALUE, sharedAssessment, sharedConfig);
+        verify(mockDao).importAssessment(TEST_APP_ID, sharedAssessment, sharedConfig);
     }
 
     @Test
@@ -1009,14 +1009,14 @@ public class AssessmentServiceTest extends Mockito {
         Assessment sharedAssessment = AssessmentTest.createAssessment();
         when(mockDao.getAssessment(SHARED_APP_ID, GUID)).thenReturn(Optional.of(sharedAssessment));
 
-        when(mockDao.getAssessmentRevisions(APP_ID_VALUE, NEW_IDENTIFIER, 0, 1, true))
+        when(mockDao.getAssessmentRevisions(TEST_APP_ID, NEW_IDENTIFIER, 0, 1, true))
             .thenReturn(new PagedResourceList<>(ImmutableList.of(), 0));
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false))
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
             .thenReturn(mockSubstudy);
         
-        service.importAssessment(APP_ID_VALUE, OWNER_ID, NEW_IDENTIFIER, GUID);
+        service.importAssessment(TEST_APP_ID, OWNER_ID, NEW_IDENTIFIER, GUID);
         
-        verify(mockDao).importAssessment(eq(APP_ID_VALUE), assessmentCaptor.capture(), configCaptor.capture());
+        verify(mockDao).importAssessment(eq(TEST_APP_ID), assessmentCaptor.capture(), configCaptor.capture());
         
         // This is at revision 1 because in this test, the new identifier is indeed new.
         assertEquals(assessmentCaptor.getValue().getIdentifier(), NEW_IDENTIFIER);
@@ -1031,12 +1031,12 @@ public class AssessmentServiceTest extends Mockito {
         Assessment sharedAssessment = AssessmentTest.createAssessment();
         when(mockDao.getAssessment(SHARED_APP_ID, GUID)).thenReturn(Optional.of(sharedAssessment));
 
-        when(mockDao.getAssessmentRevisions(APP_ID_VALUE, IDENTIFIER, 0, 1, true))
+        when(mockDao.getAssessmentRevisions(TEST_APP_ID, IDENTIFIER, 0, 1, true))
             .thenReturn(new PagedResourceList<>(ImmutableList.of(), 0));
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false))
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
             .thenReturn(mockSubstudy);
         
-        service.importAssessment(APP_ID_VALUE, null, null, GUID);
+        service.importAssessment(TEST_APP_ID, null, null, GUID);
     }
 
     @Test(expectedExceptions = BadRequestException.class, 
@@ -1045,7 +1045,7 @@ public class AssessmentServiceTest extends Mockito {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
                 .withCallerSubstudies(ImmutableSet.of(OWNER_ID, "anotherOrganization")).build());
         
-        service.importAssessment(APP_ID_VALUE, null, null, GUID);
+        service.importAssessment(TEST_APP_ID, null, null, GUID);
     }
     
     @Test(expectedExceptions = BadRequestException.class, 
@@ -1054,13 +1054,13 @@ public class AssessmentServiceTest extends Mockito {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
                 .withCallerSubstudies(ImmutableSet.of()).build());
         
-        service.importAssessment(APP_ID_VALUE, null, null, GUID);
+        service.importAssessment(TEST_APP_ID, null, null, GUID);
     }
     
     @Test(expectedExceptions = BadRequestException.class, 
             expectedExceptionsMessageRegExp = "ownerId parameter is required")
     public void importAssessmentOwnerGuidMissing() {
-        service.importAssessment(APP_ID_VALUE, "  ", null, GUID);   
+        service.importAssessment(TEST_APP_ID, "  ", null, GUID);   
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -1068,14 +1068,14 @@ public class AssessmentServiceTest extends Mockito {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
                 .withCallerSubstudies(ImmutableSet.of("notTheOwnerId")).build());
 
-        service.importAssessment(APP_ID_VALUE, OWNER_ID, null, GUID);
+        service.importAssessment(TEST_APP_ID, OWNER_ID, null, GUID);
     }
     
     @Test(expectedExceptions = EntityNotFoundException.class)
     public void importAssessmentNotFoundException() {
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false))
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
             .thenReturn(mockSubstudy);
-        service.importAssessment(APP_ID_VALUE, OWNER_ID, null, GUID);
+        service.importAssessment(TEST_APP_ID, OWNER_ID, null, GUID);
     }
     
     @Test
@@ -1093,12 +1093,12 @@ public class AssessmentServiceTest extends Mockito {
         localAssessment.setRevision(3);
         
         when(mockDao.getAssessment(SHARED_APP_ID, GUID)).thenReturn(Optional.of(sharedAssessment));
-        when(mockDao.getAssessmentRevisions(APP_ID_VALUE, IDENTIFIER, 0, 1, true))
+        when(mockDao.getAssessmentRevisions(TEST_APP_ID, IDENTIFIER, 0, 1, true))
             .thenReturn(new PagedResourceList<>(ImmutableList.of(localAssessment), 1));
         
-        when(mockDao.importAssessment(APP_ID_VALUE, sharedAssessment, sharedConfig)).thenReturn(sharedAssessment);
+        when(mockDao.importAssessment(TEST_APP_ID, sharedAssessment, sharedConfig)).thenReturn(sharedAssessment);
         
-        Assessment retValue = service.importAssessment(APP_ID_VALUE, OWNER_ID, null, GUID);
+        Assessment retValue = service.importAssessment(TEST_APP_ID, OWNER_ID, null, GUID);
         assertSame(retValue, sharedAssessment);
         assertEquals(retValue.getRevision(), 4); // 1 higher than 3
         assertEquals(retValue.getOriginGuid(), "sharedGuid");
@@ -1107,26 +1107,26 @@ public class AssessmentServiceTest extends Mockito {
         
     @Test
     public void deleteAssessment() {
-        when(mockSubstudyService.getSubstudy(APP_ID_VALUE, OWNER_ID, false))
+        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
             .thenReturn(Substudy.create());
         
         Assessment assessment = new Assessment();
         assessment.setOwnerId(OWNER_ID);
-        when(mockDao.getAssessment(APP_ID_VALUE, GUID)).thenReturn(Optional.of(assessment));
+        when(mockDao.getAssessment(TEST_APP_ID, GUID)).thenReturn(Optional.of(assessment));
         
-        service.deleteAssessment(APP_ID_VALUE, GUID);
+        service.deleteAssessment(TEST_APP_ID, GUID);
         
-        verify(mockDao).updateAssessment(APP_ID_VALUE, assessment);
+        verify(mockDao).updateAssessment(TEST_APP_ID, assessment);
         assertTrue(assessment.isDeleted());
         assertEquals(assessment.getModifiedOn(), MODIFIED_ON);
     }
     
     @Test
     public void deleteAssessmentEntityNotFound() {
-        when(mockDao.getAssessment(APP_ID_VALUE, GUID)).thenReturn(Optional.empty());
+        when(mockDao.getAssessment(TEST_APP_ID, GUID)).thenReturn(Optional.empty());
         
         try {
-            service.deleteAssessment(APP_ID_VALUE, GUID);
+            service.deleteAssessment(TEST_APP_ID, GUID);
             fail("Should have thrown exception");
         } catch(EntityNotFoundException e) {
         }
@@ -1137,10 +1137,10 @@ public class AssessmentServiceTest extends Mockito {
     public void deleteAssessmentEntityNotFoundOnLogicalAssessment() {
         Assessment assessment = new Assessment();
         assessment.setDeleted(true);
-        when(mockDao.getAssessment(APP_ID_VALUE, GUID)).thenReturn(Optional.of(assessment));
+        when(mockDao.getAssessment(TEST_APP_ID, GUID)).thenReturn(Optional.of(assessment));
         
         try {
-            service.deleteAssessment(APP_ID_VALUE, GUID);
+            service.deleteAssessment(TEST_APP_ID, GUID);
             fail("Should have thrown exception");
         } catch(EntityNotFoundException e) {
         }
@@ -1149,17 +1149,17 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void deleteAssessmentPermanently() {
-        when(mockDao.getAssessment(APP_ID_VALUE, GUID)).thenReturn(Optional.of(ASSESSMENT));
+        when(mockDao.getAssessment(TEST_APP_ID, GUID)).thenReturn(Optional.of(ASSESSMENT));
         
-        service.deleteAssessmentPermanently(APP_ID_VALUE, GUID);
+        service.deleteAssessmentPermanently(TEST_APP_ID, GUID);
         
-        verify(mockDao).deleteAssessment(APP_ID_VALUE, ASSESSMENT);
+        verify(mockDao).deleteAssessment(TEST_APP_ID, ASSESSMENT);
     }
     
     @Test
     public void deleteAssessmentPermanentlyEntityNotFoundIsQuite() {
-        when(mockDao.getAssessment(APP_ID_VALUE, GUID)).thenReturn(Optional.empty());
-        service.deleteAssessmentPermanently(APP_ID_VALUE, GUID);
+        when(mockDao.getAssessment(TEST_APP_ID, GUID)).thenReturn(Optional.empty());
+        service.deleteAssessmentPermanently(TEST_APP_ID, GUID);
         verify(mockDao, never()).deleteAssessment(any(), any());
     }
         
@@ -1172,7 +1172,7 @@ public class AssessmentServiceTest extends Mockito {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
                 .withCallerSubstudies(ImmutableSet.of("substudyD")).build());
         Assessment assessment = AssessmentTest.createAssessment();
-        service.createAssessment(APP_ID_VALUE, assessment);
+        service.createAssessment(TEST_APP_ID, assessment);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class,
@@ -1181,7 +1181,7 @@ public class AssessmentServiceTest extends Mockito {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
                 .withCallerSubstudies(ImmutableSet.of("substudyD")).build());
         Assessment assessment = AssessmentTest.createAssessment();
-        service.createAssessmentRevision(APP_ID_VALUE, GUID, assessment);
+        service.createAssessmentRevision(TEST_APP_ID, GUID, assessment);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class,
@@ -1194,9 +1194,9 @@ public class AssessmentServiceTest extends Mockito {
         Assessment existing = AssessmentTest.createAssessment();
         existing.setDeleted(false);
         existing.setOwnerId("differentId");
-        when(mockDao.getAssessment(APP_ID_VALUE, GUID)).thenReturn(Optional.of(existing));
+        when(mockDao.getAssessment(TEST_APP_ID, GUID)).thenReturn(Optional.of(existing));
         
-        service.updateAssessment(APP_ID_VALUE, assessment);
+        service.updateAssessment(TEST_APP_ID, assessment);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class,
@@ -1206,9 +1206,9 @@ public class AssessmentServiceTest extends Mockito {
                 .withCallerSubstudies(ImmutableSet.of("substudyD")).build());
         Assessment existing = AssessmentTest.createAssessment();
         existing.setDeleted(false);
-        when(mockDao.getAssessment(APP_ID_VALUE, GUID)).thenReturn(Optional.of(existing));
+        when(mockDao.getAssessment(TEST_APP_ID, GUID)).thenReturn(Optional.of(existing));
         
-        service.publishAssessment(APP_ID_VALUE, null, GUID);
+        service.publishAssessment(TEST_APP_ID, null, GUID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class,
@@ -1216,7 +1216,7 @@ public class AssessmentServiceTest extends Mockito {
     public void importAssessmentChecksOwnership() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
                 .withCallerSubstudies(ImmutableSet.of("substudyD")).build());
-        service.importAssessment(APP_ID_VALUE, OWNER_ID, null, GUID);
+        service.importAssessment(TEST_APP_ID, OWNER_ID, null, GUID);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class,
@@ -1226,9 +1226,9 @@ public class AssessmentServiceTest extends Mockito {
                 .withCallerSubstudies(ImmutableSet.of("substudyD")).build());
         Assessment existing = AssessmentTest.createAssessment();
         existing.setDeleted(false);
-        when(mockDao.getAssessment(APP_ID_VALUE, GUID)).thenReturn(Optional.of(existing));
+        when(mockDao.getAssessment(TEST_APP_ID, GUID)).thenReturn(Optional.of(existing));
         
-        service.deleteAssessment(APP_ID_VALUE, GUID);
+        service.deleteAssessment(TEST_APP_ID, GUID);
     }
         
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -1238,7 +1238,7 @@ public class AssessmentServiceTest extends Mockito {
         sharedAssessment.setOwnerId("wrongApp:wrongsubstudy");
         when(mockDao.getAssessment(SHARED_APP_ID, GUID)).thenReturn(Optional.of(sharedAssessment));
         
-        service.updateSharedAssessment(APP_ID_VALUE, sharedAssessment);
+        service.updateSharedAssessment(TEST_APP_ID, sharedAssessment);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -1248,7 +1248,7 @@ public class AssessmentServiceTest extends Mockito {
         sharedAssessment.setOwnerId(null);
         when(mockDao.getAssessment(SHARED_APP_ID, GUID)).thenReturn(Optional.of(sharedAssessment));
         
-        service.updateSharedAssessment(APP_ID_VALUE, sharedAssessment);
+        service.updateSharedAssessment(TEST_APP_ID, sharedAssessment);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -1258,7 +1258,7 @@ public class AssessmentServiceTest extends Mockito {
         sharedAssessment.setOwnerId("A:B:C");
         when(mockDao.getAssessment(SHARED_APP_ID, GUID)).thenReturn(Optional.of(sharedAssessment));
         
-        service.updateSharedAssessment(APP_ID_VALUE, sharedAssessment);
+        service.updateSharedAssessment(TEST_APP_ID, sharedAssessment);
     }
     
     private void addMarkupToSensitiveFields(Assessment assessment) {

--- a/src/test/java/org/sagebionetworks/bridge/services/ExternalIdServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ExternalIdServiceTest.java
@@ -55,7 +55,7 @@ public class ExternalIdServiceTest {
         MockitoAnnotations.initMocks(this);
         
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerStudyId(TEST_APP_ID).build());
+                .withCallerAppId(TEST_APP_ID).build());
         study = Study.create();
         study.setIdentifier(TEST_APP_ID);
         extId = ExternalIdentifier.create(TEST_APP_ID, ID);
@@ -149,7 +149,7 @@ public class ExternalIdServiceTest {
         when(externalIdDao.getExternalId(TEST_APP_ID, ID)).thenReturn(Optional.empty());
         
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerStudyId(TEST_APP_ID)
+                .withCallerAppId(TEST_APP_ID)
                 .withCallerSubstudies(SUBSTUDIES).build());
         
         ExternalIdentifier newExtId = ExternalIdentifier.create(TEST_APP_ID,
@@ -165,7 +165,7 @@ public class ExternalIdServiceTest {
         extId.setSubstudyId(null); // not set by caller
         
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerStudyId(TEST_APP_ID)
+                .withCallerAppId(TEST_APP_ID)
                 .withCallerSubstudies(ImmutableSet.of(SUBSTUDY_ID, "anotherSubstudy")).build());
         
         externalIdService.createExternalId(extId, false);
@@ -205,7 +205,7 @@ public class ExternalIdServiceTest {
     @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteExternalIdPermanentlyOutsideSubstudiesThrows() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerStudyId(TEST_APP_ID)
+                .withCallerAppId(TEST_APP_ID)
                 .withCallerSubstudies(SUBSTUDIES).build());        
         extId.setSubstudyId("someOtherId");
         when(externalIdDao.getExternalId(TEST_APP_ID, ID)).thenReturn(Optional.of(extId));

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/BaseControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/BaseControllerTest.java
@@ -812,7 +812,7 @@ public class BaseControllerTest extends Mockito {
     public void getSessionPopulatesTheRequestContext() {
         RequestContext context = new RequestContext.Builder().withRequestId(REQUEST_ID).build();
         assertNotNull(context.getId());
-        assertNull(context.getCallerStudyId());
+        assertNull(context.getCallerAppId());
         assertEquals(ImmutableSet.of(), context.getCallerSubstudies());
         assertFalse(context.isAdministrator());
         BridgeUtils.setRequestContext(context);
@@ -832,7 +832,7 @@ public class BaseControllerTest extends Mockito {
         
         context = BridgeUtils.getRequestContext();
         assertEquals(context.getId(), REQUEST_ID);
-        assertEquals(context.getCallerStudyId(), TEST_APP_ID);
+        assertEquals(context.getCallerAppId(), TEST_APP_ID);
         assertEquals(context.getCallerSubstudies(), USER_SUBSTUDY_IDS);
         assertTrue(context.isAdministrator());
         assertTrue(context.isInRole(DEVELOPER));

--- a/src/test/java/org/sagebionetworks/bridge/validators/ExternalIdValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/ExternalIdValidatorTest.java
@@ -43,7 +43,7 @@ public class ExternalIdValidatorTest {
     public void validates() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
                 .withCallerSubstudies(ImmutableSet.of("substudy-id"))
-                .withCallerStudyId(TEST_APP_ID).build());
+                .withCallerAppId(TEST_APP_ID).build());
         
         when(substudyService.getSubstudy(TEST_APP_ID, "substudy-id", false)).thenReturn(Substudy.create());
         ExternalIdentifier id = ExternalIdentifier.create(TEST_APP_ID, "one-id");
@@ -55,7 +55,7 @@ public class ExternalIdValidatorTest {
     @Test
     public void validatesV3() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerStudyId(TEST_APP_ID).build());
+                .withCallerAppId(TEST_APP_ID).build());
         
         ExternalIdentifier id = ExternalIdentifier.create(TEST_APP_ID, "one-id");
         
@@ -120,7 +120,7 @@ public class ExternalIdValidatorTest {
     public void substudyIdCanBeAnythingForAdmins() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(Roles.ADMIN))
-                .withCallerStudyId(TEST_APP_ID).build());
+                .withCallerAppId(TEST_APP_ID).build());
         
         when(substudyService.getSubstudy(TEST_APP_ID, "substudy-id", false)).thenReturn(Substudy.create());
         ExternalIdentifier id = ExternalIdentifier.create(TEST_APP_ID, "one-id");
@@ -133,7 +133,7 @@ public class ExternalIdValidatorTest {
     public void substudyIdMustMatchCallersSubstudies() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
                 .withCallerSubstudies(ImmutableSet.of("substudyB"))
-                .withCallerStudyId(TEST_APP_ID).build());
+                .withCallerAppId(TEST_APP_ID).build());
         
         when(substudyService.getSubstudy(TEST_APP_ID, "substudy-id", false)).thenReturn(Substudy.create());
         ExternalIdentifier id = ExternalIdentifier.create(TEST_APP_ID, "one-id");


### PR DESCRIPTION
Also got rid of a local appId constant in favor of the global TEST_APP_ID constant in a few tests.