### PR TITLE
Refactor authorization utils for greater reuse and clarity.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/AuthEvaluator.java
+++ b/src/main/java/org/sagebionetworks/bridge/AuthEvaluator.java
@@ -1,0 +1,163 @@
+package org.sagebionetworks.bridge;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
+
+/**
+ * Utility for creating rules that can evaluate authorization for a caller. Currently referenced
+ * by the AuthUtils class, but could be used elsewhere.
+ */
+public class AuthEvaluator {
+    private final Set<Predicate<Map<String,String>>> predicates;
+    
+    public AuthEvaluator() {
+        predicates = new HashSet<>();
+    }
+    /**
+     * Caller must have one of the supplied roles. If no roles are included, the caller must 
+     * have any role (they must be an administrative account).
+     */
+    public AuthEvaluator hasAnyRole(Roles...roles) {
+        predicates.add((factMap) -> {
+            RequestContext context = RequestContext.get();
+            return (roles.length == 0) ?
+                    context.isAdministrator() :
+                    context.isInRole(ImmutableSet.copyOf(roles));
+        });
+        return this;
+    }
+    /**
+     * The caller is a member of an organization that sponsors the target study.
+     */
+    public AuthEvaluator canAccessStudy() {
+        predicates.add((factMap) -> {
+            String studyId = factMap.get("studyId");
+            return RequestContext.get().getOrgSponsoredStudies().contains(studyId);
+        });
+        return this;
+    }
+    
+    /**
+     * This remains a huge loophole that we have to eliminate. We might want to
+     * verify that the study they are manipulating/reading is in their list of
+     * callerEnrolledStudies, instead of making exceptions for the empty study
+     * array.
+     */
+    public AuthEvaluator callerConsideredGlobal() {
+        predicates.add((factMap) -> {
+            return RequestContext.get().getOrgSponsoredStudies().isEmpty();
+        });
+        return this;
+    }
+    
+    /**
+     * The caller’s session is bound to the target app.
+     */
+    public AuthEvaluator isInApp() {
+        predicates.add((factMap) -> {
+            String appId = factMap.get("appId");
+            return appId != null && appId.equals(RequestContext.get().getCallerAppId()); 
+        });
+        return this;
+    }
+    /**
+     * The caller is a member of the target organization.
+     */
+    public AuthEvaluator isInOrg() {
+        predicates.add((factMap) -> {
+            String orgId = factMap.get("orgId");
+            return orgId != null && orgId.equals(RequestContext.get().getCallerOrgMembership()); 
+        });
+        return this;
+    }
+    /**
+     * The caller is operating on their own account (the target user ID).
+     */
+    public AuthEvaluator isSelf() {
+        predicates.add((factMap) -> {
+            String userId = factMap.get("userId");
+            return userId != null && userId.equals(RequestContext.get().getCallerUserId()); 
+        });
+        return this;
+    }
+    /**
+     * Either the left- or right-hand portion of the expression needs to be true (but not both).
+     */
+    public AuthEvaluator or() {
+        return new OrAuthEvaluator(this);
+    }
+    /**
+     * Check the authorization rule and throw an exception if it fails.
+     * 
+     * @throws org.sagebionetworks.bridge.exceptions.UnauthorizedException
+     */
+    public void checkAndThrow(String arg1, String val1) {
+        if (!check(arg1, val1)) {
+            throw new UnauthorizedException();
+        }
+    }
+    /**
+     * Check the authorization rule and throw an exception if it fails.
+     * 
+     * @throws org.sagebionetworks.bridge.exceptions.UnauthorizedException
+     */
+    public void checkAndThrow(String arg1, String val1, String arg2, String val2) {
+        if (!check(arg1, val1, arg2, val2)) {
+            throw new UnauthorizedException();
+        }
+    }
+    /**
+     * Return true if the authorization rule passes, false otherwise. Missing, blank, and 
+     * null values fail authorization tests.
+     */
+    public boolean check() {
+        return checkInternal(ImmutableMap.of());
+    }
+    /**
+     * Return true if the authorization rule passes, false otherwise. Missing, blank, and 
+     * null values fail authorization tests.
+     */
+    public boolean check(String arg1, String val1) {
+        Map<String,String> factMap = new HashMap<>(); // can contain nulls
+        factMap.put(arg1, val1);
+        return checkInternal(factMap);
+    }
+    /**
+     * Return true if the authorization rule passes, false otherwise. Missing, blank, and 
+     * null values fail authorization tests.
+     */
+    public boolean check(String arg1, String val1, String arg2, String val2) {
+        Map<String,String> factMap = new HashMap<>(); // can contain nulls
+        factMap.put(arg1, val1);
+        factMap.put(arg2, val2);
+        return checkInternal(factMap);
+    }
+    protected boolean checkInternal(Map<String,String> factMap) {
+        // this happens on the stack and should be thread-safe. 
+        for (Predicate<Map<String,String>> predicate : predicates) {
+            if (!predicate.test(factMap)) {
+                return false;
+            }
+        }
+        return true;
+    }
+    private static class OrAuthEvaluator extends AuthEvaluator {
+        AuthEvaluator evaluator;
+        
+        private OrAuthEvaluator(AuthEvaluator evaluator) {
+            this.evaluator = evaluator;
+        }
+        @Override
+        protected boolean checkInternal(Map<String, String> factMap) {
+            return super.checkInternal(factMap) || evaluator.checkInternal(factMap);
+        }
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
@@ -1,71 +1,103 @@
 package org.sagebionetworks.bridge;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.sagebionetworks.bridge.BridgeConstants.CALLER_NOT_MEMBER_ERROR;
-import static org.sagebionetworks.bridge.BridgeUtils.isEmpty;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
+import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
 import static org.sagebionetworks.bridge.Roles.WORKER;
 
 import java.util.Set;
-
-import com.google.common.collect.ImmutableSet;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 
+/**
+ * Utility methods to check caller authorization in service methods. Note that in all of these checks, 
+ * ADMIN and SUPERADMIN roles will always pass and are implicit.  
+ */
 public class AuthUtils {
     private static final Logger LOG = LoggerFactory.getLogger(AuthUtils.class);
-
-    public static void checkSelfStudyResearcherOrAdmin(String userId, String studyId) {
-        if (!(isSelf(userId) || isInRoles(studyId, ADMIN, RESEARCHER))) {
-            throw new UnauthorizedException();
-        }
-    }
+    
+    private static final AuthEvaluator ORG_MEMBER = new AuthEvaluator().isInOrg().or()
+            .hasAnyRole(ADMIN);
+    
+    private static final AuthEvaluator STUDY_TEAM_MEMBER_OR_WORKER = new AuthEvaluator().canAccessStudy().or()
+            .hasAnyRole(WORKER, ADMIN).or()
+            .callerConsideredGlobal();
+    
+    private static final AuthEvaluator SELF_STUDY_TEAM_MEMBER_OR_WORKER = new AuthEvaluator().isSelf().or()
+            .canAccessStudy().or()
+            .hasAnyRole(WORKER, ADMIN).or()
+            .callerConsideredGlobal();
+    
+    private static final AuthEvaluator SELF_OR_WORKER = new AuthEvaluator().isSelf().or()
+            .hasAnyRole(WORKER, ADMIN).or()
+            .callerConsideredGlobal();
+    
+    private static final AuthEvaluator SELF_OR_STUDY_RESEARCHER = new AuthEvaluator().isSelf().or()
+            .canAccessStudy().hasAnyRole(RESEARCHER).or()
+            .hasAnyRole(ADMIN);
+    
+    private static final AuthEvaluator STUDY_RESEARCHER = new AuthEvaluator().canAccessStudy().hasAnyRole(RESEARCHER)
+            .or().hasAnyRole(ADMIN);
+    
+    private static final AuthEvaluator SELF_OR_RESEARCHER = new AuthEvaluator().isSelf().or()
+            .hasAnyRole(RESEARCHER, ADMIN);
+    
+    private static final AuthEvaluator ORG_MEMBER_OF_SHARED_OWNER = new AuthEvaluator().isInApp().isInOrg().or()
+            .hasAnyRole(ADMIN);
     
     /**
-     * This check does not verify that the caller is in a specific study, so the
-     * caller may still not have access rights to a particular object. The 
-     * participants APIs, for example, only check the accessibility of accounts
-     * at a deeper level during the query, but are otherwise globally available
-     * to all administrative accounts. 
+     * Is the caller operating on their own account, or a person with the researcher role and access
+     * to the indicated study? 
+     * 
+     * @throws UnauthorizedException
      */
-    public static void checkSelfResearcherOrAdmin(String targetUserId) {
-        if (!(isSelf(targetUserId) || isInRoles(null, ADMIN, RESEARCHER))) {
-            throw new UnauthorizedException();
-        }
+    public static void checkSelfOrStudyResearcher(String userId, String studyId) {
+        SELF_OR_STUDY_RESEARCHER.checkAndThrow("userId", userId, "studyId", studyId);
+    }
+    
+    public static void checkStudyResearcher(String studyId) {
+        STUDY_RESEARCHER.checkAndThrow("studyId", studyId);
     }
     
     /**
-     * Check that the caller is a member of this organization. Note that this does not verify
+     * This is only called from the ParticipantController and the ParticipantReportController, where 
+     * the calls are not scoped, and instead, the search filters out accounts that are not visible to 
+     * the caller. We are probably keeping this API, so will need an alternative set of study-specific 
+     * roles for multi-study apps.
+     * 
+     * @throws UnauthorizedException
+     */
+    public static void checkSelfOrResearcher(String targetUserId) {
+        SELF_OR_RESEARCHER.checkAndThrow("userId", targetUserId);
+    }
+    
+    /**
+     * Is the account a member of this organization? Note that this does not verify
      * the organization is in the caller's app...this can only be done by trying to load the 
-     * organization with this ID, which includes the appId as part of the organization's 
-     * primary key. (Passing in appId to this method is tautological since it comes from the 
-     * caller's session, which is also where the appId in the RequestContext comes from. 
+     * organization with this ID.
+     * 
+     * @throws UnauthorizedException
      */
-    public static void checkOrgMembership(String orgId) {
-        if (!isInOrganization(orgId)) {
-            throw new UnauthorizedException("Caller is not a member of " + orgId);    
-        }
+    public static void checkOrgMember(String orgId) {
+        ORG_MEMBER.checkAndThrow("orgId", orgId);
     }
     
     /**
-     * The same rules apply as checkOwnership, however you are examining the caller against a compound
-     * value stored in the assessment's originId. The call succeeds if you're a superadmin (there are 
-     * no shared app admins), or if the caller is in the app and organization that owns the shared 
-     * assessment. 
+     * The same rules apply as checkOrgMember, however you are examining the caller against a compound
+     * value stored in the assessment's originId. The call succeeds if the caller is in the app and 
+     * organization that owns the shared assessment. 
+     * 
+     * @throws UnauthorizedException
      */
-    public static void checkSharedAssessmentOwnership(String callerAppId, String guid, String ownerId) {
+    public static void checkOrgMemberOfSharedAssessmentOwner(String callerAppId, String guid, String ownerId) {
         checkNotNull(callerAppId);
         checkNotNull(guid);
         checkNotNull(ownerId);
-
-        RequestContext context = RequestContext.get();
-        if (context.isInRole(ADMIN)) {
-            return;
-        }
+        
         String[] parts = ownerId.split(":", 2);
         // This happens in tests, we expect it to never happens in production. So log if it does.
         if (parts.length != 2) {
@@ -74,49 +106,63 @@ public class AuthUtils {
         }
         String originAppId = parts[0];
         String originOrgId = parts[1];
-        String callerOrgMembership = context.getCallerOrgMembership();
-        if (originAppId.equals(callerAppId) && originOrgId.equals(callerOrgMembership)) {
-            return;
-        }
-        throw new UnauthorizedException(CALLER_NOT_MEMBER_ERROR);
-    }
-    
-    public static void checkStudyScopedToCaller(String studyId) {
-        if (!isStudyScopedToCaller(studyId)) {
-            throw new UnauthorizedException();
-        }
-    }
-    
-    public static final boolean isStudyScopedToCaller(String studyId) {
-        RequestContext context = RequestContext.get();
-        Set<String> callerStudies = context.getOrgSponsoredStudies();
         
-        return context.isInRole(ADMIN, WORKER) || isEmpty(callerStudies) || callerStudies.contains(studyId);
+        ORG_MEMBER_OF_SHARED_OWNER.checkAndThrow("appId", originAppId, "orgId", originOrgId);
     }
     
     /**
-     * If the user is an admin or a superadmin, this returns true. For other roles, the 
-     * caller must be in one of the roles, and they must be a member of an organization 
-     * that gives them access to the study.
+     * Does this caller have access to the study? 
+     * 
+     * @throws UnauthorizedException
      */
-    public static final boolean isInRoles(String studyId, Roles... roles) {
-        Set<Roles> roleSet = ImmutableSet.copyOf(roles);
-        RequestContext context = RequestContext.get();
-        if (roleSet.contains(ADMIN) && context.isInRole(ADMIN)) {
-            return true;
-        }
-        Set<String> sponsoredStudies = context.getOrgSponsoredStudies();
-        boolean canAccessStudy = sponsoredStudies.isEmpty() || studyId == null 
-                || sponsoredStudies.contains(studyId);
-        return (canAccessStudy && context.isInRole(roleSet));
+    public static void checkStudyTeamMemberOrWorker(String studyId) {
+        STUDY_TEAM_MEMBER_OR_WORKER.checkAndThrow("studyId", studyId);
     }
     
-    public static final boolean isInOrganization(String orgId) {
-        RequestContext context = RequestContext.get();
-        return context.isInRole(ADMIN) || orgId.equals(context.getCallerOrgMembership());
+    /**
+     * Is the account a member of this organization? Note that this does not verify
+     * the organization is in the caller's app...this can only be done by trying to load the 
+     * organization with this ID. 
+     */
+    public static final boolean isOrgMember(String orgId) {
+        return ORG_MEMBER.check("orgId", orgId);
     }
     
-    private static final boolean isSelf(String userId) {
-        return userId != null && userId.equals(RequestContext.get().getCallerUserId());
+    /**
+     * Does this caller have access to the study? 
+     */
+    public static final boolean isStudyTeamMemberOrWorker(String studyId) {
+        return STUDY_TEAM_MEMBER_OR_WORKER.check("studyId", studyId);
+    }
+    
+    /**
+     * Is the caller 1) referring to their own account, 2) a member of an 
+     * organization that can access the target study, or 3) a worker account? 
+     */
+    public static final boolean isSelfOrStudyTeamMemberOrWorker(String studyId, String userId) {
+        return SELF_STUDY_TEAM_MEMBER_OR_WORKER.check("studyId", studyId, "userId", userId);
+    }
+    
+    /**
+     * Is the caller 1) referring to their own account, or 2) a worker account? 
+     */
+    public static final boolean isSelfOrWorker(String userId) {
+        return SELF_OR_WORKER.check("userId", userId);
+    }
+    
+    /**
+     * Is the caller in the required role? Superadmins always pass this check, but not admins.
+     */
+    public static boolean isInRole(Set<Roles> callerRoles, Roles requiredRole) {
+        return (callerRoles != null && requiredRole != null && 
+            (callerRoles.contains(SUPERADMIN) || callerRoles.contains(requiredRole)));
+    }
+    
+    /**
+     * Is the caller in the required role? Superadmins always pass this check, but not admin.
+     */
+    public static boolean isInRole(Set<Roles> callerRoles, Set<Roles> requiredRoles) {
+        return callerRoles != null && requiredRoles != null && 
+                requiredRoles.stream().anyMatch(role -> isInRole(callerRoles, role));
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/RequestContext.java
+++ b/src/main/java/org/sagebionetworks/bridge/RequestContext.java
@@ -133,10 +133,10 @@ public class RequestContext {
         return callerRoles != null && !callerRoles.isEmpty();
     }
     public boolean isInRole(Roles... roles) {
-        return BridgeUtils.isInRole(callerRoles, Sets.newHashSet(roles));
+        return AuthUtils.isInRole(callerRoles, Sets.newHashSet(roles));
     }
     public boolean isInRole(Set<Roles> roleSet) {
-        return BridgeUtils.isInRole(callerRoles, roleSet);
+        return AuthUtils.isInRole(callerRoles, roleSet);
     }
     public String getCallerUserId() { 
         return callerUserId;

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -165,7 +165,7 @@ public class HibernateAccountDao implements AccountDao {
         
         // If the caller is a member of an organization, then they can only see accounts in the studies 
         // sponsored by that organization. ADMIN accounts are exempt from this requirement.
-        if (!AuthUtils.isStudyScopedToCaller(null)) {
+        if (!AuthUtils.isStudyTeamMemberOrWorker(null)) {
             Set<String> callerStudies = context.getOrgSponsoredStudies();
             builder.append("AND enrollment.studyId IN (:studies)", "studies", callerStudies);
         }

--- a/src/main/java/org/sagebionetworks/bridge/models/accounts/UserSession.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/accounts/UserSession.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.Map;
 import java.util.Set;
 
-import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.AuthUtils;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.config.Environment;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
@@ -96,10 +96,10 @@ public class UserSession {
         return ConsentStatus.isConsentCurrent(consentStatuses);
     }
     public boolean isInRole(Roles role) {
-        return BridgeUtils.isInRole(participant.getRoles(), role);
+        return AuthUtils.isInRole(participant.getRoles(), role);
     }
     public boolean isInRole(Set<Roles> roleSet) {
-        return BridgeUtils.isInRole(participant.getRoles(), roleSet);
+        return AuthUtils.isInRole(participant.getRoles(), roleSet);
     }
     // These are accessed so frequently it is worth having convenience accessors
     @JsonIgnore

--- a/src/main/java/org/sagebionetworks/bridge/services/AssessmentConfigService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AssessmentConfigService.java
@@ -3,7 +3,7 @@ package org.sagebionetworks.bridge.services;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.sagebionetworks.bridge.AuthUtils.checkOrgMembership;
+import static org.sagebionetworks.bridge.AuthUtils.checkOrgMember;
 
 import java.util.Map;
 import java.util.Set;
@@ -74,7 +74,7 @@ public class AssessmentConfigService {
         checkNotNull(config);
         
         Assessment assessment = assessmentService.getAssessmentByGuid(appId, guid);
-        checkOrgMembership(assessment.getOwnerId());
+        checkOrgMember(assessment.getOwnerId());
         
         AssessmentConfig existing = dao.getAssessmentConfig(guid)
                 .orElseThrow(() -> new EntityNotFoundException(AssessmentConfig.class));
@@ -97,7 +97,7 @@ public class AssessmentConfigService {
             throw new BadRequestException("Updates to configuration are missing");
         }
         Assessment assessment = assessmentService.getAssessmentByGuid(appId, guid);
-        checkOrgMembership(assessment.getOwnerId());
+        checkOrgMember(assessment.getOwnerId());
         
         Map<String, Set<PropertyInfo>> fields = assessment.getCustomizationFields();
         

--- a/src/main/java/org/sagebionetworks/bridge/services/AssessmentResourceService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AssessmentResourceService.java
@@ -5,8 +5,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.jsoup.safety.Whitelist.simpleText;
-import static org.sagebionetworks.bridge.AuthUtils.checkOrgMembership;
-import static org.sagebionetworks.bridge.AuthUtils.checkSharedAssessmentOwnership;
+import static org.sagebionetworks.bridge.AuthUtils.checkOrgMember;
+import static org.sagebionetworks.bridge.AuthUtils.checkOrgMemberOfSharedAssessmentOwner;
 import static org.sagebionetworks.bridge.BridgeConstants.SHARED_APP_ID;
 import static org.sagebionetworks.bridge.BridgeUtils.sanitizeHTML;
 import static org.sagebionetworks.bridge.models.ResourceList.CATEGORIES;
@@ -107,7 +107,7 @@ public class AssessmentResourceService {
         checkNotNull(resource);
         
         Assessment assessment = assessmentService.getLatestAssessment(appId, assessmentId);
-        checkOrgMembership(assessment.getOwnerId());
+        checkOrgMember(assessment.getOwnerId());
         
         DateTime timestamp = getCreatedOn();
         resource.setGuid(generateGuid());
@@ -132,7 +132,7 @@ public class AssessmentResourceService {
         
         Assessment assessment = assessmentService.getLatestAssessment(appId, assessmentId);
         
-        checkOrgMembership(assessment.getOwnerId());
+        checkOrgMember(assessment.getOwnerId());
         
         return updateResourceInternal(appId, assessmentId, assessment, resource);
     }
@@ -145,7 +145,7 @@ public class AssessmentResourceService {
         
         Assessment assessment = assessmentService.getLatestAssessment(SHARED_APP_ID, assessmentId);
         
-        checkSharedAssessmentOwnership(callerAppId, assessment.getGuid(), assessment.getOwnerId());
+        checkOrgMemberOfSharedAssessmentOwner(callerAppId, assessment.getGuid(), assessment.getOwnerId());
         
         return updateResourceInternal(SHARED_APP_ID, assessmentId, assessment, resource);
     }
@@ -178,7 +178,7 @@ public class AssessmentResourceService {
         
         // Verify access to this.
         Assessment assessment = assessmentService.getLatestAssessment(appId, assessmentId);
-        checkOrgMembership(assessment.getOwnerId());
+        checkOrgMember(assessment.getOwnerId());
         
         AssessmentResource resource = dao.getResource(appId, guid)
                 .orElseThrow(() -> new EntityNotFoundException(AssessmentResource.class));
@@ -207,7 +207,7 @@ public class AssessmentResourceService {
         // Must have imported the assessment already before you move resources
         Assessment assessment = assessmentService.getLatestAssessment(appId, assessmentId);
         // Cannot import a resource unless you are member of the org that owns the assessment
-        checkOrgMembership(assessment.getOwnerId());
+        checkOrgMember(assessment.getOwnerId());
         return copyResources(SHARED_APP_ID, appId, assessment, guids);
     }
     
@@ -218,7 +218,7 @@ public class AssessmentResourceService {
         // Must have published the assessment already before you move resources
         Assessment assessment = assessmentService.getLatestAssessment(SHARED_APP_ID, assessmentId);
         // Cannot publish a resource unless you are member of the org that owns the shared assessment
-        checkSharedAssessmentOwnership(appId, assessment.getGuid(), assessment.getOwnerId());
+        checkOrgMemberOfSharedAssessmentOwner(appId, assessment.getGuid(), assessment.getOwnerId());
         return copyResources(appId, SHARED_APP_ID, assessment, guids);
     }
     

--- a/src/main/java/org/sagebionetworks/bridge/services/AssessmentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AssessmentService.java
@@ -6,8 +6,8 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.jsoup.safety.Whitelist.none;
 import static org.jsoup.safety.Whitelist.simpleText;
-import static org.sagebionetworks.bridge.AuthUtils.checkOrgMembership;
-import static org.sagebionetworks.bridge.AuthUtils.checkSharedAssessmentOwnership;
+import static org.sagebionetworks.bridge.AuthUtils.checkOrgMember;
+import static org.sagebionetworks.bridge.AuthUtils.checkOrgMemberOfSharedAssessmentOwner;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.NEGATIVE_OFFSET_ERROR;
@@ -159,7 +159,7 @@ public class AssessmentService {
         if (existing.isDeleted() && assessment.isDeleted()) {
             throw new EntityNotFoundException(Assessment.class);
         }
-        checkOrgMembership(existing.getOwnerId());
+        checkOrgMember(existing.getOwnerId());
         
         return updateAssessmentInternal(appId, assessment, existing);
     }
@@ -174,7 +174,7 @@ public class AssessmentService {
             throw new EntityNotFoundException(Assessment.class);
         }
 
-        checkSharedAssessmentOwnership(callerAppId, existing.getGuid(), existing.getOwnerId());
+        checkOrgMemberOfSharedAssessmentOwner(callerAppId, existing.getGuid(), existing.getOwnerId());
         
         return updateAssessmentInternal(SHARED_APP_ID, assessment, existing);
     }
@@ -275,7 +275,7 @@ public class AssessmentService {
         AssessmentConfig configToPublish =  configService.getAssessmentConfig(appId, guid);
         Assessment original = Assessment.copy(assessmentToPublish);
         
-        checkOrgMembership(assessmentToPublish.getOwnerId());
+        checkOrgMember(assessmentToPublish.getOwnerId());
         
         if (StringUtils.isNotBlank(newIdentifier)) {
             assessmentToPublish.setIdentifier(newIdentifier);
@@ -330,7 +330,7 @@ public class AssessmentService {
         if (isBlank(ownerId)) {
             throw new BadRequestException("ownerId parameter is required");
         }
-        checkOrgMembership(ownerId);
+        checkOrgMember(ownerId);
 
         Assessment sharedAssessment = getAssessmentByGuid(SHARED_APP_ID, guid);
         AssessmentConfig sharedConfig = configService.getSharedAssessmentConfig(SHARED_APP_ID, guid);
@@ -360,7 +360,7 @@ public class AssessmentService {
         if (assessment.isDeleted()) {
             throw new EntityNotFoundException(Assessment.class);
         }
-        checkOrgMembership(assessment.getOwnerId());
+        checkOrgMember(assessment.getOwnerId());
         
         assessment.setDeleted(true);
         assessment.setModifiedOn(getModifiedOn());
@@ -396,7 +396,7 @@ public class AssessmentService {
         AssessmentValidator validator = new AssessmentValidator(appId, organizationService);
         Validate.entityThrowingException(validator, assessment);
         
-        checkOrgMembership(assessment.getOwnerId());
+        checkOrgMember(assessment.getOwnerId());
 
         AssessmentConfig config = new AssessmentConfig();
         config.setCreatedOn(timestamp);

--- a/src/main/java/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -344,7 +344,7 @@ public class AuthenticationService {
                 .findAny()
                 .orElseThrow(() -> new EntityNotFoundException(Account.class));
 
-        AuthUtils.checkStudyScopedToCaller(en.getStudyId());
+        AuthUtils.checkStudyTeamMemberOrWorker(en.getStudyId());
 
         String password = generatePassword(app.getPasswordPolicy().getMinLength());
         accountService.changePassword(account, null, password);

--- a/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
@@ -1,7 +1,8 @@
 package org.sagebionetworks.bridge.services;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.sagebionetworks.bridge.AuthUtils.checkSelfStudyResearcherOrAdmin;
+import static org.sagebionetworks.bridge.AuthUtils.checkSelfOrStudyResearcher;
+import static org.sagebionetworks.bridge.AuthUtils.checkStudyResearcher;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.NEGATIVE_OFFSET_ERROR;
@@ -63,7 +64,7 @@ public class EnrollmentService {
         checkNotNull(appId);
         checkNotNull(studyId);
         
-        checkSelfStudyResearcherOrAdmin(null, studyId);
+        checkStudyResearcher(studyId);
 
         if (offsetBy != null && offsetBy < 0) {
             throw new BadRequestException(NEGATIVE_OFFSET_ERROR);
@@ -86,7 +87,7 @@ public class EnrollmentService {
         if (account == null) {
             throw new EntityNotFoundException(Account.class);
         }
-        checkSelfStudyResearcherOrAdmin(account.getId(), userId);
+        checkSelfOrStudyResearcher(account.getId(), userId);
 
         return enrollmentDao.getEnrollmentsForUser(appId, userId);
     }
@@ -116,7 +117,7 @@ public class EnrollmentService {
         
         Validate.entityThrowingException(INSTANCE, newEnrollment);
         
-        checkSelfStudyResearcherOrAdmin(account.getId(), newEnrollment.getStudyId());
+        checkSelfOrStudyResearcher(account.getId(), newEnrollment.getStudyId());
 
         for (Enrollment existingEnrollment : account.getEnrollments()) {
             if (existingEnrollment.getStudyId().equals(newEnrollment.getStudyId())) {
@@ -176,7 +177,7 @@ public class EnrollmentService {
         
         Validate.entityThrowingException(INSTANCE, enrollment);
         
-        checkSelfStudyResearcherOrAdmin(account.getId(), enrollment.getStudyId());
+        checkSelfOrStudyResearcher(account.getId(), enrollment.getStudyId());
         
         // If supplied, this value should be the same timestamp as the withdrewOn
         // value in the signature. Otherwise just set it here. 

--- a/src/main/java/org/sagebionetworks/bridge/services/OrganizationService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/OrganizationService.java
@@ -3,7 +3,7 @@ package org.sagebionetworks.bridge.services;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.sagebionetworks.bridge.AuthUtils.checkOrgMembership;
+import static org.sagebionetworks.bridge.AuthUtils.checkOrgMember;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.NEGATIVE_OFFSET_ERROR;
@@ -177,7 +177,7 @@ public class OrganizationService {
         // Throws if organization does not exist.
         getOrganization(appId, identifier);
         
-        checkOrgMembership(identifier);
+        checkOrgMember(identifier);
         
         AccountSummarySearch scopedSearch = new AccountSummarySearch.Builder()
                 .copyOf(search)
@@ -198,7 +198,7 @@ public class OrganizationService {
         Account account = accountDao.getAccount(accountId)
                 .orElseThrow(() -> new EntityNotFoundException(Account.class));
         
-        checkOrgMembership(identifier);
+        checkOrgMember(identifier);
 
         account.setOrgMembership(identifier);
         accountDao.updateAccount(account);
@@ -216,7 +216,7 @@ public class OrganizationService {
         Account account = accountDao.getAccount(accountId)
                 .orElseThrow(() -> new EntityNotFoundException(Account.class));
         
-        checkOrgMembership(identifier);
+        checkOrgMember(identifier);
         
         // Indicate if caller is trying to remove someone from an org they don't belong to
         if (account.getOrgMembership() == null || !account.getOrgMembership().equals(identifier)) {

--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -548,7 +548,7 @@ public class ParticipantService {
     private void updateAccountAndRoles(App app, Account account, StudyParticipant participant, boolean isNew) {
         // Do this much earlier in the call and avoid some expensive operations like password hashing.
         for (String studyId : participant.getExternalIds().keySet()) {
-            if (!AuthUtils.isStudyScopedToCaller(studyId)) {
+            if (!AuthUtils.isStudyTeamMemberOrWorker(studyId)) {
                 throw new BadRequestException(studyId + " is not a study of the caller");
             }
         }

--- a/src/main/java/org/sagebionetworks/bridge/services/SponsorService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/SponsorService.java
@@ -2,7 +2,7 @@
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.sagebionetworks.bridge.AuthUtils.checkOrgMembership;
+import static org.sagebionetworks.bridge.AuthUtils.checkOrgMember;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.NEGATIVE_OFFSET_ERROR;
@@ -126,7 +126,7 @@ public class SponsorService {
         checkNotNull(studyId);
         checkNotNull(orgId);
         
-        checkOrgMembership(orgId);
+        checkOrgMember(orgId);
         
         // The database constraints are thrown and converted to EntityNotFoundExceptions
         // if either the organization or the study do not exist, or if the org already
@@ -141,7 +141,7 @@ public class SponsorService {
         checkNotNull(studyId);
         checkNotNull(orgId);
         
-        checkOrgMembership(orgId);
+        checkOrgMember(orgId);
 
         if (sponsorDao.doesOrganizationSponsorStudy(appId, studyId, orgId)) {
             // Currently we allow you to remove the last sponsor from a study. There is no 

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentController.java
@@ -59,7 +59,8 @@ public class EnrollmentController extends BaseController {
         int pageSizeInt = BridgeUtils.getIntOrDefault(pageSize, API_DEFAULT_PAGE_SIZE);
         boolean includeTestersBool = Boolean.valueOf(includeTesters);
 
-        return service.getEnrollmentsForStudy(session.getAppId(), studyId, filter, includeTestersBool, offsetByInt, pageSizeInt);        
+        return service.getEnrollmentsForStudy(session.getAppId(), studyId, filter, includeTestersBool, offsetByInt,
+                pageSizeInt);
     }
     
     @PostMapping("/v5/studies/{studyId}/enrollments")

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
@@ -1,6 +1,6 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
-import static org.sagebionetworks.bridge.AuthUtils.checkSelfResearcherOrAdmin;
+import static org.sagebionetworks.bridge.AuthUtils.checkSelfOrResearcher;
 import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeUtils.getDateTimeOrDefault;
 import static org.sagebionetworks.bridge.BridgeUtils.getIntOrDefault;
@@ -106,7 +106,7 @@ public class ParticipantController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     public StatusMessage createSmsRegistration(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        checkSelfResearcherOrAdmin(userId);
+        checkSelfOrResearcher(userId);
         
         App app = appService.getApp(session.getAppId());
 
@@ -174,7 +174,7 @@ public class ParticipantController extends BaseController {
     @DeleteMapping("/v3/participants/{userId}")
     public StatusMessage deleteTestParticipant(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        checkSelfResearcherOrAdmin(userId);
+        checkSelfOrResearcher(userId);
         App app = appService.getApp(session.getAppId());
         
         StudyParticipant participant = participantService.getParticipant(app, userId, false);
@@ -368,7 +368,7 @@ public class ParticipantController extends BaseController {
             APPLICATION_JSON_UTF8_VALUE })
     public String getRequestInfo(@PathVariable String userId) throws JsonProcessingException {
         UserSession session = getAdministrativeSession();
-        checkSelfResearcherOrAdmin(userId);
+        checkSelfOrResearcher(userId);
         App app = appService.getApp(session.getAppId());
 
         // Verify it's in the same app as the researcher.
@@ -384,7 +384,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}")
     public StatusMessage updateParticipant(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        checkSelfResearcherOrAdmin(userId);
+        checkSelfOrResearcher(userId);
         App app = appService.getApp(session.getAppId());
 
         StudyParticipant participant = parseJson(StudyParticipant.class);
@@ -400,7 +400,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/signOut")
     public StatusMessage signOut(@PathVariable String userId, @RequestParam(required = false) boolean deleteReauthToken) {
         UserSession session = getAdministrativeSession();
-        checkSelfResearcherOrAdmin(userId);
+        checkSelfOrResearcher(userId);
         App app = appService.getApp(session.getAppId());
 
         participantService.signUserOut(app, userId, deleteReauthToken);
@@ -411,7 +411,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/requestResetPassword")
     public StatusMessage requestResetPassword(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        checkSelfResearcherOrAdmin(userId);
+        checkSelfOrResearcher(userId);
         App app = appService.getApp(session.getAppId());
 
         participantService.requestResetPassword(app, userId);
@@ -426,7 +426,7 @@ public class ParticipantController extends BaseController {
             @RequestParam(required = false) String offsetKey, @RequestParam(required = false) String pageSize)
             throws Exception {
         UserSession session = getAdministrativeSession();
-        checkSelfResearcherOrAdmin(userId);
+        checkSelfOrResearcher(userId);
         App app = appService.getApp(session.getAppId());
         
         return getActivityHistoryInternalV2(app, userId, activityGuid, scheduledOnStart,
@@ -439,7 +439,7 @@ public class ParticipantController extends BaseController {
             @RequestParam(required = false) String scheduledOnEnd, @RequestParam(required = false) String offsetKey,
             @RequestParam(required = false) String pageSize) throws Exception {
         UserSession session = getAdministrativeSession();
-        checkSelfResearcherOrAdmin(userId);
+        checkSelfOrResearcher(userId);
         App app = appService.getApp(session.getAppId());
         
         return getActivityHistoryV3Internal(app, userId, activityType, referentGuid, scheduledOnStart,
@@ -449,7 +449,7 @@ public class ParticipantController extends BaseController {
     @DeleteMapping("/v3/participants/{userId}/activities")
     public StatusMessage deleteActivities(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        checkSelfResearcherOrAdmin(userId);
+        checkSelfOrResearcher(userId);
         App app = appService.getApp(session.getAppId());
 
         participantService.deleteActivities(app, userId);
@@ -460,7 +460,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/resendEmailVerification")
     public StatusMessage resendEmailVerification(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        checkSelfResearcherOrAdmin(userId);
+        checkSelfOrResearcher(userId);
         App app = appService.getApp(session.getAppId());
 
         participantService.resendVerification(app, ChannelType.EMAIL, userId);
@@ -471,7 +471,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/resendPhoneVerification")
     public StatusMessage resendPhoneVerification(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        checkSelfResearcherOrAdmin(userId);
+        checkSelfOrResearcher(userId);
         App app = appService.getApp(session.getAppId());
 
         participantService.resendVerification(app, ChannelType.PHONE, userId);
@@ -482,7 +482,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/consents/{guid}/resendConsent")
     public StatusMessage resendConsentAgreement(@PathVariable String userId, @PathVariable String guid) {
         UserSession session = getAdministrativeSession();
-        checkSelfResearcherOrAdmin(userId);
+        checkSelfOrResearcher(userId);
         App app = appService.getApp(session.getAppId());
         
         SubpopulationGuid subpopGuid = SubpopulationGuid.create(guid);
@@ -494,7 +494,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/consents/withdraw")
     public StatusMessage withdrawFromApp(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        checkSelfResearcherOrAdmin(userId);
+        checkSelfOrResearcher(userId);
         App app = appService.getApp(session.getAppId());
         
         Withdrawal withdrawal = parseJson(Withdrawal.class);
@@ -508,7 +508,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/consents/{guid}/withdraw")
     public StatusMessage withdrawConsent(@PathVariable String userId, @PathVariable String guid) {
         UserSession session = getAdministrativeSession();
-        checkSelfResearcherOrAdmin(userId);
+        checkSelfOrResearcher(userId);
         App app = appService.getApp(session.getAppId());
         
         Withdrawal withdrawal = parseJson(Withdrawal.class);
@@ -525,7 +525,7 @@ public class ParticipantController extends BaseController {
             @RequestParam(required = false) String startTime, @RequestParam(required = false) String endTime,
             @RequestParam(required = false) Integer pageSize, @RequestParam(required = false) String offsetKey) {
         UserSession session = getAdministrativeSession();
-        checkSelfResearcherOrAdmin(userId);
+        checkSelfOrResearcher(userId);
         App app = appService.getApp(session.getAppId());
         
         DateTime startTimeDate = getDateTimeOrDefault(startTime, null);
@@ -537,7 +537,7 @@ public class ParticipantController extends BaseController {
     @GetMapping("/v3/participants/{userId}/notifications")
     public ResourceList<NotificationRegistration> getNotificationRegistrations(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        checkSelfResearcherOrAdmin(userId);
+        checkSelfOrResearcher(userId);
         App app = appService.getApp(session.getAppId());
         
         List<NotificationRegistration> registrations = participantService.listRegistrations(app, userId);
@@ -549,7 +549,7 @@ public class ParticipantController extends BaseController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public StatusMessage sendNotification(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        checkSelfResearcherOrAdmin(userId);
+        checkSelfOrResearcher(userId);
         App app = appService.getApp(session.getAppId());
         
         NotificationMessage message = parseJson(NotificationMessage.class);
@@ -566,7 +566,7 @@ public class ParticipantController extends BaseController {
     @GetMapping("/v3/participants/{userId}/activityEvents")
     public ResourceList<ActivityEvent> getActivityEvents(@PathVariable String userId) {
         UserSession researcherSession = getAdministrativeSession();
-        checkSelfResearcherOrAdmin(userId);
+        checkSelfOrResearcher(userId);
         App app = appService.getApp(researcherSession.getAppId());
 
         return new ResourceList<>(participantService.getActivityEvents(app, userId));

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportController.java
@@ -1,6 +1,6 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
-import static org.sagebionetworks.bridge.AuthUtils.checkSelfResearcherOrAdmin;
+import static org.sagebionetworks.bridge.AuthUtils.checkSelfOrResearcher;
 import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeUtils.getDateTimeOrDefault;
 import static org.sagebionetworks.bridge.BridgeUtils.getIntOrDefault;
@@ -128,7 +128,7 @@ public class ParticipantReportController extends BaseController {
             @PathVariable String identifier, @RequestParam(required = false) String startDate,
             @RequestParam(required = false) String endDate) {
         UserSession session = getAdministrativeSession();
-        checkSelfResearcherOrAdmin(userId);
+        checkSelfOrResearcher(userId);
         
         return getParticipantReportInternal(session.getAppId(), userId, identifier, startDate, endDate);
     }
@@ -162,7 +162,7 @@ public class ParticipantReportController extends BaseController {
             @RequestParam(required = false) String endTime, @RequestParam(required = false) String offsetKey,
             @RequestParam(required = false) String pageSize) {
         UserSession session = getAdministrativeSession();
-        checkSelfResearcherOrAdmin(userId);
+        checkSelfOrResearcher(userId);
         
         return getParticipantReportInternalV4(session.getAppId(), userId, identifier, 
                 startTime, endTime, offsetKey, pageSize);

--- a/src/main/java/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
@@ -88,7 +88,7 @@ public class StudyParticipantValidator implements Validator {
                 Optional<Organization> opt = organizationService.getOrganizationOpt(app.getIdentifier(), orgId);
                 if (!opt.isPresent()) {
                     errors.rejectValue("orgMembership", "is not a valid organization");
-                } else if (!AuthUtils.isInOrganization(orgId)) {
+                } else if (!AuthUtils.isOrgMember(orgId)) {
                     errors.rejectValue("orgMembership", "cannot be set by caller");
                 }
             }

--- a/src/test/java/org/sagebionetworks/bridge/AuthEvaluatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/AuthEvaluatorTest.java
@@ -1,0 +1,204 @@
+package org.sagebionetworks.bridge;
+
+import static org.sagebionetworks.bridge.RequestContext.NULL_INSTANCE;
+import static org.sagebionetworks.bridge.Roles.DEVELOPER;
+import static org.sagebionetworks.bridge.Roles.RESEARCHER;
+import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
+import static org.sagebionetworks.bridge.Roles.WORKER;
+import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
+import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableSet;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
+
+public class AuthEvaluatorTest {
+
+    @AfterMethod
+    public void afterMethod() {
+        RequestContext.set(NULL_INSTANCE);
+    }
+    
+    @Test
+    public void canAccessStudy() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(DEVELOPER))
+                .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
+        
+        AuthEvaluator evaluator = new AuthEvaluator().canAccessStudy();
+        
+        assertTrue(evaluator.check("studyId", "study2"));
+        assertFalse(evaluator.check());
+        assertFalse(evaluator.check("studyId", "study3"));
+        assertFalse(evaluator.check("userId", "user"));
+    }
+    
+    // This does need to go away
+    @Test
+    public void callerConsideredGlobal() {
+        AuthEvaluator evaluator = new AuthEvaluator().callerConsideredGlobal();
+        assertTrue(evaluator.check("studyId", "study2"));
+    }
+    
+    @Test
+    public void hasAnyRole() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
+        
+        AuthEvaluator evaluator = new AuthEvaluator().hasAnyRole(DEVELOPER, RESEARCHER);
+        assertTrue(evaluator.check());
+        assertTrue(evaluator.check("studyId", "study3")); // params are just ignored
+        
+        evaluator = new AuthEvaluator().hasAnyRole(WORKER);
+        assertFalse(evaluator.check());
+        assertFalse(evaluator.check("studyId", "study3")); // params are just ignored
+    }
+    
+    @Test
+    public void hasAnyRoleIsAnyKindOfAdministrator() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
+        
+        AuthEvaluator evaluator = new AuthEvaluator().hasAnyRole();
+        assertTrue(evaluator.check());
+        
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of()).build());
+        assertFalse(evaluator.check());
+    }
+    
+    @Test
+    public void hasAnyRoleAlwaysPassesForSuperadmin() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(SUPERADMIN)).build());
+        
+        AuthEvaluator evaluator = new AuthEvaluator().hasAnyRole(RESEARCHER);
+        assertTrue(evaluator.check());
+    }
+    
+    @Test
+    public void isInApp() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerAppId(TEST_APP_ID).build());
+        
+        AuthEvaluator evaluator = new AuthEvaluator().isInApp();
+        
+        assertTrue(evaluator.check("appId", TEST_APP_ID));
+        assertFalse(evaluator.check());
+        assertFalse(evaluator.check("appId", "some-other-app-id"));
+        assertFalse(evaluator.check("userId", USER_ID));
+    }
+
+    @Test
+    public void isInOrg() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerOrgMembership(TEST_ORG_ID).build());
+        
+        AuthEvaluator evaluator = new AuthEvaluator().isInOrg();
+        
+        assertTrue(evaluator.check("orgId", TEST_ORG_ID));
+        assertFalse(evaluator.check());
+        assertFalse(evaluator.check("orgId", "some-other-org-id"));
+        assertFalse(evaluator.check("userId", USER_ID));
+    }
+    
+    @Test
+    public void isSelf() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId(USER_ID).build());
+        
+        AuthEvaluator evaluator = new AuthEvaluator().isSelf();
+        assertTrue(evaluator.check("userId", USER_ID));
+        assertFalse(evaluator.check());
+        assertFalse(evaluator.check("userId", "another-user-id"));
+        assertFalse(evaluator.check("studyId", USER_ID));
+    }
+    
+    @Test
+    public void andConditionsEnforced() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerOrgMembership(TEST_ORG_ID)
+                .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
+
+        AuthEvaluator evaluator = new AuthEvaluator().isInOrg().hasAnyRole(RESEARCHER);
+        assertTrue(evaluator.check("orgId", TEST_ORG_ID));
+        
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerOrgMembership("another-org")
+                .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
+        assertFalse(evaluator.check("orgId", TEST_ORG_ID));
+        
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerOrgMembership(TEST_ORG_ID)
+                .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
+        assertFalse(evaluator.check("orgId", TEST_ORG_ID));
+    }
+    
+    @Test
+    public void orConditionsEnforced() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerOrgMembership(TEST_ORG_ID)
+                .withCallerUserId(USER_ID).build());
+
+        AuthEvaluator evaluator = new AuthEvaluator().isInOrg().or().isSelf();
+        // left side passes
+        assertTrue(evaluator.check("orgId", TEST_ORG_ID, "userId", "wrong-id"));
+        
+        // right side passes
+        assertTrue(evaluator.check("orgId", "wrong-organization", "userId", USER_ID));
+        
+        // both sides pass
+        assertTrue(evaluator.check("orgId", TEST_ORG_ID, "userId", USER_ID));
+        
+        // both sides fail
+        assertFalse(evaluator.check("orgId", "wrong-organization", "userId", "wrong-id"));
+    }
+
+    @Test
+    public void checkAndThrowOneArgPasses() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerOrgMembership(TEST_ORG_ID).build());
+
+        AuthEvaluator evaluator = new AuthEvaluator().isInOrg();
+        
+        evaluator.checkAndThrow("orgId", TEST_ORG_ID);
+    }
+    
+    @Test
+    public void checkAndThrowTwoArgsPasses() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId(USER_ID)
+                .withCallerOrgMembership(TEST_ORG_ID).build());
+
+        AuthEvaluator evaluator = new AuthEvaluator().isInOrg().isSelf();
+        
+        evaluator.checkAndThrow("orgId", TEST_ORG_ID, "userId", USER_ID);
+    }
+
+    @Test(expectedExceptions = UnauthorizedException.class)
+    public void checkAndThrowOneArgThrows() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerOrgMembership(TEST_ORG_ID).build());
+
+        AuthEvaluator evaluator = new AuthEvaluator().isInOrg();
+        
+        evaluator.checkAndThrow("orgId", "foo");
+    }
+
+    @Test(expectedExceptions = UnauthorizedException.class)
+    public void checkAndThrowTwoArgsThrows() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId(USER_ID)
+                .withCallerOrgMembership(TEST_ORG_ID).build());
+
+        AuthEvaluator evaluator = new AuthEvaluator().isInOrg().isSelf();
+        
+        evaluator.checkAndThrow("orgId", "foo", "userId", "foo");
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.bridge;
 
-import static org.sagebionetworks.bridge.BridgeConstants.CALLER_NOT_MEMBER_ERROR;
 import static org.sagebionetworks.bridge.RequestContext.NULL_INSTANCE;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
+import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
 import static org.sagebionetworks.bridge.Roles.WORKER;
 import static org.sagebionetworks.bridge.TestConstants.GUID;
 import static org.sagebionetworks.bridge.TestConstants.OWNER_ID;
@@ -14,6 +14,8 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.TestConstants.USER_ID;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+
+import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -28,14 +30,14 @@ public class AuthUtilsTest extends Mockito {
     
     @AfterMethod
     public void afterMethod() {
-        RequestContext.set(RequestContext.NULL_INSTANCE);
+        RequestContext.set(NULL_INSTANCE);
     }
     
     @Test
     public void checkSelfStudyResearcherOrAdminSucceedsForSelf() {
         RequestContext.set(new RequestContext.Builder().withCallerUserId(USER_ID).build());
         
-        AuthUtils.checkSelfStudyResearcherOrAdmin(USER_ID, TEST_STUDY_ID);
+        AuthUtils.checkSelfOrStudyResearcher(USER_ID, TEST_STUDY_ID);
     }
     
     @Test
@@ -45,7 +47,7 @@ public class AuthUtilsTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
                 .build());
         
-        AuthUtils.checkSelfStudyResearcherOrAdmin(USER_ID, TEST_STUDY_ID);
+        AuthUtils.checkSelfOrStudyResearcher(USER_ID, TEST_STUDY_ID);
     }
 
     @Test
@@ -54,7 +56,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ADMIN))
                 .build());
         
-        AuthUtils.checkSelfStudyResearcherOrAdmin(USER_ID, TEST_STUDY_ID);
+        AuthUtils.checkSelfOrStudyResearcher(USER_ID, TEST_STUDY_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -64,7 +66,7 @@ public class AuthUtilsTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of("someOtherStudy"))
                 .build());
         
-        AuthUtils.checkSelfStudyResearcherOrAdmin(USER_ID, TEST_STUDY_ID);
+        AuthUtils.checkSelfOrStudyResearcher(USER_ID, TEST_STUDY_ID);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -74,23 +76,15 @@ public class AuthUtilsTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
                 .build());
         
-        AuthUtils.checkSelfStudyResearcherOrAdmin(USER_ID, TEST_STUDY_ID);
+        AuthUtils.checkSelfOrStudyResearcher(USER_ID, TEST_STUDY_ID);
     }
 
-    @Test
-    public void checkOrgMembershipSucceedsForAdmin() {
-        RequestContext.set(new RequestContext.Builder()
-                .withCallerRoles(ImmutableSet.of(ADMIN)).build());
-        
-        AuthUtils.checkOrgMembership(TEST_ORG_ID);
-    }
-    
     @Test
     public void checkOrgMembershipSucceedsForMatchingOrgId() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID).build());
         
-        AuthUtils.checkOrgMembership(TEST_ORG_ID);
+        AuthUtils.checkOrgMember(TEST_ORG_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -98,14 +92,14 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership("another-organization").build());
         
-        AuthUtils.checkOrgMembership(TEST_ORG_ID);
+        AuthUtils.checkOrgMember(TEST_ORG_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
     public void checkOrgMembershipFailsOnNullOrg() {
         RequestContext.set(new RequestContext.Builder().build());
         
-        AuthUtils.checkOrgMembership(TEST_ORG_ID);
+        AuthUtils.checkOrgMember(TEST_ORG_ID);
     }
     
     @Test
@@ -113,59 +107,57 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID).build());
         
-        AuthUtils.checkOrgMembership(TEST_ORG_ID);
+        AuthUtils.checkOrgMember(TEST_ORG_ID);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
     public void checkOrgMembershipAndThrowFails() {
         RequestContext.set(new RequestContext.Builder().build());
         
-        AuthUtils.checkOrgMembership(TEST_ORG_ID);
+        AuthUtils.checkOrgMember(TEST_ORG_ID);
     }
     
     @Test
     public void checkSharedOwnershipAdminUser() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());
-        AuthUtils.checkSharedAssessmentOwnership(TEST_APP_ID, GUID, SHARED_OWNER_ID);
+        AuthUtils.checkOrgMemberOfSharedAssessmentOwner(TEST_APP_ID, GUID, SHARED_OWNER_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
     public void checkSharedOwnershipAgainstNonGlobalOwnerId() {
         RequestContext.set(NULL_INSTANCE);
-        AuthUtils.checkSharedAssessmentOwnership(TEST_APP_ID, GUID, OWNER_ID);
+        AuthUtils.checkOrgMemberOfSharedAssessmentOwner(TEST_APP_ID, GUID, OWNER_ID);
     }
     
     @Test
     public void sharedOwnershipUserInOrder() {
         RequestContext.set(new RequestContext.Builder()
+                .withCallerAppId(TEST_APP_ID)
                 .withCallerOrgMembership(OWNER_ID).build());
-        AuthUtils.checkSharedAssessmentOwnership(TEST_APP_ID, GUID, SHARED_OWNER_ID);
+        AuthUtils.checkOrgMemberOfSharedAssessmentOwner(TEST_APP_ID, GUID, SHARED_OWNER_ID);
     }
-    
-    @Test(expectedExceptions = UnauthorizedException.class,
-            expectedExceptionsMessageRegExp = CALLER_NOT_MEMBER_ERROR)
+
+    @Test(expectedExceptions = UnauthorizedException.class)
     public void checkSharedOwnershipScopedUserOrgIdIsMissing() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership("notValidOwner").build());
-        AuthUtils.checkSharedAssessmentOwnership(TEST_APP_ID, GUID, SHARED_OWNER_ID);
+        AuthUtils.checkOrgMemberOfSharedAssessmentOwner(TEST_APP_ID, GUID, SHARED_OWNER_ID);
     }
     
-    @Test(expectedExceptions = UnauthorizedException.class,
-            expectedExceptionsMessageRegExp = CALLER_NOT_MEMBER_ERROR)
+    @Test(expectedExceptions = UnauthorizedException.class)
     public void checkSharedOwnershipWrongAppId() { 
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_APP_ID).build());
-        AuthUtils.checkSharedAssessmentOwnership(TEST_APP_ID, GUID, "other:"+OWNER_ID);        
+        AuthUtils.checkOrgMemberOfSharedAssessmentOwner(TEST_APP_ID, GUID, "other:"+OWNER_ID);        
     }
     
-    @Test(expectedExceptions = UnauthorizedException.class,
-            expectedExceptionsMessageRegExp = CALLER_NOT_MEMBER_ERROR)
+    @Test(expectedExceptions = UnauthorizedException.class)
     public void checkSharedOwnershipGlobalUserWrongAppId() { 
         RequestContext.set(NULL_INSTANCE);
         // still doesn't pass because the appId must always match (global users must call 
         // this API after associating to the right app context):
-        AuthUtils.checkSharedAssessmentOwnership(TEST_APP_ID, GUID, "other:"+OWNER_ID);        
+        AuthUtils.checkOrgMemberOfSharedAssessmentOwner(TEST_APP_ID, GUID, "other:"+OWNER_ID);        
     }
     
     @Test
@@ -173,7 +165,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId(USER_ID).build());
         
-        AuthUtils.checkSelfResearcherOrAdmin(USER_ID);
+        AuthUtils.checkSelfOrResearcher(USER_ID);
     }
     
     @Test
@@ -182,7 +174,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(RESEARCHER))
                 .withCallerUserId("notUserId").build());
         
-        AuthUtils.checkSelfResearcherOrAdmin(USER_ID);
+        AuthUtils.checkSelfOrResearcher(USER_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -191,7 +183,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(DEVELOPER))
                 .withCallerUserId("notUserId").build());
         
-        AuthUtils.checkSelfResearcherOrAdmin(USER_ID);
+        AuthUtils.checkSelfOrResearcher(USER_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -200,7 +192,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(DEVELOPER))
                 .withCallerUserId("notUserId").build());
         
-        AuthUtils.checkSelfResearcherOrAdmin(USER_ID);
+        AuthUtils.checkSelfOrResearcher(USER_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -208,50 +200,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of("studyA", "studyB")).build());
         
-        AuthUtils.checkStudyScopedToCaller(TEST_STUDY_ID);
-    }
-    
-    @Test
-    public void isInRoleNullStudyIdAndAdmin() {
-        RequestContext.set(new RequestContext.Builder()
-                .withCallerRoles(ImmutableSet.of(ADMIN)).build());
-        
-        assertTrue(AuthUtils.isInRoles(null, ADMIN));
-    }
-    
-    @Test
-    public void isInRoleEmptyStudyIds() {
-        RequestContext.set(new RequestContext.Builder()
-                .withOrgSponsoredStudies(ImmutableSet.of())
-                .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
-        
-        assertTrue(AuthUtils.isInRoles(TEST_STUDY_ID, DEVELOPER));
-    }
-    
-    @Test
-    public void isInRoleMatchingStudyId() {
-        RequestContext.set(new RequestContext.Builder()
-                .withOrgSponsoredStudies(ImmutableSet.of("A", TEST_STUDY_ID, "B"))
-                .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
-        
-        assertTrue(AuthUtils.isInRoles(TEST_STUDY_ID, DEVELOPER));
-    }
-    
-    @Test
-    public void isInRoleExcludedStudyId() {
-        RequestContext.set(new RequestContext.Builder()
-                .withOrgSponsoredStudies(ImmutableSet.of("A", "B"))
-                .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
-        
-        assertFalse(AuthUtils.isInRoles(TEST_STUDY_ID, DEVELOPER));
-    }
-
-    @Test
-    public void isInRoleExcludedWrongRole() {
-        RequestContext.set(new RequestContext.Builder()
-                .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
-        
-        assertFalse(AuthUtils.isInRoles(null, ADMIN));
+        AuthUtils.checkStudyTeamMemberOrWorker(TEST_STUDY_ID);
     }
     
     @Test
@@ -259,7 +208,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
         
-        assertFalse( AuthUtils.isStudyScopedToCaller(TEST_STUDY_ID) );
+        assertFalse( AuthUtils.isStudyTeamMemberOrWorker(TEST_STUDY_ID) );
     }
     
     @Test
@@ -267,7 +216,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
         
-        assertFalse( AuthUtils.isStudyScopedToCaller(null) );
+        assertFalse( AuthUtils.isStudyTeamMemberOrWorker(null) );
     }
     
     @Test
@@ -276,7 +225,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(WORKER))
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
         
-        assertTrue( AuthUtils.isStudyScopedToCaller(TEST_STUDY_ID) );
+        assertTrue( AuthUtils.isStudyTeamMemberOrWorker(TEST_STUDY_ID) );
     }
 
     @Test
@@ -285,21 +234,47 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ADMIN))
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
         
-        assertTrue( AuthUtils.isStudyScopedToCaller(TEST_STUDY_ID) );
+        assertTrue( AuthUtils.isStudyTeamMemberOrWorker(TEST_STUDY_ID) );
     }
     
-    @Test
-    public void isStudyScopedToCallerSucceedsForGlobalUser() {
-        RequestContext.set(new RequestContext.Builder().build());
-        
-        assertTrue( AuthUtils.isStudyScopedToCaller(TEST_STUDY_ID) );
-    }
-
     @Test
     public void isStudyScopedToCallerSucceedsForOrgSponsoredStudy() {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
         
-        assertTrue( AuthUtils.isStudyScopedToCaller("study2") );
+        assertTrue( AuthUtils.isStudyTeamMemberOrWorker("study2") );
     }
+
+    @Test
+    public void isInRoleMethodsAreNullSafe() {
+        assertFalse(AuthUtils.isInRole(null, (Roles)null));
+        assertFalse(AuthUtils.isInRole(null, (Set<Roles>)null));
+    }
+    
+    @Test
+    public void isInRoleForSuperadminMatchesEverything() {
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), DEVELOPER));
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), RESEARCHER));
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), ADMIN));
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), WORKER));
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), ImmutableSet.of(DEVELOPER)));
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), ImmutableSet.of(RESEARCHER)));
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), ImmutableSet.of(ADMIN)));
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), ImmutableSet.of(WORKER)));
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), ImmutableSet.of(DEVELOPER, ADMIN)));
+    }
+    
+    @Test
+    public void isInRole() {
+        assertFalse(AuthUtils.isInRole(ImmutableSet.of(ADMIN), DEVELOPER));
+        assertFalse(AuthUtils.isInRole(ImmutableSet.of(ADMIN), RESEARCHER));
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ADMIN));
+        assertFalse(AuthUtils.isInRole(ImmutableSet.of(ADMIN), WORKER));
+        assertFalse(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(DEVELOPER)));
+        assertFalse(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(RESEARCHER)));
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(ADMIN)));
+        assertFalse(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(WORKER)));
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(DEVELOPER, ADMIN)));
+    }
+    
 }

