### PR TITLE
Change error reporting when location lookup fails, and update to the new (as of this morning) location API provided by external partner

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/CRCController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/CRCController.java
@@ -329,19 +329,21 @@ public class CRCController extends BaseController {
             
             int statusCode = response.getStatusLine().getStatusCode();
             if (statusCode != 200 && statusCode != 201) {
-                LOG.warn("Error retrieving location, id = " + locationId + ", status = " + statusCode
-                        + ", response body = " + resBody);
+                logWarningMessage(locationId, statusCode, resBody);
                 return;
             }
             JsonNode bundleJson = BridgeObjectMapper.get().readTree(resBody);
             if (!bundleJson.has("entry") || ((ArrayNode)bundleJson.get("entry")).size() == 0) {
-                LOG.warn("Error retrieving location, id = " + locationId + ", status = " + statusCode
-                        + ", response body = " + resBody);
+                logWarningMessage(locationId, statusCode, resBody);
                 return;
             }
-            JsonNode locationJson = bundleJson.get("entry").get(0).get("resource");
-            JsonNode telecom = locationJson.get("telecom");
-            JsonNode address = locationJson.get("address");
+            JsonNode resJson = bundleJson.get("entry").get(0).get("resource");
+            if (resJson == null) {
+                logWarningMessage(locationId, statusCode, resBody);
+                return;
+            }
+            JsonNode telecom = resJson.get("telecom");
+            JsonNode address = resJson.get("address");
             
             ArrayNode participants = (ArrayNode)node.get("participant");
             if (participants != null) {
@@ -368,6 +370,13 @@ public class CRCController extends BaseController {
             return;
         }
         LOG.info("Location added to appointment record for user " + account.getId());
+    }
+
+    private void logWarningMessage(String locationId, int statusCode, String resBody) {
+        // May or may not be utilized
+        String errorMsg = "Error retrieving location, id = " + locationId + ", status = " + statusCode
+                + ", response body = " + resBody;
+        LOG.warn(errorMsg);
     }
 
     void addGeocodingInformation(ObjectNode actor) {

--- a/src/main/resources/BridgeServer2.conf
+++ b/src/main/resources/BridgeServer2.conf
@@ -181,12 +181,12 @@ synapse.oauth.client.secret = dummy-value
 # To reverse geocode location of appointments in CRC controller
 crc.geocode.api.key = dummy-value
 
-cuimc.test.location.url = http://34.192.153.148:8080/nypcovi/Location/${location}
+cuimc.test.location.url = https://xeperno.nyp.org/nypcovi/Location/_search
 cuimc.test.username = dummy-value
 cuimc.test.password = dummy-value
 
 # These are not currently the production endpoint.
-cuimc.prod.location.url = https://xeperno.nyp.org/nypcovi/Location/${location}
+cuimc.prod.location.url = https://xeperno.nyp.org/nypcovi/Location/_search
 cuimc.prod.username = dummy-value
 cuimc.prod.password = dummy-value
 


### PR DESCRIPTION
I've tested this manually using the integration tests and providing valid and invalid location identifiers. I won't add valid location identifiers to the integration tests though, as this would call out to Columbia and might be fragile for our tests.