### PR TITLE
Assessment ownership now expressed by association to an organization.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
@@ -1,13 +1,22 @@
 package org.sagebionetworks.bridge;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.sagebionetworks.bridge.BridgeConstants.CALLER_NOT_MEMBER_ERROR;
+import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
+
+import com.google.common.collect.ImmutableSet;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 
 public class AuthUtils {
+    private static final Logger LOG = LoggerFactory.getLogger(AuthUtils.class);
     
     /**
-     * Unless you are a SUPERADMIN, you can only list the members of your own organization.
+     * Unless you are a superadmin, you can only list the members of your own organization.
      */
     public static boolean checkOrgMembership(String proposedOrgId) {
         RequestContext context = BridgeUtils.getRequestContext();
@@ -20,5 +29,53 @@ public class AuthUtils {
         if (!checkOrgMembership(proposedOrgId)) {
             throw new UnauthorizedException("Caller is not a member of " + proposedOrgId);    
         }
+    }
+    
+    /**
+     * If the caller is an app admin or superadmin, they can set any organization. Otherwise, the 
+     * organization must match the caller's organization. We do not need to validate the org ID since 
+     * it was validated when it was set as an organizational relationship on the account. 
+     */
+    public static void checkAssessmentOwnership(String appId, String ownerId) {
+        RequestContext rc = BridgeUtils.getRequestContext();
+        String callerOrgMembership = rc.getCallerOrgMembership();
+        if (isBlank(ownerId)) {
+            throw new UnauthorizedException(CALLER_NOT_MEMBER_ERROR);
+        }
+        if (rc.isInRole(ImmutableSet.of(SUPERADMIN, ADMIN)) || ownerId.equals(callerOrgMembership)) {
+            return;
+        }
+        throw new UnauthorizedException(CALLER_NOT_MEMBER_ERROR);
+    }
+    
+    /**
+     * The same rules apply as checkOwnership, however you are examining the caller against a compound
+     * value stored in the assessment's originId. The call succeeds if you're a superadmin (ther are 
+     * no shared app admins), or if the caller is in the app and organization that owns the shared 
+     * assessment. 
+     */
+    public static void checkSharedAssessmentOwnership(String callerAppId, String guid, String ownerId) {
+        RequestContext rc = BridgeUtils.getRequestContext();
+        String callerOrgMembership = rc.getCallerOrgMembership();
+        if (ownerId == null) {
+            LOG.error("Owner ID is null, guid=" + guid);
+            throw new UnauthorizedException(CALLER_NOT_MEMBER_ERROR);
+        }
+        String[] parts = ownerId.split(":", 2);
+        // This happens in tests, we expect it to never happens in production. So log if it does.
+        if (parts.length != 2) {
+            LOG.error("Could not parse shared assessment ownerID, guid=" + guid + ", ownerId=" + ownerId);
+            throw new UnauthorizedException(CALLER_NOT_MEMBER_ERROR);
+        }
+        String originAppId = parts[0];
+        String originOrgId = parts[1];
+        
+        if (rc.isInRole(ImmutableSet.of(SUPERADMIN))) {
+            return;
+        }
+        if (originAppId.equals(callerAppId) && originOrgId.equals(callerOrgMembership)) {
+            return;
+        }
+        throw new UnauthorizedException(CALLER_NOT_MEMBER_ERROR);
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/src/main/java/org/sagebionetworks/bridge/BridgeConstants.java
@@ -30,7 +30,7 @@ public class BridgeConstants {
     public static final String MAX_USERS_ERROR = "While app is in evaluation mode, it may not exceed %s accounts.";
     public static final String BRIDGE_IDENTIFIER_ERROR = "must contain only lower-case letters and/or numbers with optional dashes";
     public static final String BRIDGE_EVENT_ID_ERROR = "must contain only lower- or upper-case letters, numbers, dashes, and/or underscores";
-    public static final String CALLER_NOT_MEMBER_ERROR = "Assessment must be associated to one of the caller’s organizations.";
+    public static final String CALLER_NOT_MEMBER_ERROR = "Assessment must be associated to the caller’s organization.";
     public static final String NEGATIVE_OFFSET_ERROR = "offsetBy cannot be negative";
     public static final String NONPOSITIVE_REVISION_ERROR = "revision cannot be less than 1";
 

--- a/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
@@ -6,7 +6,6 @@ import static java.lang.Integer.parseInt;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.sagebionetworks.bridge.BridgeConstants.CALLER_NOT_MEMBER_ERROR;
 import static org.sagebionetworks.bridge.BridgeConstants.CKEDITOR_WHITELIST;
 import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
 import static org.sagebionetworks.bridge.util.BridgeCollectors.toImmutableSet;
@@ -42,14 +41,11 @@ import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Entities.EscapeMode;
 import org.jsoup.safety.Cleaner;
 import org.jsoup.safety.Whitelist;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
-import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.json.BridgeTypeName;
 import org.sagebionetworks.bridge.time.DateUtils;
 import org.sagebionetworks.bridge.models.Tuple;
@@ -81,7 +77,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 public class BridgeUtils {
-    private static final Logger LOG = LoggerFactory.getLogger(BridgeUtils.class);
 
     public static class SubstudyAssociations {
         private final Set<String> substudyIdsVisibleToCaller;
@@ -698,47 +693,6 @@ public class BridgeUtils {
             Object[] enums = enumType.getEnumConstants();
             throw new BadRequestException(value + " is not a valid " + enumType.getSimpleName() + " (use: "
                     + COMMA_SPACE_JOINER.join(enums).toLowerCase() + ")");
-        }
-    }
-    
-    /**
-     * If the caller has no organizational membership, then they can set any organization (however they 
-     * must set one, unlike the implementation of substudy relationships to user accounts). In this 
-     * case we check the org ID to ensure it's valid. If the caller has organizational memberships, 
-     * then the caller must be a member of the organization being cited. At that point we do not need 
-     * to validate the org ID since it was validated when it was set as an organizational relationship
-     * on the account. 
-     */
-    public static void checkOwnership(String appId, String ownerId) {
-        if (isBlank(ownerId)) {
-            throw new UnauthorizedException(CALLER_NOT_MEMBER_ERROR);
-        }
-        Set<String> callerSubstudies = BridgeUtils.getRequestContext().getCallerSubstudies();
-        if (callerSubstudies.isEmpty() || callerSubstudies.contains(ownerId)) {
-            return;
-        }
-        throw new UnauthorizedException(CALLER_NOT_MEMBER_ERROR);
-    }
-    
-    public static void checkSharedOwnership(String callerAppId, String guid, String ownerId) {
-        if (ownerId == null) {
-            LOG.error("Owner ID is null, guid=" + guid);
-            throw new UnauthorizedException(CALLER_NOT_MEMBER_ERROR);
-        }
-        String[] parts = ownerId.split(":", 2);
-        // This happens in tests, we expect it to never happens in production. So log if it does.
-        if (parts.length != 2) {
-            LOG.error("Could not parse shared assessment ownerID, guid=" + guid + ", ownerId=" + ownerId);
-            throw new UnauthorizedException(CALLER_NOT_MEMBER_ERROR);
-        }
-        String originAppId = parts[0];
-        String originOrgId = parts[1];
-        Set<String> callerSubstudies = BridgeUtils.getRequestContext().getCallerSubstudies();
-        boolean scopedUser = !callerSubstudies.isEmpty();
-        boolean orgMember = callerSubstudies.contains(originOrgId);
-        
-        if (!callerAppId.equals(originAppId) || (scopedUser && !orgMember)) {
-            throw new UnauthorizedException(CALLER_NOT_MEMBER_ERROR);
         }
     }
     

--- a/src/main/java/org/sagebionetworks/bridge/services/AssessmentConfigService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AssessmentConfigService.java
@@ -3,7 +3,7 @@ package org.sagebionetworks.bridge.services;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.sagebionetworks.bridge.BridgeUtils.checkOwnership;
+import static org.sagebionetworks.bridge.AuthUtils.checkAssessmentOwnership;
 
 import java.util.Map;
 import java.util.Set;
@@ -55,8 +55,10 @@ public class AssessmentConfigService {
     public AssessmentConfig getAssessmentConfig(String appId, String guid) {
         checkArgument(isNotBlank(guid));
         
-        Assessment assessment = assessmentService.getAssessmentByGuid(appId, guid);
-        checkOwnership(appId, assessment.getOwnerId());
+        // Check the assessment exists
+        assessmentService.getAssessmentByGuid(appId, guid);
+        // Note: we were checking organizational access to the config but we've refined our model
+        // such that assessments are public for assignment, so they can be read by anyone.
         
         return dao.getAssessmentConfig(guid).orElseThrow(() -> new EntityNotFoundException(AssessmentConfig.class));
     }
@@ -72,7 +74,7 @@ public class AssessmentConfigService {
         checkNotNull(config);
         
         Assessment assessment = assessmentService.getAssessmentByGuid(appId, guid);
-        checkOwnership(appId, assessment.getOwnerId());
+        checkAssessmentOwnership(appId, assessment.getOwnerId());
         
         AssessmentConfig existing = dao.getAssessmentConfig(guid)
                 .orElseThrow(() -> new EntityNotFoundException(AssessmentConfig.class));
@@ -95,7 +97,7 @@ public class AssessmentConfigService {
             throw new BadRequestException("Updates to configuration are missing");
         }
         Assessment assessment = assessmentService.getAssessmentByGuid(appId, guid);
-        checkOwnership(appId, assessment.getOwnerId());
+        checkAssessmentOwnership(appId, assessment.getOwnerId());
         
         Map<String, Set<PropertyInfo>> fields = assessment.getCustomizationFields();
         

--- a/src/main/java/org/sagebionetworks/bridge/services/AssessmentResourceService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AssessmentResourceService.java
@@ -5,9 +5,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.jsoup.safety.Whitelist.simpleText;
+import static org.sagebionetworks.bridge.AuthUtils.checkAssessmentOwnership;
+import static org.sagebionetworks.bridge.AuthUtils.checkSharedAssessmentOwnership;
 import static org.sagebionetworks.bridge.BridgeConstants.SHARED_APP_ID;
-import static org.sagebionetworks.bridge.BridgeUtils.checkOwnership;
-import static org.sagebionetworks.bridge.BridgeUtils.checkSharedOwnership;
 import static org.sagebionetworks.bridge.BridgeUtils.sanitizeHTML;
 import static org.sagebionetworks.bridge.models.ResourceList.CATEGORIES;
 import static org.sagebionetworks.bridge.models.ResourceList.INCLUDE_DELETED;
@@ -107,7 +107,7 @@ public class AssessmentResourceService {
         checkNotNull(resource);
         
         Assessment assessment = assessmentService.getLatestAssessment(appId, assessmentId);
-        checkOwnership(appId, assessment.getOwnerId());
+        checkAssessmentOwnership(appId, assessment.getOwnerId());
         
         DateTime timestamp = getCreatedOn();
         resource.setGuid(generateGuid());
@@ -132,7 +132,7 @@ public class AssessmentResourceService {
         
         Assessment assessment = assessmentService.getLatestAssessment(appId, assessmentId);
         
-        checkOwnership(appId, assessment.getOwnerId());
+        checkAssessmentOwnership(appId, assessment.getOwnerId());
         
         return updateResourceInternal(appId, assessmentId, assessment, resource);
     }
@@ -145,7 +145,7 @@ public class AssessmentResourceService {
         
         Assessment assessment = assessmentService.getLatestAssessment(SHARED_APP_ID, assessmentId);
         
-        checkSharedOwnership(callerAppId, assessment.getGuid(), assessment.getOwnerId());
+        checkSharedAssessmentOwnership(callerAppId, assessment.getGuid(), assessment.getOwnerId());
         
         return updateResourceInternal(SHARED_APP_ID, assessmentId, assessment, resource);
     }
@@ -178,7 +178,7 @@ public class AssessmentResourceService {
         
         // Verify access to this.
         Assessment assessment = assessmentService.getLatestAssessment(appId, assessmentId);
-        checkOwnership(appId, assessment.getOwnerId());
+        checkAssessmentOwnership(appId, assessment.getOwnerId());
         
         AssessmentResource resource = dao.getResource(appId, guid)
                 .orElseThrow(() -> new EntityNotFoundException(AssessmentResource.class));
@@ -207,7 +207,7 @@ public class AssessmentResourceService {
         // Must have imported the assessment already before you move resources
         Assessment assessment = assessmentService.getLatestAssessment(appId, assessmentId);
         // Cannot import a resource unless you are member of the org that owns the assessment
-        checkOwnership(appId, assessment.getOwnerId());
+        checkAssessmentOwnership(appId, assessment.getOwnerId());
         return copyResources(SHARED_APP_ID, appId, assessment, guids);
     }
     
@@ -218,7 +218,7 @@ public class AssessmentResourceService {
         // Must have published the assessment already before you move resources
         Assessment assessment = assessmentService.getLatestAssessment(SHARED_APP_ID, assessmentId);
         // Cannot publish a resource unless you are member of the org that owns the shared assessment
-        checkSharedOwnership(appId, assessment.getGuid(), assessment.getOwnerId());
+        checkSharedAssessmentOwnership(appId, assessment.getGuid(), assessment.getOwnerId());
         return copyResources(appId, SHARED_APP_ID, assessment, guids);
     }
     

--- a/src/main/java/org/sagebionetworks/bridge/services/OrganizationService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/OrganizationService.java
@@ -40,6 +40,8 @@ public class OrganizationService {
     
     private AccountDao accountDao;
     
+    private SessionUpdateService sessionUpdateService;
+    
     @Autowired
     final void setOrganizationDao(OrganizationDao orgDao) {
         this.orgDao = orgDao;
@@ -48,6 +50,11 @@ public class OrganizationService {
     @Autowired
     final void setAccountDao(AccountDao accountDao) {
         this.accountDao = accountDao;
+    }
+    
+    @Autowired
+    final void setSessionUpdateService(SessionUpdateService sessionUpdateService) {
+        this.sessionUpdateService = sessionUpdateService;
     }
     
     DateTime getCreatedOn() {
@@ -177,6 +184,7 @@ public class OrganizationService {
 
         account.setOrgMembership(identifier);
         accountDao.updateAccount(account, null);
+        sessionUpdateService.updateOrgMembership(account.getId(), identifier);
     }
     
     public void removeMember(String appId, String identifier, AccountId accountId) {
@@ -198,5 +206,7 @@ public class OrganizationService {
         }
         account.setOrgMembership(null);
         accountDao.updateAccount(account, null);
+        sessionUpdateService.updateOrgMembership(account.getId(), null);
     }
+
 }

--- a/src/main/java/org/sagebionetworks/bridge/services/SessionUpdateService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/SessionUpdateService.java
@@ -93,6 +93,15 @@ public class SessionUpdateService {
         
         cacheProvider.setUserSession(newSession);
     }
+    
+    public void updateOrgMembership(String userId, String newOrgId) {
+        UserSession session = cacheProvider.getUserSessionByUserId(userId);
+        if (session != null) {
+            session.setParticipant(new StudyParticipant.Builder().copyOf(
+                    session.getParticipant()).withOrgMembership(newOrgId).build());
+            cacheProvider.setUserSession(session);
+        }
+    }
 
     private StudyParticipant.Builder builder(UserSession session) {
         return new StudyParticipant.Builder().copyOf(session.getParticipant());

--- a/src/main/java/org/sagebionetworks/bridge/validators/AssessmentValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/AssessmentValidator.java
@@ -15,16 +15,16 @@ import org.springframework.validation.Validator;
 import org.sagebionetworks.bridge.models.OperatingSystem;
 import org.sagebionetworks.bridge.models.assessments.Assessment;
 import org.sagebionetworks.bridge.models.assessments.config.PropertyInfo;
-import org.sagebionetworks.bridge.services.SubstudyService;
+import org.sagebionetworks.bridge.services.OrganizationService;
 
 public class AssessmentValidator implements Validator {
 
-    private final SubstudyService substudyService;
     private final String appId;
+    private final OrganizationService organizationService;
     
-    public AssessmentValidator(SubstudyService substudyService, String appId) {
-        this.substudyService = substudyService;
+    public AssessmentValidator(String appId, OrganizationService organizationService) {
         this.appId = appId;
+        this.organizationService = organizationService;
     }
     
     @Override
@@ -81,17 +81,17 @@ public class AssessmentValidator implements Validator {
         if (isBlank(assessment.getOwnerId())) {
             errors.rejectValue("ownerId", CANNOT_BE_BLANK);
         } else {
-            String substudyId = null;
-            String ownerId = null;
+            String ownerAppId = null;
+            String ownerOrgId = null;
             if (SHARED_APP_ID.equals(appId)) {
                 String[] parts = assessment.getOwnerId().split(":");
-                substudyId = parts[0];
-                ownerId = parts[1];
+                ownerAppId = parts[0];
+                ownerOrgId = parts[1];
             } else {
-                substudyId = appId;
-                ownerId = assessment.getOwnerId();
+                ownerAppId = appId;
+                ownerOrgId = assessment.getOwnerId();
             }
-            if (substudyService.getSubstudy(substudyId, ownerId, false) == null) {
+            if (organizationService.getOrganization(ownerAppId, ownerOrgId) == null) {
                 errors.rejectValue("ownerId", "is not a valid organization ID");
             }
         }

--- a/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
@@ -71,13 +71,6 @@ public class AuthUtilsTest {
         AuthUtils.checkOrgMembershipAndThrow(TEST_ORG_ID);
     }
     
-    @Test(expectedExceptions = UnauthorizedException.class,
-            expectedExceptionsMessageRegExp = CALLER_NOT_MEMBER_ERROR)
-    public void checkOwnershipOwnerIdIsBlank() {
-        BridgeUtils.setRequestContext(NULL_INSTANCE);
-        AuthUtils.checkAssessmentOwnership(TEST_APP_ID, null);
-    }
-    
     @Test
     public void checkOwnershipAdminUser() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
@@ -96,15 +89,8 @@ public class AuthUtilsTest {
             expectedExceptionsMessageRegExp = CALLER_NOT_MEMBER_ERROR)
     public void checkOwnershipScopedUserOrgIdIsMissing() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("notValidOwner")).build());
+                .withCallerOrgMembership("notValidOwner").build());
         AuthUtils.checkAssessmentOwnership(TEST_APP_ID, OWNER_ID);
-    }
-    
-    @Test(expectedExceptions = UnauthorizedException.class,
-            expectedExceptionsMessageRegExp = CALLER_NOT_MEMBER_ERROR)
-    public void checkSharedOwnershipOwnerIdIsBlank() {
-        BridgeUtils.setRequestContext(NULL_INSTANCE);
-        AuthUtils.checkSharedAssessmentOwnership(TEST_APP_ID, GUID, null);
     }
     
     @Test
@@ -132,7 +118,7 @@ public class AuthUtilsTest {
             expectedExceptionsMessageRegExp = CALLER_NOT_MEMBER_ERROR)
     public void checkSharedOwnershipScopedUserOrgIdIsMissing() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("notValidOwner")).build());
+                .withCallerOrgMembership("notValidOwner").build());
         AuthUtils.checkSharedAssessmentOwnership(TEST_APP_ID, GUID, SHARED_OWNER_ID);
     }
     
@@ -140,7 +126,7 @@ public class AuthUtilsTest {
             expectedExceptionsMessageRegExp = CALLER_NOT_MEMBER_ERROR)
     public void checkSharedOwnershipWrongAppId() { 
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of(TEST_APP_ID)).build());
+                .withCallerOrgMembership(TEST_APP_ID).build());
         AuthUtils.checkSharedAssessmentOwnership(TEST_APP_ID, GUID, "other:"+OWNER_ID);        
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -1,14 +1,10 @@
 package org.sagebionetworks.bridge;
 
-import static org.sagebionetworks.bridge.BridgeConstants.CALLER_NOT_MEMBER_ERROR;
-import static org.sagebionetworks.bridge.RequestContext.NULL_INSTANCE;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
 import static org.sagebionetworks.bridge.Roles.WORKER;
-import static org.sagebionetworks.bridge.TestConstants.GUID;
-import static org.sagebionetworks.bridge.TestConstants.OWNER_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.models.assessments.ResourceCategory.LICENSE;
 import static org.sagebionetworks.bridge.models.assessments.ResourceCategory.PUBLICATION;
@@ -50,7 +46,6 @@ import org.testng.annotations.Test;
 import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
-import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.ExternalIdentifier;
@@ -71,7 +66,6 @@ import com.google.common.collect.Sets;
 public class BridgeUtilsTest {
     
     private static final LocalDateTime LOCAL_DATE_TIME = LocalDateTime.parse("2010-10-10T10:10:10.111");
-    private static final String SHARED_OWNER_ID = TEST_APP_ID + ":" + OWNER_ID;
     
     @AfterMethod
     public void after() {
@@ -927,86 +921,6 @@ public class BridgeUtilsTest {
         assertTrue(BridgeUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(ADMIN)));
         assertFalse(BridgeUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(WORKER)));
         assertTrue(BridgeUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(DEVELOPER, ADMIN)));
-    }
-    
-    @Test(expectedExceptions = UnauthorizedException.class,
-            expectedExceptionsMessageRegExp = CALLER_NOT_MEMBER_ERROR)
-    public void checkOwnershipOwnerIdIsBlank() {
-        BridgeUtils.setRequestContext(NULL_INSTANCE);
-        BridgeUtils.checkOwnership(TEST_APP_ID, null);
-    }
-    
-    @Test
-    public void checkOwnershipGlobalUser() {
-        BridgeUtils.setRequestContext(NULL_INSTANCE);
-        BridgeUtils.checkOwnership(TEST_APP_ID, OWNER_ID);
-    }
-    
-    @Test
-    public void checkOwnershipScopedUser() {
-        BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of(OWNER_ID)).build());
-        BridgeUtils.checkOwnership(TEST_APP_ID, OWNER_ID);
-    }
-    
-    @Test(expectedExceptions = UnauthorizedException.class,
-            expectedExceptionsMessageRegExp = CALLER_NOT_MEMBER_ERROR)
-    public void checkOwnershipScopedUserOrgIdIsMissing() {
-        BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("notValidOwner")).build());
-        BridgeUtils.checkOwnership(TEST_APP_ID, OWNER_ID);
-    }
-    
-    @Test(expectedExceptions = UnauthorizedException.class,
-            expectedExceptionsMessageRegExp = CALLER_NOT_MEMBER_ERROR)
-    public void checkSharedOwnershipOwnerIdIsBlank() {
-        BridgeUtils.setRequestContext(NULL_INSTANCE);
-        BridgeUtils.checkSharedOwnership(TEST_APP_ID, GUID, null);
-    }
-    
-    @Test
-    public void checkSharedOwnershipGlobalUser() {
-        BridgeUtils.setRequestContext(NULL_INSTANCE);
-        BridgeUtils.checkSharedOwnership(TEST_APP_ID, GUID, SHARED_OWNER_ID);
-    }
-    
-    @Test(expectedExceptions = UnauthorizedException.class,
-            expectedExceptionsMessageRegExp = CALLER_NOT_MEMBER_ERROR)
-    public void checkSharedOwnershipAgainstNonGlobalOwnerId() {
-        BridgeUtils.setRequestContext(NULL_INSTANCE);
-        BridgeUtils.checkSharedOwnership(TEST_APP_ID, GUID, OWNER_ID);
-    }
-    
-    @Test
-    public void sharedOwnershipScopedUser() {
-        BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of(OWNER_ID)).build());
-        BridgeUtils.checkSharedOwnership(TEST_APP_ID, GUID, SHARED_OWNER_ID);
-    }
-    
-    @Test(expectedExceptions = UnauthorizedException.class,
-            expectedExceptionsMessageRegExp = CALLER_NOT_MEMBER_ERROR)
-    public void checkSharedOwnershipScopedUserOrgIdIsMissing() {
-        BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("notValidOwner")).build());
-        BridgeUtils.checkSharedOwnership(TEST_APP_ID, GUID, SHARED_OWNER_ID);
-    }
-    
-    @Test(expectedExceptions = UnauthorizedException.class,
-            expectedExceptionsMessageRegExp = CALLER_NOT_MEMBER_ERROR)
-    public void checkSharedOwnershipWrongAppId() { 
-        BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of(TEST_APP_ID)).build());
-        BridgeUtils.checkSharedOwnership(TEST_APP_ID, GUID, "other:"+OWNER_ID);        
-    }
-    
-    @Test(expectedExceptions = UnauthorizedException.class,
-            expectedExceptionsMessageRegExp = CALLER_NOT_MEMBER_ERROR)
-    public void checkSharedOwnershipGlobalUserWrongAppId() { 
-        BridgeUtils.setRequestContext(NULL_INSTANCE);
-        // still doesn't pass because the appId must always match (global users must call 
-        // this API after associating to the right app context):
-        BridgeUtils.checkSharedOwnership(TEST_APP_ID, GUID, "other:"+OWNER_ID);        
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/AssessmentConfigServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AssessmentConfigServiceTest.java
@@ -10,6 +10,7 @@ import static org.sagebionetworks.bridge.TestConstants.GUID;
 import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
 import static org.sagebionetworks.bridge.TestConstants.OWNER_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
@@ -132,10 +133,10 @@ public class AssessmentConfigServiceTest extends Mockito {
             expectedExceptionsMessageRegExp = "AssessmentConfig not found.")
     public void getSharedAssessmentConfigNotFound() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("substudyA")).build());
