### PR TITLE
Casing issue in develop environment

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/hibernate/OrganizationPersistenceExceptionConverter.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/OrganizationPersistenceExceptionConverter.java
@@ -20,7 +20,7 @@ public class OrganizationPersistenceExceptionConverter implements PersistenceExc
             String message = Throwables.getRootCause(throwable).getMessage();
             if (message.matches(".*a foreign key constraint fails.*fk_os_organization.*")) {
                 message = STUDY_CONSTRAINT;
-            } else if (message.matches(".*a foreign key constraint fails.*accounts_ibfk_1.*")) {
+            } else if (message.matches(".*a foreign key constraint fails.*[aA]ccounts_ibfk_1.*")) {
                 message = ACCOUNT_CONSTRAINT;
             }
             return new ConstraintViolationException.Builder().withMessage(message).build();

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/OrganizationPersistenceExceptionConverterTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/OrganizationPersistenceExceptionConverterTest.java
@@ -23,10 +23,14 @@ public class OrganizationPersistenceExceptionConverterTest extends Mockito {
             +"key constraint fails (`bridgedb`.`organizationsstudies`, CONSTRAINT `fk_os_organization` "
             +"FOREIGN KEY (`appId`, `orgId`) REFERENCES `Organizations` (`appId`, `identifier`))";
     
-    public static final String ACCOUNT_CONSTRAINT_RAW = "Cannot delete or update a parent row: a foreign key constraint "
+    public static final String ACCOUNT_CONSTRAINT_RAW1 = "Cannot delete or update a parent row: a foreign key constraint "
             +"fails (`bridgedb`.`accounts`, CONSTRAINT `accounts_ibfk_1` FOREIGN KEY (`studyId`, "
             +"`orgMembership`) REFERENCES `Organizations` (`appId`, `identifier`))";
 
+    public static final String ACCOUNT_CONSTRAINT_RAW2 = "Cannot delete or update a parent row: a foreign key constraint "
+            +"fails (`BridgeDB`.`Accounts`, CONSTRAINT `Accounts_ibfk_1` FOREIGN KEY (`studyId`, "
+            +"`orgMembership`) REFERENCES `Organizations` (`appId`, `identifier`))";
+    
     private OrganizationPersistenceExceptionConverter converter;
     
     @Mock
@@ -51,8 +55,19 @@ public class OrganizationPersistenceExceptionConverterTest extends Mockito {
     }
 
     @Test
-    public void convertsAccountConstraint() throws Exception {
-        SQLIntegrityConstraintViolationException sqle = new SQLIntegrityConstraintViolationException(ACCOUNT_CONSTRAINT_RAW);
+    public void convertsAccountConstraint1() throws Exception {
+        SQLIntegrityConstraintViolationException sqle = new SQLIntegrityConstraintViolationException(ACCOUNT_CONSTRAINT_RAW1);
+        org.hibernate.exception.ConstraintViolationException cve = new org.hibernate.exception.ConstraintViolationException("", sqle, "");
+        PersistenceException pe = new PersistenceException(cve);
+        
+        RuntimeException retValue = converter.convert(pe, Organization.create());
+        assertEquals(retValue.getMessage(), OrganizationPersistenceExceptionConverter.ACCOUNT_CONSTRAINT);
+    }
+    
+    // The casing in some environments is different...this still works.
+    @Test
+    public void convertsAccountConstraint2() throws Exception {
+        SQLIntegrityConstraintViolationException sqle = new SQLIntegrityConstraintViolationException(ACCOUNT_CONSTRAINT_RAW2);
         org.hibernate.exception.ConstraintViolationException cve = new org.hibernate.exception.ConstraintViolationException("", sqle, "");
         PersistenceException pe = new PersistenceException(cve);
         


### PR DESCRIPTION
Integration tests are failing because native SQL exception from MySQL is cased slightly differently than my development machine. Catch both variants in OrganizationPersistenceExceptionConverter.