### PR TITLE
Fix for inability to switch studies if you're a superadmin without a Synapse User ID.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AppController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AppController.java
@@ -169,16 +169,15 @@ public class AppController extends BaseController {
         if (session.getParticipant().getRoles().isEmpty()) {
             throw new UnauthorizedException(APP_ACCESS_EXCEPTION_MSG);
         }
-        List<String> appIds = accountService.getAppIdsForUser(session.getParticipant().getSynapseUserId());
-        
         Stream<App> stream = null;
-        // In our current app permissions model, an admin in the API app is a 
-        // "cross-app admin" and can see all apps and can switch between all apps, 
-        // so check for this condition.
         if (session.isInRole(SUPERADMIN)) {
+            // Superadmins can see all apps and can switch between all apps.
             stream = appService.getApps().stream()
                 .filter(s -> s.isActive());
         } else {
+            // Otherwise, apps are linked by Synapse user ID.
+            List<String> appIds = accountService
+                    .getAppIdsForUser(session.getParticipant().getSynapseUserId());
             stream = appIds.stream()
                 .map(id -> appService.getApp(id))
                 .filter(s -> s.isActive() && appIds.contains(s.getIdentifier()));

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AppControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AppControllerTest.java
@@ -880,6 +880,33 @@ public class AppControllerTest extends Mockito {
         controller.getAppMemberships();
     }
     
+    @Test
+    public void getAppMembershipsForSuperadminNoSynapseId() throws Exception {
+        StudyParticipant participant = new StudyParticipant.Builder()
+                .withRoles(ImmutableSet.of(SUPERADMIN)).build();
+        when(mockSession.getParticipant()).thenReturn(participant);
+        when(mockSession.isInRole(SUPERADMIN)).thenReturn(true);
+        doReturn(mockSession).when(controller).getAuthenticatedSession();
+        
+        App app1 = App.create();
+        app1.setName("Name1");
+        app1.setActive(true);
+        App app2 = App.create();
+        app2.setActive(true);
+        app2.setName("Name2");
+        
+        when(mockAppService.getApps()).thenReturn(ImmutableList.of(app1, app2));
+        
+        String returnValue = controller.getAppMemberships();
+        ResourceList<App> list = BridgeObjectMapper.get().readValue(returnValue, new TypeReference<ResourceList<App>>() {});
+        
+        assertEquals(list.getItems().size(), 2);
+        assertEquals(list.getItems().get(0).getName(), "Name1");
+        assertEquals(list.getItems().get(1).getName(), "Name2");
+        
+        verify(mockAppService, never()).getApp(any());
+    }
+    
     private App mockApp(String name, String appId, boolean active) {
         App app = App.create();
         app.setName(name);


### PR DESCRIPTION
The service being called was throwing an exception at the lack of a Synapse ID, before testing for the superadmin role and calling an entirely different API to get all app IDs. Rearranged the call order of these.