### PR TITLE
Move update of participant before the export of the report from Columbia

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/CRCController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/CRCController.java
@@ -518,6 +518,9 @@ public class CRCController extends BaseController {
             throw new EntityNotFoundException(Account.class);
         }
 
+        updateState(account, state);
+        accountService.updateAccount(account, null);
+
         try {
             ObjectNode metadata = JsonNodeFactory.instance.objectNode();
             metadata.put("type", reportName);
@@ -546,9 +549,6 @@ public class CRCController extends BaseController {
         int status = (results.getItems().isEmpty()) ? 201 : 200;
 
         reportService.saveParticipantReport(appId, reportName, account.getHealthCode(), report);
-
-        updateState(account, state);
-        accountService.updateAccount(account, null);
         return status;
     }
     


### PR DESCRIPTION
As a result of updating the account after creating the health data record, we capture the data groups before they are properly updated, and this is messing up Megha's logic processing the data in Synapse. Change the order of operations when saving a report.