### PR TITLE
enrollment API

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
@@ -12,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
+import org.sagebionetworks.bridge.services.SponsorService;
 
 public class AuthUtils {
     private static final Logger LOG = LoggerFactory.getLogger(AuthUtils.class);
@@ -87,5 +88,20 @@ public class AuthUtils {
             return;
         }
         throw new UnauthorizedException(CALLER_NOT_MEMBER_ERROR);
+    }
+    
+    public static boolean checkSelfAdminOrSponsor(SponsorService sponsorService, String studyId, String userId) {
+        RequestContext context = BridgeUtils.getRequestContext();
+        String callerOrgMembership = context.getCallerOrgMembership();
+        String callerUserId = context.getCallerUserId();
+        return context.isInRole(ADMIN) || 
+                sponsorService.isStudySponsoredBy(studyId, callerOrgMembership) ||
+                (callerUserId != null && callerUserId.equals(userId));
+    }
+    
+    public static void checkSelfAdminOrSponsorAndThrow(SponsorService sponsorService, String studyId, String userId) {
+        if (!checkSelfAdminOrSponsor(sponsorService, studyId, userId)) {
+            throw new UnauthorizedException();
+        }
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/dao/EnrollmentDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dao/EnrollmentDao.java
@@ -1,0 +1,13 @@
+package org.sagebionetworks.bridge.dao;
+
+import org.sagebionetworks.bridge.models.PagedResourceList;
+import org.sagebionetworks.bridge.models.studies.Enrollment;
+import org.sagebionetworks.bridge.models.studies.EnrollmentFilter;
+
+public interface EnrollmentDao {
+    /**
+     * Get accounts that have been enrolled in the study (past and present).
+     */
+    PagedResourceList<Enrollment> getEnrollmentsForStudy(String appId, String studyId, 
+            EnrollmentFilter filter, Integer offsetBy, Integer pageSize);
+}

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateEnrollment.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateEnrollment.java
@@ -3,58 +3,117 @@ package org.sagebionetworks.bridge.hibernate;
 import java.util.Objects;
 
 import javax.persistence.Column;
+import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
 import javax.persistence.JoinColumn;
 import javax.persistence.Table;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import org.joda.time.DateTime;
+
+import org.sagebionetworks.bridge.json.BridgeTypeName;
 import org.sagebionetworks.bridge.models.studies.Enrollment;
 import org.sagebionetworks.bridge.models.studies.EnrollmentId;
 
 @Entity
 @Table(name = "AccountsSubstudies")
 @IdClass(EnrollmentId.class)
+@BridgeTypeName("Enrollment")
 public final class HibernateEnrollment implements Enrollment {
 
     @Id
     @Column(name = "studyId")
+    @JsonIgnore
     private String appId;
     @Id
     @Column(name = "substudyId")
+    @JsonIgnore
     private String studyId;
     @Id
     @JoinColumn(name = "account_id")
     private String accountId;
     private String externalId;
+    @Convert(converter = DateTimeToLongAttributeConverter.class)
+    private DateTime enrolledOn;
+    @Convert(converter = DateTimeToLongAttributeConverter.class)
+    private DateTime withdrawnOn;
+    private String enrolledBy;
+    private String withdrawnBy;
+    private String withdrawalNote;
+    private boolean consentRequired;
     
     // Needed for Hibernate, or else you have to create an instantiation helper class
     public HibernateEnrollment() {
     }
     
-    public HibernateEnrollment(String appId, String studyId, String accountId, String externalId) {
-        this.appId = appId;
-        this.studyId = studyId;
-        this.accountId = accountId;
-        this.externalId = externalId;
-    }
-    
     public String getAppId() {
         return appId;
+    }
+    public void setAppId(String appId) {
+        this.appId = appId;
     }
     public String getStudyId() {
         return studyId;
     }
+    public void setStudyId(String studyId) {
+        this.studyId = studyId; 
+    }
     public String getAccountId() {
         return accountId;
+    }
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
     }
     public String getExternalId() {
         return externalId;
     }
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+    public DateTime getEnrolledOn() {
+        return enrolledOn;
+    }
+    public void setEnrolledOn(DateTime enrolledOn) {
+        this.enrolledOn = enrolledOn;
+    }
+    public DateTime getWithdrawnOn() {
+        return withdrawnOn;
+    }
+    public void setWithdrawnOn(DateTime withdrawnOn) {
+        this.withdrawnOn = withdrawnOn;
+    }
+    public String getEnrolledBy() {
+        return enrolledBy;
+    }
+    public void setEnrolledBy(String enrolledBy) {
+        this.enrolledBy = enrolledBy;
+    }
+    public String getWithdrawnBy() {
+        return withdrawnBy;
+    }
+    public void setWithdrawnBy(String withdrawnBy) {
+        this.withdrawnBy = withdrawnBy;
+    }
+    public String getWithdrawalNote() {
+        return withdrawalNote;
+    }
+    public void setWithdrawalNote(String withdrawalNote) {
+        this.withdrawalNote = withdrawalNote;
+    }
+    public boolean isConsentRequired() {
+        return consentRequired;
+    }
+    public void setConsentRequired(boolean consentRequired) {
+        this.consentRequired = consentRequired;
+    }
 
     @Override
     public int hashCode() {
-        return Objects.hash(accountId, externalId, appId, studyId);
+        return Objects.hash(accountId, externalId, appId, studyId, enrolledOn, 
+                withdrawnOn, enrolledBy, withdrawnBy, withdrawalNote, consentRequired);
     }
 
     @Override
@@ -67,12 +126,21 @@ public final class HibernateEnrollment implements Enrollment {
         return Objects.equals(accountId, other.accountId) && 
                Objects.equals(externalId, other.externalId) && 
                Objects.equals(appId, other.appId) && 
-               Objects.equals(studyId, other.studyId);
+               Objects.equals(studyId, other.studyId) &&
+               Objects.equals(enrolledOn, other.enrolledOn) &&
+               Objects.equals(withdrawnOn, other.withdrawnOn) &&
+               Objects.equals(enrolledBy, other.enrolledBy) &&
+               Objects.equals(withdrawnBy, other.withdrawnBy) &&
+               Objects.equals(withdrawalNote, other.withdrawalNote) &&
+               Objects.equals(consentRequired, other.consentRequired);
     }
 
     @Override
     public String toString() {
-        return "HibernateEnrollment [appId=" + appId + ", studyId=" + studyId + ", accountId="
-                + accountId + ", externalId=" + externalId + "]";
+        return "HibernateEnrollment [appId=" + appId + ", studyId=" + studyId + ", accountId=" 
+                + accountId + ", externalId=" + externalId + ", enrolledOn=" + enrolledOn 
+                + ", withdrawnOn=" + withdrawnOn + ", enrolledBy=" + enrolledBy 
+                + ", withdrawnBy=" + withdrawnBy + ", withdrawalNote=" + withdrawalNote 
+                + ", consentRequired=" + consentRequired + "]";
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateEnrollmentDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateEnrollmentDao.java
@@ -1,0 +1,41 @@
+package org.sagebionetworks.bridge.hibernate;
+
+import java.util.List;
+
+import javax.annotation.Resource;
+
+import com.google.common.collect.ImmutableList;
+
+import org.springframework.stereotype.Component;
+
+import org.sagebionetworks.bridge.dao.EnrollmentDao;
+import org.sagebionetworks.bridge.models.PagedResourceList;
+import org.sagebionetworks.bridge.models.studies.Enrollment;
+import org.sagebionetworks.bridge.models.studies.EnrollmentFilter;
+
+@Component
+public class HibernateEnrollmentDao implements EnrollmentDao {
+
+    private HibernateHelper hibernateHelper;
+    
+    @Resource(name = "basicHibernateHelper")
+    final void setHibernateHelper(HibernateHelper hibernateHelper) {
+        this.hibernateHelper = hibernateHelper;
+    }
+    
+    @Override
+    public PagedResourceList<Enrollment> getEnrollmentsForStudy(String appId, String studyId, 
+            EnrollmentFilter filter, Integer offsetBy, Integer pageSize) {
+        QueryBuilder builder = new QueryBuilder();
+        builder.append("FROM HibernateEnrollment WHERE");
+        builder.append("appId = :appId AND studyId = :studyId", "appId", appId, "studyId", studyId);
+        builder.enrollment(filter);
+        
+        int total = hibernateHelper.queryCount("SELECT COUNT(*) " + builder.getQuery(), builder.getParameters());
+        
+        List<HibernateEnrollment> enrollments = hibernateHelper.queryGet(builder.getQuery(),
+                builder.getParameters(), offsetBy, pageSize, HibernateEnrollment.class);
+        
+        return new PagedResourceList<>(ImmutableList.copyOf(enrollments), total, true);
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/QueryBuilder.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/QueryBuilder.java
@@ -1,6 +1,8 @@
 package org.sagebionetworks.bridge.hibernate;
 
 import static java.lang.Boolean.TRUE;
+import static org.sagebionetworks.bridge.models.studies.EnrollmentFilter.ENROLLED;
+import static org.sagebionetworks.bridge.models.studies.EnrollmentFilter.WITHDRAWN;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -9,6 +11,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.models.studies.EnrollmentFilter;
 
 import com.google.common.base.Joiner;
 
@@ -59,6 +62,15 @@ class QueryBuilder {
                 phrases.add("AND acct.orgMembership IS NULL");
             } else {
                 append("AND acct.orgMembership = :orgId", "orgId", orgMembership);
+            }
+        }
+    }
+    public void enrollment(EnrollmentFilter filter) {
+        if (filter != null) {
+            if (filter == ENROLLED) {
+                phrases.add("AND withdrawnOn IS NULL");
+            } else if (filter == WITHDRAWN) {
+                phrases.add("AND withdrawnOn IS NOT NULL");
             }
         }
     }

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/SponsorPersistenceExceptionConverter.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/SponsorPersistenceExceptionConverter.java
@@ -13,7 +13,7 @@ import org.sagebionetworks.bridge.models.studies.Study;
 
 @Component
 public class SponsorPersistenceExceptionConverter implements PersistenceExceptionConverter {
-    static final String DUPLICATE_MSG = "Organization is already a sponsor of this study";
+    static final String DUPLICATE_MSG = "Organization is already a sponsor of this study.";
 
     @Override
     public RuntimeException convert(PersistenceException exception, Object entity) {

--- a/src/main/java/org/sagebionetworks/bridge/models/ResourceList.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/ResourceList.java
@@ -30,6 +30,7 @@ public class ResourceList<T> {
     public static final String EMAIL_FILTER = "emailFilter";
     public static final String END_DATE = "endDate";
     public static final String END_TIME = "endTime";
+    public static final String ENROLLMENT_FILTER = "enrollmentFilter";
     public static final String GUID = "guid";
     public static final String ID_FILTER = "idFilter";
     public static final String IDENTIFIER = "identifier";

--- a/src/main/java/org/sagebionetworks/bridge/models/studies/Enrollment.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/studies/Enrollment.java
@@ -2,35 +2,98 @@ package org.sagebionetworks.bridge.models.studies;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import org.joda.time.DateTime;
+
 import org.sagebionetworks.bridge.hibernate.HibernateEnrollment;
+import org.sagebionetworks.bridge.models.BridgeEntity;
 
 /**
- * Represents the enrollment of a participant in a study. If the record exists, the user 
- * is enrolled in the given study. (If not, the user is not enrolled in the study.)
- * Note that this is currently in transition (right now this record associates admin users
- * to studies, rather than looking at their organizational membership, and many existing
- * accounts do *not* have an enrollment record even though accounts are enrolled in the 
- * study. This will be migrated.
+ * Represents the enrollment of a participant in a study. Enrollment in the Bridge sense 
+ * is a little broader than active enrollment in a study. An enrollment record can be 
+ * created as soon as an account is being tracked in a study (e.g. an account is created 
+ * with an external ID, which is always associated to a study), and the record will 
+ * continue to exist if the user withdraws. However, it is not a complete history of 
+ * consent activity; that continues to be recorded in the user's consent history and 
+ * consent signatures. This record only records the current state of the account.
  */
-public interface Enrollment {
+@JsonDeserialize(as=HibernateEnrollment.class)
+public interface Enrollment extends BridgeEntity {
     
     static Enrollment create(String appId, String studyId, String accountId) {
         checkNotNull(appId);
         checkNotNull(studyId);
         checkNotNull(accountId);
-        return new HibernateEnrollment(appId, studyId, accountId, null);
+        
+        HibernateEnrollment enrollment = new HibernateEnrollment();
+        enrollment.setAppId(appId);
+        enrollment.setStudyId(studyId);
+        enrollment.setAccountId(accountId);
+        return enrollment;
     }
     
     static Enrollment create(String appId, String studyId, String accountId, String externalId) {
         checkNotNull(appId);
         checkNotNull(studyId);
         checkNotNull(accountId);
+
+        HibernateEnrollment enrollment = new HibernateEnrollment();
+        enrollment.setAppId(appId);
+        enrollment.setStudyId(studyId);
+        enrollment.setAccountId(accountId);
         // it's ok for external ID to be null
-        return new HibernateEnrollment(appId, studyId, accountId, externalId);
+        enrollment.setExternalId(externalId);
+        return enrollment;
     }
     
+    @JsonIgnore
     String getAppId();
+    void setAppId(String appId);
+    
+    @JsonIgnore
     String getStudyId();
+    void setStudyId(String studyId);
+    
+    @JsonProperty("userId")
     String getAccountId();
+    void setAccountId(String accountId);
+    
     String getExternalId();
+    void setExternalId(String externalId);
+    
+    /** Should the participant still be required to sign the study's required consent (if any)? 
+     * If true, we will check the user's consent state during authentication; if false, consent
+     * state will be ignored. Defaults to true.
+     */
+    boolean isConsentRequired();
+    void setConsentRequired(boolean consentRequired);
+    
+    /** The signedOn timestamp of a consent signature, or the time of record creation. */
+    DateTime getEnrolledOn();
+    void setEnrolledOn(DateTime enrolledOn);
+    
+    /** The withdrewOn timestamp of a consent signature, or time of withdrawal of an enrollment record. */
+    DateTime getWithdrawnOn();
+    void setWithdrawnOn(DateTime withdrawnOn);
+    
+    /** If the enrollment is created by someone other than the participant, the user ID of the 
+     * caller who enrolled this participant.
+     */
+    String getEnrolledBy();
+    void setEnrolledBy(String accountId);
+
+    /** If the enrollment is withdrawn by someone other than the participant, the user ID of the 
+     * caller who withdrew the participant from the study.
+     */
+    String getWithdrawnBy();
+    void setWithdrawnBy(String accountId);
+    
+    /** If withdrawn by a third party, a note can be recorded about why the participant was removed
+     * from the study.
+     */
+    String getWithdrawalNote();
+    void setWithdrawalNote(String note);
 }

--- a/src/main/java/org/sagebionetworks/bridge/models/studies/EnrollmentFilter.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/studies/EnrollmentFilter.java
@@ -1,0 +1,7 @@
+package org.sagebionetworks.bridge.models.studies;
+
+public enum EnrollmentFilter {
+    ENROLLED,
+    WITHDRAWN,
+    ALL
+}

--- a/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
@@ -1,0 +1,194 @@
+package org.sagebionetworks.bridge.services;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.sagebionetworks.bridge.AuthUtils.checkSelfAdminOrSponsorAndThrow;
+import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
+import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
+import static org.sagebionetworks.bridge.BridgeConstants.NEGATIVE_OFFSET_ERROR;
+import static org.sagebionetworks.bridge.BridgeConstants.PAGE_SIZE_ERROR;
+import static org.sagebionetworks.bridge.models.ResourceList.ENROLLMENT_FILTER;
+import static org.sagebionetworks.bridge.models.ResourceList.OFFSET_BY;
+import static org.sagebionetworks.bridge.models.ResourceList.PAGE_SIZE;
+import static org.sagebionetworks.bridge.validators.EnrollmentValidator.INSTANCE;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.joda.time.DateTime;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.dao.EnrollmentDao;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
+import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
+import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.models.PagedResourceList;
+import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
+import org.sagebionetworks.bridge.models.studies.Enrollment;
+import org.sagebionetworks.bridge.models.studies.EnrollmentFilter;
+import org.sagebionetworks.bridge.validators.Validate;
+
+@Component
+public class EnrollmentService {
+    
+    private AccountService accountService;
+    
+    private SponsorService sponsorService;
+    
+    private EnrollmentDao enrollmentDao;
+    
+    @Autowired
+    public final void setAccountService(AccountService accountService) {
+        this.accountService = accountService;
+    }
+    
+    @Autowired
+    public final void setSponsorService(SponsorService sponsorService) {
+        this.sponsorService = sponsorService;
+    }
+    
+    @Autowired
+    public final void setEnrollmentDao(EnrollmentDao enrollmentDao) {
+        this.enrollmentDao = enrollmentDao;
+    }
+    
+    protected DateTime getEnrollmentDateTime() {
+        return DateTime.now();
+    }
+
+    protected DateTime getWithdrawalDateTime() {
+        return DateTime.now();
+    }
+    
+    /**
+     * Get enrollments in a study. This API will be expanded to retrieve and sort the data for 
+     * common reporting requirements (e.g. how many people have withdrawn from the study).
+     */
+    public PagedResourceList<Enrollment> getEnrollmentsForStudy(String appId, String studyId, 
+            EnrollmentFilter filter, Integer offsetBy, Integer pageSize) {
+        checkNotNull(appId);
+        checkNotNull(studyId);
+        
+        checkSelfAdminOrSponsorAndThrow(sponsorService, studyId, null);
+
+        if (offsetBy != null && offsetBy < 0) {
+            throw new BadRequestException(NEGATIVE_OFFSET_ERROR);
+        }
+        if (pageSize != null && (pageSize < API_MINIMUM_PAGE_SIZE || pageSize > API_MAXIMUM_PAGE_SIZE)) {
+            throw new BadRequestException(PAGE_SIZE_ERROR);
+        }
+        return enrollmentDao.getEnrollmentsForStudy(appId, studyId, filter, offsetBy, pageSize)
+                .withRequestParam(OFFSET_BY, offsetBy)
+                .withRequestParam(PAGE_SIZE, pageSize)
+                .withRequestParam(ENROLLMENT_FILTER, filter);
+    }
+    
+    /**
+     * For methods that are going to save the account, this method handles enrollment but does not persist it.
+     */
+    public Enrollment enroll(Account account, Enrollment enrollment) {
+        checkNotNull(account);
+        checkNotNull(enrollment);
+        
+        Validate.entityThrowingException(INSTANCE, enrollment);
+        
+        checkSelfAdminOrSponsorAndThrow(sponsorService, enrollment.getStudyId(), enrollment.getAccountId());
+
+        for (Enrollment existingEnrollment : account.getEnrollments()) {
+            // appId and accountId are always going to match, given the way these 
+            // records are loaded. We only need to look for the studyId. 
+            if (existingEnrollment.getStudyId().equals(enrollment.getStudyId())) {
+                if (existingEnrollment.getWithdrawnOn() != null) {
+                    account.getEnrollments().remove(existingEnrollment);
+                    break;
+                } else {
+                    throw new EntityAlreadyExistsException(Enrollment.class,
+                        ImmutableMap.of("accountId", account.getId(), "studyId", enrollment.getStudyId()));
+                }
+            }
+        }
+        enrollment.setWithdrawnOn(null);
+        enrollment.setWithdrawnBy(null);
+        enrollment.setWithdrawalNote(null);
+        enrollment.setExternalId(enrollment.getExternalId());
+        if (enrollment.getEnrolledOn() == null) {
+            enrollment.setEnrolledOn(getEnrollmentDateTime());
+        }
+        String callerUserId = BridgeUtils.getRequestContext().getCallerUserId();
+        if (!account.getId().equals(callerUserId)) {
+            enrollment.setEnrolledBy(callerUserId);
+        }
+
+        account.getEnrollments().add(enrollment);
+        return enrollment;
+    }
+    
+    public Enrollment enroll(Enrollment enrollment) {
+        checkNotNull(enrollment);
+        
+        // verify this has appId and accountId
+        Validate.entityThrowingException(INSTANCE, enrollment);
+        
+        AccountId accountId = AccountId.forId(enrollment.getAppId(), enrollment.getAccountId());
+        Account account = accountService.getAccount(accountId);
+        if (account == null) {
+            throw new EntityNotFoundException(Account.class);
+        }
+        enroll(account, enrollment);
+        accountService.updateAccount(account, null);
+        return enrollment;
+    }
+    
+    /**
+     * For methods that are going to save the account, this method withdraws the account but does not persist it.
+     */
+    public Enrollment unenroll(Account account, Enrollment enrollment) {
+        checkNotNull(account);
+        checkNotNull(enrollment);
+        
+        Validate.entityThrowingException(INSTANCE, enrollment);
+        
+        checkSelfAdminOrSponsorAndThrow(sponsorService, enrollment.getStudyId(), enrollment.getAccountId());
+        
+        // If supplied, this value should be the same timestamp as the withdrewOn
+        // value in the signature. Otherwise just set it here. 
+        if (enrollment.getWithdrawnOn() == null) {
+            enrollment.setWithdrawnOn(getWithdrawalDateTime());
+        }
+        String callerUserId = BridgeUtils.getRequestContext().getCallerUserId();
+        String withdrawnBy = (!account.getId().equals(callerUserId)) ? callerUserId : null;
+        enrollment.setWithdrawnBy(withdrawnBy);
+        
+        for (Enrollment existingEnrollment : account.getEnrollments()) {
+            if (existingEnrollment.getStudyId().equals(enrollment.getStudyId())) {
+                if (existingEnrollment.getWithdrawnOn() != null) {
+                    throw new EntityAlreadyExistsException(Enrollment.class, 
+                            "Participant is already withdrawn from study.", 
+                            ImmutableMap.of("studyId", enrollment.getStudyId()));
+                } else {
+                    existingEnrollment.setWithdrawnOn(enrollment.getWithdrawnOn());
+                    existingEnrollment.setWithdrawnBy(enrollment.getWithdrawnBy());
+                    existingEnrollment.setWithdrawalNote(enrollment.getWithdrawalNote());
+                    return existingEnrollment;
+                }
+            }
+        }
+        throw new EntityNotFoundException(Enrollment.class);
+    }
+    
+    public Enrollment unenroll(Enrollment enrollment) {
+        checkNotNull(enrollment);
+        
+        Validate.entityThrowingException(INSTANCE, enrollment);
+        
+        AccountId accountId = AccountId.forId(enrollment.getAppId(), enrollment.getAccountId());
+        Account account = accountService.getAccount(accountId);
+        if (account == null) {
+            throw new EntityNotFoundException(Account.class);
+        }
+        enrollment = unenroll(account, enrollment);
+        accountService.updateAccount(account, null);
+        return enrollment;
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/services/SponsorService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/SponsorService.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.services;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.sagebionetworks.bridge.AuthUtils.checkOrgMembershipAndThrow;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
@@ -12,6 +13,7 @@ import static org.sagebionetworks.bridge.models.ResourceList.PAGE_SIZE;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.SponsorDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.models.PagedResourceList;
@@ -113,5 +115,15 @@ public class SponsorService {
             organizationService.getOrganization(appId, orgId);
             throw new BadRequestException(String.format(NOT_A_SPONSOR_MSG, orgId, studyId));
         }
+    }
+    
+    public boolean isStudySponsoredBy(String studyId, String orgId) {
+        checkNotNull(studyId);
+        
+        if (isBlank(studyId) || isBlank(orgId)) {
+            return false;
+        }
+        String appId = BridgeUtils.getRequestContext().getCallerAppId();
+        return sponsorDao.doesOrganizationSponsorStudy(appId, studyId, orgId);
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentController.java
@@ -7,6 +7,7 @@ import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -58,7 +59,7 @@ public class EnrollmentController extends BaseController {
         return service.enroll(enrollment);
     }
     
-    @PostMapping("/v5/studies/{studyId}/enrollments/{userId}")
+    @DeleteMapping("/v5/studies/{studyId}/enrollments/{userId}")
     public Enrollment unenroll(@PathVariable String studyId, @PathVariable String userId) {
         UserSession session = getAuthenticatedSession(RESEARCHER, ADMIN);
         

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentController.java
@@ -60,13 +60,12 @@ public class EnrollmentController extends BaseController {
     }
     
     @DeleteMapping("/v5/studies/{studyId}/enrollments/{userId}")
-    public Enrollment unenroll(@PathVariable String studyId, @PathVariable String userId) {
+    public Enrollment unenroll(@PathVariable String studyId, @PathVariable String userId,
+            @RequestParam(required = false) String withdrawalNote) {
         UserSession session = getAuthenticatedSession(RESEARCHER, ADMIN);
         
-        Enrollment enrollment = parseJson(Enrollment.class);
-        enrollment.setAppId(session.getAppId());
-        enrollment.setStudyId(studyId);
-        enrollment.setAccountId(userId);
+        Enrollment enrollment = Enrollment.create(session.getAppId(), studyId, userId);
+        enrollment.setWithdrawalNote(withdrawalNote);
         
         return service.unenroll(enrollment);
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentController.java
@@ -1,0 +1,72 @@
+package org.sagebionetworks.bridge.spring.controllers;
+
+import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
+import static org.sagebionetworks.bridge.Roles.ADMIN;
+import static org.sagebionetworks.bridge.Roles.RESEARCHER;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.models.PagedResourceList;
+import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.studies.Enrollment;
+import org.sagebionetworks.bridge.models.studies.EnrollmentFilter;
+import org.sagebionetworks.bridge.services.EnrollmentService;
+
+@CrossOrigin
+@RestController
+public class EnrollmentController extends BaseController {
+
+    private EnrollmentService service;
+    
+    @Autowired
+    final void setEnrollmentService(EnrollmentService service) {
+        this.service = service;
+    }
+    
+    @GetMapping("/v5/studies/{studyId}/enrollments")
+    public PagedResourceList<Enrollment> getEnrollmentsForStudy(@PathVariable String studyId,
+            @RequestParam(required = false) String offsetBy, 
+            @RequestParam(required = false) String pageSize,
+            @RequestParam(required = false) String enrollmentFilter) {
+        UserSession session = getAuthenticatedSession(RESEARCHER, ADMIN);
+        
+        EnrollmentFilter filter = BridgeUtils.getEnumOrDefault(enrollmentFilter, EnrollmentFilter.class, null);
+        int offsetByInt = BridgeUtils.getIntOrDefault(offsetBy, 0);
+        int pageSizeInt = BridgeUtils.getIntOrDefault(pageSize, API_DEFAULT_PAGE_SIZE);
+
+        return service.getEnrollmentsForStudy(session.getAppId(), studyId, filter, offsetByInt, pageSizeInt);        
+    }
+    
+    @PostMapping("/v5/studies/{studyId}/enrollments")
+    @ResponseStatus(HttpStatus.CREATED)
+    public Enrollment enroll(@PathVariable String studyId) {
+        UserSession session = getAuthenticatedSession(RESEARCHER, ADMIN);
+        
+        Enrollment enrollment = parseJson(Enrollment.class);
+        enrollment.setAppId(session.getAppId());
+        enrollment.setStudyId(studyId);
+        
+        return service.enroll(enrollment);
+    }
+    
+    @PostMapping("/v5/studies/{studyId}/enrollments/{userId}")
+    public Enrollment unenroll(@PathVariable String studyId, @PathVariable String userId) {
+        UserSession session = getAuthenticatedSession(RESEARCHER, ADMIN);
+        
+        Enrollment enrollment = parseJson(Enrollment.class);
+        enrollment.setAppId(session.getAppId());
+        enrollment.setStudyId(studyId);
+        enrollment.setAccountId(userId);
+        
+        return service.unenroll(enrollment);
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/validators/EnrollmentValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/EnrollmentValidator.java
@@ -1,0 +1,32 @@
+package org.sagebionetworks.bridge.validators;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL_OR_EMPTY;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.validation.Errors;
+
+import org.sagebionetworks.bridge.models.studies.Enrollment;
+
+public class EnrollmentValidator extends AbstractValidator {
+    public static final EnrollmentValidator INSTANCE = new EnrollmentValidator();
+    
+    @Override
+    public void validate(Object target, Errors errors) {
+        Enrollment enrollment = (Enrollment)target;
+
+        if (StringUtils.isBlank(enrollment.getAppId())) {
+            errors.rejectValue("appId", CANNOT_BE_NULL_OR_EMPTY);
+        }
+        if (StringUtils.isBlank(enrollment.getAccountId())) {
+            errors.rejectValue("userId", CANNOT_BE_NULL_OR_EMPTY);
+        }
+        if (StringUtils.isBlank(enrollment.getStudyId())) {
+            errors.rejectValue("studyId", CANNOT_BE_NULL_OR_EMPTY);
+        }
+        if (enrollment.getExternalId() != null && isBlank(enrollment.getExternalId())) {
+            errors.rejectValue("externalId", "cannot be blank");
+        }        
+    }
+
+}

--- a/src/main/resources/db/changelog/changelog.sql
+++ b/src/main/resources/db/changelog/changelog.sql
@@ -394,3 +394,15 @@ MODIFY COLUMN `category` enum('CUSTOMIZATION_OPTIONS', 'DATA_REPOSITORY',
     'PUBLICATION', 'RELEASE_NOTE', 'SAMPLE_APP', 'SAMPLE_DATA', 
     'SCREENSHOT', 'VIDEO_PREVIEW', 'SEE_ALSO', 'USED_IN_STUDY', 'WEBSITE', 
     'OTHER') NOT NULL;
+    
+-- changeset bridge:19
+
+ALTER TABLE `AccountsSubstudies`
+ADD COLUMN `consentRequired` tinyint(1) DEFAULT '0',
+ADD COLUMN `enrolledOn` bigint(20),
+ADD COLUMN `withdrawnOn` bigint(20),
+ADD COLUMN `enrolledBy` varchar(255),
+ADD COLUMN `withdrawnBy` varchar(255),
+ADD COLUMN `withdrawalNote` varchar(255),
+ADD CONSTRAINT `fk_enrolledBy` FOREIGN KEY (`enrolledBy`) REFERENCES `Accounts` (`id`),
+ADD CONSTRAINT `fk_withdrawnBy` FOREIGN KEY (`withdrawnBy`) REFERENCES `Accounts` (`id`);

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateEnrollmentDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateEnrollmentDaoTest.java
@@ -1,0 +1,62 @@
+package org.sagebionetworks.bridge.hibernate;
+
+import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
+import static org.testng.Assert.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableList;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.models.PagedResourceList;
+import org.sagebionetworks.bridge.models.studies.Enrollment;
+
+public class HibernateEnrollmentDaoTest extends Mockito {
+    
+    @Mock
+    HibernateHelper mockHelper;
+    
+    @Captor
+    ArgumentCaptor<String> queryCaptor;
+    
+    @Captor
+    ArgumentCaptor<Map<String,Object>> paramsCaptor;
+    
+    @InjectMocks
+    HibernateEnrollmentDao dao;
+    
+    @BeforeMethod
+    public void beforeMethod() {
+        MockitoAnnotations.initMocks(this);
+    }
+    
+    @Test
+    public void getEnrollmentsForStudy() {
+        HibernateEnrollment en1 = new HibernateEnrollment();
+        HibernateEnrollment en2 = new HibernateEnrollment();
+        List<HibernateEnrollment> page = ImmutableList.of(en1, en2);
+        
+        when(mockHelper.queryCount(any(), any())).thenReturn(20);
+        when(mockHelper.queryGet(any(), any(), any(), any(), eq(HibernateEnrollment.class))).thenReturn(page);
+        
+        PagedResourceList<Enrollment> retValue = dao.getEnrollmentsForStudy(TEST_APP_ID, TEST_STUDY_ID, null, 10, 75);
+        assertEquals(retValue.getTotal(), Integer.valueOf(20));
+        assertEquals(retValue.getItems(), page);
+        
+        verify(mockHelper).queryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(10), eq(75),
+                eq(HibernateEnrollment.class));
+        assertEquals(queryCaptor.getValue(), "FROM HibernateEnrollment WHERE appId = :appId AND studyId = :studyId");
+        assertEquals(paramsCaptor.getValue().get("appId"), TEST_APP_ID);
+        assertEquals(paramsCaptor.getValue().get("studyId"), TEST_STUDY_ID);
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateEnrollmentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateEnrollmentTest.java
@@ -1,9 +1,19 @@
 package org.sagebionetworks.bridge.hibernate;
 
+import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
+import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.studies.Enrollment;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
@@ -17,12 +27,66 @@ public class HibernateEnrollmentTest {
     }
     
     @Test
+    public void canSerialize() throws Exception {
+        Enrollment enrollment = new HibernateEnrollment();
+        enrollment.setAppId(TEST_APP_ID);
+        enrollment.setStudyId(TEST_STUDY_ID);
+        enrollment.setAccountId("accountId");
+        enrollment.setExternalId("externalId");
+        enrollment.setEnrolledOn(CREATED_ON);
+        enrollment.setWithdrawnOn(MODIFIED_ON);
+        enrollment.setEnrolledBy("enrolledBy");
+        enrollment.setWithdrawnBy("withdrawnBy");
+        enrollment.setWithdrawalNote("note");
+        enrollment.setConsentRequired(true);
+        
+        JsonNode node = BridgeObjectMapper.get().valueToTree(enrollment);
+        
+        assertEquals(node.get("userId").textValue(), "accountId");
+        assertEquals(node.get("externalId").textValue(), "externalId");
+        assertEquals(node.get("enrolledOn").textValue(), CREATED_ON.toString());
+        assertEquals(node.get("enrolledBy").textValue(), "enrolledBy");
+        assertEquals(node.get("withdrawnOn").textValue(), MODIFIED_ON.toString());
+        assertEquals(node.get("withdrawnBy").textValue(), "withdrawnBy");
+        assertEquals(node.get("withdrawalNote").textValue(), "note");
+        assertTrue(node.get("consentRequired").booleanValue());
+        assertEquals(node.get("type").textValue(), "Enrollment");
+        
+        Enrollment deser = BridgeObjectMapper.get().readValue(node.toString(), Enrollment.class);
+        assertNull(deser.getAppId());
+        assertNull(deser.getStudyId());
+        assertEquals(deser.getAccountId(), "accountId");
+        assertEquals(deser.getExternalId(), "externalId");
+        assertEquals(deser.getEnrolledOn(), CREATED_ON);
+        assertEquals(deser.getEnrolledBy(), "enrolledBy");
+        assertEquals(deser.getWithdrawnOn(), MODIFIED_ON);
+        assertEquals(deser.getWithdrawnBy(), "withdrawnBy");
+        assertEquals(deser.getWithdrawalNote(), "note");
+        assertTrue(deser.isConsentRequired());
+    }
+    
+    @Test
     public void test() {
-        HibernateEnrollment enrollment = new HibernateEnrollment(TEST_APP_ID, "studyId", "accountId", "externalId");
+        Enrollment enrollment = new HibernateEnrollment();
+        enrollment.setAppId(TEST_APP_ID);
+        enrollment.setStudyId(TEST_STUDY_ID);
+        enrollment.setAccountId("accountId");
+        enrollment.setExternalId("externalId");
+        enrollment.setEnrolledOn(CREATED_ON);
+        enrollment.setWithdrawnOn(MODIFIED_ON);
+        enrollment.setEnrolledBy("enrolledBy");
+        enrollment.setWithdrawnBy("withdrawnBy");
+        enrollment.setWithdrawalNote("note");
+        enrollment.setConsentRequired(true);
         
         assertEquals(enrollment.getAppId(), TEST_APP_ID);
-        assertEquals(enrollment.getStudyId(), "studyId");
+        assertEquals(enrollment.getStudyId(), TEST_STUDY_ID);
         assertEquals(enrollment.getAccountId(), "accountId");
         assertEquals(enrollment.getExternalId(), "externalId");
+        assertEquals(enrollment.getEnrolledOn(), CREATED_ON);
+        assertEquals(enrollment.getWithdrawnOn(), MODIFIED_ON);
+        assertEquals(enrollment.getEnrolledBy(), "enrolledBy");
+        assertEquals(enrollment.getWithdrawnBy(), "withdrawnBy");
+        assertEquals(enrollment.getWithdrawalNote(), "note");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/QueryBuilderTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/QueryBuilderTest.java
@@ -6,6 +6,8 @@ import com.google.common.collect.ImmutableSet;
 
 import org.testng.annotations.Test;
 
+import org.sagebionetworks.bridge.models.studies.EnrollmentFilter;
+
 public class QueryBuilderTest {
 
     @Test
@@ -65,5 +67,24 @@ public class QueryBuilderTest {
         builder.orgMembership("foo");
         assertEquals(builder.getQuery(), "AND acct.orgMembership = :orgId");
         assertEquals(builder.getParameters().get("orgId"), "foo");
+    }
+    
+    @Test
+    public void enrollment() {
+        QueryBuilder builder = new QueryBuilder();
+        builder.enrollment(EnrollmentFilter.ENROLLED);
+        assertEquals(builder.getQuery(), "AND withdrawnOn IS NULL");
+        
+        builder = new QueryBuilder();
+        builder.enrollment(EnrollmentFilter.WITHDRAWN);
+        assertEquals(builder.getQuery(), "AND withdrawnOn IS NOT NULL");
+        
+        builder = new QueryBuilder();
+        builder.enrollment(EnrollmentFilter.ALL);
+        assertEquals(builder.getQuery(), "");
+        
+        builder = new QueryBuilder();
+        builder.enrollment(null);
+        assertEquals(builder.getQuery(), "");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/studies/EnrollmentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/studies/EnrollmentTest.java
@@ -7,7 +7,7 @@ import static org.testng.Assert.assertNull;
 import org.testng.annotations.Test;
 
 public class EnrollmentTest {
-
+    
     @Test
     public void createSmall() {
         Enrollment enrollment = Enrollment.create(TEST_APP_ID, "studyId", "accountId");

--- a/src/test/java/org/sagebionetworks/bridge/services/EnrollmentServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/EnrollmentServiceTest.java
@@ -1,0 +1,471 @@
+package org.sagebionetworks.bridge.services;
+
+import static org.sagebionetworks.bridge.BridgeConstants.NEGATIVE_OFFSET_ERROR;
+import static org.sagebionetworks.bridge.BridgeConstants.PAGE_SIZE_ERROR;
+import static org.sagebionetworks.bridge.Roles.ADMIN;
+import static org.sagebionetworks.bridge.Roles.DEVELOPER;
+import static org.sagebionetworks.bridge.Roles.RESEARCHER;
+import static org.sagebionetworks.bridge.TestConstants.ACCOUNT_ID;
+import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
+import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
+import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
+import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.models.ResourceList.ENROLLMENT_FILTER;
+import static org.sagebionetworks.bridge.models.ResourceList.OFFSET_BY;
+import static org.sagebionetworks.bridge.models.ResourceList.PAGE_SIZE;
+import static org.sagebionetworks.bridge.models.studies.EnrollmentFilter.ENROLLED;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+
+import org.joda.time.DateTime;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.RequestContext;
+import org.sagebionetworks.bridge.dao.EnrollmentDao;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
+import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
+import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
+import org.sagebionetworks.bridge.models.PagedResourceList;
+import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.studies.Enrollment;
+import org.sagebionetworks.bridge.models.studies.EnrollmentFilter;
+
+public class EnrollmentServiceTest extends Mockito {
+
+    @Mock
+    AccountService mockAccountService;
+    
+    @Mock
+    SponsorService mockSponsorService;
+    
+    @Mock
+    EnrollmentDao mockEnrollmentDao;
+    
+    @InjectMocks
+    @Spy
+    EnrollmentService service;
+    
+    @Captor
+    ArgumentCaptor<Account> accountCaptor;
+    
+    @BeforeMethod
+    public void beforeMethod() {
+        MockitoAnnotations.initMocks(this);
+        doReturn(CREATED_ON).when(service).getEnrollmentDateTime();
+        doReturn(MODIFIED_ON).when(service).getWithdrawalDateTime();
+    }
+    
+    @Test
+    public void getEnrollmentsForStudy() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(ADMIN)).build());
+        
+        PagedResourceList<Enrollment> page = new PagedResourceList<>(ImmutableList.of(), 10);
+        when(mockEnrollmentDao.getEnrollmentsForStudy(TEST_APP_ID, TEST_STUDY_ID, ENROLLED, 10, 50)).thenReturn(page);
+        
+        PagedResourceList<Enrollment> retValue = service.getEnrollmentsForStudy(TEST_APP_ID, TEST_STUDY_ID, ENROLLED, 10, 50);
+        assertSame(retValue, page);
+        assertEquals(retValue.getRequestParams().get(OFFSET_BY), Integer.valueOf(10));
+        assertEquals(retValue.getRequestParams().get(PAGE_SIZE), Integer.valueOf(50));
+        assertEquals(retValue.getRequestParams().get(ENROLLMENT_FILTER), EnrollmentFilter.ENROLLED);
+        
+        verify(mockEnrollmentDao).getEnrollmentsForStudy(TEST_APP_ID, TEST_STUDY_ID, ENROLLED, 10, 50);
+    }
+    
+    @Test
+    public void getEnrollmentsForStudyWithDefaults() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(ADMIN)).build());
+        
+        PagedResourceList<Enrollment> page = new PagedResourceList<>(ImmutableList.of(), 10);
+        when(mockEnrollmentDao.getEnrollmentsForStudy(TEST_APP_ID, TEST_STUDY_ID, null, null, null)).thenReturn(page);
+        
+        PagedResourceList<Enrollment> retValue = service.getEnrollmentsForStudy(TEST_APP_ID, TEST_STUDY_ID, null, null, null);
+        assertSame(retValue, page);
+        
+        verify(mockEnrollmentDao).getEnrollmentsForStudy(TEST_APP_ID, TEST_STUDY_ID, null, null, null);
+    }
+        
+    @Test(expectedExceptions = UnauthorizedException.class)
+    public void getEnrollmentsForStudyNotAuthorized() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerUserId("adminUser")
+                .withCallerOrgMembership(TEST_ORG_ID).build());
+        when(mockSponsorService.isStudySponsoredBy(TEST_STUDY_ID, TEST_ORG_ID)).thenReturn(false);
+        
+        service.getEnrollmentsForStudy(TEST_APP_ID, TEST_STUDY_ID, null, 10, 50);
+    }
+
+    @Test(expectedExceptions = BadRequestException.class, expectedExceptionsMessageRegExp = NEGATIVE_OFFSET_ERROR)
+    public void getEnrollmentsForStudyOffsetNegative() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(ADMIN)).build());
+
+        service.getEnrollmentsForStudy(TEST_APP_ID, TEST_STUDY_ID, null, -1, 50);
+    }
+
+    @Test(expectedExceptions = BadRequestException.class, expectedExceptionsMessageRegExp = PAGE_SIZE_ERROR)
+    public void getEnrollmentsForStudyUnderMin() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(ADMIN)).build());
+
+        service.getEnrollmentsForStudy(TEST_APP_ID, TEST_STUDY_ID, null, 0, 0);
+    }
+    
+    @Test(expectedExceptions = BadRequestException.class, expectedExceptionsMessageRegExp = PAGE_SIZE_ERROR)
+    public void getEnrollmentsForStudyOverMax() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(ADMIN)).build());
+
+        service.getEnrollmentsForStudy(TEST_APP_ID, TEST_STUDY_ID, null, 0, 1000);
+    }
+    
+    @Test
+    public void enrollBySelf() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerUserId(USER_ID)
+                .withCallerRoles(ImmutableSet.of(ADMIN)).build());
+        
+        // This should not effect the behavior of the enrollment.
+        Enrollment otherStudy = Enrollment.create(TEST_APP_ID, "otherStudy", USER_ID);
+        
+        Account account = Account.create();
+        account.setId(USER_ID);
+        account.setEnrollments(Sets.newHashSet(otherStudy));
+        when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
+        
+        DateTime timestamp = DateTime.now();
+        
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        enrollment.setExternalId("extId");
+        enrollment.setEnrolledOn(timestamp);
+
+        Enrollment retValue = service.enroll(enrollment);
+        assertEquals(retValue.getAppId(), TEST_APP_ID);
+        assertEquals(retValue.getStudyId(), TEST_STUDY_ID);
+        assertEquals(retValue.getAccountId(), USER_ID);
+        assertEquals(retValue.getExternalId(), "extId");
+        assertEquals(retValue.getEnrolledOn(), timestamp);
+        assertNull(retValue.getEnrolledBy());
+        assertNull(retValue.getWithdrawnOn());
+        assertNull(retValue.getWithdrawnBy());
+        assertNull(retValue.getWithdrawalNote());
+        assertFalse(retValue.isConsentRequired());
+    }
+    
+    @Test
+    public void enrollByThirdPartyAdmin() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerUserId("adminUser")
+                .withCallerRoles(ImmutableSet.of(ADMIN)).build());
+        
+        Account account = Account.create();
+        account.setId(USER_ID);
+        when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
+        
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+
+        Enrollment retValue = service.enroll(enrollment);
+        assertEquals(retValue.getAccountId(), USER_ID);
+        assertEquals(retValue.getEnrolledBy(), "adminUser");
+    }
+    
+    @Test
+    public void enrollByThirdPartyResearcher() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerUserId("adminUser")
+                .withCallerOrgMembership(TEST_ORG_ID)
+                .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
+        
+        when(mockSponsorService.isStudySponsoredBy(TEST_STUDY_ID, TEST_ORG_ID)).thenReturn(Boolean.TRUE);
+        
+        Account account = Account.create();
+        account.setId(USER_ID);
+        when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
+        
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+
+        Enrollment retValue = service.enroll(enrollment);
+        assertEquals(retValue.getAccountId(), USER_ID);
+        assertEquals(retValue.getEnrolledBy(), "adminUser");
+    }
+    
+    @Test(expectedExceptions = EntityAlreadyExistsException.class)
+    public void enrollAlreadyExists() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerUserId(USER_ID)
+                .withCallerRoles(ImmutableSet.of(ADMIN)).build());
+        
+        Account account = Account.create();
+        account.setId(USER_ID);
+        
+        Enrollment existing = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment otherStudy = Enrollment.create(TEST_APP_ID, "otherStudy", USER_ID);
+        account.setEnrollments(ImmutableSet.of(existing, otherStudy));
+        
+        when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
+        
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        service.enroll(enrollment);
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class, 
+            expectedExceptionsMessageRegExp = "Account not found.")
+    public void enrollAccountNotFound() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerUserId(USER_ID)
+                .withCallerRoles(ImmutableSet.of(ADMIN)).build());
+        
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        enrollment.setExternalId("extId");
+
+        service.enroll(enrollment);
+    }
+    
+    @Test
+    public void enrollAlreadyExistsButIsWithdrawn() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerUserId(USER_ID)
+                .withCallerRoles(ImmutableSet.of(ADMIN)).build());
+        
+        Account account = Account.create();
+        account.setId(USER_ID);
+        
+        Enrollment unrelatedEnrollment = Enrollment.create(TEST_APP_ID, "someOtherStudy", USER_ID);
+        
+        Enrollment existing = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        // This should cause the enrollment to be recreated.
+        existing.setWithdrawnOn(MODIFIED_ON);
+        account.setEnrollments(Sets.newHashSet(unrelatedEnrollment, existing));
+        
+        when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
+        
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        enrollment.setExternalId("extId");
+        
+        Enrollment retValue = service.enroll(enrollment);
+        assertEquals(retValue.getAppId(), TEST_APP_ID);
+        assertEquals(retValue.getStudyId(), TEST_STUDY_ID);
+        assertEquals(retValue.getAccountId(), USER_ID);
+        assertEquals(retValue.getExternalId(), "extId");
+        assertEquals(retValue.getEnrolledOn(), CREATED_ON);
+        assertNull(retValue.getEnrolledBy());
+        assertNull(retValue.getWithdrawnOn());
+        assertNull(retValue.getWithdrawnBy());
+        assertNull(retValue.getWithdrawalNote());
+        assertFalse(retValue.isConsentRequired());
+    }
+    
+    @Test(expectedExceptions = UnauthorizedException.class)
+    public void enrollNotAuthorizedAsAdmin() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerUserId("adminUser")
+                .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
+        
+        Account account = Account.create();
+        account.setId(USER_ID);
+        when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
+        
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+
+        service.enroll(enrollment);
+    }
+    
+    @Test(expectedExceptions = UnauthorizedException.class)
+    public void enrollNotAuthorizedAsStudyResearcher() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerUserId("adminUser")
+                .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
+        
+        // the call to sponsorService returns null
+        
+        Account account = Account.create();
+        account.setId(USER_ID);
+        when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
+        
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+
+        service.enroll(enrollment);
+    }
+    
+    @Test
+    public void unenrollBySelf() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerUserId(USER_ID).build());
+                
+        Enrollment existing = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment otherStudy = Enrollment.create(TEST_APP_ID, "otherStudy", USER_ID);
+        
+        Account account = Account.create();
+        account.setId(USER_ID);
+        account.setEnrollments(Sets.newHashSet(otherStudy, existing));
+        when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
+        
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        enrollment.setWithdrawnOn(MODIFIED_ON);
+        enrollment.setWithdrawalNote("Withdrawal reason");
+        
+        Enrollment retValue = service.unenroll(enrollment);
+        assertEquals(retValue.getWithdrawnOn(), MODIFIED_ON);
+        assertNull(retValue.getWithdrawnBy());
+        assertEquals(retValue.getWithdrawalNote(), "Withdrawal reason");
+
+        verify(mockAccountService).updateAccount(accountCaptor.capture(), isNull());
+        Enrollment captured = Iterables.getLast(accountCaptor.getValue().getEnrollments(), null);
+        assertEquals(captured.getWithdrawnOn(), MODIFIED_ON);
+        assertNull(captured.getWithdrawnBy());
+        assertEquals(captured.getWithdrawalNote(), "Withdrawal reason");        
+    }
+    
+    @Test
+    public void unenrollByThirdPartyAdmin() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerUserId("adminUser")
+                .withCallerRoles(ImmutableSet.of(ADMIN)).build());
+                
+        Enrollment existing = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        
+        Account account = Account.create();
+        account.setId(USER_ID);
+        account.setEnrollments(Sets.newHashSet(existing));
+        when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
+        
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        enrollment.setWithdrawnOn(MODIFIED_ON);
+        enrollment.setWithdrawalNote("Withdrawal reason");
+        
+        Enrollment retValue = service.unenroll(enrollment);
+        assertEquals(retValue.getWithdrawnOn(), MODIFIED_ON);
+        assertEquals(retValue.getWithdrawnBy(), "adminUser");
+        assertEquals(retValue.getWithdrawalNote(), "Withdrawal reason");
+
+        verify(mockAccountService).updateAccount(accountCaptor.capture(), isNull());
+        Enrollment captured = Iterables.getFirst(accountCaptor.getValue().getEnrollments(), null);
+        assertEquals(captured.getWithdrawnOn(), MODIFIED_ON);
+        assertEquals(captured.getWithdrawnBy(), "adminUser");
+        assertEquals(captured.getWithdrawalNote(), "Withdrawal reason");
+    }
+    
+    @Test
+    public void unenrollByThirdPartyResearcher() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerUserId("adminUser")
+                .withCallerOrgMembership(TEST_ORG_ID)
+                .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
+        
+        when(mockSponsorService.isStudySponsoredBy(TEST_STUDY_ID, TEST_ORG_ID)).thenReturn(Boolean.TRUE);
+                
+        Enrollment existing = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        
+        Account account = Account.create();
+        account.setId(USER_ID);
+        account.setEnrollments(Sets.newHashSet(existing));
+        when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
+        
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        enrollment.setWithdrawnOn(MODIFIED_ON);
+        enrollment.setWithdrawalNote("Withdrawal reason");
+        
+        Enrollment retValue = service.unenroll(enrollment);
+        assertEquals(retValue.getWithdrawnOn(), MODIFIED_ON);
+        assertEquals(retValue.getWithdrawnBy(), "adminUser");
+        assertEquals(retValue.getWithdrawalNote(), "Withdrawal reason");
+
+        verify(mockAccountService).updateAccount(accountCaptor.capture(), isNull());
+        Enrollment captured = Iterables.getFirst(accountCaptor.getValue().getEnrollments(), null);
+        assertEquals(captured.getWithdrawnOn(), MODIFIED_ON);
+        assertEquals(captured.getWithdrawnBy(), "adminUser");
+        assertEquals(captured.getWithdrawalNote(), "Withdrawal reason");
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void unenrollDoesNotExists() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(ADMIN)).build());
+        
+        Account account = Account.create();
+        account.setId(USER_ID);
+        when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
+        
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        service.unenroll(enrollment);
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class, 
+            expectedExceptionsMessageRegExp = "Account not found.")
+    public void unenrollAccountNotFound() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(ADMIN)).build());
+        
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        service.unenroll(enrollment);
+    }
+    
+    @Test(expectedExceptions = EntityAlreadyExistsException.class, 
+            expectedExceptionsMessageRegExp = "Participant is already withdrawn from study.")
+    public void unenrollAlreadyExistsButIsWithdrawn() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(ADMIN)).build());
+        
+        Enrollment existing = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        existing.setWithdrawnOn(MODIFIED_ON);
+        
+        Account account = Account.create();
+        account.setId(USER_ID);
+        account.setEnrollments(Sets.newHashSet(existing));
+        when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
+        
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        service.unenroll(enrollment);
+    }
+    
+    @Test(expectedExceptions = UnauthorizedException.class)
+    public void unenrollNotAuthorizedAsAdmin() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerUserId("adminUser")
+                .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
+        
+        Account account = Account.create();
+        account.setId(USER_ID);
+        when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
+        
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        service.unenroll(enrollment);
+    }
+    
+    @Test(expectedExceptions = UnauthorizedException.class)
+    public void unenrollNotAuthorizedAsStudyResearcher() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerUserId("adminUser")
+                .withCallerOrgMembership(TEST_ORG_ID)
+                .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
+        
+        when(mockSponsorService.isStudySponsoredBy(TEST_STUDY_ID, TEST_ORG_ID)).thenReturn(Boolean.FALSE);
+
+        Account account = Account.create();
+        account.setId(USER_ID);
+        when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
+
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        service.unenroll(enrollment);
+    }    
+}

