### PR TITLE
Give "admin" specified in config SUPERADMIN permission

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/DefaultAppBootstrapper.java
+++ b/src/main/java/org/sagebionetworks/bridge/DefaultAppBootstrapper.java
@@ -99,7 +99,7 @@ public class DefaultAppBootstrapper  implements ApplicationListener<ContextRefre
             StudyParticipant admin = new StudyParticipant.Builder()
                     .withEmail(config.get("admin.email"))
                     .withPassword(config.get("admin.password"))
-                    .withRoles(ImmutableSet.of(ADMIN, RESEARCHER)).build();
+                    .withRoles(ImmutableSet.of(SUPERADMIN, RESEARCHER)).build();
             userAdminService.createUser(app, admin, API_SUBPOP, false, false);
 
             StudyParticipant dev = new StudyParticipant.Builder()

--- a/src/main/java/org/sagebionetworks/bridge/DefaultAppBootstrapper.java
+++ b/src/main/java/org/sagebionetworks/bridge/DefaultAppBootstrapper.java
@@ -99,7 +99,7 @@ public class DefaultAppBootstrapper  implements ApplicationListener<ContextRefre
             StudyParticipant admin = new StudyParticipant.Builder()
                     .withEmail(config.get("admin.email"))
                     .withPassword(config.get("admin.password"))
-                    .withRoles(ImmutableSet.of(SUPERADMIN, RESEARCHER)).build();
+                    .withRoles(ImmutableSet.of(SUPERADMIN)).build();
             userAdminService.createUser(app, admin, API_SUBPOP, false, false);
 
             StudyParticipant dev = new StudyParticipant.Builder()

--- a/src/test/java/org/sagebionetworks/bridge/DefaultStudyBootstrapperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/DefaultStudyBootstrapperTest.java
@@ -123,7 +123,7 @@ public class DefaultStudyBootstrapperTest extends Mockito {
         assertEquals(SHARED_SUBPOP, subpopCaptor.getAllValues().get(2));
         
         StudyParticipant admin = participantCaptor.getAllValues().get(0);
-        assertEquals(admin.getRoles(), ImmutableSet.of(ADMIN, RESEARCHER));
+        assertEquals(admin.getRoles(), ImmutableSet.of(SUPERADMIN, RESEARCHER));
         assertEquals(admin.getEmail(), config.get("admin.email"));
         assertEquals(admin.getPassword(), config.get("admin.password"));
         

--- a/src/test/java/org/sagebionetworks/bridge/DefaultStudyBootstrapperTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/DefaultStudyBootstrapperTest.java
@@ -123,7 +123,7 @@ public class DefaultStudyBootstrapperTest extends Mockito {
         assertEquals(SHARED_SUBPOP, subpopCaptor.getAllValues().get(2));
         
         StudyParticipant admin = participantCaptor.getAllValues().get(0);
-        assertEquals(admin.getRoles(), ImmutableSet.of(SUPERADMIN, RESEARCHER));
+        assertEquals(admin.getRoles(), ImmutableSet.of(SUPERADMIN));
         assertEquals(admin.getEmail(), config.get("admin.email"));
         assertEquals(admin.getPassword(), config.get("admin.password"));
         


### PR DESCRIPTION
Giving SUPERADMIN instead of ADMIN permission for the StudyParticipant specified by admin.email in config file, so that we don't need to promote admin manually for the integration tests.