### PR TITLE
Enhancements to account searches.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -1,3 +1,4 @@
+
 package org.sagebionetworks.bridge.hibernate;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -153,12 +154,11 @@ public class HibernateAccountDao implements AccountDao {
             if (search.getEndTime() != null) {
                 builder.append("AND acct.createdOn <= :endTime", "endTime", search.getEndTime());
             }
-            if (search.getOrgMembership() != null) {
-                builder.append("AND acct.orgMembership = :orgId", "orgId", search.getOrgMembership());
-            }
             if (search.getLanguage() != null) {
                 builder.append("AND :language IN ELEMENTS(acct.languages)", "language", search.getLanguage());
             }
+            builder.adminOnly(search.isAdminOnly());
+            builder.orgMembership(search.getOrgMembership());
             builder.dataGroups(search.getAllOfGroups(), "IN");
             builder.dataGroups(search.getNoneOfGroups(), "NOT IN");
         }

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/QueryBuilder.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/QueryBuilder.java
@@ -42,6 +42,25 @@ class QueryBuilder {
             phrases.add("AND (" + Joiner.on(" AND ").join(clauses) + ")");
         }
     }
+    public void adminOnly(Boolean isAdmin) {
+        if (isAdmin != null) {
+            if (isAdmin.booleanValue()) {
+                phrases.add("AND size(acct.roles) > 0");
+            } else {
+                phrases.add("AND size(acct.roles) = 0");
+            }
+        }
+    }
+    public void orgMembership(String orgMembership) {
+        if (orgMembership != null) {
+            if ("<none>".equals(orgMembership.toLowerCase())) {
+                phrases.add("AND acct.orgMembership IS NULL");
+            } else {
+                append("AND acct.orgMembership = :orgId", "orgId", orgMembership);
+            }
+        }
+    }
+    
     public String getQuery() {
         return BridgeUtils.SPACE_JOINER.join(phrases);
     }

