### PR TITLE
Self

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
@@ -104,7 +104,7 @@ public class ParticipantController extends BaseController {
         participantService.createSmsRegistration(app, userId);
         return new StatusMessage("SMS notification registration created");
     }
-    
+
     @PostMapping("/v3/participants/self")
     public JsonNode updateSelfParticipant() {
         UserSession session = getAuthenticatedSession();
@@ -289,14 +289,12 @@ public class ParticipantController extends BaseController {
         
         return StudyParticipant.API_NO_HEALTH_CODE_WRITER.writeValueAsString(participant);
     }
-    
+
     @GetMapping(path="/v3/participants/{userId}", produces={APPLICATION_JSON_UTF8_VALUE})
     public String getParticipant(@PathVariable String userId, @RequestParam(defaultValue = "true") boolean consents)
             throws Exception {
-        UserSession session = getAuthenticatedSession(DEVELOPER, RESEARCHER, ADMIN);
-        if ("self".equals(userId)) {
-            userId = session.getId();
-        }
+        UserSession session = getAuthenticatedSession(RESEARCHER);
+
         checkSelfOrResearcherAndThrow(userId);
         App app = appService.getApp(session.getAppId());
 
@@ -307,13 +305,7 @@ public class ParticipantController extends BaseController {
             throw new EntityNotFoundException(Account.class);
         }
         
-        StudyParticipant participant; 
-        if (session.getId().equals(userId)) {
-            CriteriaContext context = getCriteriaContext(session);
-            participant = participantService.getSelfParticipant(app, context, consents);
-        } else {
-            participant = participantService.getParticipant(app, userId, consents);
-        }
+        StudyParticipant participant = participantService.getParticipant(app, userId, consents);
         
         ObjectWriter writer = (app.isHealthCodeExportEnabled() || session.isInRole(ADMIN)) ?
                 StudyParticipant.API_WITH_HEALTH_CODE_WRITER :

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
@@ -295,7 +295,6 @@ public class ParticipantController extends BaseController {
             throws Exception {
         UserSession session = getAuthenticatedSession(RESEARCHER);
 
-        checkSelfOrResearcherAndThrow(userId);
         App app = appService.getApp(session.getAppId());
 
         // Do not allow lookup by health code if health code access is disabled. Allow it however

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
@@ -413,40 +413,41 @@ public class ParticipantControllerTest extends Mockito {
     }
 
     @Test
-    public void getParticipantForSelfReturnsNoHealthCodeForDeveloper() throws Exception {
-        participant = new StudyParticipant.Builder().withRoles(ImmutableSet.of(DEVELOPER))
+    public void getParticipantReturnsNoHealthCodeForDeveloper() throws Exception {
+        participant = new StudyParticipant.Builder().withRoles(ImmutableSet.of(DEVELOPER, RESEARCHER))
                 .withStudyIds(CALLER_STUDIES).withId(USER_ID).build();
         session.setParticipant(participant);
         
         app.setHealthCodeExportEnabled(false);
         StudyParticipant studyParticipant = new StudyParticipant.Builder().withFirstName("Test")
-                .withId(USER_ID).withHealthCode(HEALTH_CODE).build();
-        when(mockParticipantService.getSelfParticipant(eq(app), any(), eq(true))).thenReturn(studyParticipant);
+                .withId("aUser").withHealthCode(HEALTH_CODE).build();
+        when(mockParticipantService.getParticipant(app, "aUser", true)).thenReturn(studyParticipant);
 
-        String json = controller.getParticipant("self", true);
+        String json = controller.getParticipant("aUser", true);
 
         StudyParticipant retrievedParticipant = MAPPER.readValue(json, StudyParticipant.class);
 
-        assertEquals(retrievedParticipant.getFirstName(), "Test");
-        assertNull(retrievedParticipant.getHealthCode());
+        // You do not get the health code, because export of the health code is not enabled and
+        // the caller is not an admin.
+        assertNull(retrievedParticipant.getHealthCode(), HEALTH_CODE);
     }
     
     @Test
-    public void getParticipantForSelfReturnsHealthCodeForAdmin() throws Exception {
-        participant = new StudyParticipant.Builder().withRoles(ImmutableSet.of(ADMIN))
+    public void getParticipantReturnsHealthCodeForAdmin() throws Exception {
+        participant = new StudyParticipant.Builder().withRoles(ImmutableSet.of(ADMIN, RESEARCHER))
                 .withId(USER_ID).withStudyIds(CALLER_STUDIES).withId(USER_ID).build();
         session.setParticipant(participant);
 
         app.setHealthCodeExportEnabled(false);
         StudyParticipant studyParticipant = new StudyParticipant.Builder().withFirstName("Test")
-                .withId(USER_ID).withHealthCode(HEALTH_CODE).build();
-        when(mockParticipantService.getSelfParticipant(eq(app), any(), eq(true))).thenReturn(studyParticipant);
+                .withId("aUser").withHealthCode(HEALTH_CODE).build();
+        when(mockParticipantService.getParticipant(app, "aUser", true)).thenReturn(studyParticipant);
 
-        String json = controller.getParticipant("self", true);
+        String json = controller.getParticipant("aUser", true);
 
         StudyParticipant retrievedParticipant = MAPPER.readValue(json, StudyParticipant.class);
 
-        assertEquals(retrievedParticipant.getFirstName(), "Test");
+        // You still get the health code, even though export of the health code is not enabled.
         assertEquals(retrievedParticipant.getHealthCode(), HEALTH_CODE);
     }
     


### PR DESCRIPTION
Basically the permission are much laxer on the existing "self" call and it's best to leave it as is. So the call for a user by an ID does not need to accommodate the self logic. Undid that, and adjusted the tests to verify that admins will always get back a health code, whether it's enabled for an app or not.