### PR TITLE
Add minutes to complete

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/models/assessments/Assessment.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/assessments/Assessment.java
@@ -21,6 +21,7 @@ public class Assessment implements BridgeEntity {
         dto.setSummary(assessment.getSummary());
         dto.setValidationStatus(assessment.getValidationStatus());
         dto.setNormingStatus(assessment.getNormingStatus());
+        dto.setMinutesToComplete(assessment.getMinutesToComplete());
         dto.setOsName(assessment.getOsName());
         dto.setOriginGuid(assessment.getOriginGuid());
         dto.setOwnerId(assessment.getOwnerId());
@@ -47,6 +48,7 @@ public class Assessment implements BridgeEntity {
     private String originGuid;
     private String validationStatus;
     private String normingStatus;
+    private Integer minutesToComplete;
     private Set<String> tags;
     private Map<String, Set<PropertyInfo>> customizationFields;
     private DateTime createdOn;
@@ -113,7 +115,13 @@ public class Assessment implements BridgeEntity {
     }
     public void setNormingStatus(String normingStatus) {
         this.normingStatus = normingStatus;
-    }    
+    }
+    public Integer getMinutesToComplete() { 
+        return minutesToComplete;
+    }
+    public void setMinutesToComplete(Integer minutesToComplete) {
+        this.minutesToComplete = minutesToComplete;
+    }
     public Set<String> getTags() {
         return tags;
     }

--- a/src/main/java/org/sagebionetworks/bridge/models/assessments/HibernateAssessment.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/assessments/HibernateAssessment.java
@@ -42,6 +42,7 @@ public class HibernateAssessment {
         assessment.setSummary(dto.getSummary());
         assessment.setValidationStatus(dto.getValidationStatus());
         assessment.setNormingStatus(dto.getNormingStatus());
+        assessment.setMinutesToComplete(dto.getMinutesToComplete());
         assessment.setOsName(dto.getOsName());
         assessment.setOriginGuid(dto.getOriginGuid());
         assessment.setOwnerId(dto.getOwnerId());
@@ -63,6 +64,7 @@ public class HibernateAssessment {
     private String summary;
     private String validationStatus;
     private String normingStatus;
+    private Integer minutesToComplete;
     // same constants used in BridgeServer2
     private String osName;
     
@@ -138,7 +140,13 @@ public class HibernateAssessment {
     }
     public void setNormingStatus(String normingStatus) {
         this.normingStatus = normingStatus;
-    }    
+    }
+    public Integer getMinutesToComplete() {
+        return this.minutesToComplete;
+    }
+    public void setMinutesToComplete(Integer minutesToComplete) {
+        this.minutesToComplete = minutesToComplete;
+    }
     public String getOsName() {
         return osName;
     }

--- a/src/main/java/org/sagebionetworks/bridge/validators/AssessmentValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/AssessmentValidator.java
@@ -5,6 +5,7 @@ import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_EVENT_ID_ERROR;
 import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_EVENT_ID_PATTERN;
 import static org.sagebionetworks.bridge.BridgeConstants.SHARED_APP_ID;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
+import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NEGATIVE;
 
 import java.util.Map;
 import java.util.Set;
@@ -94,6 +95,9 @@ public class AssessmentValidator implements Validator {
             if (organizationService.getOrganization(ownerAppId, ownerOrgId) == null) {
                 errors.rejectValue("ownerId", "is not a valid organization ID");
             }
+        }
+        if (assessment.getMinutesToComplete() != null && assessment.getMinutesToComplete() < 0) {
+            errors.rejectValue("minutesToComplete", CANNOT_BE_NEGATIVE);
         }
     }
 }

--- a/src/main/resources/db/changelog/changelog.sql
+++ b/src/main/resources/db/changelog/changelog.sql
@@ -406,3 +406,9 @@ ADD COLUMN `withdrawnBy` varchar(255),
 ADD COLUMN `withdrawalNote` varchar(255),
 ADD CONSTRAINT `fk_enrolledBy` FOREIGN KEY (`enrolledBy`) REFERENCES `Accounts` (`id`),
 ADD CONSTRAINT `fk_withdrawnBy` FOREIGN KEY (`withdrawnBy`) REFERENCES `Accounts` (`id`);
+
+-- changeset bridge:20
+
+ALTER TABLE `Assessments`
+ADD COLUMN `minutesToComplete` int(10) DEFAULT NULL;
+

--- a/src/test/java/org/sagebionetworks/bridge/models/assessments/AssessmentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/assessments/AssessmentTest.java
@@ -134,6 +134,7 @@ public class AssessmentTest {
         dto.setOriginGuid("originGuid");
         dto.setValidationStatus("validationStatus");
         dto.setNormingStatus("normingStatus");
+        dto.setMinutesToComplete(10);
         dto.setTags(STRING_TAGS);
         dto.setCustomizationFields(CUSTOMIZATION_FIELDS);
         dto.setCreatedOn(CREATED_ON);

--- a/src/test/java/org/sagebionetworks/bridge/models/assessments/HibernateAssessmentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/assessments/HibernateAssessmentTest.java
@@ -43,6 +43,7 @@ public class HibernateAssessmentTest {
         assessment.setSummary("summary");
         assessment.setValidationStatus("validationStatus");
         assessment.setNormingStatus("normingStatus");
+        assessment.setMinutesToComplete(10);
         assessment.setOsName(ANDROID);
         assessment.setOriginGuid("originGuid");
         assessment.setOwnerId(OWNER_ID);
@@ -64,6 +65,7 @@ public class HibernateAssessmentTest {
         assertEquals(assessment.getSummary(), "summary");
         assertEquals(assessment.getValidationStatus(), "validationStatus");
         assertEquals(assessment.getNormingStatus(), "normingStatus");
+        assertEquals(assessment.getMinutesToComplete(), new Integer(10));
         assertEquals(assessment.getOsName(), ANDROID);
         assertEquals(assessment.getOriginGuid(), "originGuid");
         assertEquals(assessment.getOwnerId(), OWNER_ID);

--- a/src/test/java/org/sagebionetworks/bridge/validators/AssessmentValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/AssessmentValidatorTest.java
@@ -7,6 +7,7 @@ import static org.sagebionetworks.bridge.TestConstants.OWNER_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
+import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NEGATIVE;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -91,6 +92,11 @@ public class AssessmentValidatorTest extends Mockito {
     public void titleEmpty() {
         assessment.setTitle("");
         assertValidatorMessage(validator, assessment, "title", CANNOT_BE_BLANK);
+    }
+    @Test
+    public void minutesToCompleteNegative() {
+        assessment.setMinutesToComplete(-1);
+        assertValidatorMessage(validator, assessment, "minutesToComplete", CANNOT_BE_NEGATIVE);
     }
     @Test
     public void osNameNull() {


### PR DESCRIPTION
This is information that is very common in every design of shared components/assessments. Given in minutes so times can be aggregated for constructs like sessions.