+                .withCallerOrgMembership(TEST_ORG_ID).build());
         
         Assessment assessment = AssessmentTest.createAssessment();
-        assessment.setOwnerId("api:substudyA");
+        assessment.setOwnerId(TEST_APP_ID + ":" + TEST_ORG_ID);
         when(mockAssessmentService.getAssessmentByGuid(SHARED_APP_ID, GUID))
             .thenReturn(assessment);
         
@@ -332,10 +333,10 @@ public class AssessmentConfigServiceTest extends Mockito {
             expectedExceptionsMessageRegExp = "AssessmentConfig not found.")
     public void getAssessmentConfigEntityNotFound() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerOrgMembership("substudyA").build());
+                .withCallerOrgMembership(TEST_ORG_ID).build());
         
         Assessment assessment = AssessmentTest.createAssessment();
-        assessment.setOwnerId("substudyB");
+        assessment.setOwnerId("orgB");
         when(mockAssessmentService.getAssessmentByGuid(TEST_APP_ID, GUID))
             .thenReturn(assessment);
         
@@ -346,10 +347,10 @@ public class AssessmentConfigServiceTest extends Mockito {
             expectedExceptionsMessageRegExp = CALLER_NOT_MEMBER_ERROR)
     public void updateAssessmentConfigCheckOwnership() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("substudyA")).build());
