### PR TITLE
Revert "Remove migration code to move off of studyIdentifier."

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/models/accounts/AccountSummary.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/accounts/AccountSummary.java
@@ -13,6 +13,20 @@ import com.google.common.collect.Iterables;
 @JsonDeserialize(builder = AccountSummary.Builder.class)
 public final class AccountSummary {
     
+    // This is the one class that exposes this object through the API. Because this 
+    // may involve updating some downstream projects like BridgeWorkerPlatform, leave
+    // it until the full refactor to getAppId() is done, then swap out. getStudyId has
+    // been added and will be refactored to getAppId in the next step of migration.
+    public final static class StudyIdentifier {
+        private final String identifier;
+        StudyIdentifier(String identifier) {
+            this.identifier = identifier;
+        }
+        public String getIdentifier() {
+            return identifier;
+        }
+    }
+    
     private final String firstName;
     private final String lastName;
     private final String email;
@@ -90,6 +104,10 @@ public final class AccountSummary {
 
     public AccountStatus getStatus() {
         return status;
+    }
+    
+    public StudyIdentifier getStudyIdentifier() {
+        return new StudyIdentifier(appId);
     }
     
     public String getAppId() { 

--- a/src/test/java/org/sagebionetworks/bridge/cache/CacheProviderMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/cache/CacheProviderMockTest.java
@@ -395,7 +395,7 @@ public class CacheProviderMockTest {
                 "'environment':'local',"+
                 "'sessionToken':'"+DECRYPTED_SESSION_TOKEN+"',"+
                 "'internalSessionToken':'4f0937a5-6ebf-451b-84bc-fbf649b9e93c',"+
-                "'appId':'" + TEST_APP_ID + "',"+
+                "'studyIdentifier':{'identifier':'"+TEST_APP_ID+"', 'type':'StudyIdentifier'},"+
                 "'consentStatuses':{"+
                     "'"+TEST_APP_ID+"':{'name':'Default Consent Group',"+
                         "'subpopulationGuid':'"+TEST_APP_ID+"',"+

--- a/src/test/java/org/sagebionetworks/bridge/cache/CacheProviderStudyMigrationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/cache/CacheProviderStudyMigrationTest.java
@@ -1,0 +1,158 @@
+package org.sagebionetworks.bridge.cache;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.List;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.models.RequestInfo;
+import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.itp.IntentToParticipate;
+import org.sagebionetworks.bridge.models.subpopulations.Subpopulation;
+import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
+import org.sagebionetworks.bridge.redis.JedisOps;
+
+public class CacheProviderStudyMigrationTest extends Mockito {
+    private static final TypeReference<List<Subpopulation>> SURVEY_LIST_REF = new TypeReference<List<Subpopulation>>() {};
+    
+    @Mock
+    JedisOps mockJedisOps;
+    
+    @InjectMocks
+    CacheProvider provider;
+    
+    @BeforeMethod
+    public void beforeMethod() {
+        MockitoAnnotations.initMocks(this);
+        provider.setSessionExpireInSeconds(10);
+    }
+
+    @Test
+    public void requestInfoConvertedWithAppId() throws Exception {
+        String json = TestUtils.createJson("{'userId':'userId','timeZone':'UTC',"+
+                "'appId':'"+TEST_APP_ID+"'}");
+        CacheKey key = CacheKey.requestInfo("userId");
+        when(mockJedisOps.get(key.toString())).thenReturn(json);
+        
+        RequestInfo info = provider.getRequestInfo("userId");
+        
+        assertEquals(info.getAppId(), TEST_APP_ID);
+    }
+
+    @Test
+    public void requestInfoConvertedWithStudyIdentifier() throws Exception {
+        String json = TestUtils.createJson("{'userId':'userId','timeZone':'UTC',"+
+                "'studyIdentifier':'"+TEST_APP_ID+"'}");
+        CacheKey key = CacheKey.requestInfo("userId");
+        when(mockJedisOps.get(key.toString())).thenReturn(json);
+        
+        RequestInfo info = provider.getRequestInfo("userId");
+        
+        assertEquals(info.getAppId(), TEST_APP_ID);
+    }
+    
+    @Test
+    public void userSesssionWithStudyIdentifier() { 
+        String json = TestUtils.createJson(
+                "{'studyIdentifier':'"+TEST_APP_ID+"','sessionToken':'aToken'}");
+
+        doReturn("aUser").when(mockJedisOps).get("aToken:session2");
+        doReturn(json).when(mockJedisOps).get("aUser:session2:user");
+        
+        UserSession session = provider.getUserSession("aToken");
+        assertEquals(session.getAppId(), TEST_APP_ID);
+    }
+    
+    @Test
+    public void userSessionWithAppId() {
+        String json = TestUtils.createJson(
+                "{'appId':'"+TEST_APP_ID+"','sessionToken':'aToken'}");
+
+        doReturn("aUser").when(mockJedisOps).get("aToken:session2");
+        doReturn(json).when(mockJedisOps).get("aUser:session2:user");
+        
+        UserSession session = provider.getUserSession("aToken");
+        assertEquals(session.getAppId(), TEST_APP_ID);
+    }
+    
+    @Test
+    public void intentToParticipanteWithStudyId() throws Exception {
+        String json = TestUtils.createJson("{'studyId':'"+TEST_APP_ID+
+                "','email':'email@email.com','subpopGuid':'subpopGuid',"+
+                "'scope':'all_qualified_researchers',"+
+                "'type':'IntentToParticipate'}");
+        
+        CacheKey key = CacheKey.itp(SubpopulationGuid.create("subpopGuid"), 
+                TEST_APP_ID, "email@email.com");
+        when(mockJedisOps.get(key.toString())).thenReturn(json);
+        
+        IntentToParticipate itp = provider.getObject(key, IntentToParticipate.class);
+        assertEquals(itp.getAppId(), TEST_APP_ID);
+    }
+    
+    @Test
+    public void intentToParticipanteWithAppId() throws Exception {
+        String json = TestUtils.createJson("{'appId':'"+TEST_APP_ID+
+                "','email':'email@email.com','subpopGuid':'subpopGuid',"+
+                "'scope':'all_qualified_researchers',"+
+                "'type':'IntentToParticipate'}");
+        
+        CacheKey key = CacheKey.itp(SubpopulationGuid.create("subpopGuid"), 
+                TEST_APP_ID, "email@email.com");
+        when(mockJedisOps.get(key.toString())).thenReturn(json);
+        
+        IntentToParticipate itp = provider.getObject(key, IntentToParticipate.class);
+        assertEquals(itp.getAppId(), TEST_APP_ID);
+    }
+    
+    @Test
+    public void subpopulationWithStudyIdentifier() throws Exception {
+        String json = TestUtils.createJson("{'studyIdentifier':'"+TEST_APP_ID+"','type':'Subpopulation'}");
+        CacheKey key = CacheKey.subpop(SubpopulationGuid.create("subpopGuid"), TEST_APP_ID);
+        when(mockJedisOps.get(key.toString())).thenReturn(json);
+        
+        Subpopulation subpop = provider.getObject(key, Subpopulation.class);
+        assertEquals(subpop.getAppId(), TEST_APP_ID);
+    }
+    
+    @Test
+    public void subpopulationWithAppId() throws Exception {
+        String json = TestUtils.createJson("{'appId':'"+TEST_APP_ID+"','type':'Subpopulation'}");
+        CacheKey key = CacheKey.subpop(SubpopulationGuid.create("subpopGuid"), TEST_APP_ID);
+        when(mockJedisOps.get(key.toString())).thenReturn(json);
+        
+        Subpopulation subpop = provider.getObject(key, Subpopulation.class);
+        assertEquals(subpop.getAppId(), TEST_APP_ID);
+    }
+    
+    @Test
+    public void subpopulationListWithStudyId() {
+        String json = TestUtils.createJson("[{'studyIdentifier':'"+TEST_APP_ID+"','type':'Subpopulation'}]");
+        CacheKey key = CacheKey.subpopList(TEST_APP_ID);
+        when(mockJedisOps.get(key.toString())).thenReturn(json);
+        
+        List<Subpopulation> subpops = provider.getObject(key, SURVEY_LIST_REF);
+        assertEquals(subpops.get(0).getAppId(), TEST_APP_ID);
+    }
+    
+    @Test
+    public void subpopulationListWithAppId() {
+        String json = TestUtils.createJson("[{'appId':'"+TEST_APP_ID+"','type':'Subpopulation'}]");
+        CacheKey key = CacheKey.subpopList(TEST_APP_ID);
+        when(mockJedisOps.get(key.toString())).thenReturn(json);
+        
+        List<Subpopulation> subpops = provider.getObject(key, SURVEY_LIST_REF);
+        assertEquals(subpops.get(0).getAppId(), TEST_APP_ID);
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/AccountSummaryTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/AccountSummaryTest.java
@@ -42,6 +42,8 @@ public class AccountSummaryTest {
         assertEquals(node.get("createdOn").textValue(), TIMESTAMP.toString());
         assertEquals(node.get("status").textValue(), "disabled");
         assertEquals(node.get("appId").textValue(), TEST_APP_ID);
+        assertEquals(node.get("studyIdentifier").get("identifier").textValue(), TEST_APP_ID);
+        assertEquals(node.get("studyIdentifier").get("type").textValue(), "StudyIdentifier");
         assertEquals(node.get("substudyIds").get(0).textValue(), "substudy1");
         assertEquals(node.get("substudyIds").get(1).textValue(), "substudy2");
         assertEquals(node.get("externalId").textValue(), "externalId1");

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/SubpopulationControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/SubpopulationControllerTest.java
@@ -118,6 +118,7 @@ public class SubpopulationControllerTest extends Mockito {
         JsonNode node = BridgeObjectMapper.get().readTree(result);
         JsonNode oneSubpop = node.get("items").get(0);
         assertNull(oneSubpop.get("appId"));
+        assertNull(oneSubpop.get("studyIdentifier"));
 
         ResourceList<Subpopulation> rList = BridgeObjectMapper.get().readValue(result, SUBPOP_TYPE_REF);
         assertEquals(rList.getItems(), list);


### PR DESCRIPTION
Reverts Sage-Bionetworks/BridgeServer2#211. We have objects stored long-term in Redis that require this code to deserialize correctly (RequestInfo objects).