### PR TITLE
For new APIs, remove deprecated ResourceList properties

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/models/DateRangeResourceList.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/DateRangeResourceList.java
@@ -9,22 +9,29 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class DateRangeResourceList<T> extends ResourceList<T> {
     
+    public DateRangeResourceList(List<T> items, boolean suppressDeprecated) {
+        super(items, suppressDeprecated);
+    }
+    
     @JsonCreator
     public DateRangeResourceList(@JsonProperty(ITEMS) List<T> items) {
-        super(items);
+        this(items, false);
     }
     
     @Deprecated
     public LocalDate getStartDate() {
-        return getLocalDate(START_DATE);
+        return (suppressDeprecated) ? null : getLocalDate(START_DATE);
     }
     @Deprecated
     public LocalDate getEndDate() {
-        return getLocalDate(END_DATE);
+        return (suppressDeprecated) ? null : getLocalDate(END_DATE);
     }
     @Override
     @Deprecated
     public Integer getTotal() {
+        if (suppressDeprecated) {
+            return null;
+        }
         // This is necessary solely to keep current integration tests passing. 
         // The total property is going away on everything except PagedResourceList.
         Integer total = super.getTotal();

--- a/src/main/java/org/sagebionetworks/bridge/models/DateTimeRangeResourceList.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/DateTimeRangeResourceList.java
@@ -12,19 +12,24 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 public class DateTimeRangeResourceList<T> extends ResourceList<T> {
     
+    public DateTimeRangeResourceList(List<T> items, boolean suppressDeprecated) {
+        super(items, suppressDeprecated);
+    }
+
     @JsonCreator
     public DateTimeRangeResourceList(@JsonProperty(ITEMS) List<T> items) {
-        super(items);
+        super(items, false);
     }
+    
     @Deprecated
     @JsonSerialize(using = DateTimeSerializer.class)
     public DateTime getStartTime() {
-        return getDateTime(START_TIME);
+        return (suppressDeprecated) ? null : getDateTime(START_TIME);
     }
     @Deprecated
     @JsonSerialize(using = DateTimeSerializer.class)
     public DateTime getEndTime() {
-        return getDateTime(END_TIME);
+        return (suppressDeprecated) ? null : getDateTime(END_TIME);
     }
     public DateTimeRangeResourceList<T> withRequestParam(String key, Object value) {
         super.withRequestParam(key, value);

--- a/src/main/java/org/sagebionetworks/bridge/models/ForwardCursorPagedResourceList.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/ForwardCursorPagedResourceList.java
@@ -24,41 +24,44 @@ public class ForwardCursorPagedResourceList<T> extends ResourceList<T> {
     
     private final @Nullable String nextPageOffsetKey;
 
-    @JsonCreator
-    public ForwardCursorPagedResourceList(
-            @JsonProperty(ITEMS) List<T> items, 
-            @JsonProperty(NEXT_PAGE_OFFSET_KEY) String nextPageOffsetKey) {
-        super(items);
+    public ForwardCursorPagedResourceList(List<T> items, String nextPageOffsetKey, boolean suppressDeprecated) {
+        super(items, suppressDeprecated);
         this.nextPageOffsetKey = nextPageOffsetKey;
+    }
+
+    @JsonCreator
+    public ForwardCursorPagedResourceList(@JsonProperty(ITEMS) List<T> items,
+            @JsonProperty(NEXT_PAGE_OFFSET_KEY) String nextPageOffsetKey) {
+        this(items, nextPageOffsetKey, false);
     }
     
     @Deprecated
     @JsonSerialize(using = DateTimeSerializer.class)
     public DateTime getStartTime() {
-        return getDateTime(START_TIME);
+        return (suppressDeprecated) ? null : getDateTime(START_TIME);
     }
     @Deprecated
     @JsonSerialize(using = DateTimeSerializer.class)
     public DateTime getEndTime() {
-        return getDateTime(END_TIME);
+        return (suppressDeprecated) ? null : getDateTime(END_TIME);
     }
     @Deprecated
     @JsonSerialize(using = DateTimeSerializer.class)
     public DateTime getScheduledOnStart() {
-        return getDateTime(SCHEDULED_ON_START);
+        return (suppressDeprecated) ? null : getDateTime(SCHEDULED_ON_START);
     }
     @Deprecated
     @JsonSerialize(using = DateTimeSerializer.class)
     public DateTime getScheduledOnEnd() {
-        return getDateTime(SCHEDULED_ON_END);
+        return (suppressDeprecated) ? null : getDateTime(SCHEDULED_ON_END);
     }
     @Deprecated
     public String getOffsetKey() {
-        return nextPageOffsetKey;
+        return (suppressDeprecated) ? null : nextPageOffsetKey;
     }
     @Deprecated
     public Integer getPageSize() {
-        return (Integer)getRequestParams().get(PAGE_SIZE);
+        return (suppressDeprecated) ? null : (Integer)getRequestParams().get(PAGE_SIZE);
     }
     public String getNextPageOffsetKey() {
         return nextPageOffsetKey;

--- a/src/main/java/org/sagebionetworks/bridge/models/PagedResourceList.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/PagedResourceList.java
@@ -32,32 +32,38 @@ public class PagedResourceList<T> extends ResourceList<T> {
     public PagedResourceList(
             @JsonProperty(ITEMS) List<T> items, 
             @JsonProperty(TOTAL) Integer total) {
-        super(items);
+        super(items, false);
         checkNotNull(total);
         this.total = total;
     }
 
+    public PagedResourceList(List<T> items, Integer total, boolean suppressDeprecated) {
+        super(items, suppressDeprecated);
+        checkNotNull(total);
+        this.total = total;
+    }
+    
     @Deprecated
     public String getEmailFilter() {
-        return (String)getRequestParams().get(EMAIL_FILTER);
+        return (suppressDeprecated) ? null : (String)getRequestParams().get(EMAIL_FILTER);
     }
     @Deprecated
     @JsonSerialize(using = DateTimeSerializer.class)
     public DateTime getStartTime() {
-        return getDateTime(START_TIME);
+        return (suppressDeprecated) ? null : getDateTime(START_TIME);
     }
     @Deprecated
     @JsonSerialize(using = DateTimeSerializer.class)
     public DateTime getEndTime() {
-        return getDateTime(END_TIME);
+        return (suppressDeprecated) ? null : getDateTime(END_TIME);
     }
     @Deprecated
-    public int getPageSize() {
-        return (Integer)getRequestParams().get(PAGE_SIZE);
+    public Integer getPageSize() {
+        return (suppressDeprecated) ? null : (Integer)getRequestParams().get(PAGE_SIZE);
     }
     @Deprecated
     public Integer getOffsetBy() {
-        return (Integer)getRequestParams().get(OFFSET_BY);
+        return (suppressDeprecated) ? null : (Integer)getRequestParams().get(OFFSET_BY);
     }
     public Integer getTotal() {
         return total;

--- a/src/main/java/org/sagebionetworks/bridge/models/ReportTypeResourceList.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/ReportTypeResourceList.java
@@ -9,13 +9,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ReportTypeResourceList<T> extends ResourceList<T> {
     
+    public ReportTypeResourceList(List<T> items, boolean suppressDeprecated) {
+        super(items, suppressDeprecated);
+    }
     @JsonCreator
     public ReportTypeResourceList(@JsonProperty(ITEMS) List<T> items) {
-        super(items);
+        super(items, false);
     }
     @Deprecated
     public ReportType getReportType() {
-        return (ReportType)getRequestParams().get(REPORT_TYPE);
+        return (suppressDeprecated) ? null : (ReportType)getRequestParams().get(REPORT_TYPE);
     }
     public ReportTypeResourceList<T> withRequestParam(String key, Object value) {
         super.withRequestParam(key, value);

--- a/src/main/java/org/sagebionetworks/bridge/models/ResourceList.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/ResourceList.java
@@ -16,7 +16,10 @@ import com.google.common.collect.ImmutableMap;
 
 /**
  * Basic list of items, not paged, as calculated based on the parameters that were 
- * sent to the server and are included in the <code>ResourceList</code>.
+ * sent to the server and are included in the <code>ResourceList</code>. As a step 
+  * toward eliminating the deprecated properties on this class, it now takes a flag
+  * that causes these fields to be null and thus, they will be excluded from JSON 
+  * payloads. New APIs can set this flag to true.
  */
 public class ResourceList<T> {
     
@@ -56,13 +59,26 @@ public class ResourceList<T> {
     
     private final List<T> items;
     private final Map<String,Object> requestParams = new HashMap<>();
+    protected final boolean suppressDeprecated;
 
-    @JsonCreator
-    public ResourceList(@JsonProperty(ITEMS) List<T> items) {
+    /**
+     * 
+     * @param items
+     * @param suppressDeprecated
+     *      set to true to suppress deprecated fields in JSON serialization of the class.
+     */
+    public ResourceList(List<T> items, boolean suppressDeprecated) {
         checkNotNull(items);
         this.items = items;
         this.requestParams.put(TYPE, REQUEST_PARAMS);
+        this.suppressDeprecated = suppressDeprecated;
     }
+
+    @JsonCreator
+    public ResourceList(@JsonProperty(ITEMS) List<T> items) {
+        this(items, false);
+    }
+
     public List<T> getItems() {
         return items;
     }
@@ -83,7 +99,7 @@ public class ResourceList<T> {
     }
     @Deprecated
     public Integer getTotal() {
-        return (items.isEmpty()) ? null : items.size();
+        return (suppressDeprecated || items.isEmpty()) ? null : items.size();
     }
     protected DateTime getDateTime(String fieldName) {
         String value = (String)requestParams.get(fieldName);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AppController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AppController.java
@@ -183,7 +183,7 @@ public class AppController extends BaseController {
                 .filter(s -> s.isActive() && appIds.contains(s.getIdentifier()));
         }
         List<App> apps = stream.sorted(APP_COMPARATOR).collect(toList());
-        return APP_LIST_WRITER.writeValueAsString(new ResourceList<App>(apps));
+        return APP_LIST_WRITER.writeValueAsString(new ResourceList<App>(apps, true));
     }
 
     @PostMapping(path = {"/v1/apps", "/v3/studies"})

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AssessmentResourceController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AssessmentResourceController.java
@@ -146,6 +146,6 @@ public class AssessmentResourceController extends BaseController {
         Set<String> resourceGuids = parseJson(STRING_SET_TYPEREF);
         
         List<AssessmentResource> resources = service.publishAssessmentResources(appId, assessmentId, resourceGuids);
-        return new ResourceList<AssessmentResource>(resources);
+        return new ResourceList<AssessmentResource>(resources, true);
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/SharedAssessmentResourceController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/SharedAssessmentResourceController.java
@@ -102,6 +102,6 @@ public class SharedAssessmentResourceController extends BaseController {
         Set<String> resourceGuids = parseJson(STRING_SET_TYPEREF);
         
         List<AssessmentResource> resources = service.importAssessmentResources(appId, assessmentId, resourceGuids);
-        return new ResourceList<AssessmentResource>(resources);
+        return new ResourceList<AssessmentResource>(resources, true);
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyController.java
@@ -44,7 +44,7 @@ public class StudyController extends BaseController {
 
         List<Study> studies = service.getStudies(session.getAppId(), includeDeleted);
 
-        return new ResourceList<>(studies).withRequestParam(INCLUDE_DELETED, includeDeleted);
+        return new ResourceList<>(studies, true).withRequestParam(INCLUDE_DELETED, includeDeleted);
     }
 
     @PostMapping(path = {"/v5/studies", "/v3/substudies"})

--- a/src/test/java/org/sagebionetworks/bridge/models/DateRangeResourceListTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/DateRangeResourceListTest.java
@@ -26,12 +26,13 @@ public class DateRangeResourceListTest {
                 .withRequestParam(END_DATE, LocalDate.parse("2016-02-23"));
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(list);
-        assertEquals(node.get("startDate").asText(), "2016-02-03");
-        assertEquals(node.get("endDate").asText(), "2016-02-23");
-        assertEquals(node.get("requestParams").get("startDate").asText(), "2016-02-03");
-        assertEquals(node.get("requestParams").get("endDate").asText(), "2016-02-23");
-        assertEquals(node.get("requestParams").get(ResourceList.TYPE).asText(), ResourceList.REQUEST_PARAMS);
-        assertEquals(node.get("type").asText(), "DateRangeResourceList");
+        assertEquals(node.get("startDate").textValue(), "2016-02-03");
+        assertEquals(node.get("endDate").textValue(), "2016-02-23");
+        assertEquals(node.get("total").intValue(), 3);
+        assertEquals(node.get("requestParams").get("startDate").textValue(), "2016-02-03");
+        assertEquals(node.get("requestParams").get("endDate").textValue(), "2016-02-23");
+        assertEquals(node.get("requestParams").get(ResourceList.TYPE).textValue(), ResourceList.REQUEST_PARAMS);
+        assertEquals(node.get("type").textValue(), "DateRangeResourceList");
         assertEquals(node.get("items").size(), 3);
         assertEquals(node.get("items").get(0).asText(), "1");
         assertEquals(node.get("items").get(1).asText(), "2");
@@ -49,6 +50,19 @@ public class DateRangeResourceListTest {
         assertEquals(list.getRequestParams().get("startDate"), "2016-02-03");
         assertEquals(list.getRequestParams().get("endDate"), "2016-02-23");
         assertEquals(list.getRequestParams().get(ResourceList.TYPE), ResourceList.REQUEST_PARAMS);
+    }
+    
+    @Test
+    public void canSerializeWithoutDeprecated() {
+        DateRangeResourceList<String> list = new DateRangeResourceList<>(
+                Lists.newArrayList("1", "2", "3"), true)
+                .withRequestParam(START_DATE, LocalDate.parse("2016-02-03"))
+                .withRequestParam(END_DATE, LocalDate.parse("2016-02-23"));
+        
+        JsonNode node = BridgeObjectMapper.get().valueToTree(list);
+        assertNull(node.get("startDate"));
+        assertNull(node.get("endDate"));
+        assertNull(node.get("total"));
     }
     
     @SuppressWarnings("deprecation")

--- a/src/test/java/org/sagebionetworks/bridge/models/DateTimeRangeResourceListTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/DateTimeRangeResourceListTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.models;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 import java.util.List;
 
@@ -43,4 +44,17 @@ public class DateTimeRangeResourceListTest {
         // We never deserialize this on the server side (only in the SDK).
     }
     
+    @Test
+    public void canSerializeWithoutDeprecated() {
+        DateTime startTime = DateTime.parse("2016-02-03T10:10:10.000-08:00");
+        DateTime endTime = DateTime.parse("2016-02-23T14:14:14.000-08:00");
+        List<String> items = Lists.newArrayList("1", "2", "3");
+        DateTimeRangeResourceList<String> list = new DateTimeRangeResourceList<>(items, true)
+                .withRequestParam(ResourceList.START_TIME, startTime)
+                .withRequestParam(ResourceList.END_TIME, endTime);
+        
+        JsonNode node = BridgeObjectMapper.get().valueToTree(list);
+        assertNull(node.get("startTime"));
+        assertNull(node.get("endTime"));
+    }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/ForwardCursorPagedResourceListTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/ForwardCursorPagedResourceListTest.java
@@ -101,6 +101,36 @@ public class ForwardCursorPagedResourceListTest {
     }
     
     @Test
+    public void canSerializeWithoutDeprecated() throws Exception {
+        List<AccountSummary> accounts = Lists.newArrayListWithCapacity(2);
+        accounts.add(SUMMARY1);
+        accounts.add(SUMMARY2);
+        
+        DateTime startTime = DateTime.parse("2016-02-03T10:10:10.000-08:00");
+        DateTime endTime = DateTime.parse("2016-02-23T14:14:14.000-08:00");
+        
+        ForwardCursorPagedResourceList<AccountSummary> page = new ForwardCursorPagedResourceList<AccountSummary>(
+                accounts, "nextOffsetKey", true)
+                .withRequestParam(ResourceList.OFFSET_KEY, "offsetKey")
+                .withRequestParam(ResourceList.START_TIME, startTime)
+                .withRequestParam(ResourceList.END_TIME, endTime)
+                .withRequestParam(ResourceList.SCHEDULED_ON_START, startTime)
+                .withRequestParam(ResourceList.SCHEDULED_ON_END, endTime)
+                .withRequestParam(ResourceList.PAGE_SIZE, 100)
+                .withRequestParam(ResourceList.EMAIL_FILTER, "filterString");
+        
+        JsonNode node = BridgeObjectMapper.get().valueToTree(page);
+        
+        assertNull(node.get("offsetKey"));
+        assertNull(node.get("startTime"));
+        assertNull(node.get("endTime"));
+        assertNull(node.get("scheduledOnStart"));
+        assertNull(node.get("scheduledOnEnd"));
+        assertNull(node.get("pageSize"));
+        assertNull(node.get("total"));
+    }
+    
+    @Test
     public void hasNext() {
         ForwardCursorPagedResourceList<AccountSummary> list;
         JsonNode node;

--- a/src/test/java/org/sagebionetworks/bridge/models/PagedResourceListTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/PagedResourceListTest.java
@@ -4,6 +4,7 @@ import static org.sagebionetworks.bridge.TestConstants.EMAIL;
 import static org.sagebionetworks.bridge.TestConstants.SUMMARY1;
 import static org.sagebionetworks.bridge.TestConstants.SUMMARY2;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 import java.util.List;
 import java.util.Map;
@@ -69,7 +70,7 @@ public class PagedResourceListTest {
                 new TypeReference<PagedResourceList<AccountSummary>>() {});
 
         assertEquals(serPage.getTotal(), page.getTotal());
-        assertEquals(serPage.getPageSize(), 100);
+        assertEquals(serPage.getPageSize(), (Integer)100);
         assertEquals(serPage.getOffsetBy(), (Integer)123);
         assertEquals(serPage.getStartTime(), startTime);
         assertEquals(serPage.getEndTime(), endTime);
@@ -80,6 +81,31 @@ public class PagedResourceListTest {
         assertEquals(serParams, params);
         
         assertEquals(serPage.getItems(), page.getItems());
+    }
+    
+    @Test
+    public void canSerializeWithoutDeprecatedFields() throws Exception {
+        List<AccountSummary> accounts = Lists.newArrayListWithCapacity(2);
+        accounts.add(SUMMARY1);
+        accounts.add(SUMMARY2);
+
+        DateTime startTime = DateTime.parse("2016-02-03T10:10:10.000-08:00");
+        DateTime endTime = DateTime.parse("2016-02-23T14:14:14.000-08:00");
+        
+        PagedResourceList<AccountSummary> page = new PagedResourceList<AccountSummary>(accounts, 2, true)
+                .withRequestParam("offsetBy", 123)
+                .withRequestParam("pageSize", 100)
+                .withRequestParam("startTime", startTime)
+                .withRequestParam("endTime", endTime)
+                .withRequestParam("emailFilter", "filterString");
+        
+        JsonNode node = BridgeObjectMapper.get().valueToTree(page);
+        assertEquals(node.get("total").intValue(), 2);
+        assertNull(node.get("offsetBy"));
+        assertNull(node.get("pageSize"));
+        assertNull(node.get("emailFilter"));
+        assertNull(node.get("startTime"));
+        assertNull(node.get("endTime"));
     }
     
     @Test(expectedExceptions = NullPointerException.class)

--- a/src/test/java/org/sagebionetworks/bridge/models/ReportTypeResourceListTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/ReportTypeResourceListTest.java
@@ -8,6 +8,7 @@ import org.sagebionetworks.bridge.models.reports.ReportType;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -45,5 +46,23 @@ public class ReportTypeResourceListTest {
         assertEquals(node.size(), 5);
         
         // We never deserialize this on the server side (only in the SDK).
+    }
+    
+    @Test
+    public void canSerializeWithoutDeprecated() throws Exception {
+        ReportIndex index1 = ReportIndex.create();
+        index1.setKey("doesn't matter what this is");
+        index1.setIdentifier("foo");
+        
+        ReportIndex index2 = ReportIndex.create();
+        index2.setKey("doesn't matter what this is");
+        index2.setIdentifier("bar");
+        index2.setPublic(true);
+        
+        ReportTypeResourceList<ReportIndex> list = new ReportTypeResourceList<>(Lists.newArrayList(index1, index2),
+                true).withRequestParam(ResourceList.REPORT_TYPE, ReportType.PARTICIPANT);
+        
+        JsonNode node = BridgeObjectMapper.get().valueToTree(list);
+        assertNull(node.get("reportType"));
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/ResourceListTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/ResourceListTest.java
@@ -24,9 +24,8 @@ public class ResourceListTest {
 
     @SuppressWarnings("deprecation")
     @Test
-    public void canSerialize() throws Exception {
-        
-        ResourceList<String> list = new ResourceList<>(ImmutableList.of("A","B","C"))
+    public void canSerializeWithDeprecated() throws Exception {
+        ResourceList<String> list = new ResourceList<>(ImmutableList.of("A","B","C"), false)
                 .withRequestParam("test", 13L);
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(list);
@@ -49,6 +48,15 @@ public class ResourceListTest {
         assertEquals(deser.getRequestParams().get(ResourceList.TYPE), ResourceList.REQUEST_PARAMS);
     }
     
+    @Test
+    public void canSerializeWithoutDeprecated() throws Exception {
+        ResourceList<String> list = new ResourceList<>(ImmutableList.of("A","B","C"), true)
+                .withRequestParam("test", 13L);
+        
+        JsonNode node = BridgeObjectMapper.get().valueToTree(list);
+        assertNull(node.get("total"));
+    }
+
     @Test
     public void noTotalPropertyWhenListEmpty() {
         ResourceList<String> list = new ResourceList<>(ImmutableList.of());


### PR DESCRIPTION
I'm pulling this out of the sponsors pull request to reduce it's size and ensure everything is getting tested. Looking at the APIs I realized there's a lot of slop in the deprecated properties that I would like to remove in new APIs. So there's a flag which can be set by new APIs to remove deprecated properties from the JSON. Doesn't break existing integration tests.