+                .withCallerOrgMembership(TEST_ORG_ID).build());
         
         Assessment assessment = AssessmentTest.createAssessment();
-        assessment.setOwnerId("substudyB");
+        assessment.setOwnerId("orgB");
         when(mockAssessmentService.getAssessmentByGuid(TEST_APP_ID, GUID))
             .thenReturn(assessment);
         
@@ -361,10 +362,10 @@ public class AssessmentConfigServiceTest extends Mockito {
             expectedExceptionsMessageRegExp = CALLER_NOT_MEMBER_ERROR)
     public void customizeAssessmentConfigCheckOwnership() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("substudyA")).build());
+                .withCallerOrgMembership(TEST_ORG_ID).build());
         
         Assessment assessment = AssessmentTest.createAssessment();
-        assessment.setOwnerId("substudyB");
+        assessment.setOwnerId("orgB");
         when(mockAssessmentService.getAssessmentByGuid(TEST_APP_ID, GUID))
             .thenReturn(assessment);
         

--- a/src/test/java/org/sagebionetworks/bridge/services/AssessmentConfigServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AssessmentConfigServiceTest.java
@@ -8,6 +8,7 @@ import static org.sagebionetworks.bridge.RequestContext.NULL_INSTANCE;
 import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
 import static org.sagebionetworks.bridge.TestConstants.GUID;
 import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
