### PR TITLE
Allow app to have other oauth clients that authenticate with Synapse.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/src/main/java/org/sagebionetworks/bridge/BridgeConstants.java
@@ -17,6 +17,8 @@ public class BridgeConstants {
 
     public static final String SAGE_ID = "sage-bionetworks";
     public static final String SAGE_NAME = "Sage Bionetworks";
+    
+    public static final String SYNAPSE_OAUTH_VENDOR_ID = "synapse";
 
     public static final String ID_FIELD_NAME = "identifier";
     public static final String TYPE_FIELD_NAME = "type";

--- a/src/main/java/org/sagebionetworks/bridge/validators/AppValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/AppValidator.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.validators;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.sagebionetworks.bridge.BridgeConstants.SYNAPSE_OAUTH_VENDOR_ID;
 import static org.sagebionetworks.bridge.BridgeUtils.COMMA_SPACE_JOINER;
 
 import java.lang.reflect.Field;
@@ -196,6 +197,9 @@ public class AppValidator implements Validator {
         
         for (Map.Entry<String, OAuthProvider> entry : app.getOAuthProviders().entrySet()) {
             String fieldName = "oauthProviders["+entry.getKey()+"]";
+            if (SYNAPSE_OAUTH_VENDOR_ID.equals(entry.getKey())) {
+                errors.rejectValue(fieldName, "is a reserved vendor ID");
+            }
             OAuthProvider provider = entry.getValue();
             if (provider == null) {
                 errors.rejectValue(fieldName, "is required");

--- a/src/test/java/org/sagebionetworks/bridge/validators/AppValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/AppValidatorTest.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.validators;
 
+import static org.sagebionetworks.bridge.BridgeConstants.SYNAPSE_OAUTH_VENDOR_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 
 import java.util.ArrayList;
@@ -413,6 +414,14 @@ public class AppValidatorTest {
     public void oauthProviderRequired() {
         app.getOAuthProviders().put("vendor", null);
         assertValidatorMessage(INSTANCE, app, "oauthProviders[vendor]", "is required");
+    }
+    
+    @Test
+    public void oauthProviderCannotBeCalledSynapse() {
+        OAuthProvider provider = new OAuthProvider("clientId", "secret", "endpoint",
+                CALLBACK_URL, "http://example.com/introspect");
+        app.getOAuthProviders().put("synapse", provider);
+        assertValidatorMessage(INSTANCE, app, "oauthProviders[synapse]", "is a reserved vendor ID");
     }
     
     @Test


### PR DESCRIPTION
For MTB we propose to create a separate web application that will also sign in using Synapse. Allow the OAuth providers in an App to provide information about those clients so this can be added on a per-app basis.