### PR TITLE
Changing behavior of CRC controller again.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/CRCController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/CRCController.java
@@ -182,9 +182,9 @@ public class CRCController extends BaseController {
         // This is temporary so we can start using the CRC system in production, 
         // while continuing to test. The calling code should not update the state of
         // the user if it receives a 400.
-        if (!account.getDataGroups().contains(TEST_USER_GROUP)) {
-            throw new BadRequestException("Production accounts are not yet enabled.");
-        }
+//        if (!account.getDataGroups().contains(TEST_USER_GROUP)) {
+//            throw new BadRequestException("Production accounts are not yet enabled.");
+//        }
         // All the code related to requesting a lab order will be removed once we've 
         // confirmed that this is Columbia's final approach to the integration.
         // createLabOrder(account);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/CRCController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/CRCController.java
@@ -12,7 +12,6 @@ import static org.sagebionetworks.bridge.BridgeUtils.parseAccountId;
 import static org.sagebionetworks.bridge.BridgeUtils.resolveTemplate;
 import static org.sagebionetworks.bridge.spring.controllers.CRCController.AccountStates.SELECTED;
 import static org.sagebionetworks.bridge.spring.controllers.CRCController.AccountStates.TESTS_CANCELLED;
-import static org.sagebionetworks.bridge.spring.controllers.CRCController.AccountStates.TESTS_REQUESTED;
 import static org.sagebionetworks.bridge.spring.controllers.CRCController.AccountStates.TESTS_SCHEDULED;
 import static org.sagebionetworks.bridge.util.BridgeCollectors.toImmutableSet;
 
@@ -186,9 +185,11 @@ public class CRCController extends BaseController {
         if (!account.getDataGroups().contains(TEST_USER_GROUP)) {
             throw new BadRequestException("Production accounts are not yet enabled.");
         }
-        createLabOrder(account);
+        // All the code related to requesting a lab order will be removed once we've 
+        // confirmed that this is Columbia's final approach to the integration.
+        // createLabOrder(account);
 
-        updateState(account, TESTS_REQUESTED);
+        updateState(account, SELECTED);
         accountService.updateAccount(account, null);
         return new StatusMessage("Participant updated.");
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportController.java
@@ -25,7 +25,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import org.sagebionetworks.bridge.AuthUtils;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.DateRangeResourceList;

--- a/src/test/java/org/sagebionetworks/bridge/models/studies/EnrollmentIdTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/studies/EnrollmentIdTest.java
@@ -5,8 +5,6 @@ import static org.testng.Assert.assertEquals;
 
 import org.testng.annotations.Test;
 
-import org.sagebionetworks.bridge.models.studies.EnrollmentId;
-
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/CRCControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/CRCControllerTest.java
@@ -265,7 +265,32 @@ public class CRCControllerTest extends Mockito {
     public void getUserAgentDefault() {
         assertEquals(controller.getUserAgent(), "<Unknown>");
     }
+
+    @Test
+    public void updateParticipantSetsSelected() throws Exception {
+        when(mockRequest.getHeader(AUTHORIZATION)).thenReturn(AUTHORIZATION_HEADER_VALUE);
+        when(mockAccountService.authenticate(any(), any())).thenReturn(account);
+        
+        when(mockAccountService.getAccount(ACCOUNT_ID_FOR_HC)).thenReturn(account);
+        
+        HttpResponse mockResponse = mock(HttpResponse.class);
+        StatusLine mockStatusLine = mock(StatusLine.class);
+        when(mockResponse.getStatusLine()).thenReturn(mockStatusLine);
+        when(mockStatusLine.getStatusCode()).thenReturn(200);
+                
+        doReturn(mockResponse).when(controller).put(any(), any(), any());
+        
+        StatusMessage message = controller.updateParticipant("healthcode:"+HEALTH_CODE);
+        assertEquals(message.getMessage(), CRCController.UPDATE_MSG);
+
+        verify(mockAccountService).updateAccount(account, null);
+        verify(controller, never()).createLabOrder(account);
+
+        assertEquals(account.getDataGroups(), makeSetOf(CRCController.AccountStates.SELECTED, "group1"));
+        assertFalse(BridgeUtils.getRequestContext().getCallerStudies().isEmpty());
+    }
     
+    /*
     @Test
     public void updateParticipantCallsExternalTest() throws Exception {
         when(mockRequest.getHeader(AUTHORIZATION)).thenReturn(AUTHORIZATION_HEADER_VALUE);
@@ -326,6 +351,7 @@ public class CRCControllerTest extends Mockito {
                 +"'COVID Recovery Corps'}}]}"));
         assertFalse(BridgeUtils.getRequestContext().getCallerStudies().isEmpty());
     }
+    */
     
     @Test(expectedExceptions = EntityNotFoundException.class, 
             expectedExceptionsMessageRegExp = "Account not found.")

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/CRCControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/CRCControllerTest.java
@@ -361,7 +361,7 @@ public class CRCControllerTest extends Mockito {
                 
         controller.updateParticipant("healthcode:"+HEALTH_CODE);
     }
-    
+    /*
     @Test(expectedExceptions = BadRequestException.class, 
             expectedExceptionsMessageRegExp = "Production accounts are not yet enabled.")
     public void updateParticipantFailsOnProductionAccount() throws Exception {
@@ -373,6 +373,7 @@ public class CRCControllerTest extends Mockito {
         
         controller.updateParticipant("healthcode:"+HEALTH_CODE);
     }
+    */
 
     @Test
     public void externalIdAccountSubmitsCorrectCredentials() throws Exception {

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportControllerTest.java
@@ -45,7 +45,6 @@ import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.RequestContext;
-import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoApp;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;


### PR DESCRIPTION
Columbia wants to call us rather than us calling them, which is great and will remove a lot of our code (once they have really done this...they might change approach again). Updated one method to reflect new integration strategy.

I also removed any check as to the test/production status of the account, because Columbia is going to handle it on their end...they know our test users are tagged with a "test_user" tag.