+import static org.sagebionetworks.bridge.TestConstants.OWNER_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
@@ -145,7 +146,11 @@ public class AssessmentConfigServiceTest extends Mockito {
     
     @Test
     public void updateAssessmentConfig() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerOrgMembership(OWNER_ID).build());
+        
         Assessment assessment = AssessmentTest.createAssessment();
+        assessment.setOwnerId(OWNER_ID);
         assessment.setOriginGuid(GUID);
         when(mockAssessmentService.getAssessmentByGuid(TEST_APP_ID, GUID))
             .thenReturn(assessment);
@@ -176,6 +181,8 @@ public class AssessmentConfigServiceTest extends Mockito {
     @Test(expectedExceptions = InvalidEntityException.class, 
             expectedExceptionsMessageRegExp = ".*config is required.*")
     public void updateAssessmentConfigInvalid() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerOrgMembership(OWNER_ID).build());
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setOriginGuid(GUID);
         when(mockAssessmentService.getAssessmentByGuid(TEST_APP_ID, GUID))
@@ -194,7 +201,11 @@ public class AssessmentConfigServiceTest extends Mockito {
     
     @Test
     public void customizeAssessmentConfig() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerOrgMembership(OWNER_ID).build());
+        
         Assessment assessment = AssessmentTest.createAssessment();
+        assessment.setOwnerId(OWNER_ID);
         assessment.setCustomizationFields(ImmutableMap.of("anIdentifier", ImmutableSet.of(
                 new PropertyInfo.Builder().withPropName("stringValue").build(),
                 new PropertyInfo.Builder().withPropName("intValue").build(),
@@ -231,6 +242,9 @@ public class AssessmentConfigServiceTest extends Mockito {
     @Test(expectedExceptions = InvalidEntityException.class, 
             expectedExceptionsMessageRegExp = ".*identifier is missing.*")
     public void customizeAssessmentConfigInvalid() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerOrgMembership(OWNER_ID).build());
+        
         AssessmentConfigValidator val = new AssessmentConfigValidator.Builder()
                 .addValidator("*", new AbstractValidator() {
                     public void validate(Object target, Errors errors) {
@@ -243,6 +257,7 @@ public class AssessmentConfigServiceTest extends Mockito {
         doReturn(val).when(service).getValidator();
         
         Assessment assessment = AssessmentTest.createAssessment();
+        assessment.setOwnerId(OWNER_ID);
         assessment.setCustomizationFields(ImmutableMap.of("anIdentifier", ImmutableSet.of(
                 new PropertyInfo.Builder().withPropName("stringValue").build(),
                 new PropertyInfo.Builder().withPropName("intValue").build(),
@@ -268,7 +283,11 @@ public class AssessmentConfigServiceTest extends Mockito {
     
     @Test
     public void customizeAssessmentConfigUnchanged() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerOrgMembership(OWNER_ID).build());
+        
         Assessment assessment = AssessmentTest.createAssessment();
+        assessment.setOwnerId(OWNER_ID);
         assessment.setCustomizationFields(ImmutableMap.of("anIdentifier", ImmutableSet.of(
                 new PropertyInfo.Builder().withPropName("stringValue").build()
         )));
@@ -309,11 +328,11 @@ public class AssessmentConfigServiceTest extends Mockito {
         return configNode;
     }
 
-    @Test(expectedExceptions = UnauthorizedException.class,
-            expectedExceptionsMessageRegExp = CALLER_NOT_MEMBER_ERROR)
-    public void getAssessmentConfigCheckOwnership() {
+    @Test(expectedExceptions = EntityNotFoundException.class,
+            expectedExceptionsMessageRegExp = "AssessmentConfig not found.")
+    public void getAssessmentConfigEntityNotFound() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("substudyA")).build());
+                .withCallerOrgMembership("substudyA").build());
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setOwnerId("substudyB");

--- a/src/test/java/org/sagebionetworks/bridge/services/AssessmentResourceServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AssessmentResourceServiceTest.java
@@ -10,8 +10,8 @@ import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
 import static org.sagebionetworks.bridge.TestConstants.OWNER_ID;
 import static org.sagebionetworks.bridge.TestConstants.RESOURCE_CATEGORIES;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
 import static org.sagebionetworks.bridge.TestConstants.TIMESTAMP;
-import static org.sagebionetworks.bridge.TestConstants.USER_SUBSTUDY_IDS;
 import static org.sagebionetworks.bridge.models.ResourceList.CATEGORIES;
 import static org.sagebionetworks.bridge.models.ResourceList.INCLUDE_DELETED;
 import static org.sagebionetworks.bridge.models.ResourceList.MAX_REVISION;
@@ -200,9 +200,10 @@ public class AssessmentResourceServiceTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class)
     public void createResourceChecksAssessmentOwnership() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("substudy2")).build());
+                .withCallerOrgMembership(TEST_ORG_ID).build());
         
         Assessment assessment = AssessmentTest.createAssessment();
+        assessment.setOwnerId("orgB");
         when(mockAssessmentService.getLatestAssessment(TEST_APP_ID, ASSESSMENT_ID)).thenReturn(assessment);
         
         service.createResource(TEST_APP_ID, ASSESSMENT_ID, new AssessmentResource());
@@ -304,10 +305,8 @@ public class AssessmentResourceServiceTest extends Mockito {
     
     @Test(expectedExceptions = UnauthorizedException.class)
     public void updateResourceChecksAssessmentOwnership() {
-        BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("substudy2")).build());
-
         Assessment assessment = AssessmentTest.createAssessment();
+        assessment.setOwnerId(TEST_ORG_ID);
         when(mockAssessmentService.getLatestAssessment(TEST_APP_ID, ASSESSMENT_ID)).thenReturn(assessment);
         
         AssessmentResource resource = AssessmentResourceTest.createAssessmentResource();
@@ -372,7 +371,8 @@ public class AssessmentResourceServiceTest extends Mockito {
     
     @Test(expectedExceptions = UnauthorizedException.class)
     public void updateSharedResourceFails() {
-        BridgeUtils.setRequestContext(new RequestContext.Builder().withCallerSubstudies(USER_SUBSTUDY_IDS).build());
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerOrgMembership(TEST_ORG_ID).build());
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setOwnerId(TEST_APP_ID + ":anotherOrg");
@@ -405,9 +405,10 @@ public class AssessmentResourceServiceTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class)
     public void deleteResourceChecksAssessmentOwnership() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("substudy2")).build());        
+                .withCallerOrgMembership(TEST_ORG_ID).build());        
 
         Assessment assessment = AssessmentTest.createAssessment();
+        assessment.setOwnerId("owner-id");
         when(mockAssessmentService.getLatestAssessment(TEST_APP_ID, ASSESSMENT_ID)).thenReturn(assessment);
 
         service.deleteResource(TEST_APP_ID, ASSESSMENT_ID, GUID);
@@ -605,9 +606,10 @@ public class AssessmentResourceServiceTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class)
     public void importAssessmentResourcesCallerWrongOrg() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("notOwnerId")).build());
