### PR TITLE
DynamoDB tables should be created with on-demand throughput

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <apache.http.version>4.5.6</apache.http.version>
-        <aws.version>1.11.198</aws.version>
+        <aws.version>1.11.851</aws.version>
         <hibernate.version>5.2.9.Final</hibernate.version>
         <jackson.version>2.10.0</jackson.version>
         <java.version>1.8</java.version>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>bridge-base</artifactId>
-            <version>2.7.24</version>
+            <version>2.7.27</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoHealthCode.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoHealthCode.java
@@ -14,7 +14,6 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBVersionAttribute;
  * avoid collisions of health code. We do not trust that the underlying RNG
  * is always a solid one.
  */
-@DynamoThroughput(readCapacity=50, writeCapacity=25)
 @DynamoDBTable(tableName = "HealthCode")
 public class DynamoHealthCode {
 

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataRecord.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataRecord.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.joda.deser.LocalDateDeserializer;
 
 /** DynamoDB implementation of {@link org.sagebionetworks.bridge.models.healthdata.HealthDataRecord}. */
-@DynamoThroughput(readCapacity=43, writeCapacity=10)
 @DynamoDBTable(tableName = "HealthDataRecord3")
 @JsonFilter("filter")
 public class DynamoHealthDataRecord implements HealthDataRecord {

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataRecordEx3.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataRecordEx3.java
@@ -17,7 +17,6 @@ import org.sagebionetworks.bridge.json.DateTimeToLongDeserializer;
 import org.sagebionetworks.bridge.json.DateTimeToLongSerializer;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecordEx3;
 
-@DynamoThroughput(readCapacity=2, writeCapacity=2)
 @DynamoDBTable(tableName = "HealthDataRecordEx3")
 public class DynamoHealthDataRecordEx3 implements HealthDataRecordEx3 {
     public static final String APPID_CREATEDON_INDEX = "appId-createdOn-index";

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoSmsMessage.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoSmsMessage.java
@@ -15,7 +15,6 @@ import org.sagebionetworks.bridge.json.DateTimeToPrimitiveLongDeserializer;
 import org.sagebionetworks.bridge.models.sms.SmsMessage;
 import org.sagebionetworks.bridge.models.sms.SmsType;
 
-@DynamoThroughput(readCapacity=1, writeCapacity=1)
 @DynamoDBTable(tableName = "SmsMessage")
 public class DynamoSmsMessage implements SmsMessage {
     private String phoneNumber;

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoUpload2.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoUpload2.java
@@ -30,7 +30,6 @@ import com.google.common.collect.ImmutableList;
  * This DynamoDB table stores metadata for Bridge uploads. This class also defines global secondary indices, which can
  * be used for more efficient queries.
  */
-@DynamoThroughput(readCapacity=40, writeCapacity=20)
 @DynamoDBTable(tableName = "Upload2")
 public class DynamoUpload2 implements Upload {
     private long contentLength;

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadDedupe.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadDedupe.java
@@ -11,7 +11,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.joda.time.LocalDate;
 
 /** DDB implementation of UploadDedupe. */
-@DynamoThroughput(readCapacity=5, writeCapacity=10)
 @DynamoDBTable(tableName = "UploadDedupe2")
 public class DynamoUploadDedupe {
     private String healthCode;

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchema.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchema.java
@@ -38,7 +38,6 @@ import org.sagebionetworks.bridge.validators.Validate;
  * The DynamoDB implementation of UploadSchema. This is a mutable class with getters and setters so that it can work
  * with the DynamoDB mapper.
  */
-@DynamoThroughput(readCapacity=15, writeCapacity=1)
 @DynamoDBTable(tableName = "UploadSchema")
 @JsonFilter("filter")
 public class DynamoUploadSchema implements UploadSchema {
@@ -253,7 +252,7 @@ public class DynamoUploadSchema implements UploadSchema {
     @JsonIgnore
     @Override
     public UploadSchemaKey getSchemaKey() {
-        return new UploadSchemaKey.Builder().withStudyId(appId).withSchemaId(schemaId).withRevision(rev).build();
+        return new UploadSchemaKey.Builder().withAppId(appId).withSchemaId(schemaId).withRevision(rev).build();
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-2874

Incorporates https://github.com/Sage-Bionetworks/bridge-base/pull/64 and cleans up the now-defunct DynamoThroughput annotations