### PR TITLE
Assure backwards compatibility of ExternalIdentifier

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoExternalIdentifier.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoExternalIdentifier.java
@@ -11,7 +11,6 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexRangeKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import com.amazonaws.services.dynamodbv2.model.ProjectionType;
-import com.fasterxml.jackson.annotation.JsonAlias;
 
 /**
  * Implementation of external identifier.
@@ -38,7 +37,6 @@ public final class DynamoExternalIdentifier implements ExternalIdentifier {
         return appId;
     }
     @Override
-    @JsonAlias("studyId")
     public void setAppId(String appId) {
         this.appId = appId;
     }

--- a/src/main/java/org/sagebionetworks/bridge/models/accounts/ExternalIdentifier.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/accounts/ExternalIdentifier.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.models.accounts;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import org.sagebionetworks.bridge.dynamodb.DynamoExternalIdentifier;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
@@ -10,7 +11,7 @@ import org.sagebionetworks.bridge.models.BridgeEntity;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @BridgeTypeName("ExternalIdentifier")
-@JsonDeserialize(as=DynamoExternalIdentifier.class)
+@JsonDeserialize(builder = ExternalIdentifier.Builder.class)
 public interface ExternalIdentifier extends BridgeEntity {
 
     static ExternalIdentifier create(String appId, String identifier) {
@@ -31,4 +32,48 @@ public interface ExternalIdentifier extends BridgeEntity {
     
     String getHealthCode();
     void setHealthCode(String healthCode);
+    
+    public static class Builder {
+        private String appId;
+        private String studyId;
+        private String substudyId;
+        private String identifier;
+        private String healthCode;
+        
+        public Builder withAppId(String appId) {
+            this.appId = appId;
+            return this;
+        }
+        public Builder withStudyId(String studyId) {
+            this.studyId = studyId;
+            return this;
+        }
+        public Builder withSubstudyId(String substudyId) {
+            this.substudyId = substudyId;
+            return this;
+        }
+        public Builder withIdentifier(String identifier) {
+            this.identifier = identifier;
+            return this;
+        }
+        public Builder withHealthCode(String healthCode) {
+            this.healthCode = healthCode;
+            return this;
+        }
+        public ExternalIdentifier build() {
+            DynamoExternalIdentifier extId = new DynamoExternalIdentifier();
+            extId.setIdentifier(identifier);
+            extId.setHealthCode(healthCode);
+            // We can't do this with @JsonAlias because we're shifting the studyId
+            // two places at this point, from substudyId -> studyId and studyId -> appId. 
+            if (isNotBlank(studyId) && isNotBlank(substudyId)) {
+                extId.setAppId(studyId);
+                extId.setStudyId(substudyId);
+            } else {
+                extId.setAppId(appId);
+                extId.setStudyId(studyId);
+            }
+            return extId;
+        }
+    }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/ExternalIdentifierTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/ExternalIdentifierTest.java
@@ -37,4 +37,19 @@ public class ExternalIdentifierTest {
         assertEquals(node.get("type").textValue(), "ExternalIdentifier");
     }
     
+    @Test
+    public void testMigrationToNewNomenclature() throws Exception {
+        String oldJson = TestUtils.createJson("{'identifier':'AAA','studyId':'study-id', 'substudyId': 'substudy-id'}");
+        ExternalIdentifier identifier = BridgeObjectMapper.get().readValue(oldJson, ExternalIdentifier.class);
+        assertEquals(identifier.getIdentifier(), "AAA");
+        assertEquals(identifier.getAppId(), "study-id");
+        assertEquals(identifier.getStudyId(), "substudy-id");
+        
+        String newJson = TestUtils.createJson("{'identifier':'AAA','appId':'app-id', 'studyId': 'study-id'}");
+        identifier = BridgeObjectMapper.get().readValue(newJson, ExternalIdentifier.class);
+        assertEquals(identifier.getIdentifier(), "AAA");
+        assertEquals(identifier.getAppId(), "app-id");
+        assertEquals(identifier.getStudyId(), "study-id");
+    }
+    
 }


### PR DESCRIPTION
The external identifier API is widely used and I realized while working on the BSM that there is a naming conflict with studyId... it was shifted to appId with a @JsonAlias annotation, but then shifting substudyId to studyId you would want to put another annotation, but both are @JsonAlias("studyId"), which is ambiguous. Added a builder so we can do more precise deserialization of old and new JSON.