### PR TITLE
Add getActiveEnrollments()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 .project
 test-output/
 dump.rdb
+bin/

--- a/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
@@ -114,7 +114,7 @@ public class BridgeUtils {
 
     public static Map<String,String> mapStudyMemberships(Account account) {
         ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<>();
-        for (Enrollment enrollment : account.getEnrollments()) {
+        for (Enrollment enrollment : account.getActiveEnrollments()) {
             String value = (enrollment.getExternalId() == null) ? 
                     "<none>" : enrollment.getExternalId();
             builder.put(enrollment.getStudyId(), value);
@@ -140,14 +140,14 @@ public class BridgeUtils {
     }
 
     public static Set<String> collectExternalIds(Account account) {
-        return account.getEnrollments().stream()
+        return account.getActiveEnrollments().stream()
                 .map(Enrollment::getExternalId)
                 .filter(Objects::nonNull)
                 .collect(toImmutableSet());
     }
     
     public static Set<String> collectStudyIds(Account account) {
-        return account.getEnrollments().stream()
+        return account.getActiveEnrollments().stream()
                 .map(Enrollment::getStudyId)
                 .collect(toImmutableSet());
     }

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAccount.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAccount.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.hibernate;
 
 import static java.lang.Boolean.TRUE;
+import static org.sagebionetworks.bridge.util.BridgeCollectors.toImmutableSet;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -42,6 +43,7 @@ import org.sagebionetworks.bridge.models.accounts.Phone;
 import org.sagebionetworks.bridge.models.accounts.SharingScope;
 import org.sagebionetworks.bridge.models.studies.Enrollment;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
 
 /** MySQL implementation of accounts via Hibernate. */
@@ -475,5 +477,13 @@ public class HibernateAccount implements Account {
     @Override
     public void setEnrollments(Set<Enrollment> enrollments) {
         this.enrollments = enrollments;
+    }
+    
+    @Transient
+    @JsonIgnore
+    public Set<Enrollment> getActiveEnrollments() {
+        return getEnrollments().stream()
+                .filter(en -> en.getWithdrawnOn() == null)
+                .collect(toImmutableSet());
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/models/accounts/Account.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/accounts/Account.java
@@ -225,4 +225,7 @@ public interface Account extends BridgeEntity {
     
     void setEnrollments(Set<Enrollment> enrollments);
     Set<Enrollment> getEnrollments();
+    
+    /** Get all enrollments that have not been withdrawn. */
+    Set<Enrollment> getActiveEnrollments();
 }

--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -260,7 +260,7 @@ public class ParticipantService {
         Account account = getAccountThrowingException(accountId); // already filters for study
         
         StudyParticipant.Builder builder = new StudyParticipant.Builder();
-        StudyAssociations assoc = BridgeUtils.studyAssociationsVisibleToCaller(account.getEnrollments());
+        StudyAssociations assoc = BridgeUtils.studyAssociationsVisibleToCaller(account.getActiveEnrollments());
         copyAccountToParticipant(builder, assoc, account);
         copyConsentStatusToParticipant(builder, account, context);
         if (includeHistory) {
@@ -288,7 +288,7 @@ public class ParticipantService {
         }
 
         StudyParticipant.Builder builder = new StudyParticipant.Builder();
-        StudyAssociations assoc = studyAssociationsVisibleToCaller(account.getEnrollments());
+        StudyAssociations assoc = studyAssociationsVisibleToCaller(account.getActiveEnrollments());
         copyAccountToParticipant(builder, assoc, account);
 
         if (includeHistory) {
@@ -587,7 +587,7 @@ public class ParticipantService {
         // for that account if it is signed in, so we MUST destroy the session. 
         if (isNew || getRequestContext().isInRole(ADMIN)) {
             // Copy to prevent concurrent modification exceptions
-            Set<Enrollment> enrollments = ImmutableSet.copyOf(account.getEnrollments());
+            Set<Enrollment> enrollments = ImmutableSet.copyOf(account.getActiveEnrollments());
             
             // Remove study relationship if it's not desired and unassign external ID
             for (Enrollment enrollment : enrollments) {
@@ -601,8 +601,7 @@ public class ParticipantService {
             Set<String> existingStudyIds = BridgeUtils.collectStudyIds(account);
             for (String studyId : participant.getStudyIds()) {
                 if (!existingStudyIds.contains(studyId)) {
-                    Enrollment enrollment = Enrollment.create(
-                            account.getAppId(), studyId, account.getId());
+                    Enrollment enrollment = Enrollment.create(account.getAppId(), studyId, account.getId());
                     account.getEnrollments().add(enrollment);
                     clearCache = true;
                 }

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountTest.java
@@ -3,10 +3,12 @@ package org.sagebionetworks.bridge.hibernate;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
+import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
 import static org.sagebionetworks.bridge.TestConstants.PHONE;
 import static org.sagebionetworks.bridge.TestConstants.SYNAPSE_USER_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
+import static org.sagebionetworks.bridge.TestConstants.USER_ID;
 import static org.sagebionetworks.bridge.models.accounts.AccountStatus.UNVERIFIED;
 import static org.sagebionetworks.bridge.models.accounts.SharingScope.NO_SHARING;
 import static org.testng.Assert.assertEquals;
@@ -24,9 +26,11 @@ import org.joda.time.DateTime;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.Roles;
+import org.sagebionetworks.bridge.models.studies.Enrollment;
 import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -295,6 +299,20 @@ public class HibernateAccountTest {
         assertTrue(account.getRoles().isEmpty());
         assertTrue(account.getConsentSignatureHistory(SubpopulationGuid.create("nada")).isEmpty());
         assertTrue(account.getAllConsentSignatureHistories().isEmpty());
+    }
+    
+    @Test
+    public void getActiveEnrollments() {
+        Enrollment en1 = Enrollment.create(TEST_APP_ID, "studyA", USER_ID);
+        Enrollment en2 = Enrollment.create(TEST_APP_ID, "studyB", USER_ID);
+        Enrollment en3 = Enrollment.create(TEST_APP_ID, "studyC", USER_ID);
+        en2.setWithdrawnOn(CREATED_ON);
+        Set<Enrollment> enrollments = ImmutableSet.of(en1, en2, en3);
+        
+        HibernateAccount account = new HibernateAccount();
+        account.setEnrollments(enrollments);
+        
+        assertEquals(account.getActiveEnrollments(), ImmutableSet.of(en1, en3));
     }
     
     private HibernateAccountConsent getHibernateAccountConsent(Long withdrewOn) {

--- a/src/test/java/org/sagebionetworks/bridge/services/UserAdminServiceMockTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/UserAdminServiceMockTest.java
@@ -325,7 +325,7 @@ public class UserAdminServiceMockTest {
         
         doReturn("userId").when(account).getId();
         doReturn("healthCode").when(account).getHealthCode();
-        doReturn(enrollments).when(account).getEnrollments();
+        doReturn(enrollments).when(account).getActiveEnrollments();
         doReturn(account).when(accountService).getAccount(accountId);
         
         service.deleteUser(app, "userId");


### PR DESCRIPTION
This is a small change that should have no impact yet, since we aren't using the withdrawal fields of enrollments. The next change will finally integrate this with subpopulations and consent, making enrollment in a study a mandatory part of the existing consent system.