+                .withCallerOrgMembership("notOwnerId").build());
         
         Assessment assessment = AssessmentTest.createAssessment();
+        assessment.setOwnerId(TEST_ORG_ID);
         when(mockAssessmentService.getLatestAssessment(TEST_APP_ID, ASSESSMENT_ID)).thenReturn(assessment);
         
         Set<String> guids = ImmutableSet.of("guid1", "guid2", "guid3");
@@ -655,7 +657,7 @@ public class AssessmentResourceServiceTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class)
     public void publishAssessmentResourcesCallerWrongOrg() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("wrongOwnerId")).build());
+                .withCallerOrgMembership("wrongOwnerId").build());
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setOwnerId(TEST_APP_ID+":"+OWNER_ID);
@@ -669,7 +671,7 @@ public class AssessmentResourceServiceTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class)
     public void publishAssessmentResourcesCallerWrongAppContext() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of(OWNER_ID)).build());
+                .withCallerOrgMembership(OWNER_ID).build());
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setOwnerId(TEST_APP_ID+":"+OWNER_ID);

--- a/src/test/java/org/sagebionetworks/bridge/services/AssessmentResourceServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AssessmentResourceServiceTest.java
@@ -87,6 +87,9 @@ public class AssessmentResourceServiceTest extends Mockito {
         when(service.getCreatedOn()).thenReturn(CREATED_ON);
         when(service.getModifiedOn()).thenReturn(MODIFIED_ON);
         when(service.generateGuid()).thenReturn(GUID);
+        
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerOrgMembership(OWNER_ID).build());
     }
     
     @AfterMethod
@@ -584,9 +587,10 @@ public class AssessmentResourceServiceTest extends Mockito {
     @Test
     public void importAssessmentResourcesCallerCorrectOrg() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of(OWNER_ID)).build());
+                .withCallerOrgMembership(OWNER_ID).build());
 
         Assessment assessment = AssessmentTest.createAssessment();
+        assessment.setOwnerId(OWNER_ID);
         when(mockAssessmentService.getLatestAssessment(TEST_APP_ID, ASSESSMENT_ID)).thenReturn(assessment);
         
         Set<String> guids = ImmutableSet.of("guid1", "guid2", "guid3");
@@ -629,9 +633,9 @@ public class AssessmentResourceServiceTest extends Mockito {
     }
     
     @Test
-    public void publishAssessmentResourcesScopedOwner() {
+    public void publishAssessmentResourcesOwnerInOrg() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of(OWNER_ID)).build());
+                .withCallerOrgMembership(OWNER_ID).build());
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setOwnerId(TEST_APP_ID+":"+OWNER_ID);

--- a/src/test/java/org/sagebionetworks/bridge/services/AssessmentServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AssessmentServiceTest.java
@@ -1279,16 +1279,6 @@ public class AssessmentServiceTest extends Mockito {
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void updateSharedAssessmentChecksOwnershipWhenMissing() {
-        Assessment sharedAssessment = AssessmentTest.createAssessment();
-        sharedAssessment.setDeleted(false);
-        sharedAssessment.setOwnerId(null);
-        when(mockDao.getAssessment(SHARED_APP_ID, GUID)).thenReturn(Optional.of(sharedAssessment));
-        
-        service.updateSharedAssessment(TEST_APP_ID, sharedAssessment);
-    }
-    
-    @Test(expectedExceptions = UnauthorizedException.class)
     public void updateSharedAssessmentChecksOwnershipWhenFormattedIncorrectly() {
         Assessment sharedAssessment = AssessmentTest.createAssessment();
         sharedAssessment.setDeleted(false);

--- a/src/test/java/org/sagebionetworks/bridge/services/AssessmentServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AssessmentServiceTest.java
@@ -6,6 +6,8 @@ import static org.sagebionetworks.bridge.BridgeConstants.NONPOSITIVE_REVISION_ER
 import static org.sagebionetworks.bridge.BridgeConstants.PAGE_SIZE_ERROR;
 import static org.sagebionetworks.bridge.BridgeConstants.SHARED_APP_ID;
 import static org.sagebionetworks.bridge.RequestContext.NULL_INSTANCE;
+import static org.sagebionetworks.bridge.Roles.ADMIN;
+import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
 import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
 import static org.sagebionetworks.bridge.TestConstants.GUID;
 import static org.sagebionetworks.bridge.TestConstants.IDENTIFIER;
@@ -59,7 +61,7 @@ import org.sagebionetworks.bridge.models.assessments.Assessment;
 import org.sagebionetworks.bridge.models.assessments.AssessmentTest;
 import org.sagebionetworks.bridge.models.assessments.config.AssessmentConfig;
 import org.sagebionetworks.bridge.models.assessments.config.PropertyInfo;
-import org.sagebionetworks.bridge.models.substudies.Substudy;
+import org.sagebionetworks.bridge.models.organizations.Organization;
 
 public class AssessmentServiceTest extends Mockito {
     private static final String NEW_IDENTIFIER = "oneNewId";
@@ -77,10 +79,10 @@ public class AssessmentServiceTest extends Mockito {
     AssessmentConfigService mockConfigService;
     
     @Mock
-    SubstudyService mockSubstudyService;
+    OrganizationService mockOrganizationService;
     
     @Mock
-    Substudy mockSubstudy;
+    Organization mockOrganization;
     
     @Captor
     ArgumentCaptor<Assessment> assessmentCaptor;
@@ -99,6 +101,11 @@ public class AssessmentServiceTest extends Mockito {
         when(service.getCreatedOn()).thenReturn(CREATED_ON);
         when(service.getModifiedOn()).thenReturn(MODIFIED_ON);
         when(service.getPageSize()).thenReturn(5);
+        
+        // The default assumption is that you are in the correct organization (or else
+        // you are an administrator). 
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerOrgMembership(OWNER_ID).build());
     }
     
     @AfterMethod
@@ -143,8 +150,8 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void createAssessment() {
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
-                .thenReturn(mockSubstudy);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+                .thenReturn(mockOrganization);
         when(mockDao.getAssessmentRevisions(any(), any(), anyInt(), anyInt(), anyBoolean()))
             .thenReturn(EMPTY_LIST);
         
@@ -171,8 +178,8 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void createAssessmentAdjustsOsNameAlias() {
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
-            .thenReturn(mockSubstudy);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+            .thenReturn(mockOrganization);
         when(mockDao.getAssessmentRevisions(any(), any(), anyInt(), anyInt(), anyBoolean()))
             .thenReturn(EMPTY_LIST);
         
@@ -187,7 +194,7 @@ public class AssessmentServiceTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class)
     public void createAssessmentUnauthorized() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("substudyD")).build());
+                .withCallerOrgMembership("substudyD").build());
         Assessment assessment = AssessmentTest.createAssessment();
         service.createAssessment(TEST_APP_ID, assessment);
     }
