### PR TITLE
UploadSchema updated (from controller to DAO)

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchema.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchema.java
@@ -53,7 +53,7 @@ public class DynamoUploadSchema implements UploadSchema {
     private UploadSchemaType schemaType;
     private String surveyGuid;
     private Long surveyCreatedOn;
-    private String studyId;
+    private String appId;
     private Long version;
     private boolean deleted;
 
@@ -87,7 +87,7 @@ public class DynamoUploadSchema implements UploadSchema {
     @DynamoDBHashKey
     @JsonIgnore
     public String getKey() {
-        if (StringUtils.isBlank(studyId)) {
+        if (StringUtils.isBlank(appId)) {
             // No study ID means we can't generate a key. However, we should still return null, because this case might
             // still come up (such as querying by secondary index), and we don't want to crash.
             return null;
@@ -96,7 +96,7 @@ public class DynamoUploadSchema implements UploadSchema {
             // Similarly here.
             return null;
         }
-        return String.format("%s:%s", studyId, schemaId);
+        return String.format("%s:%s", appId, schemaId);
     }
 
     /**
@@ -115,7 +115,7 @@ public class DynamoUploadSchema implements UploadSchema {
         Preconditions.checkArgument(!parts[0].isEmpty(), "key has empty study ID");
         Preconditions.checkArgument(!parts[1].isEmpty(), "key has empty schema ID");
 
-        this.studyId = parts[0];
+        this.appId = parts[0];
         this.schemaId = parts[1];
     }
 
@@ -253,7 +253,7 @@ public class DynamoUploadSchema implements UploadSchema {
     @JsonIgnore
     @Override
     public UploadSchemaKey getSchemaKey() {
-        return new UploadSchemaKey.Builder().withStudyId(studyId).withSchemaId(schemaId).withRevision(rev).build();
+        return new UploadSchemaKey.Builder().withStudyId(appId).withSchemaId(schemaId).withRevision(rev).build();
     }
 
     /** {@inheritDoc} */
@@ -307,16 +307,28 @@ public class DynamoUploadSchema implements UploadSchema {
      */
     @DynamoDBIndexHashKey(attributeName = "studyId", globalSecondaryIndexName = "studyId-index")
     @Override
-    public String getStudyId() {
-        return studyId;
+    public String getAppId() {
+        return appId;
     }
 
-    /** @see #getStudyId */
+    /** @see #getAppId */
     @Override
-    public void setStudyId(String studyId) {
-        this.studyId = studyId;
+    public void setAppId(String appId) {
+        this.appId = appId;
+    }
+    
+    // Currently exposed to workers
+    @DynamoDBIgnore
+    @Override
+    public String getStudyId() {
+        return appId;
     }
 
+    // Currently exposed to workers
+    public void setStudyId(String studyId) {
+        this.appId = studyId;
+    }
+    
     /**
      * <p>
      * Version number of a particular schema revision. This is used to detect concurrent modification. Callers should

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
@@ -89,19 +89,19 @@ public class DynamoUploadSchemaDao implements UploadSchemaDao {
 
     /** {@inheritDoc} */
     @Override
-    public List<UploadSchema> getAllUploadSchemasAllRevisions(String studyId, boolean includeDeleted) {
+    public List<UploadSchema> getAllUploadSchemasAllRevisions(String appId, boolean includeDeleted) {
         DynamoUploadSchema hashKey = new DynamoUploadSchema();
-        hashKey.setAppId(studyId);
+        hashKey.setAppId(appId);
         return indexHelper(STUDY_ID_INDEX_NAME, hashKey, includeDeleted);
     }
 
     /** {@inheritDoc} */
     @Override
-    public List<UploadSchema> getUploadSchemaAllRevisionsById(String studyId, String schemaId,
+    public List<UploadSchema> getUploadSchemaAllRevisionsById(String appId, String schemaId,
             boolean includeDeleted) {
         // Make hash key.
         DynamoUploadSchema key = new DynamoUploadSchema();
-        key.setAppId(studyId);
+        key.setAppId(appId);
         key.setSchemaId(schemaId);
 
         // Get all revisions, in reverse sort order (highest first)
@@ -120,9 +120,9 @@ public class DynamoUploadSchemaDao implements UploadSchemaDao {
 
     /** {@inheritDoc} */
     @Override
-    public UploadSchema getUploadSchemaByIdAndRevision(String studyId, String schemaId, int revision) {
+    public UploadSchema getUploadSchemaByIdAndRevision(String appId, String schemaId, int revision) {
         DynamoUploadSchema key = new DynamoUploadSchema();
-        key.setAppId(studyId);
+        key.setAppId(appId);
         key.setSchemaId(schemaId);
         key.setRevision(revision);
 
@@ -131,10 +131,10 @@ public class DynamoUploadSchemaDao implements UploadSchemaDao {
 
     /** {@inheritDoc} */
     @Override
-    public UploadSchema getUploadSchemaLatestRevisionById(String studyId, String schemaId) {
+    public UploadSchema getUploadSchemaLatestRevisionById(String appId, String schemaId) {
         // Make hash key.
         DynamoUploadSchema key = new DynamoUploadSchema();
-        key.setAppId(studyId);
+        key.setAppId(appId);
         key.setSchemaId(schemaId);
 
         // Get the latest revision. This is accomplished by scanning the range key backwards.

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDao.java
@@ -91,7 +91,7 @@ public class DynamoUploadSchemaDao implements UploadSchemaDao {
     @Override
     public List<UploadSchema> getAllUploadSchemasAllRevisions(String studyId, boolean includeDeleted) {
         DynamoUploadSchema hashKey = new DynamoUploadSchema();
-        hashKey.setStudyId(studyId);
+        hashKey.setAppId(studyId);
         return indexHelper(STUDY_ID_INDEX_NAME, hashKey, includeDeleted);
     }
 
@@ -101,7 +101,7 @@ public class DynamoUploadSchemaDao implements UploadSchemaDao {
             boolean includeDeleted) {
         // Make hash key.
         DynamoUploadSchema key = new DynamoUploadSchema();
-        key.setStudyId(studyId);
+        key.setAppId(studyId);
         key.setSchemaId(schemaId);
 
         // Get all revisions, in reverse sort order (highest first)
@@ -122,7 +122,7 @@ public class DynamoUploadSchemaDao implements UploadSchemaDao {
     @Override
     public UploadSchema getUploadSchemaByIdAndRevision(String studyId, String schemaId, int revision) {
         DynamoUploadSchema key = new DynamoUploadSchema();
-        key.setStudyId(studyId);
+        key.setAppId(studyId);
         key.setSchemaId(schemaId);
         key.setRevision(revision);
 
@@ -134,7 +134,7 @@ public class DynamoUploadSchemaDao implements UploadSchemaDao {
     public UploadSchema getUploadSchemaLatestRevisionById(String studyId, String schemaId) {
         // Make hash key.
         DynamoUploadSchema key = new DynamoUploadSchema();
-        key.setStudyId(studyId);
+        key.setAppId(studyId);
         key.setSchemaId(schemaId);
 
         // Get the latest revision. This is accomplished by scanning the range key backwards.

--- a/src/main/java/org/sagebionetworks/bridge/models/upload/UploadSchema.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/upload/UploadSchema.java
@@ -22,7 +22,7 @@ import org.sagebionetworks.bridge.schema.UploadSchemaKey;
 @JsonDeserialize(as = DynamoUploadSchema.class)
 public interface UploadSchema extends BridgeEntity {
     ObjectWriter PUBLIC_SCHEMA_WRITER = BridgeObjectMapper.get().writer(new SimpleFilterProvider().addFilter("filter",
-                    SimpleBeanPropertyFilter.serializeAllExcept("studyId")));
+                    SimpleBeanPropertyFilter.serializeAllExcept("studyId", "appId")));
 
     /** Creates an UploadSchema using a concrete implementation. */
     static UploadSchema create() {
@@ -126,13 +126,19 @@ public interface UploadSchema extends BridgeEntity {
     void setSurveyCreatedOn(Long surveyCreatedOn);
 
     /**
-     * Study ID that this schema lives in. This is not exposed to the callers of the upload schema API, but is
-     * available here for internal usage.
+     * App ID that this schema lives in. This is not exposed to the callers of the upload schema API, 
+     * but is available here for internal usage.
+     */
+    String getAppId();
+
+    /** @see #getAppId */
+    void setAppId(String appId);
+    
+    /**
+     * Workers receive back the studyId property and so this must be maintained 
+     * through migration to the user of appId.
      */
     String getStudyId();
-
-    /** @see #getStudyId */
-    void setStudyId(String studyId);
     
     /**
      * Is this schema revision marked as deleted?

--- a/src/main/java/org/sagebionetworks/bridge/services/UploadSchemaService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/UploadSchemaService.java
@@ -59,7 +59,7 @@ public class UploadSchemaService {
      * that rev + 1.
      */
     public UploadSchema createSchemaRevisionV4(String appId, UploadSchema schema) {
-        // Controller guarantees valid studyId and non-null uploadSchema
+        // Controller guarantees valid appId and non-null uploadSchema
         checkNotNull(appId, "appId must be non-null");
         checkNotNull(schema, "uploadSchema must be non-null");
 
@@ -71,7 +71,7 @@ public class UploadSchemaService {
             schema.setRevision(oldRev + 1);
         }
 
-        // Set study. This enforces that you can't create schemas outside of your study.
+        // Set app. This enforces that you can't create schemas outside of your app.
         schema.setAppId(appId);
 
         // validate schema
@@ -94,7 +94,7 @@ public class UploadSchemaService {
      * </p>
      */
     public UploadSchema createOrUpdateUploadSchema(String appId, UploadSchema schema) {
-        // Controller guarantees valid studyId and non-null uploadSchema
+        // Controller guarantees valid appId and non-null uploadSchema
         checkNotNull(appId, "appId must be non-null");
         checkNotNull(schema, "uploadSchema must be non-null");
 
@@ -107,7 +107,7 @@ public class UploadSchemaService {
         }
         schema.setRevision(oldRev + 1);
 
-        // Set study. This enforces that you can't create schemas outside of your study.
+        // Set app. This enforces that you can't create schemas outside of your app.
         schema.setAppId(appId);
 
         // validate schema
@@ -202,7 +202,7 @@ public class UploadSchemaService {
     // Helper method to add survey fields to schemas. This is useful so we have the same attributes for newly created
     // schemas, as well as setting them into updated schemas.
     private static void addSurveySchemaMetadata(UploadSchema schema, Survey survey) {
-        // No need to set rev or version unless updating an existing rev. Study is always taken care of by the APIs.
+        // No need to set rev or version unless updating an existing rev. App is always taken care of by the APIs.
         schema.setName(survey.getName());
         schema.setSchemaId(survey.getIdentifier());
         schema.setSchemaType(UploadSchemaType.IOS_SURVEY);
@@ -249,7 +249,7 @@ public class UploadSchemaService {
     }
     
     /**
-     * Service handler for deleting an upload schema with the specified study, schema ID, and revision. If the schema
+     * Service handler for deleting an upload schema with the specified app, schema ID, and revision. If the schema
      * doesn't exist, this API throws an EntityNotFoundException.
      */
     public void deleteUploadSchemaByIdAndRevision(String appId, String schemaId, int rev) {
@@ -277,8 +277,8 @@ public class UploadSchemaService {
         return uploadSchemaDao.getAllUploadSchemasAllRevisions(appId, includeDeleted);
     }
 
-    /** Service handler for fetching the most recent revision of all upload schemas in a study. */
-    public List<UploadSchema> getUploadSchemasForStudy(String appId, boolean includeDeleted) {
+    /** Service handler for fetching the most recent revision of all upload schemas in a app. */
+    public List<UploadSchema> getUploadSchemasForApp(String appId, boolean includeDeleted) {
         // Get all schemas. No simple query for just latest schemas.
         List<UploadSchema> allSchemasAllRevisions = getAllUploadSchemasAllRevisions(appId, includeDeleted);
 
@@ -296,7 +296,7 @@ public class UploadSchemaService {
     }
 
     /**
-     * Service handler for fetching upload schemas. This method fetches an upload schema for the specified study and
+     * Service handler for fetching upload schemas. This method fetches an upload schema for the specified app and
      * schema ID. If there is more than one revision of the schema, this fetches the latest revision. If the schema
      * doesn't exist, this handler throws an InvalidEntityException.
      */
@@ -349,7 +349,7 @@ public class UploadSchemaService {
 
     /**
      * Service handler for fetching upload schemas. This method fetches all revisions of an an upload schema for
-     * the specified study and schema ID. If the schema doesn't exist, this handler throws an EntityNotFoundException.
+     * the specified app and schema ID. If the schema doesn't exist, this handler throws an EntityNotFoundException.
      */
     public List<UploadSchema> getUploadSchemaAllRevisions(String appId, String schemaId, boolean includeDeleted) {
         if (StringUtils.isBlank(schemaId)) {
@@ -364,7 +364,7 @@ public class UploadSchemaService {
     }
 
     /**
-     * Fetches the upload schema for the specified study, schema ID, and revision. If no schema is found, this API
+     * Fetches the upload schema for the specified app, schema ID, and revision. If no schema is found, this API
      * throws an EntityNotFoundException
      */
     public UploadSchema getUploadSchemaByIdAndRev(String appId, String schemaId, int revision) {
@@ -376,7 +376,7 @@ public class UploadSchemaService {
     }
 
     /**
-     * Fetches the upload schema for the specified study, schema ID, and revision. If no schema is found, this API
+     * Fetches the upload schema for the specified app, schema ID, and revision. If no schema is found, this API
      * returns null.
      */
     public UploadSchema getUploadSchemaByIdAndRevNoThrow(String appId, String schemaId,
@@ -443,7 +443,7 @@ public class UploadSchemaService {
      */
     public UploadSchema updateSchemaRevisionV4(String appId, String schemaId, int revision,
             UploadSchema schemaToUpdate) {
-        // Controller guarantees valid studyId and non-null uploadSchema
+        // Controller guarantees valid appId and non-null uploadSchema
         checkNotNull(appId, "appId must be non-null");
         checkNotNull(schemaToUpdate, "uploadSchema must be non-null");
 
@@ -459,7 +459,7 @@ public class UploadSchemaService {
                     "and cannot be modified.");
         }
 
-        // Set study ID, schema ID, and revision. This ensures we are updating the correct schema in the correct study.
+        // Set app ID, schema ID, and revision. This ensures we are updating the correct schema in the correct app.
         schemaToUpdate.setAppId(appId);
         schemaToUpdate.setSchemaId(schemaId);
         schemaToUpdate.setRevision(revision);
@@ -507,7 +507,7 @@ public class UploadSchemaService {
 
         // If we have any errors, concat them together and throw a 400 bad request.
         if (!errorMessageList.isEmpty()) {
-            throw new BadRequestException("Can't update study " + appId + " schema " + schemaId +
+            throw new BadRequestException("Can't update app " + appId + " schema " + schemaId +
                     " revision " + revision + ": " + BridgeUtils.SEMICOLON_SPACE_JOINER.join(errorMessageList));
         }
 

--- a/src/main/java/org/sagebionetworks/bridge/services/UploadSchemaService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/UploadSchemaService.java
@@ -58,21 +58,21 @@ public class UploadSchemaService {
      * UploadSchema object. If the revision isn't specified, we'll get the latest schema rev for the schema ID and use
      * that rev + 1.
      */
-    public UploadSchema createSchemaRevisionV4(String studyId, UploadSchema schema) {
+    public UploadSchema createSchemaRevisionV4(String appId, UploadSchema schema) {
         // Controller guarantees valid studyId and non-null uploadSchema
-        checkNotNull(studyId, "studyId must be non-null");
+        checkNotNull(appId, "appId must be non-null");
         checkNotNull(schema, "uploadSchema must be non-null");
 
         // Schema ID is validated by getCurrentSchemaRevision()
 
         // Set revision if needed. 0 represents an unset schema rev.
-        int oldRev = getCurrentSchemaRevision(studyId, schema.getSchemaId());
+        int oldRev = getCurrentSchemaRevision(appId, schema.getSchemaId());
         if (schema.getRevision() == 0) {
             schema.setRevision(oldRev + 1);
         }
 
         // Set study. This enforces that you can't create schemas outside of your study.
-        schema.setStudyId(studyId);
+        schema.setAppId(appId);
 
         // validate schema
         Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
@@ -83,7 +83,7 @@ public class UploadSchemaService {
 
     /**
      * <p>
-     * Service handler for creating and updating upload schemas. This method creates an upload schema, using the study
+     * Service handler for creating and updating upload schemas. This method creates an upload schema, using the app
      * ID and schema ID of the specified schema, or updates an existing one if it already exists.
      * </p>
      * <p>
@@ -93,22 +93,22 @@ public class UploadSchemaService {
      * in a ConcurrentModificationException.
      * </p>
      */
-    public UploadSchema createOrUpdateUploadSchema(String studyId, UploadSchema schema) {
+    public UploadSchema createOrUpdateUploadSchema(String appId, UploadSchema schema) {
         // Controller guarantees valid studyId and non-null uploadSchema
-        checkNotNull(studyId, "studyId must be non-null");
+        checkNotNull(appId, "appId must be non-null");
         checkNotNull(schema, "uploadSchema must be non-null");
 
         // Schema ID is validated by getCurrentSchemaRevision()
 
         // Request should match old rev. If it does, auto-increment and write. Otherwise, throw.
-        int oldRev = getCurrentSchemaRevision(studyId, schema.getSchemaId());
+        int oldRev = getCurrentSchemaRevision(appId, schema.getSchemaId());
         if (oldRev != schema.getRevision()) {
             throw new ConcurrentModificationException(schema);
         }
         schema.setRevision(oldRev + 1);
 
         // Set study. This enforces that you can't create schemas outside of your study.
-        schema.setStudyId(studyId);
+        schema.setAppId(appId);
 
         // validate schema
         Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
@@ -121,8 +121,8 @@ public class UploadSchemaService {
      * Private helper function to get the current schema revision of the specified schema ID. Returns 0 if the schema
      * doesn't exist. This is generally useful for validating the proper revision number for making updates.
      */
-    private int getCurrentSchemaRevision(String studyId, String schemaId) {
-        UploadSchema oldSchema = getUploadSchemaNoThrow(studyId, schemaId);
+    private int getCurrentSchemaRevision(String appId, String schemaId) {
+        UploadSchema oldSchema = getUploadSchemaNoThrow(appId, schemaId);
         if (oldSchema != null) {
             return oldSchema.getRevision();
         } else {
@@ -141,12 +141,12 @@ public class UploadSchemaService {
      * creating a new schema revision.
      * </p>
      */
-    public UploadSchema createUploadSchemaFromSurvey(String studyId, Survey survey, boolean newSchemaRev) {
+    public UploadSchema createUploadSchemaFromSurvey(String appId, Survey survey, boolean newSchemaRev) {
         // https://sagebionetworks.jira.com/browse/BRIDGE-1698 - If the existing Schema ID points to a different survey
         // or a non-survey, this is an error. Having multiple surveys point to the same schema ID causes really bad
         // things to happen, and we need to prevent it.
         String schemaId = survey.getIdentifier();
-        UploadSchema oldSchema = getUploadSchemaNoThrow(studyId, schemaId);
+        UploadSchema oldSchema = getUploadSchemaNoThrow(appId, schemaId);
         if (oldSchema != null) {
             if (oldSchema.getSchemaType() != UploadSchemaType.IOS_SURVEY ||
                     !Objects.equals(oldSchema.getSurveyGuid(), survey.getGuid())) {
@@ -170,7 +170,7 @@ public class UploadSchemaService {
                 newFieldDefList.add(UploadUtil.ANSWERS_FIELD_DEF);
                 addSurveySchemaMetadata(oldSchema, survey);
                 oldSchema.setFieldDefinitions(newFieldDefList);
-                return updateSchemaRevisionV4(studyId, schemaId, oldSchema.getRevision(), oldSchema);
+                return updateSchemaRevisionV4(appId, schemaId, oldSchema.getRevision(), oldSchema);
             }
 
             // Answers field needs to be either
@@ -184,7 +184,7 @@ public class UploadSchemaService {
                 // The old schema works for the new survey. However, we want to ensure the old schema points to the
                 // latest version of the survey. Update survey metadata in the schema.
                 addSurveySchemaMetadata(oldSchema, survey);
-                return updateSchemaRevisionV4(studyId, schemaId, oldSchema.getRevision(), oldSchema);
+                return updateSchemaRevisionV4(appId, schemaId, oldSchema.getRevision(), oldSchema);
             }
 
             // If execution gets this far, that means we have a schema with an "answers" field that's not compatible.
@@ -196,7 +196,7 @@ public class UploadSchemaService {
         UploadSchema schemaToCreate = UploadSchema.create();
         addSurveySchemaMetadata(schemaToCreate, survey);
         schemaToCreate.setFieldDefinitions(ImmutableList.of(UploadUtil.ANSWERS_FIELD_DEF));
-        return createSchemaRevisionV4(studyId, schemaToCreate);
+        return createSchemaRevisionV4(appId, schemaToCreate);
     }
 
     // Helper method to add survey fields to schemas. This is useful so we have the same attributes for newly created
@@ -211,25 +211,25 @@ public class UploadSchemaService {
     }
 
     /**
-     * Service handler for deleting all revisions of the upload schema with the specified study and schema ID. If there
+     * Service handler for deleting all revisions of the upload schema with the specified app and schema ID. If there
      * are no schemas with this schema ID, this API throws an EntityNotFoundException.
      */
-    public void deleteUploadSchemaById(String studyId, String schemaId) {
+    public void deleteUploadSchemaById(String appId, String schemaId) {
         // Schema ID is validated by getUploadSchemaAllRevisions()
 
-        List<UploadSchema> schemaList = getSchemaRevisionsForDelete(studyId, schemaId);
+        List<UploadSchema> schemaList = getSchemaRevisionsForDelete(appId, schemaId);
         uploadSchemaDao.deleteUploadSchemas(schemaList);
     }
 
-    public void deleteUploadSchemaByIdPermanently(String studyId, String schemaId) {
+    public void deleteUploadSchemaByIdPermanently(String appId, String schemaId) {
         // Schema ID is validated by getUploadSchemaAllRevisions()
 
-        List<UploadSchema> schemaList = getSchemaRevisionsForDelete(studyId, schemaId);
+        List<UploadSchema> schemaList = getSchemaRevisionsForDelete(appId, schemaId);
         uploadSchemaDao.deleteUploadSchemasPermanently(schemaList);
     }
 
-    protected List<UploadSchema> getSchemaRevisionsForDelete(String studyId, String schemaId) {
-        List<UploadSchema> schemaList = getUploadSchemaAllRevisions(studyId, schemaId, true);
+    protected List<UploadSchema> getSchemaRevisionsForDelete(String appId, String schemaId) {
+        List<UploadSchema> schemaList = getUploadSchemaAllRevisions(appId, schemaId, true);
 
         List<Integer> revisions = new ArrayList<>();
         for (int i = 0; i < schemaList.size(); i++) {
@@ -252,20 +252,20 @@ public class UploadSchemaService {
      * Service handler for deleting an upload schema with the specified study, schema ID, and revision. If the schema
      * doesn't exist, this API throws an EntityNotFoundException.
      */
-    public void deleteUploadSchemaByIdAndRevision(String studyId, String schemaId, int rev) {
+    public void deleteUploadSchemaByIdAndRevision(String appId, String schemaId, int rev) {
         // Schema ID and rev are validated by getUploadSchemaByIdAndRev()
 
-        UploadSchema schema = getRevisionForDeletion(studyId, schemaId, rev);
+        UploadSchema schema = getRevisionForDeletion(appId, schemaId, rev);
         if (schema == null || schema.isDeleted()) {
             throw new EntityNotFoundException(UploadSchema.class);
         }
         uploadSchemaDao.deleteUploadSchemas(ImmutableList.of(schema));    
     }
     
-    public void deleteUploadSchemaByIdAndRevisionPermanently(String studyId, String schemaId, int rev) {
+    public void deleteUploadSchemaByIdAndRevisionPermanently(String appId, String schemaId, int rev) {
         // Schema ID and rev are validated by getUploadSchemaByIdAndRev()
 
-        UploadSchema schema = getRevisionForDeletion(studyId, schemaId, rev);
+        UploadSchema schema = getRevisionForDeletion(appId, schemaId, rev);
         if (schema == null) {
             throw new EntityNotFoundException(UploadSchema.class);
         }
@@ -273,14 +273,14 @@ public class UploadSchemaService {
     }
 
     /** Returns all revisions of all schemas. */
-    public List<UploadSchema> getAllUploadSchemasAllRevisions(String studyId, boolean includeDeleted) {
-        return uploadSchemaDao.getAllUploadSchemasAllRevisions(studyId, includeDeleted);
+    public List<UploadSchema> getAllUploadSchemasAllRevisions(String appId, boolean includeDeleted) {
+        return uploadSchemaDao.getAllUploadSchemasAllRevisions(appId, includeDeleted);
     }
 
     /** Service handler for fetching the most recent revision of all upload schemas in a study. */
-    public List<UploadSchema> getUploadSchemasForStudy(String studyId, boolean includeDeleted) {
+    public List<UploadSchema> getUploadSchemasForStudy(String appId, boolean includeDeleted) {
         // Get all schemas. No simple query for just latest schemas.
-        List<UploadSchema> allSchemasAllRevisions = getAllUploadSchemasAllRevisions(studyId, includeDeleted);
+        List<UploadSchema> allSchemasAllRevisions = getAllUploadSchemasAllRevisions(appId, includeDeleted);
 
         // Iterate schemas and pick out latest for each schema ID.
         // Find the most recent version of each schema with a unique schemaId
@@ -300,8 +300,8 @@ public class UploadSchemaService {
      * schema ID. If there is more than one revision of the schema, this fetches the latest revision. If the schema
      * doesn't exist, this handler throws an InvalidEntityException.
      */
-    public UploadSchema getUploadSchema(String studyId, String schemaId) {
-        UploadSchema schema = getUploadSchemaNoThrow(studyId, schemaId);
+    public UploadSchema getUploadSchema(String appId, String schemaId) {
+        UploadSchema schema = getUploadSchemaNoThrow(appId, schemaId);
         if (schema == null) {
             throw new EntityNotFoundException(UploadSchema.class);
         }
@@ -312,11 +312,11 @@ public class UploadSchemaService {
      * Private helper method to get the latest version of an upload schema, but doesn't throw if the schema does not
      * exist. Note that it still validates the user inputs (schemaId) and will throw a BadRequestException.
      */
-    private UploadSchema getUploadSchemaNoThrow(String studyId, String schemaId) {
+    private UploadSchema getUploadSchemaNoThrow(String appId, String schemaId) {
         if (StringUtils.isBlank(schemaId)) {
             throw new BadRequestException("Schema ID must be specified");
         }
-        return uploadSchemaDao.getUploadSchemaLatestRevisionById(studyId, schemaId);
+        return uploadSchemaDao.getUploadSchemaLatestRevisionById(appId, schemaId);
     }
     
     /**
@@ -324,14 +324,14 @@ public class UploadSchemaService {
      * exist. User inputs are validated (schemaId and revision) and the method will throw a BadRequestException if 
      * the schema is referenced as part of shared module metadata.
      */
-    private UploadSchema getRevisionForDeletion(String studyId, String schemaId, int revision) {
+    private UploadSchema getRevisionForDeletion(String appId, String schemaId, int revision) {
         if (StringUtils.isBlank(schemaId)) {
             throw new BadRequestException("Schema ID must be specified");
         }
         if (revision <= 0) {
             throw new BadRequestException("Revision must be specified and positive");
         }
-        UploadSchema schema = uploadSchemaDao.getUploadSchemaByIdAndRevision(studyId, schemaId, revision);
+        UploadSchema schema = uploadSchemaDao.getUploadSchemaByIdAndRevision(appId, schemaId, revision);
         if (schema != null) {
             Map<String,Object> parameters = new HashMap<>();
             parameters.put("schemaId", schemaId);
@@ -351,12 +351,12 @@ public class UploadSchemaService {
      * Service handler for fetching upload schemas. This method fetches all revisions of an an upload schema for
      * the specified study and schema ID. If the schema doesn't exist, this handler throws an EntityNotFoundException.
      */
-    public List<UploadSchema> getUploadSchemaAllRevisions(String studyId, String schemaId, boolean includeDeleted) {
+    public List<UploadSchema> getUploadSchemaAllRevisions(String appId, String schemaId, boolean includeDeleted) {
         if (StringUtils.isBlank(schemaId)) {
             throw new BadRequestException("Schema ID must be specified");
         }
 
-        List<UploadSchema> schemaList = uploadSchemaDao.getUploadSchemaAllRevisionsById(studyId, schemaId, includeDeleted);
+        List<UploadSchema> schemaList = uploadSchemaDao.getUploadSchemaAllRevisionsById(appId, schemaId, includeDeleted);
         if (schemaList.isEmpty()) {
             throw new EntityNotFoundException(UploadSchema.class);
         }
@@ -367,8 +367,8 @@ public class UploadSchemaService {
      * Fetches the upload schema for the specified study, schema ID, and revision. If no schema is found, this API
      * throws an EntityNotFoundException
      */
-    public UploadSchema getUploadSchemaByIdAndRev(String studyId, String schemaId, int revision) {
-        UploadSchema schema = getUploadSchemaByIdAndRevNoThrow(studyId, schemaId, revision);
+    public UploadSchema getUploadSchemaByIdAndRev(String appId, String schemaId, int revision) {
+        UploadSchema schema = getUploadSchemaByIdAndRevNoThrow(appId, schemaId, revision);
         if (schema == null) {
             throw new EntityNotFoundException(UploadSchema.class, "Can't find schema " + schemaId + "-v" + revision);
         }
@@ -379,7 +379,7 @@ public class UploadSchemaService {
      * Fetches the upload schema for the specified study, schema ID, and revision. If no schema is found, this API
      * returns null.
      */
-    public UploadSchema getUploadSchemaByIdAndRevNoThrow(String studyId, String schemaId,
+    public UploadSchema getUploadSchemaByIdAndRevNoThrow(String appId, String schemaId,
             int revision) {
         if (StringUtils.isBlank(schemaId)) {
             throw new BadRequestException("Schema ID must be specified");
@@ -388,7 +388,7 @@ public class UploadSchemaService {
             throw new BadRequestException("Revision must be specified and positive");
         }
 
-        return uploadSchemaDao.getUploadSchemaByIdAndRevision(studyId, schemaId, revision);
+        return uploadSchemaDao.getUploadSchemaByIdAndRevision(appId, schemaId, revision);
     }
 
     /**
@@ -396,12 +396,12 @@ public class UploadSchemaService {
      * schema revision for the specified schema ID, then checks the schema's min/maxAppVersion against the clientInfo.
      * If multiple schema revisions match, it returns the latest one.
      */
-    public UploadSchema getLatestUploadSchemaRevisionForAppVersion(String studyId, String schemaId,
+    public UploadSchema getLatestUploadSchemaRevisionForAppVersion(String appId, String schemaId,
             ClientInfo clientInfo) {
-        checkNotNull(studyId, "Study ID must be specified");
+        checkNotNull(appId, "App ID must be specified");
         checkNotNull(clientInfo, "Client Info must be specified");
 
-        List<UploadSchema> schemaList = getUploadSchemaAllRevisions(studyId, schemaId, false);
+        List<UploadSchema> schemaList = getUploadSchemaAllRevisions(appId, schemaId, false);
         return schemaList.stream().filter(schema -> isSchemaAvailableForClientInfo(schema, clientInfo))
                 .max((schema1, schema2) -> Integer.compare(schema1.getRevision(), schema2.getRevision())).orElse(null);
     }
@@ -441,15 +441,15 @@ public class UploadSchemaService {
      * Updating a schema revision that doesn't exist throws an EntityNotFoundException.
      * </p>
      */
-    public UploadSchema updateSchemaRevisionV4(String studyId, String schemaId, int revision,
+    public UploadSchema updateSchemaRevisionV4(String appId, String schemaId, int revision,
             UploadSchema schemaToUpdate) {
         // Controller guarantees valid studyId and non-null uploadSchema
-        checkNotNull(studyId, "studyId must be non-null");
+        checkNotNull(appId, "appId must be non-null");
         checkNotNull(schemaToUpdate, "uploadSchema must be non-null");
 
         // Get existing schema revision. This also validates schema ID and rev and throws if the schema revision
         // doesn't exist.
-        UploadSchema oldSchema = getUploadSchemaByIdAndRev(studyId, schemaId, revision);
+        UploadSchema oldSchema = getUploadSchemaByIdAndRev(appId, schemaId, revision);
         if (oldSchema.isDeleted() && schemaToUpdate.isDeleted()) {
             throw new EntityNotFoundException(UploadSchema.class);
         }
@@ -460,7 +460,7 @@ public class UploadSchemaService {
         }
 
         // Set study ID, schema ID, and revision. This ensures we are updating the correct schema in the correct study.
-        schemaToUpdate.setStudyId(studyId);
+        schemaToUpdate.setAppId(appId);
         schemaToUpdate.setSchemaId(schemaId);
         schemaToUpdate.setRevision(revision);
 
@@ -507,7 +507,7 @@ public class UploadSchemaService {
 
         // If we have any errors, concat them together and throw a 400 bad request.
         if (!errorMessageList.isEmpty()) {
-            throw new BadRequestException("Can't update study " + studyId + " schema " + schemaId +
+            throw new BadRequestException("Can't update study " + appId + " schema " + schemaId +
                     " revision " + revision + ": " + BridgeUtils.SEMICOLON_SPACE_JOINER.join(errorMessageList));
         }
 

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/UploadSchemaController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/UploadSchemaController.java
@@ -61,7 +61,7 @@ public class UploadSchemaController extends BaseController {
 
     /**
      * Play controller for POST /researcher/v1/uploadSchema/:schemaId. This API creates an upload schema, using the
-     * study for the current service endpoint and the schema of the specified schema. If the schema already exists,
+     * app for the current service endpoint and the schema of the specified schema. If the schema already exists,
      * this method updates it instead.
      *
      * @return Play result, with the created or updated schema in JSON format
@@ -142,7 +142,7 @@ public class UploadSchemaController extends BaseController {
     }
 
     /**
-     * Fetches the upload schema for the specified study, schema ID, and revision. If no schema is found, this API
+     * Fetches the upload schema for the specified app, schema ID, and revision. If no schema is found, this API
      * throws a 404 exception.
      *
      * @param schemaId
@@ -162,18 +162,19 @@ public class UploadSchemaController extends BaseController {
     }
 
     /**
-     * Cross-study worker API to get the upload schema for the specified study, schema ID, and revision.
+     * Cross-app worker API to get the upload schema for the specified app, schema ID, and revision.
      *
      * @param appId
-     *         study the schema lives in
+     *         app/study the schema lives in
      * @param schemaId
      *         schema to fetch
      * @param revision
      *         schema revision to fetch
      * @return the requested schema revision
      */
-    @GetMapping("/v3/studies/{appId}/uploadschemas/{schemaId}/revisions/{revision}")
-    public UploadSchema getUploadSchemaByStudyAndSchemaAndRev(@PathVariable String appId,
+    @GetMapping(path = {"/v1/apps/{appId}/uploadschemas/{schemaId}/revisions/{revision}",
+            "/v3/studies/{appId}/uploadschemas/{schemaId}/revisions/{revision}"})
+    public UploadSchema getUploadSchemaByAppAndSchemaAndRev(@PathVariable String appId,
             @PathVariable String schemaId, @PathVariable int revision) {
         getAuthenticatedSession(WORKER);
         return uploadSchemaService.getUploadSchemaByIdAndRev(appId, schemaId, revision);
@@ -181,17 +182,17 @@ public class UploadSchemaController extends BaseController {
 
     /**
      * Play controller for GET /v3/uploadschemas. This API fetches the most recent revision of all upload 
-     * schemas for the current study. 
+     * schemas for the current app. 
      * 
-     * @return Play result with list of schemas for this study
+     * @return Play result with list of schemas for this app
      */
     @GetMapping(path="/v3/uploadschemas", produces={APPLICATION_JSON_UTF8_VALUE})
-    public String getUploadSchemasForStudy(@RequestParam(defaultValue = "false") boolean includeDeleted)
+    public String getUploadSchemasForApp(@RequestParam(defaultValue = "false") boolean includeDeleted)
             throws Exception {
         UserSession session = getAuthenticatedSession(DEVELOPER, RESEARCHER);
         String appId = session.getAppId();
 
-        List<UploadSchema> schemaList = uploadSchemaService.getUploadSchemasForStudy(appId, Boolean.valueOf(includeDeleted));
+        List<UploadSchema> schemaList = uploadSchemaService.getUploadSchemasForApp(appId, Boolean.valueOf(includeDeleted));
         ResourceList<UploadSchema> schemaResourceList = new ResourceList<>(schemaList);
         return PUBLIC_SCHEMA_WRITER.writeValueAsString(schemaResourceList);
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/UploadSchemaController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/UploadSchemaController.java
@@ -52,10 +52,10 @@ public class UploadSchemaController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     public String createSchemaRevisionV4() throws Exception {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String studyId = session.getAppId();
+        String appId = session.getAppId();
 
         UploadSchema uploadSchema = parseJson(UploadSchema.class);
-        UploadSchema createdSchema = uploadSchemaService.createSchemaRevisionV4(studyId, uploadSchema);
+        UploadSchema createdSchema = uploadSchemaService.createSchemaRevisionV4(appId, uploadSchema);
         return PUBLIC_SCHEMA_WRITER.writeValueAsString(createdSchema);
     }
 
@@ -69,10 +69,10 @@ public class UploadSchemaController extends BaseController {
     @PostMapping(path="/v3/uploadschemas", produces={APPLICATION_JSON_UTF8_VALUE})
     public String createOrUpdateUploadSchema() throws JsonProcessingException, IOException {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String studyId = session.getAppId();
+        String appId = session.getAppId();
         
         UploadSchema uploadSchema = parseJson(UploadSchema.class);
-        UploadSchema createdSchema = uploadSchemaService.createOrUpdateUploadSchema(studyId, uploadSchema);
+        UploadSchema createdSchema = uploadSchemaService.createOrUpdateUploadSchema(appId, uploadSchema);
         return PUBLIC_SCHEMA_WRITER.writeValueAsString(createdSchema);
     }
 
@@ -114,9 +114,9 @@ public class UploadSchemaController extends BaseController {
     @GetMapping(path="/v3/uploadschemas/{schemaId}/recent", produces={APPLICATION_JSON_UTF8_VALUE})
     public String getUploadSchema(@PathVariable String schemaId) throws JsonProcessingException, IOException {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String studyId = session.getAppId();
+        String appId = session.getAppId();
         
-        UploadSchema uploadSchema = uploadSchemaService.getUploadSchema(studyId, schemaId);
+        UploadSchema uploadSchema = uploadSchemaService.getUploadSchema(appId, schemaId);
         return PUBLIC_SCHEMA_WRITER.writeValueAsString(uploadSchema);
     }
     
@@ -133,9 +133,9 @@ public class UploadSchemaController extends BaseController {
     public String getUploadSchemaAllRevisions(@PathVariable String schemaId,
             @RequestParam(defaultValue = "false") boolean includeDeleted) throws JsonProcessingException, IOException {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String studyId = session.getAppId();
+        String appId = session.getAppId();
         
-        List<UploadSchema> uploadSchemas = uploadSchemaService.getUploadSchemaAllRevisions(studyId, schemaId,
+        List<UploadSchema> uploadSchemas = uploadSchemaService.getUploadSchemaAllRevisions(appId, schemaId,
                 Boolean.valueOf(includeDeleted));
         ResourceList<UploadSchema> uploadSchemaResourceList = new ResourceList<>(uploadSchemas);
         return PUBLIC_SCHEMA_WRITER.writeValueAsString(uploadSchemaResourceList);
@@ -155,16 +155,16 @@ public class UploadSchemaController extends BaseController {
     public String getUploadSchemaByIdAndRev(@PathVariable String schemaId, @PathVariable int revision)
             throws JsonProcessingException, IOException {
         UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
-        String studyId = session.getAppId();
+        String appId = session.getAppId();
 
-        UploadSchema uploadSchema = uploadSchemaService.getUploadSchemaByIdAndRev(studyId, schemaId, revision);
+        UploadSchema uploadSchema = uploadSchemaService.getUploadSchemaByIdAndRev(appId, schemaId, revision);
         return PUBLIC_SCHEMA_WRITER.writeValueAsString(uploadSchema);
     }
 
     /**
      * Cross-study worker API to get the upload schema for the specified study, schema ID, and revision.
      *
-     * @param studyId
+     * @param appId
      *         study the schema lives in
      * @param schemaId
      *         schema to fetch
@@ -172,11 +172,11 @@ public class UploadSchemaController extends BaseController {
      *         schema revision to fetch
      * @return the requested schema revision
      */
-    @GetMapping("/v3/studies/{studyId}/uploadschemas/{schemaId}/revisions/{revision}")
-    public UploadSchema getUploadSchemaByStudyAndSchemaAndRev(@PathVariable String studyId,
+    @GetMapping("/v3/studies/{appId}/uploadschemas/{schemaId}/revisions/{revision}")
+    public UploadSchema getUploadSchemaByStudyAndSchemaAndRev(@PathVariable String appId,
             @PathVariable String schemaId, @PathVariable int revision) {
         getAuthenticatedSession(WORKER);
-        return uploadSchemaService.getUploadSchemaByIdAndRev(studyId, schemaId, revision);
+        return uploadSchemaService.getUploadSchemaByIdAndRev(appId, schemaId, revision);
     }
 
     /**
@@ -189,9 +189,9 @@ public class UploadSchemaController extends BaseController {
     public String getUploadSchemasForStudy(@RequestParam(defaultValue = "false") boolean includeDeleted)
             throws Exception {
         UserSession session = getAuthenticatedSession(DEVELOPER, RESEARCHER);
-        String studyId = session.getAppId();
+        String appId = session.getAppId();
 
-        List<UploadSchema> schemaList = uploadSchemaService.getUploadSchemasForStudy(studyId, Boolean.valueOf(includeDeleted));
+        List<UploadSchema> schemaList = uploadSchemaService.getUploadSchemasForStudy(appId, Boolean.valueOf(includeDeleted));
         ResourceList<UploadSchema> schemaResourceList = new ResourceList<>(schemaList);
         return PUBLIC_SCHEMA_WRITER.writeValueAsString(schemaResourceList);
     }
@@ -210,10 +210,10 @@ public class UploadSchemaController extends BaseController {
     public String updateSchemaRevisionV4(@PathVariable String schemaId, @PathVariable int revision)
             throws JsonProcessingException, IOException {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        String studyId = session.getAppId();
+        String appId = session.getAppId();
 
         UploadSchema uploadSchema = parseJson(UploadSchema.class);
-        UploadSchema updatedSchema = uploadSchemaService.updateSchemaRevisionV4(studyId, schemaId, revision,
+        UploadSchema updatedSchema = uploadSchemaService.updateSchemaRevisionV4(appId, schemaId, revision,
                 uploadSchema);
         return PUBLIC_SCHEMA_WRITER.writeValueAsString(updatedSchema);
     }

--- a/src/main/java/org/sagebionetworks/bridge/validators/UploadSchemaValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/UploadSchemaValidator.java
@@ -91,9 +91,9 @@ public class UploadSchemaValidator implements Validator {
                 errors.rejectValue("schemaType", "is required");
             }
 
-            // study ID
-            if (StringUtils.isBlank(uploadSchema.getStudyId())) {
-                errors.rejectValue("studyId", "is required");
+            // app ID
+            if (StringUtils.isBlank(uploadSchema.getAppId())) {
+                errors.rejectValue("appId", "is required");
             }
 
             // fieldDefinitions

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDaoMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchemaDaoMockTest.java
@@ -109,7 +109,7 @@ public class DynamoUploadSchemaDaoMockTest {
 
         // validate index hash key
         DynamoUploadSchema indexHashKey = indexHashKeyCaptor.getValue();
-        assertEquals(indexHashKey.getStudyId(), TEST_APP_ID);
+        assertEquals(indexHashKey.getAppId(), TEST_APP_ID);
 
         // Verify DAO output
         assertSame(daoOutputSchemaList, mapperOutputSchemaList);
@@ -128,7 +128,7 @@ public class DynamoUploadSchemaDaoMockTest {
 
         // validate index hash key
         DynamoUploadSchema indexHashKey = indexHashKeyCaptor.getValue();
-        assertEquals(indexHashKey.getStudyId(), TEST_APP_ID);
+        assertEquals(indexHashKey.getAppId(), TEST_APP_ID);
 
         // Verify DAO output
         assertSame(daoOutputSchemaList, mapperOutputSchemaList);
@@ -175,7 +175,7 @@ public class DynamoUploadSchemaDaoMockTest {
         // validate query
         DynamoDBQueryExpression<DynamoUploadSchema> mapperQuery = mapperQueryCaptor.getValue();
         assertFalse(mapperQuery.isScanIndexForward());
-        assertEquals(mapperQuery.getHashKeyValues().getStudyId(), TEST_APP_ID);
+        assertEquals(mapperQuery.getHashKeyValues().getAppId(), TEST_APP_ID);
         assertEquals(mapperQuery.getHashKeyValues().getSchemaId(), SCHEMA_ID);
         assertNull(mapperQuery.getQueryFilter());
 
@@ -199,7 +199,7 @@ public class DynamoUploadSchemaDaoMockTest {
         // validate query
         DynamoDBQueryExpression<DynamoUploadSchema> mapperQuery = mapperQueryCaptor.getValue();
         assertFalse(mapperQuery.isScanIndexForward());
-        assertEquals(mapperQuery.getHashKeyValues().getStudyId(), TEST_APP_ID);
+        assertEquals(mapperQuery.getHashKeyValues().getAppId(), TEST_APP_ID);
         assertEquals(mapperQuery.getHashKeyValues().getSchemaId(), SCHEMA_ID);
         assertEquals(mapperQuery.getQueryFilter().toString(),
                 "{deleted={AttributeValueList: [{N: 1,}],ComparisonOperator: NE}}");
@@ -223,7 +223,7 @@ public class DynamoUploadSchemaDaoMockTest {
 
         // validate intermediate args
         DynamoUploadSchema mapperInputSchema = mapperInputSchemaCaptor.getValue();
-        assertEquals(mapperInputSchema.getStudyId(), TEST_APP_ID);
+        assertEquals(mapperInputSchema.getAppId(), TEST_APP_ID);
         assertEquals(mapperInputSchema.getSchemaId(), SCHEMA_ID);
         assertEquals(mapperInputSchema.getRevision(), SCHEMA_REV);
     }
@@ -247,7 +247,7 @@ public class DynamoUploadSchemaDaoMockTest {
         DynamoDBQueryExpression<DynamoUploadSchema> mapperQuery = mapperQueryCaptor.getValue();
         assertFalse(mapperQuery.isScanIndexForward());
         assertEquals(mapperQuery.getLimit().intValue(), 1);
-        assertEquals(mapperQuery.getHashKeyValues().getStudyId(), TEST_APP_ID);
+        assertEquals(mapperQuery.getHashKeyValues().getAppId(), TEST_APP_ID);
         assertEquals(mapperQuery.getHashKeyValues().getSchemaId(), SCHEMA_ID);
 
         // Verify DAO output

--- a/src/test/java/org/sagebionetworks/bridge/services/HealthDataServiceSubmitHealthDataTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/HealthDataServiceSubmitHealthDataTest.java
@@ -95,7 +95,7 @@ public class HealthDataServiceSubmitHealthDataTest {
     public void before() throws Exception {
         // Mock Schema Service.
         schema = UploadSchema.create();
-        schema.setStudyId(TEST_APP_ID);
+        schema.setAppId(TEST_APP_ID);
         schema.setSchemaId(SCHEMA_ID);
         schema.setRevision(SCHEMA_REV);
 

--- a/src/test/java/org/sagebionetworks/bridge/services/ScheduledActivityServiceResolveLinksTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ScheduledActivityServiceResolveLinksTest.java
@@ -84,7 +84,7 @@ public class ScheduledActivityServiceResolveLinksTest {
 
         // Mock schema service to provide a concrete schema. Schema only cares about ID and rev.
         UploadSchema schema = UploadSchema.create();
-        schema.setStudyId(TEST_APP_ID);
+        schema.setAppId(TEST_APP_ID);
         schema.setSchemaId(SCHEMA_ID);
         schema.setRevision(SCHEMA_REV);
 

--- a/src/test/java/org/sagebionetworks/bridge/services/UploadSchemaServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/UploadSchemaServiceTest.java
@@ -135,7 +135,7 @@ public class UploadSchemaServiceTest {
 
         // Validate we set key parameters when passing the schema to the DAO, including study ID and rev.
         UploadSchema daoInputSchema = daoInputSchemaCaptor.getValue();
-        assertEquals(daoInputSchema.getStudyId(), TEST_APP_ID);
+        assertEquals(daoInputSchema.getAppId(), TEST_APP_ID);
         assertEquals(daoInputSchema.getRevision(), expectedRev);
 
         // Validate DAO input is also svcOutput.
@@ -219,7 +219,7 @@ public class UploadSchemaServiceTest {
 
             // Validate we set key parameters when passing the schema to the DAO, including study ID and rev.
             UploadSchema daoInputSchema = daoInputSchemaCaptor.getValue();
-            assertEquals(daoInputSchema.getStudyId(), TEST_APP_ID);
+            assertEquals(daoInputSchema.getAppId(), TEST_APP_ID);
             assertEquals(daoInputSchema.getRevision(), expectedRev.intValue());
 
             // Validate DAO input is also svcOutput.
@@ -975,7 +975,7 @@ public class UploadSchemaServiceTest {
 
         // Validate we set key parameters when passing the schema to the DAO, including study ID, schema ID, and rev.
         UploadSchema daoInputSchema = daoInputSchemaCaptor.getValue();
-        assertEquals(daoInputSchema.getStudyId(), TEST_APP_ID);
+        assertEquals(daoInputSchema.getAppId(), TEST_APP_ID);
         assertEquals(daoInputSchema.getSchemaId(), SCHEMA_ID);
         assertEquals(daoInputSchema.getRevision(), SCHEMA_REV);
 

--- a/src/test/java/org/sagebionetworks/bridge/services/UploadSchemaServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/UploadSchemaServiceTest.java
@@ -504,7 +504,7 @@ public class UploadSchemaServiceTest {
         when(dao.getAllUploadSchemasAllRevisions(TEST_APP_ID, false)).thenReturn(daoOutputSchemaList);
 
         // execute and validate
-        List<UploadSchema> svcOutputSchemaList = svc.getUploadSchemasForStudy(TEST_APP_ID, false);
+        List<UploadSchema> svcOutputSchemaList = svc.getUploadSchemasForApp(TEST_APP_ID, false);
         assertEquals(svcOutputSchemaList.size(), 2);
 
         // List might be in any order, so convert it to a map.

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/UploadSchemaControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/UploadSchemaControllerTest.java
@@ -209,7 +209,7 @@ public class UploadSchemaControllerTest extends Mockito {
 
         // Unlike the other methods, this also returns study ID
         assertEquals(result.getSchemaId(), TEST_SCHEMA_ID);
-        assertEquals(result.getStudyId(), TEST_APP_ID);
+        assertEquals(result.getAppId(), TEST_APP_ID);
     }
 
     @Test
@@ -232,7 +232,7 @@ public class UploadSchemaControllerTest extends Mockito {
 
         UploadSchema resultSchema = BridgeObjectMapper.get().treeToValue(itemListNode.get(0), UploadSchema.class);
         assertEquals(resultSchema.getSchemaId(), TEST_SCHEMA_ID);
-        assertNull(resultSchema.getStudyId());
+        assertNull(resultSchema.getAppId());
     }
 
     @Test
@@ -278,17 +278,17 @@ public class UploadSchemaControllerTest extends Mockito {
         UploadSchema returnedSchema3 = BridgeObjectMapper.get().treeToValue(itemsNode.get(0), UploadSchema.class);
         assertEquals(returnedSchema3.getRevision(), 3);
         assertEquals(returnedSchema3.getSchemaId(), TEST_SCHEMA_ID);
-        assertNull(returnedSchema3.getStudyId());
+        assertNull(returnedSchema3.getAppId());
 
         UploadSchema returnedSchema2 = BridgeObjectMapper.get().treeToValue(itemsNode.get(1), UploadSchema.class);
         assertEquals(returnedSchema2.getRevision(), 2);
         assertEquals(returnedSchema2.getSchemaId(), TEST_SCHEMA_ID);
-        assertNull(returnedSchema2.getStudyId());
+        assertNull(returnedSchema2.getAppId());
 
         UploadSchema returnedSchema1 = BridgeObjectMapper.get().treeToValue(itemsNode.get(2), UploadSchema.class);
         assertEquals(returnedSchema1.getRevision(), 1);
         assertEquals(returnedSchema1.getSchemaId(), TEST_SCHEMA_ID);
-        assertNull(returnedSchema1.getStudyId());
+        assertNull(returnedSchema1.getAppId());
     }
 
     @Test
@@ -398,7 +398,7 @@ public class UploadSchemaControllerTest extends Mockito {
         // Also, (most) method results don't include study ID
         UploadSchema schema = BridgeObjectMapper.get().readValue(result, UploadSchema.class);
         assertEquals(schema.getSchemaId(), TEST_SCHEMA_ID);
-        assertNull(schema.getStudyId());
+        assertNull(schema.getAppId());
     }
 
     private static void assertSchemaInArgCaptor(ArgumentCaptor<UploadSchema> argCaptor) {

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/UploadSchemaControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/UploadSchemaControllerTest.java
@@ -205,7 +205,7 @@ public class UploadSchemaControllerTest extends Mockito {
 
         // setup, execute, and validate
         UploadSchemaController controller = setupControllerWithService(mockSvc, WORKER);
-        UploadSchema result = controller.getUploadSchemaByStudyAndSchemaAndRev(TEST_APP_ID, TEST_SCHEMA_ID, 1);
+        UploadSchema result = controller.getUploadSchemaByAppAndSchemaAndRev(TEST_APP_ID, TEST_SCHEMA_ID, 1);
 
         // Unlike the other methods, this also returns study ID
         assertEquals(result.getSchemaId(), TEST_SCHEMA_ID);
@@ -216,12 +216,12 @@ public class UploadSchemaControllerTest extends Mockito {
     public void getSchemasForStudyNoDeleted() throws Exception {
         // mock UploadSchemaService
         UploadSchemaService mockSvc = mock(UploadSchemaService.class);
-        when(mockSvc.getUploadSchemasForStudy(TEST_APP_ID, false)).thenReturn(ImmutableList.of(
+        when(mockSvc.getUploadSchemasForApp(TEST_APP_ID, false)).thenReturn(ImmutableList.of(
                 makeUploadSchemaForOutput()));
 
         // setup, execute, and validate
         UploadSchemaController controller = setupControllerWithService(mockSvc, DEVELOPER, RESEARCHER);
-        String result = controller.getUploadSchemasForStudy(false);
+        String result = controller.getUploadSchemasForApp(false);
 
         JsonNode resultNode = BridgeObjectMapper.get().readTree(result);
         assertEquals(resultNode.get("type").textValue(), "ResourceList");
@@ -239,14 +239,14 @@ public class UploadSchemaControllerTest extends Mockito {
     public void getSchemasForStudyIncludeDeleted() throws Exception {
         // mock UploadSchemaService
         UploadSchemaService mockSvc = mock(UploadSchemaService.class);
-        when(mockSvc.getUploadSchemasForStudy(TEST_APP_ID, true))
+        when(mockSvc.getUploadSchemasForApp(TEST_APP_ID, true))
                 .thenReturn(ImmutableList.of(makeUploadSchemaForOutput()));
 
         // setup, execute, and validate
         UploadSchemaController controller = setupControllerWithService(mockSvc, DEVELOPER, RESEARCHER);
-        controller.getUploadSchemasForStudy(true);
+        controller.getUploadSchemasForApp(true);
         
-        verify(mockSvc).getUploadSchemasForStudy(TEST_APP_ID, true);
+        verify(mockSvc).getUploadSchemasForApp(TEST_APP_ID, true);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2Test.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/IosSchemaValidationHandler2Test.java
@@ -85,7 +85,7 @@ public class IosSchemaValidationHandler2Test {
         // To test backwards compatibility, survey schema should include both the old style fields and the new
         // "answers" field.
         UploadSchema surveySchema = UploadSchema.create();
-        surveySchema.setStudyId(TEST_STUDY_ID);
+        surveySchema.setAppId(TEST_STUDY_ID);
         surveySchema.setSchemaId("test-survey");
         surveySchema.setRevision(1);
         surveySchema.setName("iOS Survey");
@@ -121,7 +121,7 @@ public class IosSchemaValidationHandler2Test {
                         .withType(UploadFieldType.ATTACHMENT_JSON_BLOB).build()));
 
         UploadSchema nonSurveySchema = UploadSchema.create();
-        nonSurveySchema.setStudyId(TEST_STUDY_ID);
+        nonSurveySchema.setAppId(TEST_STUDY_ID);
         nonSurveySchema.setSchemaId("non-survey");
         nonSurveySchema.setRevision(1);
         nonSurveySchema.setName("Non-Survey");

--- a/src/test/java/org/sagebionetworks/bridge/upload/UploadHandlersEndToEndTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/upload/UploadHandlersEndToEndTest.java
@@ -368,7 +368,7 @@ public class UploadHandlersEndToEndTest {
         schema.setRevision(SURVEY_SCHEMA_REV);
         schema.setSchemaId(SURVEY_ID);
         schema.setSchemaType(UploadSchemaType.IOS_SURVEY);
-        schema.setStudyId(TEST_APP_ID);
+        schema.setAppId(TEST_APP_ID);
         schema.setSurveyGuid(SURVEY_GUID);
         schema.setSurveyCreatedOn(SURVEY_CREATED_ON_MILLIS);
 
@@ -559,7 +559,7 @@ public class UploadHandlersEndToEndTest {
         schema.setRevision(SCHEMA_REV);
         schema.setSchemaId(SCHEMA_ID);
         schema.setSchemaType(UploadSchemaType.IOS_DATA);
-        schema.setStudyId(TEST_APP_ID);
+        schema.setAppId(TEST_APP_ID);
 
         // set up upload files
         String cccTxtContent = "Blob file";

--- a/src/test/java/org/sagebionetworks/bridge/validators/UploadSchemaValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/UploadSchemaValidatorTest.java
@@ -70,7 +70,7 @@ public class UploadSchemaValidatorTest {
         schema.setName("happy schema 2");
         schema.setRevision(1);
         schema.setSchemaId("happy-schema-2");
-        schema.setStudyId("test-study");
+        schema.setAppId("test-study");
         schema.setSchemaType(UploadSchemaType.IOS_SURVEY);
 
         // test field def list
@@ -197,21 +197,21 @@ public class UploadSchemaValidatorTest {
     @Test(expectedExceptions = InvalidEntityException.class)
     public void validateNullStudyId() {
         UploadSchema schema = makeValidSchema();
-        schema.setStudyId(null);
+        schema.setAppId(null);
         Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
     }
 
     @Test(expectedExceptions = InvalidEntityException.class)
     public void validateEmptyStudyId() {
         UploadSchema schema = makeValidSchema();
-        schema.setStudyId("");
+        schema.setAppId("");
         Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
     }
 
     @Test(expectedExceptions = InvalidEntityException.class)
     public void validateBlankStudyId() {
         UploadSchema schema = makeValidSchema();
-        schema.setStudyId("   ");
+        schema.setAppId("   ");
         Validate.entityThrowingException(UploadSchemaValidator.INSTANCE, schema);
     }
 
@@ -291,7 +291,7 @@ public class UploadSchemaValidatorTest {
         schema.setName("valid schema");
         schema.setRevision(1);
         schema.setSchemaId("valid-schema");
-        schema.setStudyId(TEST_APP_ID);
+        schema.setAppId(TEST_APP_ID);
         schema.setSchemaType(UploadSchemaType.IOS_DATA);
         return schema;
     }


### PR DESCRIPTION
This has visible changes that will be added to the SDK:
- UploadSchema in worker APIs will have an appId and a studyId
- UploadSchemaController.getUploadSchemaByAppAndSchemaAndRev() now has an additional /v1/apps route