--- a/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
@@ -34,14 +34,14 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void checkSelfStudyResearcherOrAdminSucceedsForSelf() {
+    public void checkSelfOrStudyResearcherSucceedsForSelf() {
         RequestContext.set(new RequestContext.Builder().withCallerUserId(USER_ID).build());
         
         AuthUtils.checkSelfOrStudyResearcher(USER_ID, TEST_STUDY_ID);
     }
     
     @Test
-    public void checkSelfStudyResearcherOrAdminSucceedsForStudyResearcher() {
+    public void checkSelfOrStudyResearcherSucceedsForStudyResearcher() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(RESEARCHER))
                 .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
@@ -51,7 +51,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test
-    public void checkSelfStudyResearcherOrAdminSucceedsForAdmin() {
+    public void checkSelfOrStudyResearcherSucceedsForAdmin() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(ADMIN))
                 .build());
@@ -60,7 +60,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void checkSelfStudyResearcherOrAdminFailsForNonStudyResearcher() {
+    public void checkSelfOrStudyResearcherFailsForNonStudyResearcher() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(RESEARCHER))
                 .withOrgSponsoredStudies(ImmutableSet.of("someOtherStudy"))
@@ -70,7 +70,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void checkSelfStudyResearcherOrAdminFailsForDev() {
+    public void checkSelfOrStudyResearcherFailsForDev() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(DEVELOPER))
                 .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