--- a/src/test/java/org/sagebionetworks/bridge/services/SponsorServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/SponsorServiceTest.java
@@ -9,7 +9,9 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.models.ResourceList.OFFSET_BY;
 import static org.sagebionetworks.bridge.models.ResourceList.PAGE_SIZE;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -242,5 +244,28 @@ public class SponsorServiceTest extends Mockito {
         service.removeStudySponsor(TEST_APP_ID, TEST_STUDY_ID, TEST_ORG_ID);
         
         verify(mockSponsorDao).removeStudySponsor(TEST_APP_ID, TEST_STUDY_ID, TEST_ORG_ID);
+    }
+    
+    @Test
+    public void isStudySponsoredBy() {
+        BridgeUtils.setRequestContext(new RequestContext.Builder()
+                .withCallerAppId(TEST_APP_ID).build());
+        
+        when(mockSponsorDao.doesOrganizationSponsorStudy(TEST_APP_ID, TEST_STUDY_ID, TEST_ORG_ID)).thenReturn(true);
+        
+        boolean retValue = service.isStudySponsoredBy(TEST_STUDY_ID, TEST_ORG_ID);
+        assertTrue(retValue);
+        
+        verify(mockSponsorDao).doesOrganizationSponsorStudy(TEST_APP_ID, TEST_STUDY_ID, TEST_ORG_ID);
+    }
+
+    @Test
+    public void isStudySponsoredByStudyBlank() {
+        assertFalse(service.isStudySponsoredBy("", TEST_ORG_ID));
+    }
+
+    @Test
+    public void isStudySponsoredByOrgNull() {
+        assertFalse(service.isStudySponsoredBy(TEST_STUDY_ID, null));
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationControllerTest.java
@@ -16,7 +16,6 @@ import static org.sagebionetworks.bridge.TestUtils.createJson;
 import static org.sagebionetworks.bridge.TestUtils.getStudyParticipant;
 import static org.sagebionetworks.bridge.TestUtils.mockRequestBody;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentControllerTest.java
@@ -7,6 +7,10 @@ import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestUtils.assertCreate;
+import static org.sagebionetworks.bridge.TestUtils.assertCrossOrigin;
+import static org.sagebionetworks.bridge.TestUtils.assertDelete;
+import static org.sagebionetworks.bridge.TestUtils.assertGet;
 import static org.sagebionetworks.bridge.models.studies.EnrollmentFilter.ENROLLED;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
@@ -64,6 +68,14 @@ public class EnrollmentControllerTest extends Mockito {
     }
     
     @Test
+    public void verifyAnnotations() throws Exception {
+        assertCrossOrigin(EnrollmentController.class);
+        assertGet(EnrollmentController.class, "getEnrollmentsForStudy");
+        assertCreate(EnrollmentController.class, "enroll");
+        assertDelete(EnrollmentController.class, "unenroll");
+    }
+    
+    @Test
     public void getEnrollmentsForStudy() {
         Enrollment en1 = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, "user1");
         Enrollment en2 = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, "user2");