@@ -198,8 +205,8 @@ public class AssessmentServiceTest extends Mockito {
         assessment.setGuid(null);
         assessment.setDeleted(false);
         
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
-            .thenReturn(mockSubstudy);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+            .thenReturn(mockOrganization);
         when(mockDao.getAssessmentRevisions(any(), any(), anyInt(), anyInt(), anyBoolean()))
             .thenReturn(new PagedResourceList<>(ImmutableList.of(assessment), 1));
     
@@ -209,8 +216,8 @@ public class AssessmentServiceTest extends Mockito {
     @Test(expectedExceptions = InvalidEntityException.class,
             expectedExceptionsMessageRegExp = ".*identifier cannot be missing.*")
     public void createAssessmentInvalid() {
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
-            .thenReturn(mockSubstudy);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+            .thenReturn(mockOrganization);
         when(mockDao.getAssessmentRevisions(any(), any(), anyInt(), anyInt(), anyBoolean()))
             .thenReturn(EMPTY_LIST);
         
@@ -222,8 +229,8 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void createAssessmentScrubsMarkup() {
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
-            .thenReturn(mockSubstudy);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+            .thenReturn(mockOrganization);
         when(mockDao.getAssessmentRevisions(any(), any(), anyInt(), anyInt(), anyBoolean()))
             .thenReturn(EMPTY_LIST);
         
@@ -237,8 +244,8 @@ public class AssessmentServiceTest extends Mockito {
 
     @Test
     public void createAssessmentRevision() {
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
-                .thenReturn(mockSubstudy);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+                .thenReturn(mockOrganization);
         when(mockDao.getAssessment(TEST_APP_ID, GUID))
             .thenReturn(Optional.of(AssessmentTest.createAssessment()));
         
@@ -268,7 +275,7 @@ public class AssessmentServiceTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class)
     public void createAssessmentRevisionUnauthorized() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("substudyD")).build());
+                .withCallerOrgMembership("substudyD").build());
         Assessment assessment = AssessmentTest.createAssessment();
         service.createAssessmentRevision(TEST_APP_ID, GUID, assessment);
     }
@@ -279,8 +286,8 @@ public class AssessmentServiceTest extends Mockito {
         assessment.setGuid(null);
         assessment.setDeleted(false);
         
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
-            .thenReturn(mockSubstudy);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+            .thenReturn(mockOrganization);
         when(mockDao.getAssessmentRevisions(any(), any(), anyInt(), anyInt(), anyBoolean()))
             .thenReturn(new PagedResourceList<>(ImmutableList.of(), 0));
     
@@ -290,8 +297,8 @@ public class AssessmentServiceTest extends Mockito {
     @Test(expectedExceptions = InvalidEntityException.class,
             expectedExceptionsMessageRegExp = ".*identifier cannot be missing.*")
     public void createAssessmentRevisionInvalid() {
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
-            .thenReturn(mockSubstudy);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+            .thenReturn(mockOrganization);
         when(mockDao.getAssessment(TEST_APP_ID, GUID))
             .thenReturn(Optional.of(new Assessment()));
         
@@ -303,8 +310,8 @@ public class AssessmentServiceTest extends Mockito {
 
     @Test
     public void createAssessmentRevisionScrubsMarkup() {
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
-            .thenReturn(mockSubstudy);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+            .thenReturn(mockOrganization);
         Assessment existing = AssessmentTest.createAssessment();
         when(mockDao.getAssessment(TEST_APP_ID, GUID))
             .thenReturn(Optional.of(existing));
@@ -319,7 +326,7 @@ public class AssessmentServiceTest extends Mockito {
 
     @Test
     public void updateAssessment() {
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false)).thenReturn(mockSubstudy);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID)).thenReturn(mockOrganization);
         
         // Fill out only the fields needed to pass validation, leaving the rest to be
         // filled in by the existing assessment
@@ -347,7 +354,7 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void updateAssessmentAdjustsOsNameAlias() {
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false)).thenReturn(mockSubstudy);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID)).thenReturn(mockOrganization);
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setOsName("Both");
@@ -364,7 +371,7 @@ public class AssessmentServiceTest extends Mockito {
 
     @Test
     public void updateAssessmentSomeFieldsImmutable() {
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false)).thenReturn(mockSubstudy);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID)).thenReturn(mockOrganization);
         
         Assessment existing = AssessmentTest.createAssessment();
         when(mockDao.getAssessment(TEST_APP_ID, GUID))
@@ -408,7 +415,7 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void updateAssessmentCanDelete() {
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false)).thenReturn(mockSubstudy);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID)).thenReturn(mockOrganization);
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setDeleted(true);
@@ -425,7 +432,7 @@ public class AssessmentServiceTest extends Mockito {
 
     @Test
     public void updateAssessmentCanUndelete() {
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false)).thenReturn(mockSubstudy);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID)).thenReturn(mockOrganization);
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setDeleted(false);
@@ -456,7 +463,7 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void updateAssessmentScrubsMarkup() {
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false)).thenReturn(mockSubstudy);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID)).thenReturn(mockOrganization);
 
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setDeleted(false);
@@ -474,10 +481,10 @@ public class AssessmentServiceTest extends Mockito {
     public void updateSharedAssessment() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
                 .withCallerAppId(TEST_APP_ID)
-                .withCallerSubstudies(ImmutableSet.of(OWNER_ID)).build());
+                .withCallerOrgMembership(OWNER_ID).build());
         
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
-            .thenReturn(Substudy.create());
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+            .thenReturn(Organization.create());
         
         Assessment existing = AssessmentTest.createAssessment();
         existing.setOriginGuid("unusualGuid");
@@ -502,10 +509,10 @@ public class AssessmentServiceTest extends Mockito {
     public void updateSharedAssessmentAdjustsOsNameAlias() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
                 .withCallerAppId(TEST_APP_ID)
-                .withCallerSubstudies(ImmutableSet.of(OWNER_ID)).build());
+                .withCallerOrgMembership(OWNER_ID).build());
         
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
-            .thenReturn(Substudy.create());
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+            .thenReturn(Organization.create());
         
         Assessment existing = AssessmentTest.createAssessment();
         existing.setDeleted(false);
@@ -526,10 +533,10 @@ public class AssessmentServiceTest extends Mockito {
         
         BridgeUtils.setRequestContext(new RequestContext.Builder()
                 .withCallerAppId(TEST_APP_ID)
-                .withCallerSubstudies(ImmutableSet.of(OWNER_ID)).build());
+                .withCallerOrgMembership(OWNER_ID).build());
         
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
-            .thenReturn(Substudy.create());
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+            .thenReturn(Organization.create());
         
         Assessment existing = AssessmentTest.createAssessment();
         existing.setOwnerId(ownerIdInShared);
@@ -567,7 +574,7 @@ public class AssessmentServiceTest extends Mockito {
     public void updateSharedAssessmentUnauthorizedApp() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
                 .withCallerAppId(TEST_APP_ID)
-                .withCallerSubstudies(ImmutableSet.of(OWNER_ID)).build());
+                .withCallerOrgMembership(OWNER_ID).build());
         
         Assessment existing = AssessmentTest.createAssessment();
         existing.setDeleted(false);
@@ -583,7 +590,7 @@ public class AssessmentServiceTest extends Mockito {
     public void updateSharedAssessmentUnauthorizedOrg() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
                 .withCallerAppId(TEST_APP_ID)
-                .withCallerSubstudies(ImmutableSet.of(OWNER_ID)).build());
+                .withCallerOrgMembership(OWNER_ID).build());
         
         Assessment existing = AssessmentTest.createAssessment();
         existing.setDeleted(false);