@@ -80,7 +80,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test
-    public void checkOrgMembershipSucceedsForMatchingOrgId() {
+    public void checkOrgMemberSucceedsForMatchingOrgId() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID).build());
         
@@ -88,7 +88,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void checkOrgMembershipFailsOnMismatch() {
+    public void checkOrgMemberFailsOnMismatch() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership("another-organization").build());
         
@@ -96,14 +96,14 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void checkOrgMembershipFailsOnNullOrg() {
+    public void checkOrgMemberFailsOnNullOrg() {
         RequestContext.set(new RequestContext.Builder().build());
         
         AuthUtils.checkOrgMember(TEST_ORG_ID);
     }
     
     @Test
-    public void checkOrgMembershipAndThrowSucceeds() {
+    public void checkOrgMemberSucceeds() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID).build());
         
@@ -111,27 +111,27 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void checkOrgMembershipAndThrowFails() {
+    public void checkOrgMembershipFails() {
         RequestContext.set(new RequestContext.Builder().build());
         
         AuthUtils.checkOrgMember(TEST_ORG_ID);
     }
     
     @Test
-    public void checkSharedOwnershipAdminUser() {
+    public void checkOrgMemberOfSharedAssessmentOwnerSucceedsForAdmin() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());
         AuthUtils.checkOrgMemberOfSharedAssessmentOwner(TEST_APP_ID, GUID, SHARED_OWNER_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void checkSharedOwnershipAgainstNonGlobalOwnerId() {
+    public void checkOrgMemberOfSharedAssessmentOwnerFailsForGlobalOwnerId() {
         RequestContext.set(NULL_INSTANCE);
         AuthUtils.checkOrgMemberOfSharedAssessmentOwner(TEST_APP_ID, GUID, OWNER_ID);
     }
     
     @Test
-    public void sharedOwnershipUserInOrder() {
+    public void checkOrgMemberOfSharedAssessmentOwnerSucceedsForOwner() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerAppId(TEST_APP_ID)
                 .withCallerOrgMembership(OWNER_ID).build());
@@ -139,21 +139,21 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void checkSharedOwnershipScopedUserOrgIdIsMissing() {
+    public void checkOrgMemberOfSharedAssessmentOwnerFailsWrongOrgId() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership("notValidOwner").build());
         AuthUtils.checkOrgMemberOfSharedAssessmentOwner(TEST_APP_ID, GUID, SHARED_OWNER_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void checkSharedOwnershipWrongAppId() { 
+    public void checkOrgMemberOfSharedAssessmentOwnerFailsWrongAppId() { 
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_APP_ID).build());
         AuthUtils.checkOrgMemberOfSharedAssessmentOwner(TEST_APP_ID, GUID, "other:"+OWNER_ID);        
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void checkSharedOwnershipGlobalUserWrongAppId() { 
+    public void checkOrgMemberOfSharedAssessmentOwnerFailsUserWrongAppId() { 
         RequestContext.set(NULL_INSTANCE);
         // still doesn't pass because the appId must always match (global users must call 
         // this API after associating to the right app context):
@@ -161,7 +161,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void checkSelfOrResearcherSucceedsBecauseSelf() {
+    public void checkSelfOrResearcherSucceedsForSelf() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId(USER_ID).build());
         
@@ -169,7 +169,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void checkSelfOrResearcherSucceedsBecauseResearcher() {
+    public void checkSelfOrResearcherSucceedsForResearcher() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(RESEARCHER))
                 .withCallerUserId("notUserId").build());
@@ -187,16 +187,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void checkSelfOrResearcherAndThrow() { 
-        RequestContext.set(new RequestContext.Builder()
-                .withCallerRoles(ImmutableSet.of(DEVELOPER))
-                .withCallerUserId("notUserId").build());
-        
-        AuthUtils.checkSelfOrResearcher(USER_ID);
-    }
-    
-    @Test(expectedExceptions = UnauthorizedException.class)
-    public void checkStudyScopedToCaller() { 
+    public void checkStudyTeamMemberOrWorkerFailsOnStudyAccess() { 
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of("studyA", "studyB")).build());
         
@@ -204,7 +195,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void isStudyScopedToCallerFails() {
+    public void isStudyTeamMemberOrWorkerFails() {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
         
@@ -212,7 +203,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void isStudyScopedToCallerFailsWithNullStudyId() {
+    public void isStudyTeamMemberOrWorkerFailsOnNullStudy() {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
         
@@ -220,7 +211,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void isStudyScopedToCallerSucceedsForWorker() {
+    public void isStudyTeamMemberOrWorkerSucceedsForWorker() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(WORKER))
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
@@ -229,7 +220,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test
-    public void isStudyScopedToCallerSucceedsForAdmin() {
+    public void isStudyTeamMemberOrWorkerSucceedsForAdmin() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(ADMIN))
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
@@ -238,7 +229,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void isStudyScopedToCallerSucceedsForOrgSponsoredStudy() {
+    public void isStudyTeamMemberOrWorkerSucceedsForOrgSponsoredStudy() {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
         
@@ -276,5 +267,19 @@ public class AuthUtilsTest extends Mockito {
         assertFalse(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(WORKER)));
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(DEVELOPER, ADMIN)));
     }
+ 
+    @Test
+    public void checkOrgMembershipSucceedsForAdmin() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(ADMIN)).build());
+
+        AuthUtils.checkOrgMember(TEST_ORG_ID);
+    }
     
+    @Test
+    public void isStudyScopedToCallerSucceedsForGlobalUser() {
+        RequestContext.set(new RequestContext.Builder().build());
+        
+        AuthUtils.checkStudyTeamMemberOrWorker(TEST_STUDY_ID);
+    }
 }

--- a/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -1,11 +1,6 @@
 package org.sagebionetworks.bridge;
 
 import static java.util.stream.Collectors.toSet;
-import static org.sagebionetworks.bridge.Roles.ADMIN;
-import static org.sagebionetworks.bridge.Roles.DEVELOPER;
-import static org.sagebionetworks.bridge.Roles.RESEARCHER;
-import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
-import static org.sagebionetworks.bridge.Roles.WORKER;
 import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.USER_ID;
@@ -925,38 +920,6 @@ public class BridgeUtilsTest {
         String content = "<p id=remove-me>Test<script>This should be removed</script><img onerror=''>";
         String result = BridgeUtils.sanitizeHTML(Whitelist.none(), content);
         assertEquals(result, "Test");
-    }
-
-    @Test
-    public void isInRoleMethodsAreNullSafe() {
-        assertFalse(BridgeUtils.isInRole(null, (Roles)null));
-        assertFalse(BridgeUtils.isInRole(null, (Set<Roles>)null));
-    }
-    
-    @Test
-    public void isInRoleForSuperadminMatchesEverything() {
-        assertTrue(BridgeUtils.isInRole(ImmutableSet.of(SUPERADMIN), DEVELOPER));
-        assertTrue(BridgeUtils.isInRole(ImmutableSet.of(SUPERADMIN), RESEARCHER));
-        assertTrue(BridgeUtils.isInRole(ImmutableSet.of(SUPERADMIN), ADMIN));
-        assertTrue(BridgeUtils.isInRole(ImmutableSet.of(SUPERADMIN), WORKER));
-        assertTrue(BridgeUtils.isInRole(ImmutableSet.of(SUPERADMIN), ImmutableSet.of(DEVELOPER)));
-        assertTrue(BridgeUtils.isInRole(ImmutableSet.of(SUPERADMIN), ImmutableSet.of(RESEARCHER)));
-        assertTrue(BridgeUtils.isInRole(ImmutableSet.of(SUPERADMIN), ImmutableSet.of(ADMIN)));
-        assertTrue(BridgeUtils.isInRole(ImmutableSet.of(SUPERADMIN), ImmutableSet.of(WORKER)));
-        assertTrue(BridgeUtils.isInRole(ImmutableSet.of(SUPERADMIN), ImmutableSet.of(DEVELOPER, ADMIN)));
-    }
-    
-    @Test
-    public void isInRole() {
-        assertFalse(BridgeUtils.isInRole(ImmutableSet.of(ADMIN), DEVELOPER));
-        assertFalse(BridgeUtils.isInRole(ImmutableSet.of(ADMIN), RESEARCHER));
-        assertTrue(BridgeUtils.isInRole(ImmutableSet.of(ADMIN), ADMIN));
-        assertFalse(BridgeUtils.isInRole(ImmutableSet.of(ADMIN), WORKER));
-        assertFalse(BridgeUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(DEVELOPER)));
-        assertFalse(BridgeUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(RESEARCHER)));
-        assertTrue(BridgeUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(ADMIN)));
-        assertFalse(BridgeUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(WORKER)));
-        assertTrue(BridgeUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(DEVELOPER, ADMIN)));
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
@@ -105,19 +105,9 @@ public class HibernateAccountDaoTest extends Mockito {
     private HibernateAccountDao dao;
 
     @BeforeMethod
-    public void beforeMethod() {
-        MockitoAnnotations.initMocks(this);
-        DateTimeUtils.setCurrentMillisFixed(MOCK_DATETIME.getMillis());
-    }
-
-    @AfterMethod
-    public static void afterMethod() {
-        DateTimeUtils.setCurrentMillisSystem();
-    }
-
-    @BeforeMethod
     public void before() {
         MockitoAnnotations.initMocks(this);
+        DateTimeUtils.setCurrentMillisFixed(MOCK_DATETIME.getMillis());
         // Mock successful update.
         when(mockHibernateHelper.update(any())).thenAnswer(invocation -> {
             HibernateAccount account = invocation.getArgument(0);
@@ -139,6 +129,7 @@ public class HibernateAccountDaoTest extends Mockito {
     @AfterMethod
     public void after() {
         RequestContext.set(null);
+        DateTimeUtils.setCurrentMillisSystem();
     }
 
     @Test
@@ -518,6 +509,7 @@ public class HibernateAccountDaoTest extends Mockito {
     @Test
     public void getPagedRemovesStudiesNotInCaller() throws Exception {
         RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(RESEARCHER))
                 .withOrgSponsoredStudies(ImmutableSet.of(STUDY_A)).build());
         
         Set<Enrollment> set = ImmutableSet.of(
@@ -749,6 +741,7 @@ public class HibernateAccountDaoTest extends Mockito {
                 + "enrollment.studyId IN (:studies) GROUP BY acct.id";
         
         RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(RESEARCHER))
                 .withOrgSponsoredStudies(ImmutableSet.of("A", "B")).build());
         
         AccountSummarySearch search = new AccountSummarySearch.Builder().build();
@@ -821,6 +814,7 @@ public class HibernateAccountDaoTest extends Mockito {
     @Test
     public void unmarshallAccountSummaryFiltersStudies() throws Exception {
         RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(RESEARCHER))
                 .withOrgSponsoredStudies(ImmutableSet.of("studyB", "studyC")).build());
 
         Enrollment en1 = Enrollment.create(TEST_APP_ID, "studyA", ACCOUNT_ID, "externalIdA");

--- a/src/test/java/org/sagebionetworks/bridge/services/AssessmentResourceServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AssessmentResourceServiceTest.java
@@ -88,6 +88,7 @@ public class AssessmentResourceServiceTest extends Mockito {
         when(service.generateGuid()).thenReturn(GUID);
         
         RequestContext.set(new RequestContext.Builder()
+                .withCallerAppId(TEST_APP_ID)
                 .withCallerOrgMembership(OWNER_ID).build());
     }
     
@@ -636,6 +637,7 @@ public class AssessmentResourceServiceTest extends Mockito {
     @Test
     public void publishAssessmentResourcesOwnerInOrg() {
         RequestContext.set(new RequestContext.Builder()
+                .withCallerAppId(TEST_APP_ID)
                 .withCallerOrgMembership(OWNER_ID).build());
         
         Assessment assessment = AssessmentTest.createAssessment();

--- a/src/test/java/org/sagebionetworks/bridge/services/AssessmentServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AssessmentServiceTest.java
@@ -103,6 +103,7 @@ public class AssessmentServiceTest extends Mockito {
         // The default assumption is that you are in the correct organization (or else
         // you are an administrator). 
         RequestContext.set(new RequestContext.Builder()
+                .withCallerAppId(TEST_APP_ID)
                 .withCallerOrgMembership(OWNER_ID).build());
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/services/EnrollmentServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/EnrollmentServiceTest.java
@@ -218,7 +218,7 @@ public class EnrollmentServiceTest extends Mockito {
     public void enrollByThirdPartyResearcher() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId("adminUser")
-                .withCallerOrgMembership(TEST_ORG_ID)
+                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
                 .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
         
         when(mockSponsorService.isStudySponsoredBy(TEST_STUDY_ID, TEST_ORG_ID)).thenReturn(Boolean.TRUE);
@@ -427,7 +427,7 @@ public class EnrollmentServiceTest extends Mockito {
     public void unenrollByThirdPartyResearcher() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId("adminUser")
-                .withCallerOrgMembership(TEST_ORG_ID)
+                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
                 .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
         
         when(mockSponsorService.isStudySponsoredBy(TEST_STUDY_ID, TEST_ORG_ID)).thenReturn(Boolean.TRUE);

--- a/src/test/java/org/sagebionetworks/bridge/services/OrganizationServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/OrganizationServiceTest.java
@@ -444,8 +444,7 @@ public class OrganizationServiceTest extends Mockito {
         service.removeMember(TEST_APP_ID, IDENTIFIER, ACCOUNT_ID);
     }
 
-    @Test(expectedExceptions = UnauthorizedException.class, 
-            expectedExceptionsMessageRegExp = "Caller is not a member of.*")
+    @Test(expectedExceptions = UnauthorizedException.class)
     public void removeMemberNotAuthorized() {
         when(mockOrgDao.getOrganization(TEST_APP_ID, IDENTIFIER)).thenReturn(Optional.of(Organization.create()));
         Account account = Account.create();

--- a/src/test/java/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -255,8 +255,8 @@ public class ParticipantServiceTest extends Mockito {
         account.setAppId(TEST_APP_ID);
         account.setHealthCode(HEALTH_CODE);
         
-        RequestContext.set(new RequestContext.Builder().withCallerRoles(RESEARCH_CALLER_ROLES)
-                .withOrgSponsoredStudies(CALLER_SUBS).build());
+        RequestContext.set(new RequestContext.Builder().withCallerAppId(TEST_APP_ID)
+                .withCallerRoles(RESEARCH_CALLER_ROLES).withOrgSponsoredStudies(CALLER_SUBS).build());
     }
     
     @AfterMethod


### PR DESCRIPTION
- clean up AuthUtils (declarative behavior with AuthEvaluator class; updating documentation);
- rename utility methods to balance length of utility names with comprehensibility;
- eliminated cases where nulls were being passed into AuthUtils checks (these should have named evaluators so we can more easily identify exceptional security rules)
- additional checks against the request context required setting the context up further in some tests.

Note that AuthUtils checks could be moved out of ParticipantController and ParticipantReportController (after discussions with Dwayne about how we'll handle this), *but* they may need to stay there since new APIs will be introduced to work with participants in the scope of a specific study. 