### PR TITLE
Relax validation of assessment configs

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/AssessmentConfigService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AssessmentConfigService.java
@@ -46,6 +46,10 @@ public class AssessmentConfigService {
         return DateTime.now();
     }
     
+    AssessmentConfigValidator getValidator() {
+        return AssessmentConfigValidator.INSTANCE;
+    }
+    
     public AssessmentConfig getAssessmentConfig(String appId, String guid) {
         checkArgument(isNotBlank(guid));
         
@@ -73,7 +77,7 @@ public class AssessmentConfigService {
         config.setCreatedOn(existing.getCreatedOn());
         config.setModifiedOn(getModifiedOn());
         
-        Validate.entityThrowingException(AssessmentConfigValidator.INSTANCE, config);
+        Validate.entityThrowingException(getValidator(), config);
         
         // This is no longer a copy of a shared assessment because the config has been edited.
         // It also needs to be updated to reflect this.
@@ -103,7 +107,7 @@ public class AssessmentConfigService {
             return existing;
         }
         
-        Validate.entityThrowingException(AssessmentConfigValidator.INSTANCE, existing);
+        Validate.entityThrowingException(getValidator(), existing);
         
         existing.setModifiedOn(getModifiedOn());
         

--- a/src/main/java/org/sagebionetworks/bridge/services/AssessmentConfigService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AssessmentConfigService.java
@@ -42,10 +42,12 @@ public class AssessmentConfigService {
         this.dao = dao;
     }
     
+    // Allow timestamp to be mocked
     DateTime getModifiedOn() {
         return DateTime.now();
     }
     
+    // Allow validator to be mocked
     AssessmentConfigValidator getValidator() {
         return AssessmentConfigValidator.INSTANCE;
     }

--- a/src/test/java/org/sagebionetworks/bridge/TestUtils.java
+++ b/src/test/java/org/sagebionetworks/bridge/TestUtils.java
@@ -317,7 +317,6 @@ public class TestUtils {
             Validate.entityThrowingException(validator, object);
             fail("Should have thrown exception");
         } catch(InvalidEntityException e) {
-            System.out.println(e.getErrors());
             if (e.getErrors().get(fieldName).contains(error)) {
                 return;
             }

--- a/src/test/java/org/sagebionetworks/bridge/TestUtils.java
+++ b/src/test/java/org/sagebionetworks/bridge/TestUtils.java
@@ -317,6 +317,7 @@ public class TestUtils {
             Validate.entityThrowingException(validator, object);
             fail("Should have thrown exception");
         } catch(InvalidEntityException e) {
+            System.out.println(e.getErrors());
             if (e.getErrors().get(fieldName).contains(error)) {
                 return;
             }

--- a/src/test/java/org/sagebionetworks/bridge/models/assessments/config/ConfigVisitorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/assessments/config/ConfigVisitorTest.java
@@ -45,6 +45,16 @@ public class ConfigVisitorTest extends Mockito {
     }
     
     @Test
+    public void testRoot() throws Exception {
+        visitor.accept("", toNode("{}"));
+
+        // this is allowable and the results are correct, so no need to special case it.
+        verify(mockErrors).pushNestedPath("");
+        verify(mockErrors).rejectValue("identifier", "is missing");
+        verify(mockErrors).popNestedPath();
+    }
+    
+    @Test
     public void testPath() throws Exception {
         visitor.accept("foo.bar[1]", toNode("{}"));
             

--- a/src/test/java/org/sagebionetworks/bridge/models/assessments/config/ConfigVisitorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/assessments/config/ConfigVisitorTest.java
@@ -30,28 +30,26 @@ public class ConfigVisitorTest extends Mockito {
     public void beforeMethod() {
         MockitoAnnotations.initMocks(this);
         
+        // For the purpose of this test, we're going to create a validator
+        // that looks for an identifier on any object.
         validators = new HashMap<>();
+        validators.put("*", new AbstractValidator() {
+            public void validate(Object target, Errors errors) {
+                JsonNode node = (JsonNode)target;
+                if (!node.has("identifier")) {
+                    errors.rejectValue("identifier", "is missing");
+                }
+            }
+        });
         visitor = new ConfigVisitor(validators, mockErrors);
     }
     
-    @Test
-    public void testRoot() throws Exception {
-        visitor.accept("", toNode("{}"));
-            
-        // this is allowable and the results are correct, so no need to special case it.
-        verify(mockErrors).pushNestedPath("");
-        verify(mockErrors).rejectValue("identifier", "is missing");
-        verify(mockErrors).rejectValue("type", "is missing");
-        verify(mockErrors).popNestedPath();
-    }
-
     @Test
     public void testPath() throws Exception {
         visitor.accept("foo.bar[1]", toNode("{}"));
             
         verify(mockErrors).pushNestedPath("foo.bar[1]");
         verify(mockErrors).rejectValue("identifier", "is missing");
-        verify(mockErrors).rejectValue("type", "is missing");
         verify(mockErrors).popNestedPath();
     }
     


### PR DESCRIPTION
The configurations are complex and for the moment, we're just going to let client devs save whatever they want. When they are more confident in the format of the configs, we'll revisit this.