--- a/src/main/java/org/sagebionetworks/bridge/models/AccountSummarySearch.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/AccountSummarySearch.java
@@ -27,10 +27,11 @@ public final class AccountSummarySearch implements BridgeEntity {
     private final DateTime startTime;
     private final DateTime endTime;
     private final String orgMembership;
+    private final Boolean adminOnly;
 
     private AccountSummarySearch(int offsetBy, int pageSize, String emailFilter, String phoneFilter,
             Set<String> allOfGroups, Set<String> noneOfGroups, String language, DateTime startTime, DateTime endTime,
-            String orgId) {
+            String orgId, Boolean adminOnly) {
         this.offsetBy = offsetBy;
         this.pageSize = pageSize;
         this.emailFilter = emailFilter;
@@ -41,6 +42,7 @@ public final class AccountSummarySearch implements BridgeEntity {
         this.startTime = startTime;
         this.endTime = endTime;
         this.orgMembership = orgId;
+        this.adminOnly = adminOnly;
     }
 
     public int getOffsetBy() {
@@ -72,8 +74,25 @@ public final class AccountSummarySearch implements BridgeEntity {
     public DateTime getEndTime() {
         return endTime;
     }
+    /**
+     * If no organizational ID is supplied, all accounts will be returned. If an ID is 
+     * supplied, only accounts assigned to that organization are returned. If the 
+     * keyword value "<none>" is supplied, only accounts are returned that are NOT 
+     * assigned to any organization. adminOnly=true and orgMembership=<none> will return
+     * admin accounts that still need to be assigned to an organization (a useful 
+     * query for user interfaces). 
+     */
     public String getOrgMembership() {
         return orgMembership;
+    }
+    /**
+     * Administrative accounts are accounts with any roles that allow them to operate 
+     * against our administrative APIs (not participant-facing, and not requiring consent). 
+     * When null, the search returns all accounts. When true, returns accounts with at 
+     * least one assigned role. When false, returns accounts with no administrative roles.  
+     */
+    public Boolean isAdminOnly() {
+        return adminOnly;
     }
 
     @Override
@@ -83,7 +102,7 @@ public final class AccountSummarySearch implements BridgeEntity {
         // versus ISOChronology[-07:00] if that's the offset at the time of serialization). Using the ISO String
         // representation of the DateTime gives us equality across serialization.
         return Objects.hash(allOfGroups, emailFilter, nullsafeDateString(endTime), language, noneOfGroups, offsetBy,
-                pageSize, phoneFilter, nullsafeDateString(startTime), orgMembership);
+                pageSize, phoneFilter, nullsafeDateString(startTime), orgMembership, adminOnly);
     }
 
     @Override
@@ -103,7 +122,8 @@ public final class AccountSummarySearch implements BridgeEntity {
                 && Objects.equals(offsetBy, other.offsetBy) && Objects.equals(pageSize, other.pageSize)
                 && Objects.equals(phoneFilter, other.phoneFilter)
                 && Objects.equals(nullsafeDateString(startTime), nullsafeDateString(other.startTime))
-                && Objects.equals(orgMembership, other.orgMembership);
+                && Objects.equals(orgMembership, other.orgMembership)
+                && Objects.equals(adminOnly, other.adminOnly);
     }
     
     private String nullsafeDateString(DateTime dateTime) {
@@ -115,7 +135,7 @@ public final class AccountSummarySearch implements BridgeEntity {
         return "AccountSummarySearch [offsetBy=" + offsetBy + ", pageSize=" + pageSize + ", emailFilter=" + emailFilter
                 + ", phoneFilter=" + phoneFilter + ", allOfGroups=" + allOfGroups + ", noneOfGroups=" + noneOfGroups
                 + ", language=" + language + ", startTime=" + startTime + ", endTime=" + endTime + ", orgMembership="
-                + orgMembership + "]";
+                + orgMembership + ", adminOnly=" + adminOnly + "]";
     }
     
     public static class Builder {
@@ -129,6 +149,7 @@ public final class AccountSummarySearch implements BridgeEntity {
         private DateTime startTime;
         private DateTime endTime;
         private String orgMembership;
+        private Boolean adminOnly;
         
         public Builder withOffsetBy(Integer offsetBy) {
             this.offsetBy = offsetBy;
@@ -176,6 +197,10 @@ public final class AccountSummarySearch implements BridgeEntity {
             this.orgMembership = orgId;
             return this;
         }
+        public Builder withAdminOnly(Boolean adminOnly) {
+            this.adminOnly = adminOnly;
+            return this;
+        }
         public Builder copyOf(AccountSummarySearch search) {
             this.offsetBy = search.offsetBy;
             this.pageSize = search.pageSize;
@@ -187,13 +212,14 @@ public final class AccountSummarySearch implements BridgeEntity {
             this.startTime = search.startTime;
             this.endTime = search.endTime;
             this.orgMembership = search.orgMembership;
+            this.adminOnly = search.adminOnly;
             return this;
         }
         public AccountSummarySearch build() {
             int defaultedOffsetBy = (offsetBy == null) ? 0 : offsetBy;
             int defaultedPageSize = (pageSize == null) ? API_DEFAULT_PAGE_SIZE : pageSize;
             return new AccountSummarySearch(defaultedOffsetBy, defaultedPageSize, emailFilter, phoneFilter, allOfGroups,
-                    noneOfGroups, language, startTime, endTime, orgMembership);
+                    noneOfGroups, language, startTime, endTime, orgMembership, adminOnly);
         }
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/QueryBuilderTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/QueryBuilderTest.java
@@ -35,4 +35,35 @@ public class QueryBuilderTest {
         assertEquals(builder.getParameters().get("NOTIN1"), "C");
         assertEquals(builder.getParameters().get("NOTIN2"), "D");
     }
+    
+    @Test
+    public void testAdmin() {
+        QueryBuilder builder = new QueryBuilder();
+        builder.adminOnly(null);
+        assertEquals(builder.getQuery(), "");
+        
+        builder = new QueryBuilder();
+        builder.adminOnly(true);
+        assertEquals(builder.getQuery(), "AND size(acct.roles) > 0");
+
+        builder = new QueryBuilder();
+        builder.adminOnly(false);
+        assertEquals(builder.getQuery(), "AND size(acct.roles) = 0");
+    }
+    
+    @Test
+    public void testOrgMembership() {
+        QueryBuilder builder = new QueryBuilder();
+        builder.orgMembership(null);
+        assertEquals(builder.getQuery(), "");
+        
+        builder = new QueryBuilder();
+        builder.orgMembership("<NONE>");
+        assertEquals(builder.getQuery(), "AND acct.orgMembership IS NULL");
+
+        builder = new QueryBuilder();
+        builder.orgMembership("foo");
+        assertEquals(builder.getQuery(), "AND acct.orgMembership = :orgId");
+        assertEquals(builder.getParameters().get("orgId"), "foo");
+    }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/AccountSummarySearchTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/AccountSummarySearchTest.java
@@ -10,6 +10,7 @@ import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 
 import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -73,7 +74,8 @@ public class AccountSummarySearchTest {
             .withLanguage("en")
             .withStartTime(startTime)
             .withEndTime(endTime)
-            .withOrgMembership(TEST_ORG_ID).build();
+            .withOrgMembership(TEST_ORG_ID)
+            .withAdminOnly(true).build();
         
         String json = BridgeObjectMapper.get().writeValueAsString(search);
         JsonNode node = BridgeObjectMapper.get().readTree(json);
@@ -93,6 +95,7 @@ public class AccountSummarySearchTest {
         assertEquals(deser.getStartTime(), startTime);
         assertEquals(deser.getEndTime(), endTime);
         assertEquals(deser.getOrgMembership(), TEST_ORG_ID);
+        assertTrue(deser.isAdminOnly());
     }
     
     @Test
@@ -110,6 +113,7 @@ public class AccountSummarySearchTest {
             .withLanguage("en")
             .withStartTime(startTime)
             .withEndTime(endTime)
+            .withAdminOnly(false)
             .withOrgMembership(TEST_ORG_ID).build();
 
         AccountSummarySearch copy = new AccountSummarySearch.Builder().copyOf(search).build();
@@ -123,6 +127,7 @@ public class AccountSummarySearchTest {
         assertEquals(copy.getStartTime(), startTime);
         assertEquals(copy.getEndTime(), endTime);
         assertEquals(copy.getOrgMembership(), TEST_ORG_ID);
+        assertEquals(copy.isAdminOnly(), Boolean.FALSE);
     }
     
     @Test


### PR DESCRIPTION
Some search options to retrieve admin accounts (or not admin accounts) and to also allow you to retrieve accounts that are not assigned to any organization (adminOnly=true, orgMemberships=<none> is useful for a UI to select people to add to an organization).