@@ -596,12 +603,12 @@ public class AssessmentServiceTest extends Mockito {
     }
     
     @Test
-    public void updateSharedAssessmentSucceedsForGlobalUser() {
+    public void updateSharedAssessmentForAdmin() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerAppId(TEST_APP_ID)
-                .withCallerSubstudies(ImmutableSet.of()).build());
-        when(mockSubstudyService.getSubstudy(
-                TEST_APP_ID, OWNER_ID, false)).thenReturn(Substudy.create());
+                .withCallerRoles(ImmutableSet.of(SUPERADMIN))
+                .withCallerAppId(TEST_APP_ID).build());
+        when(mockOrganizationService.getOrganization(
+                TEST_APP_ID, OWNER_ID)).thenReturn(Organization.create());
         
         Assessment existing = AssessmentTest.createAssessment();
         existing.setDeleted(false);
@@ -636,7 +643,7 @@ public class AssessmentServiceTest extends Mockito {
 
     @Test
     public void updateSharedAssessmentCanDelete() {
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false)).thenReturn(mockSubstudy);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID)).thenReturn(mockOrganization);
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setDeleted(true);
@@ -655,7 +662,7 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void updateSharedAssessmentCanUndelete() {
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false)).thenReturn(mockSubstudy);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID)).thenReturn(mockOrganization);
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setDeleted(false);
@@ -851,8 +858,8 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void publishAssessment() {
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
-            .thenReturn(mockSubstudy);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+            .thenReturn(mockOrganization);
         
         Assessment existing =  AssessmentTest.createAssessment();
         // Change some of these values from what they should be set to on the published object.
@@ -892,7 +899,7 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void publishAssessmentWithNewIdentifier() { 
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false)).thenReturn(mockSubstudy);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID)).thenReturn(mockOrganization);
     
         Assessment existing =  AssessmentTest.createAssessment();
     
@@ -920,7 +927,7 @@ public class AssessmentServiceTest extends Mockito {
         when(mockDao.getAssessment(TEST_APP_ID, GUID)).thenReturn(Optional.of(assessment));
         
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("notTheOwnerId")).build());
+                .withCallerOrgMembership("notTheOwnerId").build());
         
         service.publishAssessment(TEST_APP_ID, null, GUID);
     }
@@ -932,8 +939,8 @@ public class AssessmentServiceTest extends Mockito {
 
     @Test
     public void publishAssessmentPriorPublishedVersion() {
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
-            .thenReturn(mockSubstudy);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+            .thenReturn(mockOrganization);
         
         Assessment local = AssessmentTest.createAssessment();
         when(mockDao.getAssessment(TEST_APP_ID, GUID)).thenReturn(Optional.of(local));
@@ -963,8 +970,8 @@ public class AssessmentServiceTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class, 
             expectedExceptionsMessageRegExp = ".*Assessment exists in shared library.*")
     public void publishAssessmentPriorPublishedVersionDifferentOwner() {
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
-            .thenReturn(mockSubstudy);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+            .thenReturn(mockOrganization);
         
         Assessment local = AssessmentTest.createAssessment();
         when(mockDao.getAssessment(TEST_APP_ID, GUID)).thenReturn(Optional.of(local));
@@ -1012,8 +1019,8 @@ public class AssessmentServiceTest extends Mockito {
 
         when(mockDao.getAssessmentRevisions(TEST_APP_ID, NEW_IDENTIFIER, 0, 1, true))
             .thenReturn(new PagedResourceList<>(ImmutableList.of(), 0));
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
-            .thenReturn(mockSubstudy);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+            .thenReturn(mockOrganization);
         
         service.importAssessment(TEST_APP_ID, OWNER_ID, NEW_IDENTIFIER, GUID);
         
@@ -1025,35 +1032,64 @@ public class AssessmentServiceTest extends Mockito {
     }
     
     @Test
-    public void importAssessmentWithDefaultedOwnerId() {
+    public void importAssessmentWithAdmin() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of(OWNER_ID)).build());
+                .withCallerRoles(ImmutableSet.of(ADMIN)).build());
         
         Assessment sharedAssessment = AssessmentTest.createAssessment();
         when(mockDao.getAssessment(SHARED_APP_ID, GUID)).thenReturn(Optional.of(sharedAssessment));
 
         when(mockDao.getAssessmentRevisions(TEST_APP_ID, IDENTIFIER, 0, 1, true))
             .thenReturn(new PagedResourceList<>(ImmutableList.of(), 0));
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
-            .thenReturn(mockSubstudy);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+            .thenReturn(mockOrganization);
         
-        service.importAssessment(TEST_APP_ID, null, null, GUID);
+        service.importAssessment(TEST_APP_ID, "new-owner-id", null, GUID);
     }
+    
+    @Test
+    public void importAssessmentWithSuperadmin() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(SUPERADMIN)).build());
+        
+        Assessment sharedAssessment = AssessmentTest.createAssessment();
+        when(mockDao.getAssessment(SHARED_APP_ID, GUID)).thenReturn(Optional.of(sharedAssessment));
+
+        when(mockDao.getAssessmentRevisions(TEST_APP_ID, IDENTIFIER, 0, 1, true))
+            .thenReturn(new PagedResourceList<>(ImmutableList.of(), 0));
+        
+        service.importAssessment(TEST_APP_ID, "new-owner-id", null, GUID);
+        
+        verify(mockDao).importAssessment(eq(TEST_APP_ID), assessmentCaptor.capture(), any());
+        assertEquals(assessmentCaptor.getValue().getOwnerId(), "new-owner-id");
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class, 
+            expectedExceptionsMessageRegExp = "Organization not found.")
+    public void importAssessmentWithAdminOrgNotFound() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(SUPERADMIN)).build());
+        
+        Assessment sharedAssessment = AssessmentTest.createAssessment();
+        when(mockDao.getAssessment(SHARED_APP_ID, GUID)).thenReturn(Optional.of(sharedAssessment));
+
+        when(mockDao.getAssessmentRevisions(TEST_APP_ID, IDENTIFIER, 0, 1, true))
+            .thenReturn(new PagedResourceList<>(ImmutableList.of(), 0));
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, "new-owner-id"))
+            .thenThrow(new EntityNotFoundException(Organization.class));
+        
+        service.importAssessment(TEST_APP_ID, "new-owner-id", null, GUID);
+        
+        verify(mockDao).importAssessment(eq(TEST_APP_ID), assessmentCaptor.capture(), any());
+        assertEquals(assessmentCaptor.getValue().getOwnerId(), "new-owner-id");
+    }
+    
 
     @Test(expectedExceptions = BadRequestException.class, 
             expectedExceptionsMessageRegExp = "ownerId parameter is required")
-    public void importAssessmentWithFailsToDefaultIfMultipleOrganizations() {
+    public void importAssessmentFailsWithNoOrgMembership() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of(OWNER_ID, "anotherOrganization")).build());
-        
-        service.importAssessment(TEST_APP_ID, null, null, GUID);
-    }
-    
-    @Test(expectedExceptions = BadRequestException.class, 
-            expectedExceptionsMessageRegExp = "ownerId parameter is required")
-    public void importAssessmentWithFailsToDefaultIfNoOrganizations() {
-        BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of()).build());
+                .withCallerOrgMembership(null).build());
         
         service.importAssessment(TEST_APP_ID, null, null, GUID);
     }
@@ -1067,15 +1103,15 @@ public class AssessmentServiceTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class)
     public void importAssessmentCallerUnauthorized() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("notTheOwnerId")).build());
+                .withCallerOrgMembership("notTheOwnerId").build());
 
         service.importAssessment(TEST_APP_ID, OWNER_ID, null, GUID);
     }
     
     @Test(expectedExceptions = EntityNotFoundException.class)
     public void importAssessmentNotFoundException() {
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
-            .thenReturn(mockSubstudy);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+            .thenReturn(mockOrganization);
         service.importAssessment(TEST_APP_ID, OWNER_ID, null, GUID);
     }
     
@@ -1108,8 +1144,8 @@ public class AssessmentServiceTest extends Mockito {
         
     @Test
     public void deleteAssessment() {
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false))
-            .thenReturn(Substudy.create());
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+            .thenReturn(Organization.create());
         
         Assessment assessment = new Assessment();
         assessment.setOwnerId(OWNER_ID);
