### PR TITLE
Return quietly when sign up contains an external ID and the account already exists.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -409,6 +409,17 @@ public class ParticipantService {
             throwExceptionIfLimitMetOrExceeded(app);
         }
         
+        // Fix for studies that call sign up with an external ID: in these cases, tools are creating the participant
+        // before the sign up call (through the Bridge Study Manager). Check and if the account with an external ID
+        // exists, return quietly. Otherwise proceed as before.
+        if (participant.getExternalId() != null) {
+            AccountId accountId = AccountId.forExternalId(app.getIdentifier(), participant.getExternalId());
+            Account account = accountService.getAccount(accountId); 
+            if (account != null) {
+                return new IdentifierHolder(account.getId());
+            }
+        }
+        
         StudyParticipantValidator validator = new StudyParticipantValidator(studyService, organizationService, app,
                 true);
         Validate.entityThrowingException(validator, participant);

--- a/src/test/java/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -339,7 +339,32 @@ public class ParticipantServiceTest extends Mockito {
         // don't update cache
         Mockito.verifyNoMoreInteractions(cacheProvider);
     }
+    
+    @Test
+    public void createParticipantAlreadyExistsWithExternalId() {
+        mockHealthCodeAndAccountRetrieval();
+        
+        AccountId accountId = AccountId.forExternalId(TEST_APP_ID, EXTERNAL_ID);
+        when(accountService.getAccount(accountId)).thenReturn(account);
+        
+        StudyParticipant participant = withParticipant()
+                .withExternalId(EXTERNAL_ID).build();
+        IdentifierHolder idHolder = participantService.createParticipant(APP, participant, true);
+        assertEquals(idHolder.getIdentifier(), ID);
+    }
 
+    @Test(expectedExceptions = InvalidEntityException.class)
+    public void createParticipantDoesNotAlreadyExistThrowsInvalidEntity() {
+        mockHealthCodeAndAccountRetrieval();
+        
+        AccountId accountId = AccountId.forExternalId(TEST_APP_ID, EXTERNAL_ID);
+        when(accountService.getAccount(accountId)).thenReturn(null);
+        
+        StudyParticipant participant = withParticipant().withExternalId(EXTERNAL_ID).build();
+        
+        participantService.createParticipant(APP, participant, true);
+    }
+    
     @Test
     public void createParticipantWithEnrollment() {
         mockHealthCodeAndAccountRetrieval();


### PR DESCRIPTION
Some apps do the following steps:

1) external ID without an account is created via the Bridge Study Manager;
2) app calls sign up with the external ID;
3) app calls sign in.

You can no longer separate an external ID from an account, so step #1 is creating the account. This fix checks for that, and continues to return 200 for step #2 so that existing apps can proceed smoothly to step #3. In the future, apps can skip step #1 by changing the JSON they submit for sign up (`"externalId": "id" --> "externalIds": {"studyId": "id"}`).