### PR TITLE
In anticipating of APIs that will page studies, convert existing API to use paging

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/dao/StudyDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dao/StudyDao.java
@@ -1,13 +1,12 @@
 package org.sagebionetworks.bridge.dao;
 
-import java.util.List;
-
+import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.VersionHolder;
 import org.sagebionetworks.bridge.models.studies.Study;
 
 public interface StudyDao {
     
-    List<Study> getStudies(String appId, boolean includeDeleted);
+    PagedResourceList<Study> getStudies(String appId, int offsetBy, int pageSize, boolean includeDeleted);
     
     Study getStudy(String appId, String studyId);
     

--- a/src/main/java/org/sagebionetworks/bridge/dao/StudyDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dao/StudyDao.java
@@ -6,7 +6,7 @@ import org.sagebionetworks.bridge.models.studies.Study;
 
 public interface StudyDao {
     
-    PagedResourceList<Study> getStudies(String appId, int offsetBy, int pageSize, boolean includeDeleted);
+    PagedResourceList<Study> getStudies(String appId, Integer offsetBy, Integer pageSize, boolean includeDeleted);
     
     Study getStudy(String appId, String studyId);
     

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudy.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudy.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.hibernate;
 
+import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -21,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 @BridgeTypeName("Study")
 public class HibernateStudy implements Study {
     @Id
+    @Column(name = "id")
     private String identifier;
     @Id
     private String appId;

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudy.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudy.java
@@ -12,6 +12,7 @@ import org.sagebionetworks.bridge.json.BridgeTypeName;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyId;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 @Entity
@@ -20,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 @BridgeTypeName("Study")
 public class HibernateStudy implements Study {
     @Id
-    private String id;
+    private String identifier;
     @Id
     private String appId;
     private String name;
@@ -33,13 +34,14 @@ public class HibernateStudy implements Study {
     private Long version;
     
     @Override
-    public String getId() {
-        return id;
+    @JsonAlias("id")
+    public String getIdentifier() {
+        return identifier;
     }
 
     @Override
-    public void setId(String id) {
-        this.id = id;
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
     }
 
     @JsonIgnore

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudyDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudyDao.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.hibernate;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static java.util.stream.Collectors.toList;
 
 import java.util.List;
 import java.util.Map;
@@ -16,6 +15,7 @@ import org.sagebionetworks.bridge.models.studies.StudyId;
 
 import org.springframework.stereotype.Component;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 @Component
@@ -28,7 +28,8 @@ public class HibernateStudyDao implements StudyDao {
     }
 
     @Override
-    public PagedResourceList<Study> getStudies(String appId, int offsetBy, int pageSize, boolean includeDeleted) {
+    public PagedResourceList<Study> getStudies(String appId, Integer offsetBy, Integer pageSize,
+            boolean includeDeleted) {
         checkNotNull(appId);
         
         Map<String,Object> parameters = ImmutableMap.of("appId", appId);
@@ -40,8 +41,8 @@ public class HibernateStudyDao implements StudyDao {
 
         List<HibernateStudy> hibStudies = hibernateHelper.queryGet(query, parameters, 
                 offsetBy, pageSize, HibernateStudy.class);
-        List<Study> studies = hibStudies.stream().map(s -> (Study)s).collect(toList());
-
+        List<Study> studies = ImmutableList.copyOf(hibStudies);
+        
         return new PagedResourceList<>(studies, total);
     }
 

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudyDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudyDao.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.hibernate;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.stream.Collectors.toList;
 
 import java.util.List;
 import java.util.Map;
@@ -8,13 +9,13 @@ import java.util.Map;
 import javax.annotation.Resource;
 
 import org.sagebionetworks.bridge.dao.StudyDao;
+import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.VersionHolder;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyId;
 
 import org.springframework.stereotype.Component;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 @Component
@@ -27,7 +28,7 @@ public class HibernateStudyDao implements StudyDao {
     }
 
     @Override
-    public List<Study> getStudies(String appId, boolean includeDeleted) {
+    public PagedResourceList<Study> getStudies(String appId, int offsetBy, int pageSize, boolean includeDeleted) {
         checkNotNull(appId);
         
         Map<String,Object> parameters = ImmutableMap.of("appId", appId);
@@ -35,8 +36,13 @@ public class HibernateStudyDao implements StudyDao {
         if (!includeDeleted) {
             query += " and deleted != 1";
         }
-        return ImmutableList.copyOf(hibernateHelper.queryGet(query, parameters, 
-                null, null, HibernateStudy.class));
+        int total = hibernateHelper.queryCount("select count(*) " + query, parameters);
+
+        List<HibernateStudy> hibStudies = hibernateHelper.queryGet(query, parameters, 
+                offsetBy, pageSize, HibernateStudy.class);
+        List<Study> studies = hibStudies.stream().map(s -> (Study)s).collect(toList());
+
+        return new PagedResourceList<>(studies, total);
     }
 
     @Override

--- a/src/main/java/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/studies/Study.java
@@ -13,8 +13,8 @@ public interface Study extends BridgeEntity {
         return new HibernateStudy();
     }
 
-    String getId();
-    void setId(String id);
+    String getIdentifier();
+    void setIdentifier(String identifier);
     
     String getAppId();
     void setAppId(String appId);

--- a/src/main/java/org/sagebionetworks/bridge/models/studies/StudyId.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/studies/StudyId.java
@@ -14,27 +14,27 @@ public final class StudyId implements Serializable {
     private String appId;
 
     @Column(name = "id")
-    private String id;
+    private String identifier;
 
     public StudyId() {
     }
  
-    public StudyId(String appId, String id) {
+    public StudyId(String appId, String identifier) {
         this.appId = appId;
-        this.id = id;
+        this.identifier = identifier;
     }
     
     public String getAppId() {
         return appId;
     }
     
-    public String getId() {
-        return id;
+    public String getIdentifier() {
+        return identifier;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(appId, id);
+        return Objects.hash(appId, identifier);
     }
 
     @Override
@@ -44,6 +44,6 @@ public final class StudyId implements Serializable {
         if (obj == null || getClass() != obj.getClass())
             return false;
         StudyId other = (StudyId) obj;
-        return Objects.equals(appId, other.appId) && Objects.equals(id, other.id);
+        return Objects.equals(appId, other.appId) && Objects.equals(identifier, other.identifier);
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.services;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.stream.Collectors.toSet;
+import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.NEGATIVE_OFFSET_ERROR;
@@ -10,11 +11,11 @@ import static org.sagebionetworks.bridge.models.ResourceList.INCLUDE_DELETED;
 import static org.sagebionetworks.bridge.models.ResourceList.OFFSET_BY;
 import static org.sagebionetworks.bridge.models.ResourceList.PAGE_SIZE;
 
-import java.util.HashSet;
 import java.util.Set;
 
 import org.joda.time.DateTime;
 
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.dao.StudyDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
@@ -56,26 +57,19 @@ public class StudyService {
      * so we can provide a cache for these infrequently changing identifiers.
      */
     public Set<String> getStudyIds(String appId) {
-        int offset = 0;
-        Set<String> identifiers = new HashSet<>();
-        PagedResourceList<Study> results = null;
-        
-        do {
-            results = getStudies(appId, offset, API_MAXIMUM_PAGE_SIZE, false);
-            identifiers.addAll(results.getItems().stream().map(Study::getIdentifier).collect(toSet()));
-            offset += API_MAXIMUM_PAGE_SIZE;
-        } while(identifiers.size() < results.getTotal());
-        
-        return identifiers;
+        return getStudies(appId, null, null, false)
+                .getItems().stream()
+                .map(Study::getIdentifier)
+                .collect(toSet());
     }
     
-    public PagedResourceList<Study> getStudies(String appId, int offsetBy, int pageSize, boolean includeDeleted) {
+    public PagedResourceList<Study> getStudies(String appId, Integer offsetBy, Integer pageSize, boolean includeDeleted) {
         checkNotNull(appId);
-
-        if (offsetBy < 0) {
+        
+        if (offsetBy != null && offsetBy < 0) {
             throw new BadRequestException(NEGATIVE_OFFSET_ERROR);
         }
-        if (pageSize < API_MINIMUM_PAGE_SIZE || pageSize > API_MAXIMUM_PAGE_SIZE) {
+        if (pageSize != null && (pageSize < API_MINIMUM_PAGE_SIZE || pageSize > API_MAXIMUM_PAGE_SIZE)) {
             throw new BadRequestException(PAGE_SIZE_ERROR);
         }
         return studyDao.getStudies(appId, offsetBy, pageSize, includeDeleted)

--- a/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
@@ -1,17 +1,27 @@
 package org.sagebionetworks.bridge.services;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.stream.Collectors.toSet;
+import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
+import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
+import static org.sagebionetworks.bridge.BridgeConstants.NEGATIVE_OFFSET_ERROR;
+import static org.sagebionetworks.bridge.BridgeConstants.PAGE_SIZE_ERROR;
+import static org.sagebionetworks.bridge.models.ResourceList.INCLUDE_DELETED;
+import static org.sagebionetworks.bridge.models.ResourceList.OFFSET_BY;
+import static org.sagebionetworks.bridge.models.ResourceList.PAGE_SIZE;
 
-import java.util.List;
+import java.util.HashSet;
 import java.util.Set;
 
 import org.joda.time.DateTime;
+
 import org.sagebionetworks.bridge.dao.StudyDao;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.VersionHolder;
 import org.sagebionetworks.bridge.models.studies.Study;
-import org.sagebionetworks.bridge.util.BridgeCollectors;
 import org.sagebionetworks.bridge.validators.StudyValidator;
 import org.sagebionetworks.bridge.validators.Validate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,14 +56,32 @@ public class StudyService {
      * so we can provide a cache for these infrequently changing identifiers.
      */
     public Set<String> getStudyIds(String appId) {
-        return getStudies(appId, false).stream()
-                .map(Study::getId).collect(BridgeCollectors.toImmutableSet());
+        int offset = 0;
+        Set<String> identifiers = new HashSet<>();
+        PagedResourceList<Study> results = null;
+        
+        do {
+            results = getStudies(appId, offset, API_MAXIMUM_PAGE_SIZE, false);
+            identifiers.addAll(results.getItems().stream().map(Study::getIdentifier).collect(toSet()));
+            offset += API_MAXIMUM_PAGE_SIZE;
+        } while(identifiers.size() < results.getTotal());
+        
+        return identifiers;
     }
     
-    public List<Study> getStudies(String appId, boolean includeDeleted) {
+    public PagedResourceList<Study> getStudies(String appId, int offsetBy, int pageSize, boolean includeDeleted) {
         checkNotNull(appId);
-        
-        return studyDao.getStudies(appId, includeDeleted);
+
+        if (offsetBy < 0) {
+            throw new BadRequestException(NEGATIVE_OFFSET_ERROR);
+        }
+        if (pageSize < API_MINIMUM_PAGE_SIZE || pageSize > API_MAXIMUM_PAGE_SIZE) {
+            throw new BadRequestException(PAGE_SIZE_ERROR);
+        }
+        return studyDao.getStudies(appId, offsetBy, pageSize, includeDeleted)
+                .withRequestParam(OFFSET_BY, offsetBy)
+                .withRequestParam(PAGE_SIZE, pageSize)
+                .withRequestParam(INCLUDE_DELETED, includeDeleted);
     }
     
     public VersionHolder createStudy(String appId, Study study) {
@@ -69,10 +97,10 @@ public class StudyService {
         study.setCreatedOn(timestamp);
         study.setModifiedOn(timestamp);
         
-        Study existing = studyDao.getStudy(appId, study.getId());
+        Study existing = studyDao.getStudy(appId, study.getIdentifier());
         if (existing != null) {
             throw new EntityAlreadyExistsException(Study.class,
-                    ImmutableMap.of("id", existing.getId()));
+                    ImmutableMap.of("id", existing.getIdentifier()));
         }
         return studyDao.createStudy(study);
     }
@@ -84,7 +112,7 @@ public class StudyService {
         study.setAppId(appId);
         Validate.entityThrowingException(StudyValidator.INSTANCE, study);
         
-        Study existing = getStudy(appId, study.getId(), true);
+        Study existing = getStudy(appId, study.getIdentifier(), true);
         if (study.isDeleted() && existing.isDeleted()) {
             throw new EntityNotFoundException(Study.class);
         }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyController.java
@@ -1,11 +1,10 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
+import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
-
-import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -18,7 +17,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import org.sagebionetworks.bridge.models.ResourceList;
+import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.StatusMessage;
 import org.sagebionetworks.bridge.models.VersionHolder;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
@@ -30,7 +30,6 @@ import org.sagebionetworks.bridge.services.StudyService;
 public class StudyController extends BaseController {
 
     static final StatusMessage DELETED_MSG = new StatusMessage("Study deleted.");
-    private static final String INCLUDE_DELETED = "includeDeleted";
     private StudyService service;
 
     @Autowired
@@ -39,12 +38,16 @@ public class StudyController extends BaseController {
     }
 
     @GetMapping(path = {"/v5/studies", "/v3/substudies"})
-    public ResourceList<Study> getStudies(@RequestParam(defaultValue = "false") boolean includeDeleted) {
+    public PagedResourceList<Study> getStudies(
+            @RequestParam(required = false) String offsetBy, 
+            @RequestParam(required = false) String pageSize,            
+            @RequestParam(defaultValue = "false") boolean includeDeleted) {
         UserSession session = getAuthenticatedSession(DEVELOPER, RESEARCHER, ADMIN);
 
-        List<Study> studies = service.getStudies(session.getAppId(), includeDeleted);
+        int offsetByInt = BridgeUtils.getIntOrDefault(offsetBy, 0);
+        int pageSizeInt = BridgeUtils.getIntOrDefault(pageSize, API_DEFAULT_PAGE_SIZE);
 
-        return new ResourceList<>(studies).withRequestParam(INCLUDE_DELETED, includeDeleted);
+        return service.getStudies(session.getAppId(), offsetByInt, pageSizeInt, includeDeleted);
     }
 
     @PostMapping(path = {"/v5/studies", "/v3/substudies"})

--- a/src/main/java/org/sagebionetworks/bridge/validators/StudyValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/StudyValidator.java
@@ -20,9 +20,9 @@ public class StudyValidator implements Validator {
     public void validate(Object object, Errors errors) {
         Study study = (Study)object;
         
-        if (isBlank(study.getId())) {
+        if (isBlank(study.getIdentifier())) {
             errors.rejectValue("id", "is required");
-        } else if (!study.getId().matches(BridgeConstants.BRIDGE_EVENT_ID_PATTERN)) {
+        } else if (!study.getIdentifier().matches(BridgeConstants.BRIDGE_EVENT_ID_PATTERN)) {
             errors.rejectValue("id", BridgeConstants.BRIDGE_EVENT_ID_ERROR);
         }
         if (isBlank(study.getAppId())) {

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateStudyDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateStudyDaoTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.testng.Assert.assertEquals;
 
-import java.util.List;
 import java.util.Map;
 
 import javax.persistence.PersistenceException;
@@ -20,6 +19,7 @@ import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.VersionHolder;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyId;
@@ -27,8 +27,8 @@ import org.sagebionetworks.bridge.models.studies.StudyId;
 import com.google.common.collect.ImmutableList;
 
 public class HibernateStudyDaoTest {
-    private static final List<HibernateStudy> STUDIES = ImmutableList.of(new HibernateStudy(),
-            new HibernateStudy());
+    private static final PagedResourceList<HibernateStudy> STUDIES = new PagedResourceList<>(
+            ImmutableList.of(new HibernateStudy(), new HibernateStudy()), 2);
     
     @Mock
     private HibernateHelper hibernateHelper;
@@ -56,14 +56,16 @@ public class HibernateStudyDaoTest {
     
     @Test
     public void getStudiesIncludeDeleted() {
-        when(hibernateHelper.queryGet(any(), any(), eq(null), eq(null), eq(HibernateStudy.class)))
-                .thenReturn(STUDIES);
+        when(hibernateHelper.queryGet(any(), any(), eq(5), eq(10), eq(HibernateStudy.class)))
+                .thenReturn(STUDIES.getItems());
+        when(hibernateHelper.queryCount(any(), any())).thenReturn(10);
         
-        List<Study> list = dao.getStudies(TEST_APP_ID, true);
-        assertEquals(list.size(), 2);
+        PagedResourceList<Study> list = dao.getStudies(TEST_APP_ID, 5, 10, true);
+        assertEquals(list.getItems(), STUDIES.getItems());
+        assertEquals(list.getTotal(), (Integer)10);
         
         verify(hibernateHelper).queryGet(queryCaptor.capture(), paramsCaptor.capture(), 
-                eq(null), eq(null), eq(HibernateStudy.class));
+                eq(5), eq(10), eq(HibernateStudy.class));
         
         assertEquals(queryCaptor.getValue(), "from HibernateStudy as study where appId=:appId");
         Map<String,Object> parameters = paramsCaptor.getValue();
@@ -72,14 +74,16 @@ public class HibernateStudyDaoTest {
 
     @Test
     public void getStudiesExcludeDeleted() {
-        when(hibernateHelper.queryGet(any(), any(), eq(null), eq(null), eq(HibernateStudy.class)))
-            .thenReturn(STUDIES);
-
-        List<Study> list = dao.getStudies(TEST_APP_ID, false);
-        assertEquals(list.size(), 2);
+        when(hibernateHelper.queryGet(any(), any(), eq(0), eq(100), eq(HibernateStudy.class)))
+            .thenReturn(STUDIES.getItems());
+        when(hibernateHelper.queryCount(any(), any())).thenReturn(10);
+        
+        PagedResourceList<Study> list = dao.getStudies(TEST_APP_ID, 0, 100, false);
+        assertEquals(list.getItems(), STUDIES.getItems());
+        assertEquals(list.getTotal(), (Integer)10);
         
         verify(hibernateHelper).queryGet(queryCaptor.capture(), paramsCaptor.capture(), 
-                eq(null), eq(null), eq(HibernateStudy.class));
+                eq(0), eq(100), eq(HibernateStudy.class));
         
         assertEquals(queryCaptor.getValue(),
                 "from HibernateStudy as study where appId=:appId and deleted != 1");
@@ -98,7 +102,7 @@ public class HibernateStudyDaoTest {
         verify(hibernateHelper).getById(eq(HibernateStudy.class), studyIdCaptor.capture());
         
         StudyId studyId = studyIdCaptor.getValue();
-        assertEquals(studyId.getId(), "id");
+        assertEquals(studyId.getIdentifier(), "id");
         assertEquals(studyId.getAppId(), TEST_APP_ID);
     }
     
@@ -136,7 +140,7 @@ public class HibernateStudyDaoTest {
         
         verify(hibernateHelper).deleteById(eq(HibernateStudy.class), studyIdCaptor.capture());
         StudyId studyId = studyIdCaptor.getValue();
-        assertEquals(studyId.getId(), "oneId");
+        assertEquals(studyId.getIdentifier(), "oneId");
         assertEquals(studyId.getAppId(), TEST_APP_ID);
     }    
 

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateStudyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateStudyTest.java
@@ -13,6 +13,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class HibernateStudyTest {
 
@@ -22,7 +23,7 @@ public class HibernateStudyTest {
     @Test
     public void canSerialize() throws Exception {
         Study study = Study.create();
-        study.setId("oneId");
+        study.setIdentifier("oneId");
         study.setAppId(TEST_APP_ID);
         study.setName("name");
         study.setDeleted(true);
@@ -32,7 +33,7 @@ public class HibernateStudyTest {
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(study);
         assertEquals(node.size(), 7);
-        assertEquals(node.get("id").textValue(), "oneId");
+        assertEquals(node.get("identifier").textValue(), "oneId");
         assertEquals(node.get("name").textValue(), "name");
         assertTrue(node.get("deleted").booleanValue());
         assertEquals(node.get("createdOn").textValue(), CREATED_ON.toString());
@@ -43,11 +44,16 @@ public class HibernateStudyTest {
         assertNull(node.get("appId"));
         
         Study deser = BridgeObjectMapper.get().readValue(node.toString(), Study.class);
-        assertEquals(deser.getId(), "oneId");
+        assertEquals(deser.getIdentifier(), "oneId");
         assertEquals(deser.getName(), "name");
         assertTrue(deser.isDeleted());
         assertEquals(deser.getCreatedOn(), CREATED_ON);
         assertEquals(deser.getModifiedOn(), MODIFIED_ON);
         assertEquals(deser.getVersion(), new Long(3));
+
+        ((ObjectNode)node).remove("id");
+        ((ObjectNode)node).put("identifier", "oneId");
+        deser = BridgeObjectMapper.get().readValue(node.toString(), Study.class);
+        assertEquals(deser.getIdentifier(), "oneId");        
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/studies/StudyIdTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/studies/StudyIdTest.java
@@ -21,6 +21,6 @@ public class StudyIdTest {
         StudyId studyId = new StudyId(TEST_APP_ID, "id");
         
         assertEquals(studyId.getAppId(), TEST_APP_ID);
-        assertEquals(studyId.getId(), "id");
+        assertEquals(studyId.getIdentifier(), "id");
     }    
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/StudyServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/StudyServiceTest.java
@@ -3,8 +3,9 @@ package org.sagebionetworks.bridge.services;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
+import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_STUDY_IDS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
@@ -12,7 +13,6 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
-import java.util.List;
 import java.util.Set;
 
 import org.joda.time.DateTime;
@@ -24,16 +24,20 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.dao.StudyDao;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
+import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.VersionHolder;
 import org.sagebionetworks.bridge.models.studies.Study;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class StudyServiceTest {
-    private static final List<Study> STUDIES = ImmutableList.of(Study.create(), Study.create());
+    private static final PagedResourceList<Study> STUDIES = new PagedResourceList<>(
+            ImmutableList.of(Study.create(), Study.create()), 5);
     private static final VersionHolder VERSION_HOLDER = new VersionHolder(1L);
     
     @Mock
@@ -66,16 +70,25 @@ public class StudyServiceTest {
     @Test
     public void getStudyIds() {
         Study studyA = Study.create();
-        studyA.setId("studyA");
+        studyA.setIdentifier("studyA");
         
         Study studyB = Study.create();
-        studyB.setId("studyB");
-        List<Study> studies = ImmutableList.of(studyA, studyB); 
+        studyB.setIdentifier("studyB");
         
-        when(studyDao.getStudies(TEST_APP_ID, false)).thenReturn(studies);
+        Study studyC = Study.create();
+        studyC.setIdentifier("studyC");
+        
+        Study studyD = Study.create();
+        studyD.setIdentifier("studyD");
+        
+        // Test that multiple pages are assembled into one set.
+        PagedResourceList<Study> studies1 = new PagedResourceList<>(ImmutableList.of(studyA, studyB), 4); 
+        PagedResourceList<Study> studies2 = new PagedResourceList<>(ImmutableList.of(studyC, studyD), 4);
+        when(studyDao.getStudies(TEST_APP_ID, 0, 100, false)).thenReturn(studies1);
+        when(studyDao.getStudies(TEST_APP_ID, 100, 100, false)).thenReturn(studies2);
         
         Set<String> studyIds = service.getStudyIds(TEST_APP_ID);
-        assertEquals(studyIds, USER_STUDY_IDS);
+        assertEquals(studyIds, ImmutableSet.of("studyA","studyB","studyC","studyD"));
     }
     
     @Test(expectedExceptions = EntityNotFoundException.class)
@@ -91,28 +104,43 @@ public class StudyServiceTest {
     
     @Test
     public void getStudiesIncludeDeleted() {
-        when(studyDao.getStudies(TEST_APP_ID, true)).thenReturn(STUDIES);
+        when(studyDao.getStudies(TEST_APP_ID, 0, 50, true)).thenReturn(STUDIES);
         
-        List<Study> returnedValue = service.getStudies(TEST_APP_ID, true);
+        PagedResourceList<Study> returnedValue = service.getStudies(TEST_APP_ID, 0, 50, true);
         assertEquals(returnedValue, STUDIES);
         
-        verify(studyDao).getStudies(TEST_APP_ID, true);
+        verify(studyDao).getStudies(TEST_APP_ID, 0, 50, true);
     }
     
     @Test
     public void getStudiesExcludeDeleted() {
-        when(studyDao.getStudies(TEST_APP_ID, false)).thenReturn(STUDIES);
+        when(studyDao.getStudies(TEST_APP_ID, 10, 20, false)).thenReturn(STUDIES);
         
-        List<Study> returnedValue = service.getStudies(TEST_APP_ID, false);
+        PagedResourceList<Study> returnedValue = service.getStudies(TEST_APP_ID, 10, 20, false);
         assertEquals(returnedValue, STUDIES);
         
-        verify(studyDao).getStudies(TEST_APP_ID, false);
+        verify(studyDao).getStudies(TEST_APP_ID, 10, 20, false);
+    }
+    
+    @Test(expectedExceptions = BadRequestException.class)
+    public void getStudiesOffsetNegative() { 
+        service.getStudies(TEST_APP_ID, -1, 20, false);
+    }
+    
+    @Test(expectedExceptions = BadRequestException.class)
+    public void getStudiesPageSizeTooSmall() { 
+        service.getStudies(TEST_APP_ID, 0, API_MINIMUM_PAGE_SIZE-1, false);
+    }
+    
+    @Test(expectedExceptions = BadRequestException.class)
+    public void getStudiesPageSizeTooLarge() { 
+        service.getStudies(TEST_APP_ID, 0, API_MAXIMUM_PAGE_SIZE+1, false);
     }
     
     @Test
     public void createStudy() {
         Study study = Study.create();
-        study.setId("oneId");
+        study.setIdentifier("oneId");
         study.setName("oneName");
         study.setAppId("junk");
         study.setVersion(10L);
@@ -129,7 +157,7 @@ public class StudyServiceTest {
         verify(studyDao).createStudy(studyCaptor.capture());
         
         Study persisted = studyCaptor.getValue();
-        assertEquals(persisted.getId(), "oneId");
+        assertEquals(persisted.getIdentifier(), "oneId");
         assertEquals(persisted.getName(), "oneName");
         assertEquals(persisted.getAppId(), TEST_APP_ID);
         assertNull(persisted.getVersion());
@@ -146,7 +174,7 @@ public class StudyServiceTest {
     @Test(expectedExceptions = EntityAlreadyExistsException.class)
     public void createStudyAlreadyExists() {
         Study study = Study.create();
-        study.setId("oneId");
+        study.setIdentifier("oneId");
         study.setName("oneName");
         
         when(studyDao.getStudy(TEST_APP_ID, "oneId")).thenReturn(study);
@@ -157,7 +185,7 @@ public class StudyServiceTest {
     @Test
     public void updateStudy() {
         Study existing = Study.create();
-        existing.setId("oneId");
+        existing.setIdentifier("oneId");
         existing.setName("oldName");
         existing.setCreatedOn(DateTime.now());
         when(studyDao.getStudy(TEST_APP_ID, "oneId")).thenReturn(existing);
@@ -165,7 +193,7 @@ public class StudyServiceTest {
 
         Study study = Study.create();
         study.setAppId("wrongAppId");
-        study.setId("oneId");
+        study.setIdentifier("oneId");
         study.setName("newName");
         
         VersionHolder versionHolder = service.updateStudy(TEST_APP_ID, study);
@@ -175,7 +203,7 @@ public class StudyServiceTest {
         
         Study returnedValue = studyCaptor.getValue();
         assertEquals(returnedValue.getAppId(), TEST_APP_ID);
-        assertEquals(returnedValue.getId(), "oneId");
+        assertEquals(returnedValue.getIdentifier(), "oneId");
         assertEquals(returnedValue.getName(), "newName");
         assertNotNull(returnedValue.getCreatedOn());
         assertNotNull(returnedValue.getModifiedOn());
@@ -189,7 +217,7 @@ public class StudyServiceTest {
     @Test(expectedExceptions = EntityNotFoundException.class)
     public void updateStudyEntityNotFound() {
         Study study = Study.create();
-        study.setId("oneId");
+        study.setIdentifier("oneId");
         study.setName("oneName");
         study.setDeleted(true);
 
@@ -203,7 +231,7 @@ public class StudyServiceTest {
         when(studyDao.getStudy(TEST_APP_ID, "oneId")).thenReturn(existing);
 
         Study study = Study.create();
-        study.setId("oneId");
+        study.setIdentifier("oneId");
         study.setName("oneName");
         study.setDeleted(true);
         

--- a/src/test/java/org/sagebionetworks/bridge/services/StudyServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/StudyServiceTest.java
@@ -75,20 +75,11 @@ public class StudyServiceTest {
         Study studyB = Study.create();
         studyB.setIdentifier("studyB");
         
-        Study studyC = Study.create();
-        studyC.setIdentifier("studyC");
-        
-        Study studyD = Study.create();
-        studyD.setIdentifier("studyD");
-        
-        // Test that multiple pages are assembled into one set.
-        PagedResourceList<Study> studies1 = new PagedResourceList<>(ImmutableList.of(studyA, studyB), 4); 
-        PagedResourceList<Study> studies2 = new PagedResourceList<>(ImmutableList.of(studyC, studyD), 4);
-        when(studyDao.getStudies(TEST_APP_ID, 0, 100, false)).thenReturn(studies1);
-        when(studyDao.getStudies(TEST_APP_ID, 100, 100, false)).thenReturn(studies2);
+        PagedResourceList<Study> studies = new PagedResourceList<>(ImmutableList.of(studyA, studyB), 2); 
+        when(studyDao.getStudies(TEST_APP_ID, null, null, false)).thenReturn(studies);
         
         Set<String> studyIds = service.getStudyIds(TEST_APP_ID);
-        assertEquals(studyIds, ImmutableSet.of("studyA","studyB","studyC","studyD"));
+        assertEquals(studyIds, ImmutableSet.of("studyA","studyB"));
     }
     
     @Test(expectedExceptions = EntityNotFoundException.class)
@@ -135,6 +126,16 @@ public class StudyServiceTest {
     @Test(expectedExceptions = BadRequestException.class)
     public void getStudiesPageSizeTooLarge() { 
         service.getStudies(TEST_APP_ID, 0, API_MAXIMUM_PAGE_SIZE+1, false);
+    }
+    
+    @Test
+    public void getStudiesWithNullParams() {
+        when(studyDao.getStudies(TEST_APP_ID, null, null, false))
+            .thenReturn(new PagedResourceList<>(ImmutableList.of(), 0));
+    
+        service.getStudies(TEST_APP_ID, null, null, false);
+        
+        verify(studyDao).getStudies(TEST_APP_ID, null, null, false);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyControllerTest.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
+import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
@@ -12,10 +13,6 @@ import static org.sagebionetworks.bridge.TestUtils.assertGet;
 import static org.sagebionetworks.bridge.TestUtils.assertPost;
 import static org.sagebionetworks.bridge.TestUtils.mockRequestBody;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-
-import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -33,6 +30,7 @@ import org.mockito.Spy;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.StatusMessage;
 import org.sagebionetworks.bridge.models.VersionHolder;
@@ -43,8 +41,8 @@ import org.sagebionetworks.bridge.services.StudyService;
 
 public class StudyControllerTest extends Mockito {
 
-    private static final String INCLUDE_DELETED_PARAM = "includeDeleted";
-    private static final List<Study> STUDIES = ImmutableList.of(Study.create(), Study.create());
+    private static final PagedResourceList<Study> STUDIES = new PagedResourceList<>(
+            ImmutableList.of(Study.create(), Study.create()), 2);
     private static final VersionHolder VERSION_HOLDER = new VersionHolder(1L);
 
     @Mock
@@ -92,27 +90,36 @@ public class StudyControllerTest extends Mockito {
     }
 
     @Test
-    public void getStudiesExcludeDeleted() throws Exception {
-        when(service.getStudies(TEST_APP_ID, false)).thenReturn(STUDIES);
+    public void getStudiesWithDefaults() throws Exception {
+        when(service.getStudies(TEST_APP_ID, 0, API_DEFAULT_PAGE_SIZE, false)).thenReturn(STUDIES);
 
-        ResourceList<Study> result = controller.getStudies(false);
+        ResourceList<Study> result = controller.getStudies(null, null, false);
 
         assertEquals(result.getItems().size(), 2);
-        assertFalse((boolean) result.getRequestParams().get(INCLUDE_DELETED_PARAM));
 
-        verify(service).getStudies(TEST_APP_ID, false);
+        verify(service).getStudies(TEST_APP_ID, 0, API_DEFAULT_PAGE_SIZE, false);
+    }
+    
+    @Test
+    public void getStudiesExcludeDeleted() throws Exception {
+        when(service.getStudies(TEST_APP_ID, 0, 50, false)).thenReturn(STUDIES);
+
+        ResourceList<Study> result = controller.getStudies("0", "50", false);
+
+        assertEquals(result.getItems().size(), 2);
+
+        verify(service).getStudies(TEST_APP_ID, 0, 50, false);
     }
 
     @Test
     public void getStudiesIncludeDeleted() throws Exception {
-        when(service.getStudies(TEST_APP_ID, true)).thenReturn(STUDIES);
+        when(service.getStudies(TEST_APP_ID, 0, 50, true)).thenReturn(STUDIES);
 
-        ResourceList<Study> result = controller.getStudies(true);
+        ResourceList<Study> result = controller.getStudies("0", "50", true);
 
         assertEquals(result.getItems().size(), 2);
-        assertTrue((boolean) result.getRequestParams().get(INCLUDE_DELETED_PARAM));
 
-        verify(service).getStudies(TEST_APP_ID, true);
+        verify(service).getStudies(TEST_APP_ID, 0, 50, true);
     }
 
     @Test
@@ -120,7 +127,7 @@ public class StudyControllerTest extends Mockito {
         when(service.createStudy(any(), any())).thenReturn(VERSION_HOLDER);
 
         Study study = Study.create();
-        study.setId("oneId");
+        study.setIdentifier("oneId");
         study.setName("oneName");
         mockRequestBody(mockRequest, study);
 
@@ -130,21 +137,21 @@ public class StudyControllerTest extends Mockito {
         verify(service).createStudy(eq(TEST_APP_ID), studyCaptor.capture());
 
         Study persisted = studyCaptor.getValue();
-        assertEquals(persisted.getId(), "oneId");
+        assertEquals(persisted.getIdentifier(), "oneId");
         assertEquals(persisted.getName(), "oneName");
     }
 
     @Test
     public void getStudy() throws Exception {
         Study study = Study.create();
-        study.setId("oneId");
+        study.setIdentifier("oneId");
         study.setName("oneName");
         when(service.getStudy(TEST_APP_ID, "id", true)).thenReturn(study);
 
         Study result = controller.getStudy("id");
         assertEquals(result, study);
 
-        assertEquals(result.getId(), "oneId");
+        assertEquals(result.getIdentifier(), "oneId");
         assertEquals(result.getName(), "oneName");
 
         verify(service).getStudy(TEST_APP_ID, "id", true);
@@ -153,7 +160,7 @@ public class StudyControllerTest extends Mockito {
     @Test
     public void updateStudy() throws Exception {
         Study study = Study.create();
-        study.setId("oneId");
+        study.setIdentifier("oneId");
         study.setName("oneName");
         mockRequestBody(mockRequest, study);
 
@@ -166,7 +173,7 @@ public class StudyControllerTest extends Mockito {
         verify(service).updateStudy(eq(TEST_APP_ID), studyCaptor.capture());
 
         Study persisted = studyCaptor.getValue();
-        assertEquals(persisted.getId(), "oneId");
+        assertEquals(persisted.getIdentifier(), "oneId");
         assertEquals(persisted.getName(), "oneName");
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -15,7 +15,7 @@ public class StudyValidatorTest {
     @Test
     public void valid() {
         study = Study.create();
-        study.setId("id");
+        study.setIdentifier("id");
         study.setAppId(TEST_APP_ID);
         study.setName("name");
         
@@ -31,7 +31,7 @@ public class StudyValidatorTest {
     @Test
     public void invalidIdentifier() {
         study = Study.create();
-        study.setId("id not valid");
+        study.setIdentifier("id not valid");
         
         TestUtils.assertValidatorMessage(VALIDATOR, study, "id", "must contain only lower- or upper-case letters, numbers, dashes, and/or underscores");
     }


### PR DESCRIPTION
The sponsors APIs may have cases where one organization (Sage) could have hundreds of studies, so switching these to be paged everywhere so we don't have multiple StudyList types in the SDK. Since these were recently substudies, I'm confident no one is using these APIs right now other than the BSM.

Also renaming "id" to "identifier" after examining our models and deciding that we slightly favor "identifier" (I feel this should be consistent in our APIs).