@@ -1171,7 +1207,7 @@ public class AssessmentServiceTest extends Mockito {
             expectedExceptionsMessageRegExp = CALLER_NOT_MEMBER_ERROR)
     public void createAssessmentChecksOwnership() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("substudyD")).build());
+                .withCallerOrgMembership("substudyD").build());
         Assessment assessment = AssessmentTest.createAssessment();
         service.createAssessment(TEST_APP_ID, assessment);
     }
@@ -1180,7 +1216,7 @@ public class AssessmentServiceTest extends Mockito {
             expectedExceptionsMessageRegExp = CALLER_NOT_MEMBER_ERROR)
     public void createAssessmentRevisionChecksOwnership() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("substudyD")).build());
+                .withCallerOrgMembership("substudyD").build());
         Assessment assessment = AssessmentTest.createAssessment();
         service.createAssessmentRevision(TEST_APP_ID, GUID, assessment);
     }
@@ -1190,7 +1226,7 @@ public class AssessmentServiceTest extends Mockito {
     public void updateAssessmentChecksOwnership() {
         Assessment assessment = AssessmentTest.createAssessment();
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of(assessment.getOwnerId())).build());
+                .withCallerOrgMembership(assessment.getOwnerId()).build());
         
         Assessment existing = AssessmentTest.createAssessment();
         existing.setDeleted(false);
@@ -1204,7 +1240,7 @@ public class AssessmentServiceTest extends Mockito {
             expectedExceptionsMessageRegExp = CALLER_NOT_MEMBER_ERROR)
     public void publishAssessmentChecksOwnership() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("substudyD")).build());
+                .withCallerOrgMembership("substudyD").build());
         Assessment existing = AssessmentTest.createAssessment();
         existing.setDeleted(false);
         when(mockDao.getAssessment(TEST_APP_ID, GUID)).thenReturn(Optional.of(existing));
@@ -1216,7 +1252,7 @@ public class AssessmentServiceTest extends Mockito {
             expectedExceptionsMessageRegExp = CALLER_NOT_MEMBER_ERROR)
     public void importAssessmentChecksOwnership() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("substudyD")).build());
+                .withCallerOrgMembership("substudyD").build());
         service.importAssessment(TEST_APP_ID, OWNER_ID, null, GUID);
     }
 
@@ -1224,7 +1260,7 @@ public class AssessmentServiceTest extends Mockito {
             expectedExceptionsMessageRegExp = CALLER_NOT_MEMBER_ERROR)
     public void deleteAssessmentChecksOwnership() {
         BridgeUtils.setRequestContext(new RequestContext.Builder()
-                .withCallerSubstudies(ImmutableSet.of("substudyD")).build());
+                .withCallerOrgMembership("substudyD").build());
         Assessment existing = AssessmentTest.createAssessment();
         existing.setDeleted(false);
         when(mockDao.getAssessment(TEST_APP_ID, GUID)).thenReturn(Optional.of(existing));

--- a/src/test/java/org/sagebionetworks/bridge/services/SessionUpdateServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/SessionUpdateServiceTest.java
@@ -5,8 +5,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
+import static org.sagebionetworks.bridge.TestConstants.USER_ID;
 import static org.sagebionetworks.bridge.models.accounts.SharingScope.ALL_QUALIFIED_RESEARCHERS;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 
 import java.util.List;
@@ -16,6 +18,7 @@ import java.util.Set;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.joda.time.DateTimeZone;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
@@ -223,5 +226,33 @@ public class SessionUpdateServiceTest {
         
         verify(mockCacheProvider).setUserSession(session);
         assertEquals(session.getParticipant().getSharingScope(), ALL_QUALIFIED_RESEARCHERS);
+    }
+    
+    @Test
+    public void updateOrgMembershipAddMembership() {
+        UserSession session = new UserSession();
+        session.setParticipant(new StudyParticipant.Builder().withOrgMembership("test").build());
+        when(mockCacheProvider.getUserSessionByUserId(USER_ID)).thenReturn(session);
+        
+        ArgumentCaptor<UserSession> sessionCaptor = ArgumentCaptor.forClass(UserSession.class);
+        
+        service.updateOrgMembership(USER_ID, "newOrgId");
+        
+        verify(mockCacheProvider).setUserSession(sessionCaptor.capture());
+        assertEquals("newOrgId", sessionCaptor.getValue().getParticipant().getOrgMembership());
+    }
+
+    @Test
+    public void updateOrgMembershipRemoveMembership() {
+        UserSession session = new UserSession();
+        session.setParticipant(new StudyParticipant.Builder().withOrgMembership("test").build());
+        when(mockCacheProvider.getUserSessionByUserId(USER_ID)).thenReturn(session);
+        
+        ArgumentCaptor<UserSession> sessionCaptor = ArgumentCaptor.forClass(UserSession.class);
+        
+        service.updateOrgMembership(USER_ID, null);
+        
+        verify(mockCacheProvider).setUserSession(sessionCaptor.capture());
+        assertNull(sessionCaptor.getValue().getParticipant().getOrgMembership());
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/validators/AssessmentValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/AssessmentValidatorTest.java
@@ -26,8 +26,8 @@ import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.assessments.Assessment;
 import org.sagebionetworks.bridge.models.assessments.AssessmentTest;
 import org.sagebionetworks.bridge.models.assessments.config.PropertyInfo;
-import org.sagebionetworks.bridge.models.substudies.Substudy;
-import org.sagebionetworks.bridge.services.SubstudyService;
+import org.sagebionetworks.bridge.models.organizations.Organization;
+import org.sagebionetworks.bridge.services.OrganizationService;
 
 public class AssessmentValidatorTest extends Mockito {
 
@@ -35,7 +35,7 @@ public class AssessmentValidatorTest extends Mockito {
     AssessmentDao mockAssessmentDao;
     
     @Mock
-    SubstudyService mockSubstudyService;
+    OrganizationService mockOrganizationService;
     
     AssessmentValidator validator;
     
@@ -49,22 +49,22 @@ public class AssessmentValidatorTest extends Mockito {
         when(mockAssessmentDao.getAssessmentRevisions(TEST_APP_ID, IDENTIFIER, 0, 1, true))
             .thenReturn(new PagedResourceList<Assessment>(ImmutableList.of(), 0));
         
-        validator = new AssessmentValidator(mockSubstudyService, TEST_APP_ID);
+        validator = new AssessmentValidator(TEST_APP_ID, mockOrganizationService);
     }
     
     @Test
     public void validAssessment() {
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, assessment.getOwnerId(), false))
-            .thenReturn(Substudy.create());
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, assessment.getOwnerId()))
+            .thenReturn(Organization.create());
         
         Validate.entityThrowingException(validator, assessment);
     }
     @Test
     public void validSharedAssessment() {
-        validator = new AssessmentValidator(mockSubstudyService, SHARED_APP_ID);
+        validator = new AssessmentValidator(SHARED_APP_ID, mockOrganizationService);
         assessment.setOwnerId(TEST_APP_ID + ":" + OWNER_ID);
         
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, OWNER_ID, false)).thenReturn(Substudy.create());
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID)).thenReturn(Organization.create());
     
         Validate.entityThrowingException(validator, assessment);
     }
@@ -109,8 +109,8 @@ public class AssessmentValidatorTest extends Mockito {
     }
     @Test
     public void osNameUniversalIsValid() {
-        when(mockSubstudyService.getSubstudy(TEST_APP_ID, assessment.getOwnerId(), false))
-            .thenReturn(Substudy.create());
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, assessment.getOwnerId()))
+            .thenReturn(Organization.create());
         
         assessment.setOsName("Universal");
         Validate.entityThrowingException(validator, assessment);


### PR DESCRIPTION
Edits to assessments can either be done by a superadmin, or by a member of the organization that owns the assessment (the creator of the assessment sets the organization ownership). 

In addition, it became apparent in integration tests that failing to update a signed in user's session was a significant security hole. If an admin removes a person from the organization, they could still operate as a member of that organization until their session expired, which really does not seem right. Expecting the admin to delete their session is depending too much on user behavior to ensure security. So I am editing the session for the user if they have one. This is something that we may wish to do elsewhere.