### PR TITLE
The self call should (always) return health code for admin users.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
@@ -5,6 +5,7 @@ import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeUtils.getDateTimeOrDefault;
 import static org.sagebionetworks.bridge.BridgeUtils.getIntOrDefault;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
+import static org.sagebionetworks.bridge.Roles.ADMINISTRATIVE_ROLES;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.WORKER;
@@ -287,7 +288,12 @@ public class ParticipantController extends BaseController {
         CriteriaContext context = getCriteriaContext(session);
         StudyParticipant participant = participantService.getSelfParticipant(app, context, consents);
         
-        return StudyParticipant.API_NO_HEALTH_CODE_WRITER.writeValueAsString(participant);
+        // Return the health code if this is an administrative account. This is because developers 
+        // should call this method to retrieve their own account.
+        ObjectWriter writer = (session.isInRole(ADMINISTRATIVE_ROLES)) ?
+                StudyParticipant.API_WITH_HEALTH_CODE_WRITER :
+                StudyParticipant.API_NO_HEALTH_CODE_WRITER;
+        return writer.writeValueAsString(participant);
     }
 
     @GetMapping(path="/v3/participants/{userId}", produces={APPLICATION_JSON_UTF8_VALUE})


### PR DESCRIPTION
The integration tests showed some problems with combining the /v3/participants/{userId} and /v3/participants/self GET calls. So I restored the self call and made a couple of changes:

1) removed the "self" logic in the call to get any account (preserving the ability of admins to always get a health code regardless of the app's setting);

2) administrative users who call the "self" endpoint will always get their own health code. This is needed for development.

This is getting directly integrated into a view of the BSM for developer-only accounts (no researcher permissions).