@@ -84,6 +96,7 @@ public class EnrollmentControllerTest extends Mockito {
         enrollment.setExternalId("anExternalId");
         enrollment.setAccountId(USER_ID);
         enrollment.setConsentRequired(true);
+        
         TestUtils.mockRequestBody(mockRequest, enrollment);
         
         Enrollment completed = new HibernateEnrollment();
@@ -95,6 +108,8 @@ public class EnrollmentControllerTest extends Mockito {
         verify(mockService).enroll(enrollmentCaptor.capture());
         
         Enrollment value = enrollmentCaptor.getValue();
+        assertEquals(value.getAppId(), TEST_APP_ID);
+        assertEquals(value.getStudyId(), TEST_STUDY_ID);
         assertEquals(value.getEnrolledOn(), CREATED_ON);
         assertEquals(value.getExternalId(), "anExternalId");
         assertEquals(value.getAccountId(), USER_ID);
@@ -120,7 +135,7 @@ public class EnrollmentControllerTest extends Mockito {
         assertEquals(value.getWithdrawnOn(), MODIFIED_ON);
         assertEquals(value.getWithdrawalNote(), "This is a note");
         assertEquals(value.getAppId(), TEST_APP_ID);
-        assertEquals(value.getAccountId(), USER_ID);
         assertEquals(value.getStudyId(), TEST_STUDY_ID);
+        assertEquals(value.getAccountId(), USER_ID);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentControllerTest.java
@@ -1,0 +1,126 @@
+package org.sagebionetworks.bridge.spring.controllers;
+
+import static org.sagebionetworks.bridge.Roles.ADMIN;
+import static org.sagebionetworks.bridge.Roles.RESEARCHER;
+import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
+import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
+import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
+import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.models.studies.EnrollmentFilter.ENROLLED;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.google.common.collect.ImmutableList;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.hibernate.HibernateEnrollment;
+import org.sagebionetworks.bridge.models.PagedResourceList;
+import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.studies.Enrollment;
+import org.sagebionetworks.bridge.services.EnrollmentService;
+
+public class EnrollmentControllerTest extends Mockito {
+    
+    @Mock
+    EnrollmentService mockService;
+    
+    @Mock
+    HttpServletRequest mockRequest;
+    
+    @Mock
+    HttpServletResponse mockResponse;
+    
+    @InjectMocks
+    @Spy
+    EnrollmentController controller;
+    
+    @Captor
+    ArgumentCaptor<Enrollment> enrollmentCaptor;
+    
+    @BeforeMethod
+    public void beforeMethod() {
+        MockitoAnnotations.initMocks(this);
+        doReturn(mockRequest).when(controller).request();
+        doReturn(mockResponse).when(controller).response();
+        
+        UserSession session = new UserSession();
+        session.setAppId(TEST_APP_ID);
+        doReturn(session).when(controller).getAuthenticatedSession(RESEARCHER, ADMIN);
+    }
+    
+    @Test
+    public void getEnrollmentsForStudy() {
+        Enrollment en1 = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, "user1");
+        Enrollment en2 = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, "user2");
+        PagedResourceList<Enrollment> page = new PagedResourceList<>(ImmutableList.of(en1, en2), 10);
+        when(mockService.getEnrollmentsForStudy(TEST_APP_ID, TEST_STUDY_ID, ENROLLED, 5, 40)).thenReturn(page);
+        
+        PagedResourceList<Enrollment> retValue = controller.getEnrollmentsForStudy(
+                TEST_STUDY_ID, "5", "40", "enrolled");
+        assertSame(retValue, page);
+        
+        verify(mockService).getEnrollmentsForStudy(TEST_APP_ID, TEST_STUDY_ID, ENROLLED, 5, 40);
+    }
+    
+    @Test
+    public void enroll() throws Exception {
+        Enrollment enrollment = new HibernateEnrollment();
+        enrollment.setEnrolledOn(CREATED_ON);
+        enrollment.setExternalId("anExternalId");
+        enrollment.setAccountId(USER_ID);
+        enrollment.setConsentRequired(true);
+        TestUtils.mockRequestBody(mockRequest, enrollment);
+        
+        Enrollment completed = new HibernateEnrollment();
+        when(mockService.enroll(any())).thenReturn(completed);
+        
+        Enrollment retValue = controller.enroll(TEST_STUDY_ID);
+        assertSame(retValue, completed);
+        
+        verify(mockService).enroll(enrollmentCaptor.capture());
+        
+        Enrollment value = enrollmentCaptor.getValue();
+        assertEquals(value.getEnrolledOn(), CREATED_ON);
+        assertEquals(value.getExternalId(), "anExternalId");
+        assertEquals(value.getAccountId(), USER_ID);
+        assertTrue(value.isConsentRequired());
+    }
+
+    @Test
+    public void unenroll() throws Exception {
+        Enrollment enrollment = new HibernateEnrollment();
+        enrollment.setWithdrawnOn(MODIFIED_ON);
+        enrollment.setWithdrawalNote("This is a note");
+        TestUtils.mockRequestBody(mockRequest, enrollment);
+
+        Enrollment completed = new HibernateEnrollment();
+        when(mockService.unenroll(any())).thenReturn(completed);
+
+        Enrollment retValue = controller.unenroll(TEST_STUDY_ID, USER_ID);
+        assertSame(retValue, completed);
+        
+        verify(mockService).unenroll(enrollmentCaptor.capture());
+        
+        Enrollment value = enrollmentCaptor.getValue();
+        assertEquals(value.getWithdrawnOn(), MODIFIED_ON);
+        assertEquals(value.getWithdrawalNote(), "This is a note");
+        assertEquals(value.getAppId(), TEST_APP_ID);
+        assertEquals(value.getAccountId(), USER_ID);
+        assertEquals(value.getStudyId(), TEST_STUDY_ID);
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentControllerTest.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.bridge.spring.controllers;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
-import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.TestConstants.USER_ID;
@@ -118,21 +117,15 @@ public class EnrollmentControllerTest extends Mockito {
 
     @Test
     public void unenroll() throws Exception {
-        Enrollment enrollment = new HibernateEnrollment();
-        enrollment.setWithdrawnOn(MODIFIED_ON);
-        enrollment.setWithdrawalNote("This is a note");
-        TestUtils.mockRequestBody(mockRequest, enrollment);
-
         Enrollment completed = new HibernateEnrollment();
         when(mockService.unenroll(any())).thenReturn(completed);
 
-        Enrollment retValue = controller.unenroll(TEST_STUDY_ID, USER_ID);
+        Enrollment retValue = controller.unenroll(TEST_STUDY_ID, USER_ID, "This is a note");
         assertSame(retValue, completed);
         
         verify(mockService).unenroll(enrollmentCaptor.capture());
         
         Enrollment value = enrollmentCaptor.getValue();
-        assertEquals(value.getWithdrawnOn(), MODIFIED_ON);
         assertEquals(value.getWithdrawalNote(), "This is a note");
         assertEquals(value.getAppId(), TEST_APP_ID);
         assertEquals(value.getStudyId(), TEST_STUDY_ID);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserManagementControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserManagementControllerTest.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
 import static org.sagebionetworks.bridge.BridgeConstants.API_APP_ID;
-import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_SESSION_EXPIRE_IN_SECONDS;
 import static org.sagebionetworks.bridge.BridgeConstants.SESSION_TOKEN_HEADER;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
@@ -19,7 +18,6 @@ import static org.sagebionetworks.bridge.TestUtils.assertPost;
 import static org.sagebionetworks.bridge.TestUtils.mockRequestBody;
 import static org.sagebionetworks.bridge.config.Environment.LOCAL;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.fail;
 
 import javax.servlet.http.Cookie;

--- a/src/test/java/org/sagebionetworks/bridge/spring/filters/MetricsFilterTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/filters/MetricsFilterTest.java
@@ -6,7 +6,6 @@ import static org.sagebionetworks.bridge.BridgeConstants.X_REQUEST_ID_HEADER;
 import static org.sagebionetworks.bridge.TestConstants.TIMESTAMP;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import javax.servlet.FilterChain;
@@ -20,7 +19,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.testng.annotations.AfterMethod;

--- a/src/test/java/org/sagebionetworks/bridge/validators/EnrollmentValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/EnrollmentValidatorTest.java
@@ -1,0 +1,90 @@
+package org.sagebionetworks.bridge.validators;
+
+import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
+import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
+import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
+import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
+import static org.sagebionetworks.bridge.validators.EnrollmentValidator.INSTANCE;
+import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL_OR_EMPTY;
+
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.models.studies.Enrollment;
+
+public class EnrollmentValidatorTest {
+    
+    Enrollment getEnrollment() {
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        enrollment.setExternalId("anExternalId");
+        enrollment.setConsentRequired(true);
+        enrollment.setEnrolledOn(CREATED_ON);
+        enrollment.setWithdrawnOn(MODIFIED_ON);
+        enrollment.setEnrolledBy(USER_ID);
+        enrollment.setWithdrawnBy("withdrawnBy");
+        enrollment.setWithdrawalNote("withdrawal note");
+        return enrollment;
+    }
+    
+    @Test
+    public void validates() {
+        Validate.entityThrowingException(INSTANCE, getEnrollment());
+    }
+
+    @Test
+    public void appIdNull() {
+        Enrollment enrollment = getEnrollment();
+        enrollment.setAppId(null);
+        assertValidatorMessage(INSTANCE, enrollment, "appId", CANNOT_BE_NULL_OR_EMPTY);
+    }
+    
+    @Test
+    public void appIdBlank() {
+        Enrollment enrollment = getEnrollment();
+        enrollment.setAppId("");
+        assertValidatorMessage(INSTANCE, enrollment, "appId", CANNOT_BE_NULL_OR_EMPTY);
+    }
+    
+    @Test
+    public void accountIdNull() {
+        Enrollment enrollment = getEnrollment();
+        enrollment.setAccountId(null);
+        assertValidatorMessage(INSTANCE, enrollment, "userId", CANNOT_BE_NULL_OR_EMPTY);
+    }
+    
+    @Test
+    public void accountIdBlank() {
+        Enrollment enrollment = getEnrollment();
+        enrollment.setAccountId("  ");
+        assertValidatorMessage(INSTANCE, enrollment, "userId", CANNOT_BE_NULL_OR_EMPTY);
+    }
+    
+    @Test
+    public void studyIdNull() {
+        Enrollment enrollment = getEnrollment();
+        enrollment.setStudyId(null);
+        assertValidatorMessage(INSTANCE, enrollment, "studyId", CANNOT_BE_NULL_OR_EMPTY);
+    }
+    
+    @Test
+    public void studyIdBlank() {
+        Enrollment enrollment = getEnrollment();
+        enrollment.setStudyId("");
+        assertValidatorMessage(INSTANCE, enrollment, "studyId", CANNOT_BE_NULL_OR_EMPTY);
+    }
+    
+    @Test
+    public void externalIdBlank() {
+        Enrollment enrollment = getEnrollment();
+        enrollment.setExternalId("");
+        assertValidatorMessage(INSTANCE, enrollment, "externalId", "cannot be blank");
+    }
+    
+    @Test
+    public void externalIdNullOK() {
+        Enrollment enrollment = getEnrollment();
+        enrollment.setExternalId(null);
+        Validate.entityThrowingException(INSTANCE, getEnrollment());
+    }
+}


### PR DESCRIPTION
An API to directly enroll users in studies (represented by the Enrollments or AccountsSubstudies table). 

- adds some extra metadata about the enrollment or withdrawal event;
- allows caller to register an external ID during enrollment without adding it to the external IDs table (which I will remove after migration)
- provides an API to show, for a given study, the people who are enrolled in and/or withdrawn from that study.

For further discussion of the API itself, see: https://sagebionetworks.jira.com/wiki/spaces/BRIDGE/pages/886440163/Bridge+v2+Implementation+Design#Enrollments

Eventually these APIs, which are scoped to particular organizations, will functionally replace the global participant APIs.

This is not articulated with our existing consent system, because once we force assignment to a study (which you can already optionally do when a user consents), our existing permissions system will cause those accounts to be hidden in some cases from existing administrative users (who we want to remove from the AccountSubstudies table). So future check-ins will further prepare to migrate all accounts (that can be migrated) to be members of an organization, or enrolled in a study, without losing the visibility of accounts through the API.