### PR TITLE
Better resolution of references in the app configs

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/models/appconfig/ConfigResolver.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/appconfig/ConfigResolver.java
@@ -26,7 +26,7 @@ public class ConfigResolver {
         this.config = BridgeConfigFactory.getConfig();
     }
     
-    /** Constructor to in mock bridge config. */
+    /** Constructor to mock bridge config. */
     public ConfigResolver(BridgeConfig config) {
         this.config = config;
     }

--- a/src/main/java/org/sagebionetworks/bridge/models/assessments/AssessmentReference.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/assessments/AssessmentReference.java
@@ -13,27 +13,27 @@ public final class AssessmentReference {
     
     private final ConfigResolver resolver;
     private final String guid;
-    private final String identifier;
+    private final String id;
     private final String sharedId;
     
     @JsonCreator
     public AssessmentReference(@JsonProperty("guid") String guid,
-            @JsonProperty("identifier") String identifier, @JsonProperty("sharedId") String sharedId) {
-        this(INSTANCE, guid, identifier, sharedId);
+            @JsonProperty("id") String id, @JsonProperty("sharedId") String sharedId) {
+        this(INSTANCE, guid, id, sharedId);
     }
 
-    public AssessmentReference(ConfigResolver resolver, String guid, String identifier, String sharedId) {
+    public AssessmentReference(ConfigResolver resolver, String guid, String id, String sharedId) {
         this.resolver = resolver;
         this.guid = guid;
-        this.identifier = identifier;
+        this.id = id;
         this.sharedId = sharedId;
     }
     
     public String getGuid() {
         return guid;
     }
-    public String getIdentifier() {
-        return identifier;
+    public String getId() {
+        return id;
     }
     public String getConfigHref() {
         if (guid == null) {
@@ -68,7 +68,7 @@ public final class AssessmentReference {
 
     @Override
     public String toString() {
-        return "AssessmentReference [identifier=" + identifier + ", sharedId=" + sharedId + ", guid=" + guid
-                + ", configHref=" + getConfigHref() + "]";
+        return "AssessmentReference [id=" + id + ", sharedId=" + sharedId + ", guid=" + guid + ", configHref="
+                + getConfigHref() + "]";
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoAppConfigTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoAppConfigTest.java
@@ -168,13 +168,13 @@ public class DynamoAppConfigTest {
         assertEquals(node.get("fileReferences").get(1).get("createdOn").textValue(), TIMESTAMP.toString());
         
         assertEquals(node.get("assessmentReferences").size(), 2);
-        assertEquals(node.get("assessmentReferences").get(0).get("identifier").textValue(), "id1");
+        assertEquals(node.get("assessmentReferences").get(0).get("id").textValue(), "id1");
         assertEquals(node.get("assessmentReferences").get(0).get("sharedId").textValue(), "sharedId1");
         assertEquals(node.get("assessmentReferences").get(0).get("guid").textValue(), "guid1");
         assertTrue(node.get("assessmentReferences").get(0).get("configHref").textValue()
                 .contains("/v1/assessments/guid1/config"));
 
-        assertEquals(node.get("assessmentReferences").get(1).get("identifier").textValue(), "id2");
+        assertEquals(node.get("assessmentReferences").get(1).get("id").textValue(), "id2");
         assertEquals(node.get("assessmentReferences").get(1).get("sharedId").textValue(), "sharedId2");
         assertEquals(node.get("assessmentReferences").get(1).get("guid").textValue(), "guid2");
         assertTrue(node.get("assessmentReferences").get(1).get("configHref").textValue()

--- a/src/test/java/org/sagebionetworks/bridge/models/assessments/AssessmentReferenceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/assessments/AssessmentReferenceTest.java
@@ -36,7 +36,7 @@ public class AssessmentReferenceTest extends Mockito {
         // should be globally unique for assessement references and is sufficient for 
         // equality. This makes detecting duplicates easier during validation.
         EqualsVerifier.forClass(AssessmentReference.class)
-            .allFieldsShouldBeUsedExcept("resolver", "identifier", "sharedId").verify();
+            .allFieldsShouldBeUsedExcept("resolver", "id", "sharedId").verify();
     }
 
     @Test
@@ -45,7 +45,7 @@ public class AssessmentReferenceTest extends Mockito {
         AssessmentReference ref = new AssessmentReference(resolver, "oneGuid", "id", "sharedId");
         
         assertEquals(ref.getGuid(), "oneGuid");
-        assertEquals(ref.getIdentifier(), "id");
+        assertEquals(ref.getId(), "id");
         assertEquals(ref.getSharedId(), "sharedId");
         assertEquals(ref.getConfigHref(), 
                 "https://ws-uat.bridge.org/v1/assessments/oneGuid/config");
@@ -57,7 +57,7 @@ public class AssessmentReferenceTest extends Mockito {
         AssessmentReference ref = new AssessmentReference(resolver, "oneGuid", null, null);
         
         assertEquals(ref.getGuid(), "oneGuid");
-        assertNull(ref.getIdentifier());
+        assertNull(ref.getId());
         assertNull(ref.getSharedId());
         assertEquals(ref.getConfigHref(), 
                 "http://ws-local.bridge.org/v1/assessments/oneGuid/config");
@@ -76,7 +76,7 @@ public class AssessmentReferenceTest extends Mockito {
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(ref);
         assertEquals(node.get("guid").textValue(), "oneGuid");
-        assertEquals(node.get("identifier").textValue(), "id");
+        assertEquals(node.get("id").textValue(), "id");
         assertEquals(node.get("sharedId").textValue(), "sharedId");
         assertEquals(node.get("configHref").textValue(), 
             "http://ws-local.bridge.org/v1/assessments/oneGuid/config");


### PR DESCRIPTION
A couple of issues surfaced by the integration tests:

1) There was a mismatch between the client and server on the name of the Assessment id ("id" vs. "Identifier"). "id" seems most common and the least friction, so I changed the server;

2) There were two ways to retrieve a single appConfig and one way resolved references and the other did not. This seems too confusing... it confused me... now both calls resolve all references and tests were updated to verify this.