### PR TITLE
Fixing validation of tech domain email addresses, among others.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.4.1</version>
+            <version>1.7</version>
         </dependency>
         <dependency>
             <!-- Needed to resolve dependency conflicts for Hibernate -->

--- a/src/test/java/org/sagebionetworks/bridge/validators/AppValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/AppValidatorTest.java
@@ -184,6 +184,9 @@ public class AppValidatorTest {
         
         app.setSupportEmail(null);
         assertValidatorMessage(INSTANCE, app, "supportEmail", "is required");
+        
+        app.setSupportEmail("alx@keywise.tech");
+        Validate.entityThrowingException(INSTANCE, app);
     }
     
     @Test


### PR DESCRIPTION
This fixes an issue discovered by one of our external partners when they tried to add a *.tech email address. The updated validation library accounts for the expanded list of top-level domains that now exist.