### PR TITLE
Fix revision-related query bug

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAssessmentDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAssessmentDao.java
@@ -84,7 +84,6 @@ class HibernateAssessmentDao implements AssessmentDao {
                 offsetBy, pageSize, HibernateAssessment.class);
         
         List<Assessment> dtos = assessments.stream().map(Assessment::create).collect(toList());
-        System.out.println(dtos);
         return new PagedResourceList<Assessment>(dtos, count, true);
     }
     

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAssessmentDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAssessmentDao.java
@@ -61,7 +61,7 @@ class HibernateAssessmentDao implements AssessmentDao {
         QueryBuilder builder = new QueryBuilder();
         builder.append("FROM (");
         builder.append("SELECT DISTINCT identifier as id, MAX(revision) AS rev FROM Assessments");
-        builder.append("GROUP BY identifier) AS latest_assessments");
+        builder.append("WHERE appId = :appId GROUP BY identifier) AS latest_assessments");
         builder.append("INNER JOIN Assessments AS a ON a.identifier = latest_assessments.id AND");
         builder.append("a.revision = latest_assessments.rev");
         
@@ -84,6 +84,7 @@ class HibernateAssessmentDao implements AssessmentDao {
                 offsetBy, pageSize, HibernateAssessment.class);
         
         List<Assessment> dtos = assessments.stream().map(Assessment::create).collect(toList());
+        System.out.println(dtos);
         return new PagedResourceList<Assessment>(dtos, count, true);
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAssessmentDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAssessmentDaoTest.java
@@ -43,20 +43,20 @@ import org.sagebionetworks.bridge.models.assessments.config.HibernateAssessmentC
 public class HibernateAssessmentDaoTest extends Mockito {
     
     private static final String QUERY_SQL_EXC_DELETED = "FROM ( SELECT DISTINCT "
-            +"identifier as id, MAX(revision) AS rev FROM Assessments GROUP BY "
-            +"identifier) AS latest_assessments INNER JOIN Assessments AS a ON "
+            +"identifier as id, MAX(revision) AS rev FROM Assessments WHERE appId = :appId "
+            +"GROUP BY identifier) AS latest_assessments INNER JOIN Assessments AS a ON "
             +"a.identifier = latest_assessments.id AND a.revision = latest_assessments.rev "
             +"WHERE appId = :appId AND deleted = 0 ORDER BY createdOn DESC";
 
     private static final String QUERY_SQL_INC_DELETED = "FROM ( SELECT DISTINCT "
-            +"identifier as id, MAX(revision) AS rev FROM Assessments GROUP BY "
-            +"identifier) AS latest_assessments INNER JOIN Assessments AS a ON "+
+            +"identifier as id, MAX(revision) AS rev FROM Assessments WHERE appId = :appId "
+            +"GROUP BY identifier) AS latest_assessments INNER JOIN Assessments AS a ON "+
             "a.identifier = latest_assessments.id AND a.revision = latest_assessments.rev "
             +"WHERE appId = :appId ORDER BY createdOn DESC";
     
     private static final String QUERY_SQL_WITH_TAGS = "FROM ( SELECT DISTINCT "
-            +"identifier as id, MAX(revision) AS rev FROM Assessments GROUP BY "
-            +"identifier) AS latest_assessments INNER JOIN Assessments AS a ON "
+            +"identifier as id, MAX(revision) AS rev FROM Assessments WHERE appId = :appId "
+            +"GROUP BY identifier) AS latest_assessments INNER JOIN Assessments AS a ON "
             +"a.identifier = latest_assessments.id AND a.revision = latest_assessments.rev "
             +"WHERE appId = :appId AND guid IN (SELECT DISTINCT assessmentGuid FROM "
             +"AssessmentTags WHERE tagValue IN :tags) AND deleted = 0 ORDER BY createdOn DESC";


### PR DESCRIPTION
The query was selecting all assessments with an identifier, sorting by revision, then weeding out by appId, which could select and then remove an assessment outside of the target app context. So for example, if you published an assessment to shared, then bumped its version in the origin app, the shared assessment stopped being returned through the API. Fixed this so the sub select also limits itself to the target app context.