### PR TITLE
Compound activity definitions refactored.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/crypto/CmsEncryptorCacheLoader.java
+++ b/src/main/java/org/sagebionetworks/bridge/crypto/CmsEncryptorCacheLoader.java
@@ -38,8 +38,8 @@ public class CmsEncryptorCacheLoader extends CacheLoader<String, CmsEncryptor> {
 
     /** {@inheritDoc} */
     @Override
-    public CmsEncryptor load(@Nonnull String studyId) throws CertificateEncodingException, IOException {
-        String pemFileName = String.format(PEM_FILENAME_FORMAT, studyId);
+    public CmsEncryptor load(@Nonnull String appId) throws CertificateEncodingException, IOException {
+        String pemFileName = String.format(PEM_FILENAME_FORMAT, appId);
 
         // download certificate
         String certPem = s3CmsHelper.readS3FileAsString(CERT_BUCKET, pemFileName);

--- a/src/main/java/org/sagebionetworks/bridge/dao/CompoundActivityDefinitionDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dao/CompoundActivityDefinitionDao.java
@@ -13,10 +13,10 @@ public interface CompoundActivityDefinitionDao {
     void deleteCompoundActivityDefinition(String appId, String taskId);
 
     /** Deletes all compound activity definitions in the specified study. Used when we physically delete a study. */
-    void deleteAllCompoundActivityDefinitionsInStudy(String appId);
+    void deleteAllCompoundActivityDefinitionsInApp(String appId);
 
     /** List all compound activity definitions in a study. */
-    List<CompoundActivityDefinition> getAllCompoundActivityDefinitionsInStudy(String appId);
+    List<CompoundActivityDefinition> getAllCompoundActivityDefinitionsInApp(String appId);
 
     /** Get a compound activity definition by ID. */
     CompoundActivityDefinition getCompoundActivityDefinition(String appId, String taskId);

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoCompoundActivityDefinition.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoCompoundActivityDefinition.java
@@ -23,7 +23,7 @@ import org.sagebionetworks.bridge.models.schedules.SurveyReference;
 @JsonFilter("filter")
 public class DynamoCompoundActivityDefinition implements CompoundActivityDefinition {
     private List<SchemaReference> schemaList = ImmutableList.of();
-    private String studyId;
+    private String appId;
     private List<SurveyReference> surveyList = ImmutableList.of();
     private String taskId;
     private Long version;
@@ -42,18 +42,18 @@ public class DynamoCompoundActivityDefinition implements CompoundActivityDefinit
     }
 
     /** {@inheritDoc} */
-    @DynamoDBHashKey
+    @DynamoDBHashKey(attributeName = "studyId")
     @Override
-    public String getStudyId() {
-        return studyId;
+    public String getAppId() {
+        return appId;
     }
 
-    /** @see #getStudyId */
+    /** @see #getAppId */
     @Override
-    public void setStudyId(String studyId) {
-        this.studyId = studyId;
+    public void setAppId(String appId) {
+        this.appId = appId;
     }
-
+    
     /** {@inheritDoc} */
     @DynamoDBTypeConverted(converter = SurveyReferenceListMarshaller.class)
     @Override

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoCompoundActivityDefinitionDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoCompoundActivityDefinitionDao.java
@@ -48,11 +48,11 @@ public class DynamoCompoundActivityDefinitionDao implements CompoundActivityDefi
 
     /** {@inheritDoc} */
     @Override
-    public void deleteCompoundActivityDefinition(String studyId, String taskId) {
+    public void deleteCompoundActivityDefinition(String appId, String taskId) {
         // For whatever reason, DynamoDBMapper requires you to load the object before you delete it. It seems like you
         // can't use Delete Expressions to make this a single atomic request.
         DynamoCompoundActivityDefinition loadedDef = (DynamoCompoundActivityDefinition) getCompoundActivityDefinition(
-                studyId, taskId);
+                appId, taskId);
 
         // Call DDB to delete.
         try {
@@ -65,9 +65,9 @@ public class DynamoCompoundActivityDefinitionDao implements CompoundActivityDefi
 
     /** {@inheritDoc} */
     @Override
-    public void deleteAllCompoundActivityDefinitionsInStudy(String studyId) {
-        // First, query for all defs in a study.
-        List<DynamoCompoundActivityDefinition> ddbDefList = getAllHelper(studyId);
+    public void deleteAllCompoundActivityDefinitionsInApp(String appId) {
+        // First, query for all defs in a app.
+        List<DynamoCompoundActivityDefinition> ddbDefList = getAllHelper(appId);
 
         // Then, batch delete.
         List<DynamoDBMapper.FailedBatch> failedBatchList = mapper.batchDelete(ddbDefList);
@@ -76,19 +76,19 @@ public class DynamoCompoundActivityDefinitionDao implements CompoundActivityDefi
 
     /** {@inheritDoc} */
     @Override
-    public List<CompoundActivityDefinition> getAllCompoundActivityDefinitionsInStudy(String studyId) {
-        List<DynamoCompoundActivityDefinition> ddbDefList = getAllHelper(studyId);
+    public List<CompoundActivityDefinition> getAllCompoundActivityDefinitionsInApp(String appId) {
+        List<DynamoCompoundActivityDefinition> ddbDefList = getAllHelper(appId);
 
         // because of generics wonkiness, we need to convert this to a list of parent class CompoundActivityDefinition
         return ImmutableList.copyOf(ddbDefList);
     }
 
-    // Helper method for getting all defs in a study. Returns the raw results using a list of the implementation type.
+    // Helper method for getting all defs in a app. Returns the raw results using a list of the implementation type.
     // This enables us to bulk load and batch delete.
-    private List<DynamoCompoundActivityDefinition> getAllHelper(String studyId) {
+    private List<DynamoCompoundActivityDefinition> getAllHelper(String appId) {
         // query expression
         DynamoCompoundActivityDefinition ddbHashKey = new DynamoCompoundActivityDefinition();
-        ddbHashKey.setStudyId(studyId);
+        ddbHashKey.setAppId(appId);
         DynamoDBQueryExpression<DynamoCompoundActivityDefinition> ddbQueryExpr =
                 new DynamoDBQueryExpression<DynamoCompoundActivityDefinition>().withHashKeyValues(ddbHashKey);
 
@@ -100,10 +100,10 @@ public class DynamoCompoundActivityDefinitionDao implements CompoundActivityDefi
 
     /** {@inheritDoc} */
     @Override
-    public CompoundActivityDefinition getCompoundActivityDefinition(String studyId, String taskId) {
+    public CompoundActivityDefinition getCompoundActivityDefinition(String appId, String taskId) {
         // create key object
         DynamoCompoundActivityDefinition ddbDef = new DynamoCompoundActivityDefinition();
-        ddbDef.setStudyId(studyId);
+        ddbDef.setAppId(appId);
         ddbDef.setTaskId(taskId);
 
         // Call DDB mapper. Throw exception if null.
@@ -127,7 +127,7 @@ public class DynamoCompoundActivityDefinitionDao implements CompoundActivityDefi
 
         // Call get() to verify the def exists. This will throw an EntityNotFoundException if it doesn't exist.
         String taskId = compoundActivityDefinition.getTaskId();
-        getCompoundActivityDefinition(compoundActivityDefinition.getStudyId(), taskId);
+        getCompoundActivityDefinition(compoundActivityDefinition.getAppId(), taskId);
 
         // Call DDB mapper to save.
         try {

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules/CompoundActivityDefinition.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules/CompoundActivityDefinition.java
@@ -21,7 +21,7 @@ import org.sagebionetworks.bridge.models.BridgeEntity;
 @JsonDeserialize(as = DynamoCompoundActivityDefinition.class)
 public interface CompoundActivityDefinition extends BridgeEntity {
     ObjectWriter PUBLIC_DEFINITION_WRITER = BridgeObjectMapper.get().writer(new SimpleFilterProvider().addFilter("filter",
-            SimpleBeanPropertyFilter.serializeAllExcept("studyId")));
+            SimpleBeanPropertyFilter.serializeAllExcept("appId")));
 
     /** Convenience method for creating a CompoundActivityDefinition using a concrete implementation. */
     static CompoundActivityDefinition create() {
@@ -42,13 +42,13 @@ public interface CompoundActivityDefinition extends BridgeEntity {
     void setSchemaList(List<SchemaReference> schemaList);
 
     /**
-     * Compound activity definitions (and task identifiers) are namespaced to studies. As such, it's important for a
-     * definition to know its study.
+     * Compound activity definitions (and task identifiers) are namespaced to apps. As such, it's important for a
+     * definition to know its app.
      */
-    String getStudyId();
+    String getAppId();
 
-    /** @see #getStudyId */
-    void setStudyId(String studyId);
+    /** @see #getAppId */
+    void setAppId(String appId);
 
     /** List of surveys in this activity definition. */
     List<SurveyReference> getSurveyList();

--- a/src/main/java/org/sagebionetworks/bridge/services/CompoundActivityDefinitionService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/CompoundActivityDefinitionService.java
@@ -37,10 +37,10 @@ public class CompoundActivityDefinitionService {
     }
 
     /** Creates a compound activity definition. */
-    public CompoundActivityDefinition createCompoundActivityDefinition(String studyId,
+    public CompoundActivityDefinition createCompoundActivityDefinition(String appId,
             CompoundActivityDefinition compoundActivityDefinition) {
-        // Set study to prevent people from creating defs in other studies.
-        compoundActivityDefinition.setStudyId(studyId);
+        // Set app to prevent people from creating defs in other studies.
+        compoundActivityDefinition.setAppId(appId);
 
         // validate def
         Validate.entityThrowingException(CompoundActivityDefinitionValidator.INSTANCE, compoundActivityDefinition);
@@ -50,55 +50,55 @@ public class CompoundActivityDefinitionService {
     }
 
     /** Deletes a compound activity definition. */
-    public void deleteCompoundActivityDefinition(String studyId, String taskId) {
+    public void deleteCompoundActivityDefinition(String appId, String taskId) {
         // validate user input (taskId)
         if (StringUtils.isBlank(taskId)) {
             throw new BadRequestException("taskId must be specified");
         }
-        checkConstraintViolations(studyId, taskId);
+        checkConstraintViolations(appId, taskId);
         
         // call through to dao
-        compoundActivityDefDao.deleteCompoundActivityDefinition(studyId, taskId);
+        compoundActivityDefDao.deleteCompoundActivityDefinition(appId, taskId);
     }
 
-    /** Deletes all compound activity definitions in the specified study. Used when we physically delete a study. */
-    public void deleteAllCompoundActivityDefinitionsInStudy(String studyId) {
-        // no user input - study comes from controller
+    /** Deletes all compound activity definitions in the specified app. Used when we physically delete an app. */
+    public void deleteAllCompoundActivityDefinitionsInApp(String appId) {
+        // no user input - app comes from controller
 
         // call through to dao
-        compoundActivityDefDao.deleteAllCompoundActivityDefinitionsInStudy(studyId);
+        compoundActivityDefDao.deleteAllCompoundActivityDefinitionsInApp(appId);
     }
 
-    /** List all compound activity definitions in a study. */
-    public List<CompoundActivityDefinition> getAllCompoundActivityDefinitionsInStudy(String studyId) {
-        // no user input - study comes from controller
+    /** List all compound activity definitions in an app. */
+    public List<CompoundActivityDefinition> getAllCompoundActivityDefinitionsInApp(String appId) {
+        // no user input - app comes from controller
 
         // call through to dao
-        return compoundActivityDefDao.getAllCompoundActivityDefinitionsInStudy(studyId);
+        return compoundActivityDefDao.getAllCompoundActivityDefinitionsInApp(appId);
     }
 
     /** Get a compound activity definition by ID. */
-    public CompoundActivityDefinition getCompoundActivityDefinition(String studyId, String taskId) {
+    public CompoundActivityDefinition getCompoundActivityDefinition(String appId, String taskId) {
         // validate user input (taskId)
         if (StringUtils.isBlank(taskId)) {
             throw new BadRequestException("taskId must be specified");
         }
 
         // call through to dao
-        return compoundActivityDefDao.getCompoundActivityDefinition(studyId, taskId);
+        return compoundActivityDefDao.getCompoundActivityDefinition(appId, taskId);
     }
 
     /** Update a compound activity definition. */
-    public CompoundActivityDefinition updateCompoundActivityDefinition(String studyId, String taskId,
+    public CompoundActivityDefinition updateCompoundActivityDefinition(String appId, String taskId,
             CompoundActivityDefinition compoundActivityDefinition) {
         // validate user input (taskId)
         if (StringUtils.isBlank(taskId)) {
             throw new BadRequestException("taskId must be specified");
         }
 
-        // Set the studyId and taskId. This prevents people from updating the wrong def or updating a def in another
-        // study.
-        compoundActivityDefinition.setStudyId(studyId);
+        // Set the appId and taskId. This prevents people from updating the wrong def or updating a def in another
+        // app.
+        compoundActivityDefinition.setAppId(appId);
         compoundActivityDefinition.setTaskId(taskId);
 
         // validate def
@@ -108,10 +108,10 @@ public class CompoundActivityDefinitionService {
         return compoundActivityDefDao.updateCompoundActivityDefinition(compoundActivityDefinition);
     }
     
-    private void checkConstraintViolations(String studyId, String taskId) {
+    private void checkConstraintViolations(String appId, String taskId) {
         // You cannot physically delete a compound activity if it is referenced by a logically deleted schedule plan. 
         // It's possible the schedule plan could be restored. All you can do is logically delete the compound activity.
-        List<SchedulePlan> plans = schedulePlanService.getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, studyId, true);
+        List<SchedulePlan> plans = schedulePlanService.getSchedulePlans(ClientInfo.UNKNOWN_CLIENT, appId, true);
         SchedulePlan match = findFirstMatchingPlan(plans, taskId);
         if (match != null) {
             throw new ConstraintViolationException.Builder().withMessage(

--- a/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
@@ -631,7 +631,7 @@ public class StudyService {
 
             // delete study data
             templateService.deleteTemplatesForStudy(existing.getIdentifier());
-            compoundActivityDefinitionService.deleteAllCompoundActivityDefinitionsInStudy(
+            compoundActivityDefinitionService.deleteAllCompoundActivityDefinitionsInApp(
                     existing.getIdentifier());
             subpopService.deleteAllSubpopulations(existing.getIdentifier());
             topicService.deleteAllTopics(existing.getIdentifier());

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/CompoundActivityDefinitionController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/CompoundActivityDefinitionController.java
@@ -58,12 +58,12 @@ public class CompoundActivityDefinitionController extends BaseController {
         return new StatusMessage("Compound activity definition has been deleted.");
     }
 
-    /** List all compound activity definitions in a study. */
+    /** List all compound activity definitions in a app. */
     @GetMapping(path="/v3/compoundactivitydefinitions", produces={APPLICATION_JSON_UTF8_VALUE})
-    public String getAllCompoundActivityDefinitionsInStudy() throws JsonProcessingException, IOException {
+    public String getAllCompoundActivityDefinitionsInApp() throws JsonProcessingException, IOException {
         UserSession session = getAuthenticatedSession(DEVELOPER);
 
-        List<CompoundActivityDefinition> defList = compoundActivityDefService.getAllCompoundActivityDefinitionsInStudy(
+        List<CompoundActivityDefinition> defList = compoundActivityDefService.getAllCompoundActivityDefinitionsInApp(
                 session.getAppId());
         ResourceList<CompoundActivityDefinition> defResourceList = new ResourceList<>(defList);
         return PUBLIC_DEFINITION_WRITER.writeValueAsString(defResourceList);

--- a/src/main/java/org/sagebionetworks/bridge/validators/CompoundActivityDefinitionValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/CompoundActivityDefinitionValidator.java
@@ -21,11 +21,11 @@ public class CompoundActivityDefinitionValidator implements Validator {
 
     /**
      * <p>
-     * Compound activity definition must have a task ID that's in the study's task ID list, and it must have at least
+     * Compound activity definition must have a task ID that's in the app's task ID list, and it must have at least
      * one schema or at least one survey.
      * </p>
      * <p>
-     * Study ID need not be specified, as the DAO will fill this in before saving it to the back-end store.
+     * App ID need not be specified, as the DAO will fill this in before saving it to the back-end store.
      * </p>
      */
     @Override
@@ -37,9 +37,9 @@ public class CompoundActivityDefinitionValidator implements Validator {
         } else {
             CompoundActivityDefinition compoundActivityDef = (CompoundActivityDefinition) target;
 
-            // studyId must be specified
-            if (isBlank(compoundActivityDef.getStudyId())) {
-                errors.rejectValue("studyId", "must be specified");
+            // appId must be specified
+            if (isBlank(compoundActivityDef.getAppId())) {
+                errors.rejectValue("appId", "must be specified");
             }
 
             // taskIdentifier must be specified and must be in the Study's list

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoCompoundActivityDefinitionDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoCompoundActivityDefinitionDaoTest.java
@@ -34,13 +34,13 @@ public class DynamoCompoundActivityDefinitionDaoTest extends Mockito {
     
     static DynamoCompoundActivityDefinition KEYS = new DynamoCompoundActivityDefinition();
     static {
-        KEYS.setStudyId(TEST_APP_ID);
+        KEYS.setAppId(TEST_APP_ID);
         KEYS.setTaskId(TASK_ID);
     }
     
     static DynamoCompoundActivityDefinition COMPOUND_ACTIVITY_DEF = new DynamoCompoundActivityDefinition();
     static {
-        COMPOUND_ACTIVITY_DEF.setStudyId(TEST_APP_ID);
+        COMPOUND_ACTIVITY_DEF.setAppId(TEST_APP_ID);
         COMPOUND_ACTIVITY_DEF.setTaskId(TASK_ID);
     }
     
@@ -70,7 +70,7 @@ public class DynamoCompoundActivityDefinitionDaoTest extends Mockito {
     @Test
     public void createCompoundActivityDefinition() {
         DynamoCompoundActivityDefinition def = new DynamoCompoundActivityDefinition();
-        def.setStudyId(TEST_APP_ID);
+        def.setAppId(TEST_APP_ID);
         def.setTaskId(TASK_ID);
         def.setVersion(1L);
         
@@ -105,17 +105,17 @@ public class DynamoCompoundActivityDefinitionDaoTest extends Mockito {
     }
 
     @Test
-    public void deleteAllCompoundActivityDefinitionsInStudy() {
+    public void deleteAllCompoundActivityDefinitionsInApp() {
         when(mockMapper.query(eq(DynamoCompoundActivityDefinition.class),
                 queryCaptor.capture())).thenReturn(mockQueryList);
         
-        dao.deleteAllCompoundActivityDefinitionsInStudy(TEST_APP_ID);
+        dao.deleteAllCompoundActivityDefinitionsInApp(TEST_APP_ID);
         
         verify(mockMapper).batchDelete(mockQueryList);
     }
 
     @Test(expectedExceptions = BridgeServiceException.class)
-    public void deleteAllCompoundActivityDefinitionsInStudyWithErrors() {
+    public void deleteAllCompoundActivityDefinitionsInAppWithErrors() {
         when(mockMapper.query(eq(DynamoCompoundActivityDefinition.class),
                 queryCaptor.capture())).thenReturn(mockQueryList);
         
@@ -130,24 +130,24 @@ public class DynamoCompoundActivityDefinitionDaoTest extends Mockito {
         when(mockFailedBatchList.iterator()).thenReturn(ImmutableList.of(failure1, failure2).iterator());
         when(mockMapper.batchDelete(mockQueryList)).thenReturn(mockFailedBatchList);
         
-        dao.deleteAllCompoundActivityDefinitionsInStudy(TEST_APP_ID);
+        dao.deleteAllCompoundActivityDefinitionsInApp(TEST_APP_ID);
         
         verify(mockMapper).batchDelete(mockQueryList);
     }
     
     @Test
-    public void getAllCompoundActivityDefinitionsInStudy() {
+    public void getAllCompoundActivityDefinitionsInApp() {
         List<DynamoCompoundActivityDefinition> defList = ImmutableList.of(
                 new DynamoCompoundActivityDefinition(),
                 new DynamoCompoundActivityDefinition());
         when(mockQueryList.toArray()).thenReturn(defList.toArray());
         when(mockMapper.query(eq(DynamoCompoundActivityDefinition.class), any())).thenReturn(mockQueryList);
         
-        List<CompoundActivityDefinition> results = dao.getAllCompoundActivityDefinitionsInStudy(TEST_APP_ID);
+        List<CompoundActivityDefinition> results = dao.getAllCompoundActivityDefinitionsInApp(TEST_APP_ID);
         assertEquals(results.size(), 2);
         
         verify(mockMapper).query(any(), queryCaptor.capture());
-        assertEquals(queryCaptor.getValue().getHashKeyValues().getStudyId(), TEST_APP_ID);
+        assertEquals(queryCaptor.getValue().getHashKeyValues().getAppId(), TEST_APP_ID);
     }
 
     @Test
@@ -159,7 +159,7 @@ public class DynamoCompoundActivityDefinitionDaoTest extends Mockito {
         
         verify(mockMapper).load(defCaptor.capture());
         CompoundActivityDefinition def = defCaptor.getValue();
-        assertEquals(def.getStudyId(), TEST_APP_ID);
+        assertEquals(def.getAppId(), TEST_APP_ID);
         assertEquals(def.getTaskId(), TASK_ID);
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoCompoundActivityDefinitionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoCompoundActivityDefinitionTest.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -86,9 +85,9 @@ public class DynamoCompoundActivityDefinitionTest {
     public void serialize() throws Exception {
         // Use schema and survey refs so this test doesn't depend on those implementations.
 
-        // start with JSON
+        // start with JSON. The appId is added in the controller and does not need to be
+        // part of the serialization test.
         String jsonText = "{\n" +
-                "   \"studyId\":\""+TEST_APP_ID+"\",\n" +
                 "   \"taskId\":\"test-task\",\n" +
                 "   \"schemaList\":[\n" +
                 BridgeObjectMapper.get().writeValueAsString(FOO_SCHEMA) + ",\n" +
@@ -104,7 +103,6 @@ public class DynamoCompoundActivityDefinitionTest {
         // convert to POJO - deserialize it as the base type, so we know it works with the base type
         DynamoCompoundActivityDefinition def = (DynamoCompoundActivityDefinition) BridgeObjectMapper.get().readValue(
                 jsonText, CompoundActivityDefinition.class);
-        assertEquals(def.getStudyId(), TEST_APP_ID);
         assertEquals(def.getTaskId(), "test-task");
         assertEquals(def.getVersion().longValue(), 42);
 
@@ -120,8 +118,7 @@ public class DynamoCompoundActivityDefinitionTest {
 
         // convert back to JSON
         JsonNode jsonNode = BridgeObjectMapper.get().convertValue(def, JsonNode.class);
-        assertEquals(jsonNode.size(), 6);
-        assertEquals(jsonNode.get("studyId").textValue(), TEST_APP_ID);
+        assertEquals(jsonNode.size(), 5);
         assertEquals(jsonNode.get("taskId").textValue(), "test-task");
         assertEquals(jsonNode.get("version").intValue(), 42);
         assertEquals(jsonNode.get("type").textValue(), "CompoundActivityDefinition");

--- a/src/test/java/org/sagebionetworks/bridge/services/CompoundActivityDefinitionServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/CompoundActivityDefinitionServiceTest.java
@@ -69,7 +69,7 @@ public class CompoundActivityDefinitionServiceTest {
         // validate dao input - It's the same as the service input, but we also set the study ID.
         CompoundActivityDefinition daoInput = daoInputCaptor.getValue();
         assertSame(serviceInput, daoInput);
-        assertEquals(daoInput.getStudyId(), TEST_APP_ID);
+        assertEquals(daoInput.getAppId(), TEST_APP_ID);
 
         // Validate that the service result is the same as the dao result.
         assertSame(serviceResult, daoResult);
@@ -162,10 +162,10 @@ public class CompoundActivityDefinitionServiceTest {
     @Test
     public void deleteAll() {
         // execute
-        service.deleteAllCompoundActivityDefinitionsInStudy(TEST_APP_ID);
+        service.deleteAllCompoundActivityDefinitionsInApp(TEST_APP_ID);
 
         // verify dao
-        verify(dao).deleteAllCompoundActivityDefinitionsInStudy(TEST_APP_ID);
+        verify(dao).deleteAllCompoundActivityDefinitionsInApp(TEST_APP_ID);
     }
 
     // LIST
@@ -174,10 +174,10 @@ public class CompoundActivityDefinitionServiceTest {
     public void list() {
         // mock dao
         List<CompoundActivityDefinition> daoResultList = ImmutableList.of(makeValidDef());
-        when(dao.getAllCompoundActivityDefinitionsInStudy(TEST_APP_ID)).thenReturn(daoResultList);
+        when(dao.getAllCompoundActivityDefinitionsInApp(TEST_APP_ID)).thenReturn(daoResultList);
 
         // execute
-        List<CompoundActivityDefinition> serviceResultList = service.getAllCompoundActivityDefinitionsInStudy(
+        List<CompoundActivityDefinition> serviceResultList = service.getAllCompoundActivityDefinitionsInApp(
                 TEST_APP_ID);
 
         // Validate that the service result is the same as the dao result.
@@ -246,7 +246,7 @@ public class CompoundActivityDefinitionServiceTest {
         // validate dao input - It's the same as the service input, but we also set the study ID.
         CompoundActivityDefinition daoInput = daoInputCaptor.getValue();
         assertSame(daoInput, serviceInput);
-        assertEquals(daoInput.getStudyId(), TEST_APP_ID);
+        assertEquals(daoInput.getAppId(), TEST_APP_ID);
         assertEquals(daoInput.getTaskId(), TASK_ID);
 
         // Validate that the service result is the same as the dao result.

--- a/src/test/java/org/sagebionetworks/bridge/services/ScheduledActivityServiceResolveLinksTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ScheduledActivityServiceResolveLinksTest.java
@@ -70,7 +70,7 @@ public class ScheduledActivityServiceResolveLinksTest {
         // Mock compound activity definition service. This compound activity contains a schema ref with an unresolved
         // revision, and a survey reference with no createdOn (published survey).
         CompoundActivityDefinition compoundActivityDefinition = CompoundActivityDefinition.create();
-        compoundActivityDefinition.setStudyId(TEST_APP_ID);
+        compoundActivityDefinition.setAppId(TEST_APP_ID);
         compoundActivityDefinition.setTaskId(COMPOUND_ACTIVITY_REF_TASK_ID);
         compoundActivityDefinition.setSchemaList(ImmutableList.of(new SchemaReference(SCHEMA_ID, null)));
         compoundActivityDefinition.setSurveyList(ImmutableList.of(new SurveyReference(SURVEY_ID, SURVEY_GUID, null)));

--- a/src/test/java/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/StudyServiceMockTest.java
@@ -707,7 +707,7 @@ public class StudyServiceMockTest extends Mockito {
 
         // verify we called the correct dependent services
         verify(mockStudyDao).deleteStudy(study);
-        verify(mockCompoundActivityDefinitionService).deleteAllCompoundActivityDefinitionsInStudy(
+        verify(mockCompoundActivityDefinitionService).deleteAllCompoundActivityDefinitionsInApp(
                 study.getIdentifier());
         verify(mockSubpopService).deleteAllSubpopulations(study.getIdentifier());
         verify(mockTopicService).deleteAllTopics(study.getIdentifier());
@@ -1626,7 +1626,7 @@ public class StudyServiceMockTest extends Mockito {
 
         verify(mockStudyDao).deleteStudy(updatedStudy);
         verify(mockCompoundActivityDefinitionService)
-                .deleteAllCompoundActivityDefinitionsInStudy(updatedStudy.getIdentifier());
+                .deleteAllCompoundActivityDefinitionsInApp(updatedStudy.getIdentifier());
         verify(mockSubpopService).deleteAllSubpopulations(updatedStudy.getIdentifier());
         verify(mockTopicService).deleteAllTopics(updatedStudy.getIdentifier());
     }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/CompoundActivityDefinitionControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/CompoundActivityDefinitionControllerTest.java
@@ -70,7 +70,7 @@ public class CompoundActivityDefinitionControllerTest extends Mockito {
         assertCrossOrigin(CompoundActivityDefinitionController.class);
         assertCreate(CompoundActivityDefinitionController.class, "createCompoundActivityDefinition");
         assertDelete(CompoundActivityDefinitionController.class, "deleteCompoundActivityDefinition");
-        assertGet(CompoundActivityDefinitionController.class, "getAllCompoundActivityDefinitionsInStudy");
+        assertGet(CompoundActivityDefinitionController.class, "getAllCompoundActivityDefinitionsInApp");
         assertGet(CompoundActivityDefinitionController.class, "getCompoundActivityDefinition");
         assertPost(CompoundActivityDefinitionController.class, "updateCompoundActivityDefinition");
     }
@@ -84,10 +84,10 @@ public class CompoundActivityDefinitionControllerTest extends Mockito {
         // Set it as the mock JSON input.
         mockRequestBody(mockRequest, controllerInput);
 
-        // mock service - Service output should have both task ID and study ID so we can test that study ID is filtered
+        // mock service - Service output should have both task ID and app ID so we can test that app ID is filtered
         // out
         CompoundActivityDefinition serviceOutput = CompoundActivityDefinition.create();
-        serviceOutput.setStudyId(TEST_APP_ID);
+        serviceOutput.setAppId(TEST_APP_ID);
         serviceOutput.setTaskId(TASK_ID);
 
         ArgumentCaptor<CompoundActivityDefinition> serviceInputCaptor = ArgumentCaptor.forClass(
@@ -99,7 +99,7 @@ public class CompoundActivityDefinitionControllerTest extends Mockito {
         String result = controller.createCompoundActivityDefinition();
         CompoundActivityDefinition controllerOutput = getDefFromResult(result);
         assertEquals(controllerOutput.getTaskId(), TASK_ID);
-        assertNull(controllerOutput.getStudyId());
+        assertNull(controllerOutput.getAppId());
 
         // validate service input
         CompoundActivityDefinition serviceInput = serviceInputCaptor.getValue();
@@ -125,14 +125,14 @@ public class CompoundActivityDefinitionControllerTest extends Mockito {
     public void list() throws Exception {
         // mock service
         CompoundActivityDefinition serviceOutput = CompoundActivityDefinition.create();
-        serviceOutput.setStudyId(TEST_APP_ID);
+        serviceOutput.setAppId(TEST_APP_ID);
         serviceOutput.setTaskId(TASK_ID);
 
-        when(defService.getAllCompoundActivityDefinitionsInStudy(TEST_APP_ID)).thenReturn(
+        when(defService.getAllCompoundActivityDefinitionsInApp(TEST_APP_ID)).thenReturn(
                 ImmutableList.of(serviceOutput));
 
         // execute and validate
-        String result = controller.getAllCompoundActivityDefinitionsInStudy();
+        String result = controller.getAllCompoundActivityDefinitionsInApp();
 
         ResourceList<CompoundActivityDefinition> controllerOutputResourceList = BridgeObjectMapper.get().readValue(
                 result, new TypeReference<ResourceList<CompoundActivityDefinition>>() {});
@@ -141,7 +141,7 @@ public class CompoundActivityDefinitionControllerTest extends Mockito {
 
         CompoundActivityDefinition controllerOutput = controllerOutputList.get(0);
         assertEquals(controllerOutput.getTaskId(), TASK_ID);
-        assertNull(controllerOutput.getStudyId());
+        assertNull(controllerOutput.getAppId());
         verify(controller).getAuthenticatedSession(Roles.DEVELOPER);
         verifyZeroInteractions(studyService);
     }
@@ -150,7 +150,7 @@ public class CompoundActivityDefinitionControllerTest extends Mockito {
     public void get() throws Exception {
         // mock service
         CompoundActivityDefinition serviceOutput = CompoundActivityDefinition.create();
-        serviceOutput.setStudyId(TEST_APP_ID);
+        serviceOutput.setAppId(TEST_APP_ID);
         serviceOutput.setTaskId(TASK_ID);
 
         when(defService.getCompoundActivityDefinition(TEST_APP_ID, TASK_ID)).thenReturn(serviceOutput);
@@ -159,7 +159,7 @@ public class CompoundActivityDefinitionControllerTest extends Mockito {
         String result = controller.getCompoundActivityDefinition(TASK_ID);
         CompoundActivityDefinition controllerOutput = getDefFromResult(result);
         assertEquals(controllerOutput.getTaskId(), TASK_ID);
-        assertNull(controllerOutput.getStudyId());
+        assertNull(controllerOutput.getAppId());
         verify(controller).getAuthenticatedSession(Roles.DEVELOPER);
         verifyZeroInteractions(studyService);
     }
@@ -175,7 +175,7 @@ public class CompoundActivityDefinitionControllerTest extends Mockito {
 
         // mock service
         CompoundActivityDefinition serviceOutput = CompoundActivityDefinition.create();
-        serviceOutput.setStudyId(TEST_APP_ID);
+        serviceOutput.setAppId(TEST_APP_ID);
         serviceOutput.setTaskId(TASK_ID);
 
         ArgumentCaptor<CompoundActivityDefinition> serviceInputCaptor = ArgumentCaptor.forClass(
@@ -187,7 +187,7 @@ public class CompoundActivityDefinitionControllerTest extends Mockito {
         String result = controller.updateCompoundActivityDefinition(TASK_ID);
         CompoundActivityDefinition controllerOutput = getDefFromResult(result);
         assertEquals(controllerOutput.getTaskId(), TASK_ID);
-        assertNull(controllerOutput.getStudyId());
+        assertNull(controllerOutput.getAppId());
 
         // validate service input
         CompoundActivityDefinition serviceInput = serviceInputCaptor.getValue();

--- a/src/test/java/org/sagebionetworks/bridge/validators/CompoundActivityDefinitionValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/CompoundActivityDefinitionValidatorTest.java
@@ -67,29 +67,29 @@ public class CompoundActivityDefinitionValidatorTest {
     }
 
     @Test
-    public void nullStudyId() {
-        blankStudyId(null);
+    public void nullAppId() {
+        blankAppId(null);
     }
 
     @Test
-    public void emptyStudyId() {
-        blankStudyId("");
+    public void emptyAppId() {
+        blankAppId("");
     }
 
     @Test
-    public void blankStudyId() {
-        blankStudyId("   ");
+    public void blankAppId() {
+        blankAppId("   ");
     }
 
-    private static void blankStudyId(String studyId) {
+    private static void blankAppId(String appId) {
         CompoundActivityDefinition def = makeValidDef();
-        def.setStudyId(studyId);
+        def.setAppId(appId);
 
         try {
             Validate.entityThrowingException(CompoundActivityDefinitionValidator.INSTANCE, def);
             fail("expected exception");
         } catch (InvalidEntityException ex) {
-            assertTrue(ex.getMessage().contains("studyId must be specified"));
+            assertTrue(ex.getMessage().contains("appId must be specified"));
         }
     }
 
@@ -138,7 +138,7 @@ public class CompoundActivityDefinitionValidatorTest {
 
     private static CompoundActivityDefinition makeValidDef() {
         CompoundActivityDefinition def = CompoundActivityDefinition.create();
-        def.setStudyId(TEST_APP_ID);
+        def.setAppId(TEST_APP_ID);
         def.setTaskId(TASK_ID);
         def.setSchemaList(SCHEMA_LIST);
         def.setSurveyList(SURVEY_LIST);


### PR DESCRIPTION
It's worth noting that there is one serialization test where I removed the "studyId" property from the JSON rather than trying to deserialize both studyId and appId. This is because we don't accept the studyId property from the JSON submitted by the caller... we always set this from the caller's session. If we want I can add code to deserialize studyId as well just to be safe.