### PR TITLE
Security refactor

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/AuthEvaluator.java
+++ b/src/main/java/org/sagebionetworks/bridge/AuthEvaluator.java
@@ -113,8 +113,8 @@ public class AuthEvaluator {
      * 
      * @throws org.sagebionetworks.bridge.exceptions.UnauthorizedException
      */
-    public void checkAndThrow() {
-        if (!check()) {
+    public void check() {
+        if (!verify()) {
             throw new UnauthorizedException();
         }
     }
@@ -123,8 +123,8 @@ public class AuthEvaluator {
      * 
      * @throws org.sagebionetworks.bridge.exceptions.UnauthorizedException
      */
-    public void checkAndThrow(String arg1, String val1) {
-        if (!check(arg1, val1)) {
+    private void check(String arg1, String val1) {
+        if (!verify(arg1, val1)) {
             throw new UnauthorizedException();
         }
     }
@@ -133,8 +133,8 @@ public class AuthEvaluator {
      * 
      * @throws org.sagebionetworks.bridge.exceptions.UnauthorizedException
      */
-    public void checkAndThrow(String arg1, String val1, String arg2, String val2) {
-        if (!check(arg1, val1, arg2, val2)) {
+    private void check(String arg1, String val1, String arg2, String val2) {
+        if (!verify(arg1, val1, arg2, val2)) {
             throw new UnauthorizedException();
         }
     }
@@ -142,29 +142,29 @@ public class AuthEvaluator {
      * Return true if the authorization rule passes, false otherwise. Missing, blank, and 
      * null values fail authorization tests.
      */
-    public boolean check() {
-        return checkInternal(ImmutableMap.of());
+    public boolean verify() {
+        return verifyInternal(ImmutableMap.of());
     }
     /**
      * Return true if the authorization rule passes, false otherwise. Missing, blank, and 
      * null values fail authorization tests.
      */
-    public boolean check(String arg1, String val1) {
+    public boolean verify(String arg1, String val1) {
         Map<String,String> factMap = new HashMap<>(); // can contain nulls
         factMap.put(arg1, val1);
-        return checkInternal(factMap);
+        return verifyInternal(factMap);
     }
     /**
      * Return true if the authorization rule passes, false otherwise. Missing, blank, and 
      * null values fail authorization tests.
      */
-    public boolean check(String arg1, String val1, String arg2, String val2) {
+    public boolean verify(String arg1, String val1, String arg2, String val2) {
         Map<String,String> factMap = new HashMap<>(); // can contain nulls
         factMap.put(arg1, val1);
         factMap.put(arg2, val2);
-        return checkInternal(factMap);
+        return verifyInternal(factMap);
     }
-    protected boolean checkInternal(Map<String,String> factMap) {
+    protected boolean verifyInternal(Map<String,String> factMap) {
         // this happens on the stack and should be thread-safe. 
         for (Predicate<Map<String,String>> predicate : predicates) {
             if (!predicate.test(factMap)) {
@@ -173,6 +173,40 @@ public class AuthEvaluator {
         }
         return true;
     }
+    
+    // UTILITY METHODS (it turns out we only have this many argument combinations).
+    
+    public boolean verifyOrgId(String orgId) {
+        return verify("orgId", orgId);
+    }
+    public boolean verifyOrgAndUserIds(String orgId, String userId) {
+        return verify("orgId", orgId, "userId", userId);
+    }
+    public boolean verifyStudyAndUserIds(String studyId, String userId) {
+        return verify("studyId", studyId, "userId", userId);
+    }
+    public boolean verifyStudyId(String studyId) {
+        return verify("studyId", studyId);
+    }
+    public void checkOrgId(String orgId) {
+        check("orgId", orgId);
+    }
+    public void checkStudyId(String studyId) {
+        check("studyId", studyId);
+    }
+    public void checkUserId(String userId) {
+        check("userId", userId);
+    }
+    public void checkOwnerId(String ownerId) {
+        check("ownerId", ownerId);
+    }
+    public void checkOrgAndUserIds(String orgId, String userId) {
+        check("orgId", orgId, "userId", userId);
+    }
+    public void checkStudyAndUserIds(String studyId, String userId) {
+        check("studyId", studyId, "userId", userId);
+    }
+    
     private static class OrAuthEvaluator extends AuthEvaluator {
         AuthEvaluator evaluator;
         
@@ -180,8 +214,8 @@ public class AuthEvaluator {
             this.evaluator = evaluator;
         }
         @Override
-        protected boolean checkInternal(Map<String, String> factMap) {
-            return super.checkInternal(factMap) || evaluator.checkInternal(factMap);
+        protected boolean verifyInternal(Map<String, String> factMap) {
+            return super.verifyInternal(factMap) || evaluator.verifyInternal(factMap);
         }
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/AuthEvaluatorField.java
+++ b/src/main/java/org/sagebionetworks/bridge/AuthEvaluatorField.java
@@ -1,0 +1,9 @@
+package org.sagebionetworks.bridge;
+
+public enum AuthEvaluatorField {
+    APP_ID,
+    ORG_ID,
+    OWNER_ID,
+    STUDY_ID,
+    USER_ID
+}

--- a/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
@@ -6,9 +6,9 @@ import static java.lang.Integer.parseInt;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.sagebionetworks.bridge.AuthUtils.isSelfWorkerOrOrgAdmin;
-import static org.sagebionetworks.bridge.AuthUtils.isSelfOrStudyTeamMemberOrWorker;
-import static org.sagebionetworks.bridge.AuthUtils.isStudyTeamMemberOrWorker;
+import static org.sagebionetworks.bridge.AuthUtils.IS_SELF_STUDY_TEAM_OR_WORKER;
+import static org.sagebionetworks.bridge.AuthUtils.IS_SELF_ORGADMIN_OR_WORKER;
+import static org.sagebionetworks.bridge.AuthUtils.IS_STUDY_TEAM_OR_WORKER;
 import static org.sagebionetworks.bridge.BridgeConstants.CKEDITOR_WHITELIST;
 import static org.sagebionetworks.bridge.util.BridgeCollectors.toImmutableSet;
 import static org.springframework.util.StringUtils.commaDelimitedListToSet;
@@ -168,7 +168,7 @@ public class BridgeUtils {
             // is an org admin, return the account. Callers that are not associated to an 
             // organization also gain access, but only while we migrate away from 
             // this kind of global account.
-            if (isSelfWorkerOrOrgAdmin(account.getOrgMembership(), account.getId())) {
+            if (IS_SELF_ORGADMIN_OR_WORKER.check("orgId", account.getOrgMembership(), "userId", account.getId())) {
                 return account;
             }
             // If after removing all enrollments that are not visible to the caller, 
@@ -196,7 +196,7 @@ public class BridgeUtils {
         ImmutableSet.Builder<String> studyIds = new ImmutableSet.Builder<>();
         ImmutableMap.Builder<String,String> externalIds = new ImmutableMap.Builder<>();
         for (Enrollment enrollment : account.getActiveEnrollments()) {
-            if (isSelfOrStudyTeamMemberOrWorker(enrollment.getStudyId(), account.getId())) {
+            if (IS_SELF_STUDY_TEAM_OR_WORKER.check("studyId", enrollment.getStudyId(), "userId", account.getId())) {
                 studyIds.add(enrollment.getStudyId());
                 if (enrollment.getExternalId() != null) {
                     externalIds.put(enrollment.getStudyId(), enrollment.getExternalId());
@@ -207,7 +207,7 @@ public class BridgeUtils {
     }
     
     public static ExternalIdentifier filterForStudy(ExternalIdentifier externalId) {
-        if (externalId != null && isStudyTeamMemberOrWorker(externalId.getStudyId())) {
+        if (externalId != null && IS_STUDY_TEAM_OR_WORKER.check("studyId", externalId.getStudyId())) {
             return externalId;
         }
         return null;

--- a/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
@@ -168,7 +168,7 @@ public class BridgeUtils {
             // is an org admin, return the account. Callers that are not associated to an 
             // organization also gain access, but only while we migrate away from 
             // this kind of global account.
-            if (IS_SELF_ORGADMIN_OR_WORKER.check("orgId", account.getOrgMembership(), "userId", account.getId())) {
+            if (IS_SELF_ORGADMIN_OR_WORKER.verifyOrgAndUserIds(account.getOrgMembership(), account.getId())) {
                 return account;
             }
             // If after removing all enrollments that are not visible to the caller, 
@@ -196,7 +196,7 @@ public class BridgeUtils {
         ImmutableSet.Builder<String> studyIds = new ImmutableSet.Builder<>();
         ImmutableMap.Builder<String,String> externalIds = new ImmutableMap.Builder<>();
         for (Enrollment enrollment : account.getActiveEnrollments()) {
-            if (IS_SELF_STUDY_TEAM_OR_WORKER.check("studyId", enrollment.getStudyId(), "userId", account.getId())) {
+            if (IS_SELF_STUDY_TEAM_OR_WORKER.verifyStudyAndUserIds(enrollment.getStudyId(), account.getId())) {
                 studyIds.add(enrollment.getStudyId());
                 if (enrollment.getExternalId() != null) {
                     externalIds.put(enrollment.getStudyId(), enrollment.getExternalId());
@@ -207,7 +207,7 @@ public class BridgeUtils {
     }
     
     public static ExternalIdentifier filterForStudy(ExternalIdentifier externalId) {
-        if (externalId != null && IS_STUDY_TEAM_OR_WORKER.check("studyId", externalId.getStudyId())) {
+        if (externalId != null && IS_STUDY_TEAM_OR_WORKER.verifyStudyId(externalId.getStudyId())) {
             return externalId;
         }
         return null;

--- a/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
@@ -7,6 +7,9 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.sagebionetworks.bridge.AuthUtils.IS_SELF_STUDY_TEAM_OR_WORKER;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.ORG_ID;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.STUDY_ID;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.USER_ID;
 import static org.sagebionetworks.bridge.AuthUtils.IS_SELF_ORGADMIN_OR_WORKER;
 import static org.sagebionetworks.bridge.AuthUtils.IS_STUDY_TEAM_OR_WORKER;
 import static org.sagebionetworks.bridge.BridgeConstants.CKEDITOR_WHITELIST;
@@ -168,7 +171,7 @@ public class BridgeUtils {
             // is an org admin, return the account. Callers that are not associated to an 
             // organization also gain access, but only while we migrate away from 
             // this kind of global account.
-            if (IS_SELF_ORGADMIN_OR_WORKER.verifyOrgAndUserIds(account.getOrgMembership(), account.getId())) {
+            if (IS_SELF_ORGADMIN_OR_WORKER.check(ORG_ID, account.getOrgMembership(), USER_ID, account.getId())) {
                 return account;
             }
             // If after removing all enrollments that are not visible to the caller, 
@@ -196,7 +199,7 @@ public class BridgeUtils {
         ImmutableSet.Builder<String> studyIds = new ImmutableSet.Builder<>();
         ImmutableMap.Builder<String,String> externalIds = new ImmutableMap.Builder<>();
         for (Enrollment enrollment : account.getActiveEnrollments()) {
-            if (IS_SELF_STUDY_TEAM_OR_WORKER.verifyStudyAndUserIds(enrollment.getStudyId(), account.getId())) {
+            if (IS_SELF_STUDY_TEAM_OR_WORKER.check(STUDY_ID, enrollment.getStudyId(), USER_ID, account.getId())) {
                 studyIds.add(enrollment.getStudyId());
                 if (enrollment.getExternalId() != null) {
                     externalIds.put(enrollment.getStudyId(), enrollment.getExternalId());
@@ -207,7 +210,7 @@ public class BridgeUtils {
     }
     
     public static ExternalIdentifier filterForStudy(ExternalIdentifier externalId) {
-        if (externalId != null && IS_STUDY_TEAM_OR_WORKER.verifyStudyId(externalId.getStudyId())) {
+        if (externalId != null && IS_STUDY_TEAM_OR_WORKER.check(STUDY_ID, externalId.getStudyId())) {
             return externalId;
         }
         return null;

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -166,7 +166,7 @@ public class HibernateAccountDao implements AccountDao {
             // If the caller is a member of an organization, then they can only see accounts in the studies 
             // sponsored by that organization. Note that this only applies now to enrollments, so admin 
             // accounts are exempt.
-            if (!TRUE.equals(search.isAdminOnly()) && !IS_STUDY_TEAM_OR_WORKER.check()) {
+            if (!TRUE.equals(search.isAdminOnly()) && !IS_STUDY_TEAM_OR_WORKER.verify()) {
                 Set<String> callerStudies = context.getOrgSponsoredStudies();
                 builder.append("AND enrollment.studyId IN (:studies)", "studies", callerStudies);
             }

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -166,7 +166,7 @@ public class HibernateAccountDao implements AccountDao {
             // If the caller is a member of an organization, then they can only see accounts in the studies 
             // sponsored by that organization. Note that this only applies now to enrollments, so admin 
             // accounts are exempt.
-            if (!TRUE.equals(search.isAdminOnly()) && !IS_STUDY_TEAM_OR_WORKER.verify()) {
+            if (!TRUE.equals(search.isAdminOnly()) && !IS_STUDY_TEAM_OR_WORKER.check()) {
                 Set<String> callerStudies = context.getOrgSponsoredStudies();
                 builder.append("AND enrollment.studyId IN (:studies)", "studies", callerStudies);
             }

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.hibernate;
 
 import static java.lang.Boolean.TRUE;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.sagebionetworks.bridge.AuthUtils.IS_STUDY_TEAM_OR_WORKER;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,7 +20,6 @@ import org.springframework.stereotype.Component;
 
 import com.google.common.collect.ImmutableList;
 
-import org.sagebionetworks.bridge.AuthUtils;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.BridgeUtils.StudyAssociations;
 import org.sagebionetworks.bridge.RequestContext;
@@ -166,7 +166,7 @@ public class HibernateAccountDao implements AccountDao {
             // If the caller is a member of an organization, then they can only see accounts in the studies 
             // sponsored by that organization. Note that this only applies now to enrollments, so admin 
             // accounts are exempt.
-            if (!TRUE.equals(search.isAdminOnly()) && !AuthUtils.isStudyTeamMemberOrWorker(null)) {
+            if (!TRUE.equals(search.isAdminOnly()) && !IS_STUDY_TEAM_OR_WORKER.check("studyId", null)) {
                 Set<String> callerStudies = context.getOrgSponsoredStudies();
                 builder.append("AND enrollment.studyId IN (:studies)", "studies", callerStudies);
             }

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -166,7 +166,7 @@ public class HibernateAccountDao implements AccountDao {
             // If the caller is a member of an organization, then they can only see accounts in the studies 
             // sponsored by that organization. Note that this only applies now to enrollments, so admin 
             // accounts are exempt.
-            if (!TRUE.equals(search.isAdminOnly()) && !IS_STUDY_TEAM_OR_WORKER.check("studyId", null)) {
+            if (!TRUE.equals(search.isAdminOnly()) && !IS_STUDY_TEAM_OR_WORKER.check()) {
                 Set<String> callerStudies = context.getOrgSponsoredStudies();
                 builder.append("AND enrollment.studyId IN (:studies)", "studies", callerStudies);
             }

--- a/src/main/java/org/sagebionetworks/bridge/services/AssessmentConfigService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AssessmentConfigService.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.services;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.ORG_ID;
 import static org.sagebionetworks.bridge.AuthUtils.IS_ORG_MEMBER;
 
 import java.util.Map;
@@ -74,7 +75,7 @@ public class AssessmentConfigService {
         checkNotNull(config);
         
         Assessment assessment = assessmentService.getAssessmentByGuid(appId, guid);
-        IS_ORG_MEMBER.checkOrgId(assessment.getOwnerId());
+        IS_ORG_MEMBER.checkAndThrow(ORG_ID, assessment.getOwnerId());
         
         AssessmentConfig existing = dao.getAssessmentConfig(guid)
                 .orElseThrow(() -> new EntityNotFoundException(AssessmentConfig.class));
@@ -97,7 +98,7 @@ public class AssessmentConfigService {
             throw new BadRequestException("Updates to configuration are missing");
         }
         Assessment assessment = assessmentService.getAssessmentByGuid(appId, guid);
-        IS_ORG_MEMBER.checkOrgId(assessment.getOwnerId());
+        IS_ORG_MEMBER.checkAndThrow(ORG_ID, assessment.getOwnerId());
         
         Map<String, Set<PropertyInfo>> fields = assessment.getCustomizationFields();
         

--- a/src/main/java/org/sagebionetworks/bridge/services/AssessmentConfigService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AssessmentConfigService.java
@@ -74,7 +74,7 @@ public class AssessmentConfigService {
         checkNotNull(config);
         
         Assessment assessment = assessmentService.getAssessmentByGuid(appId, guid);
-        IS_ORG_MEMBER.checkAndThrow("orgId", assessment.getOwnerId());
+        IS_ORG_MEMBER.checkOrgId(assessment.getOwnerId());
         
         AssessmentConfig existing = dao.getAssessmentConfig(guid)
                 .orElseThrow(() -> new EntityNotFoundException(AssessmentConfig.class));
@@ -97,7 +97,7 @@ public class AssessmentConfigService {
             throw new BadRequestException("Updates to configuration are missing");
         }
         Assessment assessment = assessmentService.getAssessmentByGuid(appId, guid);
-        IS_ORG_MEMBER.checkAndThrow("orgId", assessment.getOwnerId());
+        IS_ORG_MEMBER.checkOrgId(assessment.getOwnerId());
         
         Map<String, Set<PropertyInfo>> fields = assessment.getCustomizationFields();
         

--- a/src/main/java/org/sagebionetworks/bridge/services/AssessmentConfigService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AssessmentConfigService.java
@@ -3,7 +3,7 @@ package org.sagebionetworks.bridge.services;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.sagebionetworks.bridge.AuthUtils.checkOrgMember;
+import static org.sagebionetworks.bridge.AuthUtils.IS_ORG_MEMBER;
 
 import java.util.Map;
 import java.util.Set;
@@ -74,7 +74,7 @@ public class AssessmentConfigService {
         checkNotNull(config);
         
         Assessment assessment = assessmentService.getAssessmentByGuid(appId, guid);
-        checkOrgMember(assessment.getOwnerId());
+        IS_ORG_MEMBER.checkAndThrow("orgId", assessment.getOwnerId());
         
         AssessmentConfig existing = dao.getAssessmentConfig(guid)
                 .orElseThrow(() -> new EntityNotFoundException(AssessmentConfig.class));
@@ -97,7 +97,7 @@ public class AssessmentConfigService {
             throw new BadRequestException("Updates to configuration are missing");
         }
         Assessment assessment = assessmentService.getAssessmentByGuid(appId, guid);
-        checkOrgMember(assessment.getOwnerId());
+        IS_ORG_MEMBER.checkAndThrow("orgId", assessment.getOwnerId());
         
         Map<String, Set<PropertyInfo>> fields = assessment.getCustomizationFields();
         

--- a/src/main/java/org/sagebionetworks/bridge/services/AssessmentResourceService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AssessmentResourceService.java
@@ -5,6 +5,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.jsoup.safety.Whitelist.simpleText;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.ORG_ID;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.OWNER_ID;
 import static org.sagebionetworks.bridge.AuthUtils.IS_ORG_MEMBER;
 import static org.sagebionetworks.bridge.AuthUtils.IS_ORG_MEMBER_IN_APP;
 import static org.sagebionetworks.bridge.BridgeConstants.SHARED_APP_ID;
@@ -107,7 +109,7 @@ public class AssessmentResourceService {
         checkNotNull(resource);
         
         Assessment assessment = assessmentService.getLatestAssessment(appId, assessmentId);
-        IS_ORG_MEMBER.checkOrgId(assessment.getOwnerId());
+        IS_ORG_MEMBER.checkAndThrow(ORG_ID, assessment.getOwnerId());
         
         DateTime timestamp = getCreatedOn();
         resource.setGuid(generateGuid());
@@ -132,7 +134,7 @@ public class AssessmentResourceService {
         
         Assessment assessment = assessmentService.getLatestAssessment(appId, assessmentId);
         
-        IS_ORG_MEMBER.checkOrgId(assessment.getOwnerId());
+        IS_ORG_MEMBER.checkAndThrow(ORG_ID, assessment.getOwnerId());
         
         return updateResourceInternal(appId, assessmentId, assessment, resource);
     }
@@ -145,7 +147,7 @@ public class AssessmentResourceService {
         
         Assessment assessment = assessmentService.getLatestAssessment(SHARED_APP_ID, assessmentId);
         
-        IS_ORG_MEMBER_IN_APP.checkOwnerId(assessment.getOwnerId());
+        IS_ORG_MEMBER_IN_APP.checkAndThrow(OWNER_ID, assessment.getOwnerId());
         
         return updateResourceInternal(SHARED_APP_ID, assessmentId, assessment, resource);
     }
@@ -178,7 +180,7 @@ public class AssessmentResourceService {
         
         // Verify access to this.
         Assessment assessment = assessmentService.getLatestAssessment(appId, assessmentId);
-        IS_ORG_MEMBER.checkOrgId(assessment.getOwnerId());
+        IS_ORG_MEMBER.checkAndThrow(ORG_ID, assessment.getOwnerId());
         
         AssessmentResource resource = dao.getResource(appId, guid)
                 .orElseThrow(() -> new EntityNotFoundException(AssessmentResource.class));
@@ -207,7 +209,7 @@ public class AssessmentResourceService {
         // Must have imported the assessment already before you move resources
         Assessment assessment = assessmentService.getLatestAssessment(appId, assessmentId);
         // Cannot import a resource unless you are member of the org that owns the assessment
-        IS_ORG_MEMBER.checkOrgId(assessment.getOwnerId());
+        IS_ORG_MEMBER.checkAndThrow(ORG_ID, assessment.getOwnerId());
         return copyResources(SHARED_APP_ID, appId, assessment, guids);
     }
     
@@ -218,7 +220,7 @@ public class AssessmentResourceService {
         // Must have published the assessment already before you move resources
         Assessment assessment = assessmentService.getLatestAssessment(SHARED_APP_ID, assessmentId);
         // Cannot publish a resource unless you are member of the org that owns the shared assessment
-        IS_ORG_MEMBER_IN_APP.checkOwnerId(assessment.getOwnerId());
+        IS_ORG_MEMBER_IN_APP.checkAndThrow(OWNER_ID, assessment.getOwnerId());
         
         return copyResources(appId, SHARED_APP_ID, assessment, guids);
     }

--- a/src/main/java/org/sagebionetworks/bridge/services/AssessmentResourceService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AssessmentResourceService.java
@@ -5,8 +5,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.jsoup.safety.Whitelist.simpleText;
-import static org.sagebionetworks.bridge.AuthUtils.checkOrgMember;
-import static org.sagebionetworks.bridge.AuthUtils.checkOrgMemberOfSharedAssessmentOwner;
+import static org.sagebionetworks.bridge.AuthUtils.IS_ORG_MEMBER;
+import static org.sagebionetworks.bridge.AuthUtils.IS_ORG_MEMBER_IN_APP;
 import static org.sagebionetworks.bridge.BridgeConstants.SHARED_APP_ID;
 import static org.sagebionetworks.bridge.BridgeUtils.sanitizeHTML;
 import static org.sagebionetworks.bridge.models.ResourceList.CATEGORIES;
@@ -107,7 +107,7 @@ public class AssessmentResourceService {
         checkNotNull(resource);
         
         Assessment assessment = assessmentService.getLatestAssessment(appId, assessmentId);
-        checkOrgMember(assessment.getOwnerId());
+        IS_ORG_MEMBER.checkAndThrow("orgId", assessment.getOwnerId());
         
         DateTime timestamp = getCreatedOn();
         resource.setGuid(generateGuid());
@@ -132,7 +132,7 @@ public class AssessmentResourceService {
         
         Assessment assessment = assessmentService.getLatestAssessment(appId, assessmentId);
         
-        checkOrgMember(assessment.getOwnerId());
+        IS_ORG_MEMBER.checkAndThrow("orgId", assessment.getOwnerId());
         
         return updateResourceInternal(appId, assessmentId, assessment, resource);
     }
@@ -145,7 +145,7 @@ public class AssessmentResourceService {
         
         Assessment assessment = assessmentService.getLatestAssessment(SHARED_APP_ID, assessmentId);
         
-        checkOrgMemberOfSharedAssessmentOwner(callerAppId, assessment.getGuid(), assessment.getOwnerId());
+        IS_ORG_MEMBER_IN_APP.checkAndThrow("ownerId", assessment.getOwnerId());
         
         return updateResourceInternal(SHARED_APP_ID, assessmentId, assessment, resource);
     }
@@ -178,7 +178,7 @@ public class AssessmentResourceService {
         
         // Verify access to this.
         Assessment assessment = assessmentService.getLatestAssessment(appId, assessmentId);
-        checkOrgMember(assessment.getOwnerId());
+        IS_ORG_MEMBER.checkAndThrow("orgId", assessment.getOwnerId());
         
         AssessmentResource resource = dao.getResource(appId, guid)
                 .orElseThrow(() -> new EntityNotFoundException(AssessmentResource.class));
@@ -207,7 +207,7 @@ public class AssessmentResourceService {
         // Must have imported the assessment already before you move resources
         Assessment assessment = assessmentService.getLatestAssessment(appId, assessmentId);
         // Cannot import a resource unless you are member of the org that owns the assessment
-        checkOrgMember(assessment.getOwnerId());
+        IS_ORG_MEMBER.checkAndThrow("orgId", assessment.getOwnerId());
         return copyResources(SHARED_APP_ID, appId, assessment, guids);
     }
     
@@ -218,7 +218,8 @@ public class AssessmentResourceService {
         // Must have published the assessment already before you move resources
         Assessment assessment = assessmentService.getLatestAssessment(SHARED_APP_ID, assessmentId);
         // Cannot publish a resource unless you are member of the org that owns the shared assessment
-        checkOrgMemberOfSharedAssessmentOwner(appId, assessment.getGuid(), assessment.getOwnerId());
+        IS_ORG_MEMBER_IN_APP.checkAndThrow("ownerId", assessment.getOwnerId());
+        
         return copyResources(appId, SHARED_APP_ID, assessment, guids);
     }
     

--- a/src/main/java/org/sagebionetworks/bridge/services/AssessmentResourceService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AssessmentResourceService.java
@@ -107,7 +107,7 @@ public class AssessmentResourceService {
         checkNotNull(resource);
         
         Assessment assessment = assessmentService.getLatestAssessment(appId, assessmentId);
-        IS_ORG_MEMBER.checkAndThrow("orgId", assessment.getOwnerId());
+        IS_ORG_MEMBER.checkOrgId(assessment.getOwnerId());
         
         DateTime timestamp = getCreatedOn();
         resource.setGuid(generateGuid());
@@ -132,7 +132,7 @@ public class AssessmentResourceService {
         
         Assessment assessment = assessmentService.getLatestAssessment(appId, assessmentId);
         
-        IS_ORG_MEMBER.checkAndThrow("orgId", assessment.getOwnerId());
+        IS_ORG_MEMBER.checkOrgId(assessment.getOwnerId());
         
         return updateResourceInternal(appId, assessmentId, assessment, resource);
     }
@@ -145,7 +145,7 @@ public class AssessmentResourceService {
         
         Assessment assessment = assessmentService.getLatestAssessment(SHARED_APP_ID, assessmentId);
         
-        IS_ORG_MEMBER_IN_APP.checkAndThrow("ownerId", assessment.getOwnerId());
+        IS_ORG_MEMBER_IN_APP.checkOwnerId(assessment.getOwnerId());
         
         return updateResourceInternal(SHARED_APP_ID, assessmentId, assessment, resource);
     }
@@ -178,7 +178,7 @@ public class AssessmentResourceService {
         
         // Verify access to this.
         Assessment assessment = assessmentService.getLatestAssessment(appId, assessmentId);
-        IS_ORG_MEMBER.checkAndThrow("orgId", assessment.getOwnerId());
+        IS_ORG_MEMBER.checkOrgId(assessment.getOwnerId());
         
         AssessmentResource resource = dao.getResource(appId, guid)
                 .orElseThrow(() -> new EntityNotFoundException(AssessmentResource.class));
@@ -207,7 +207,7 @@ public class AssessmentResourceService {
         // Must have imported the assessment already before you move resources
         Assessment assessment = assessmentService.getLatestAssessment(appId, assessmentId);
         // Cannot import a resource unless you are member of the org that owns the assessment
-        IS_ORG_MEMBER.checkAndThrow("orgId", assessment.getOwnerId());
+        IS_ORG_MEMBER.checkOrgId(assessment.getOwnerId());
         return copyResources(SHARED_APP_ID, appId, assessment, guids);
     }
     
@@ -218,7 +218,7 @@ public class AssessmentResourceService {
         // Must have published the assessment already before you move resources
         Assessment assessment = assessmentService.getLatestAssessment(SHARED_APP_ID, assessmentId);
         // Cannot publish a resource unless you are member of the org that owns the shared assessment
-        IS_ORG_MEMBER_IN_APP.checkAndThrow("ownerId", assessment.getOwnerId());
+        IS_ORG_MEMBER_IN_APP.checkOwnerId(assessment.getOwnerId());
         
         return copyResources(appId, SHARED_APP_ID, assessment, guids);
     }

--- a/src/main/java/org/sagebionetworks/bridge/services/AssessmentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AssessmentService.java
@@ -159,7 +159,7 @@ public class AssessmentService {
         if (existing.isDeleted() && assessment.isDeleted()) {
             throw new EntityNotFoundException(Assessment.class);
         }
-        IS_ORG_MEMBER.checkAndThrow("orgId", existing.getOwnerId());
+        IS_ORG_MEMBER.checkOrgId(existing.getOwnerId());
         
         return updateAssessmentInternal(appId, assessment, existing);
     }
@@ -174,7 +174,7 @@ public class AssessmentService {
             throw new EntityNotFoundException(Assessment.class);
         }
 
-        IS_ORG_MEMBER_IN_APP.checkAndThrow("ownerId", existing.getOwnerId());
+        IS_ORG_MEMBER_IN_APP.checkOwnerId(existing.getOwnerId());
         
         return updateAssessmentInternal(SHARED_APP_ID, assessment, existing);
     }
@@ -275,7 +275,7 @@ public class AssessmentService {
         AssessmentConfig configToPublish =  configService.getAssessmentConfig(appId, guid);
         Assessment original = Assessment.copy(assessmentToPublish);
         
-        IS_ORG_MEMBER.checkAndThrow("orgId", assessmentToPublish.getOwnerId());
+        IS_ORG_MEMBER.checkOrgId(assessmentToPublish.getOwnerId());
         
         if (StringUtils.isNotBlank(newIdentifier)) {
             assessmentToPublish.setIdentifier(newIdentifier);
@@ -330,7 +330,7 @@ public class AssessmentService {
         if (isBlank(ownerId)) {
             throw new BadRequestException("ownerId parameter is required");
         }
-        IS_ORG_MEMBER.checkAndThrow("orgId", ownerId);
+        IS_ORG_MEMBER.checkOrgId(ownerId);
 
         Assessment sharedAssessment = getAssessmentByGuid(SHARED_APP_ID, guid);
         AssessmentConfig sharedConfig = configService.getSharedAssessmentConfig(SHARED_APP_ID, guid);
@@ -360,7 +360,7 @@ public class AssessmentService {
         if (assessment.isDeleted()) {
             throw new EntityNotFoundException(Assessment.class);
         }
-        IS_ORG_MEMBER.checkAndThrow("orgId", assessment.getOwnerId());
+        IS_ORG_MEMBER.checkOrgId(assessment.getOwnerId());
 
         assessment.setDeleted(true);
         assessment.setModifiedOn(getModifiedOn());
@@ -396,7 +396,7 @@ public class AssessmentService {
         AssessmentValidator validator = new AssessmentValidator(appId, organizationService);
         Validate.entityThrowingException(validator, assessment);
         
-        IS_ORG_MEMBER.checkAndThrow("orgId", assessment.getOwnerId());
+        IS_ORG_MEMBER.checkOrgId(assessment.getOwnerId());
 
         AssessmentConfig config = new AssessmentConfig();
         config.setCreatedOn(timestamp);

--- a/src/main/java/org/sagebionetworks/bridge/services/AssessmentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AssessmentService.java
@@ -6,6 +6,8 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.jsoup.safety.Whitelist.none;
 import static org.jsoup.safety.Whitelist.simpleText;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.ORG_ID;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.OWNER_ID;
 import static org.sagebionetworks.bridge.AuthUtils.IS_ORG_MEMBER;
 import static org.sagebionetworks.bridge.AuthUtils.IS_ORG_MEMBER_IN_APP;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
@@ -159,7 +161,7 @@ public class AssessmentService {
         if (existing.isDeleted() && assessment.isDeleted()) {
             throw new EntityNotFoundException(Assessment.class);
         }
-        IS_ORG_MEMBER.checkOrgId(existing.getOwnerId());
+        IS_ORG_MEMBER.checkAndThrow(ORG_ID, existing.getOwnerId());
         
         return updateAssessmentInternal(appId, assessment, existing);
     }
@@ -174,7 +176,7 @@ public class AssessmentService {
             throw new EntityNotFoundException(Assessment.class);
         }
 
-        IS_ORG_MEMBER_IN_APP.checkOwnerId(existing.getOwnerId());
+        IS_ORG_MEMBER_IN_APP.checkAndThrow(OWNER_ID, existing.getOwnerId());
         
         return updateAssessmentInternal(SHARED_APP_ID, assessment, existing);
     }
@@ -275,7 +277,7 @@ public class AssessmentService {
         AssessmentConfig configToPublish =  configService.getAssessmentConfig(appId, guid);
         Assessment original = Assessment.copy(assessmentToPublish);
         
-        IS_ORG_MEMBER.checkOrgId(assessmentToPublish.getOwnerId());
+        IS_ORG_MEMBER.checkAndThrow(ORG_ID ,assessmentToPublish.getOwnerId());
         
         if (StringUtils.isNotBlank(newIdentifier)) {
             assessmentToPublish.setIdentifier(newIdentifier);
@@ -330,7 +332,7 @@ public class AssessmentService {
         if (isBlank(ownerId)) {
             throw new BadRequestException("ownerId parameter is required");
         }
-        IS_ORG_MEMBER.checkOrgId(ownerId);
+        IS_ORG_MEMBER.checkAndThrow(ORG_ID, ownerId);
 
         Assessment sharedAssessment = getAssessmentByGuid(SHARED_APP_ID, guid);
         AssessmentConfig sharedConfig = configService.getSharedAssessmentConfig(SHARED_APP_ID, guid);
@@ -360,7 +362,7 @@ public class AssessmentService {
         if (assessment.isDeleted()) {
             throw new EntityNotFoundException(Assessment.class);
         }
-        IS_ORG_MEMBER.checkOrgId(assessment.getOwnerId());
+        IS_ORG_MEMBER.checkAndThrow(ORG_ID, assessment.getOwnerId());
 
         assessment.setDeleted(true);
         assessment.setModifiedOn(getModifiedOn());
@@ -396,7 +398,7 @@ public class AssessmentService {
         AssessmentValidator validator = new AssessmentValidator(appId, organizationService);
         Validate.entityThrowingException(validator, assessment);
         
-        IS_ORG_MEMBER.checkOrgId(assessment.getOwnerId());
+        IS_ORG_MEMBER.checkAndThrow(ORG_ID, assessment.getOwnerId());
 
         AssessmentConfig config = new AssessmentConfig();
         config.setCreatedOn(timestamp);

--- a/src/main/java/org/sagebionetworks/bridge/services/AssessmentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AssessmentService.java
@@ -6,8 +6,8 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.jsoup.safety.Whitelist.none;
 import static org.jsoup.safety.Whitelist.simpleText;
-import static org.sagebionetworks.bridge.AuthUtils.checkOrgMember;
-import static org.sagebionetworks.bridge.AuthUtils.checkOrgMemberOfSharedAssessmentOwner;
+import static org.sagebionetworks.bridge.AuthUtils.IS_ORG_MEMBER;
+import static org.sagebionetworks.bridge.AuthUtils.IS_ORG_MEMBER_IN_APP;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.NEGATIVE_OFFSET_ERROR;
@@ -159,7 +159,7 @@ public class AssessmentService {
         if (existing.isDeleted() && assessment.isDeleted()) {
             throw new EntityNotFoundException(Assessment.class);
         }
-        checkOrgMember(existing.getOwnerId());
+        IS_ORG_MEMBER.checkAndThrow("orgId", existing.getOwnerId());
         
         return updateAssessmentInternal(appId, assessment, existing);
     }
@@ -174,7 +174,7 @@ public class AssessmentService {
             throw new EntityNotFoundException(Assessment.class);
         }
 
-        checkOrgMemberOfSharedAssessmentOwner(callerAppId, existing.getGuid(), existing.getOwnerId());
+        IS_ORG_MEMBER_IN_APP.checkAndThrow("ownerId", existing.getOwnerId());
         
         return updateAssessmentInternal(SHARED_APP_ID, assessment, existing);
     }
@@ -275,7 +275,7 @@ public class AssessmentService {
         AssessmentConfig configToPublish =  configService.getAssessmentConfig(appId, guid);
         Assessment original = Assessment.copy(assessmentToPublish);
         
-        checkOrgMember(assessmentToPublish.getOwnerId());
+        IS_ORG_MEMBER.checkAndThrow("orgId", assessmentToPublish.getOwnerId());
         
         if (StringUtils.isNotBlank(newIdentifier)) {
             assessmentToPublish.setIdentifier(newIdentifier);
@@ -330,7 +330,7 @@ public class AssessmentService {
         if (isBlank(ownerId)) {
             throw new BadRequestException("ownerId parameter is required");
         }
-        checkOrgMember(ownerId);
+        IS_ORG_MEMBER.checkAndThrow("orgId", ownerId);
 
         Assessment sharedAssessment = getAssessmentByGuid(SHARED_APP_ID, guid);
         AssessmentConfig sharedConfig = configService.getSharedAssessmentConfig(SHARED_APP_ID, guid);
@@ -360,8 +360,8 @@ public class AssessmentService {
         if (assessment.isDeleted()) {
             throw new EntityNotFoundException(Assessment.class);
         }
-        checkOrgMember(assessment.getOwnerId());
-        
+        IS_ORG_MEMBER.checkAndThrow("orgId", assessment.getOwnerId());
+
         assessment.setDeleted(true);
         assessment.setModifiedOn(getModifiedOn());
         dao.updateAssessment(appId, assessment);
@@ -396,7 +396,7 @@ public class AssessmentService {
         AssessmentValidator validator = new AssessmentValidator(appId, organizationService);
         Validate.entityThrowingException(validator, assessment);
         
-        checkOrgMember(assessment.getOwnerId());
+        IS_ORG_MEMBER.checkAndThrow("orgId", assessment.getOwnerId());
 
         AssessmentConfig config = new AssessmentConfig();
         config.setCreatedOn(timestamp);

--- a/src/main/java/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -344,7 +344,7 @@ public class AuthenticationService {
                 .findAny()
                 .orElseThrow(() -> new EntityNotFoundException(Account.class));
 
-        IS_STUDY_TEAM_OR_WORKER.checkAndThrow("studyId", en.getStudyId());
+        IS_STUDY_TEAM_OR_WORKER.checkStudyId(en.getStudyId());
 
         String password = generatePassword(app.getPasswordPolicy().getMinLength());
         accountService.changePassword(account, null, password);

--- a/src/main/java/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.services;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.sagebionetworks.bridge.AuthUtils.IS_STUDY_TEAM_OR_WORKER;
 import static org.sagebionetworks.bridge.Roles.ADMINISTRATIVE_ROLES;
 import static org.sagebionetworks.bridge.models.accounts.AccountSecretType.REAUTH;
 import static org.sagebionetworks.bridge.services.AuthenticationService.ChannelType.EMAIL;
@@ -8,7 +9,6 @@ import static org.sagebionetworks.bridge.services.AuthenticationService.ChannelT
 
 import org.apache.commons.lang3.StringUtils;
 
-import org.sagebionetworks.bridge.AuthUtils;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.PasswordGenerator;
 import org.sagebionetworks.bridge.RequestContext;
@@ -344,7 +344,7 @@ public class AuthenticationService {
                 .findAny()
                 .orElseThrow(() -> new EntityNotFoundException(Account.class));
 
-        AuthUtils.checkStudyTeamMemberOrWorker(en.getStudyId());
+        IS_STUDY_TEAM_OR_WORKER.checkAndThrow("studyId", en.getStudyId());
 
         String password = generatePassword(app.getPasswordPolicy().getMinLength());
         accountService.changePassword(account, null, password);

--- a/src/main/java/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.services;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.STUDY_ID;
 import static org.sagebionetworks.bridge.AuthUtils.IS_STUDY_TEAM_OR_WORKER;
 import static org.sagebionetworks.bridge.Roles.ADMINISTRATIVE_ROLES;
 import static org.sagebionetworks.bridge.models.accounts.AccountSecretType.REAUTH;
@@ -344,7 +345,7 @@ public class AuthenticationService {
                 .findAny()
                 .orElseThrow(() -> new EntityNotFoundException(Account.class));
 
-        IS_STUDY_TEAM_OR_WORKER.checkStudyId(en.getStudyId());
+        IS_STUDY_TEAM_OR_WORKER.checkAndThrow(STUDY_ID, en.getStudyId());
 
         String password = generatePassword(app.getPasswordPolicy().getMinLength());
         accountService.changePassword(account, null, password);

--- a/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
@@ -1,8 +1,8 @@
 package org.sagebionetworks.bridge.services;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.sagebionetworks.bridge.AuthUtils.checkSelfOrStudyResearcher;
-import static org.sagebionetworks.bridge.AuthUtils.checkStudyResearcher;
+import static org.sagebionetworks.bridge.AuthUtils.IS_SELF_OR_STUDY_RESEARCHER;
+import static org.sagebionetworks.bridge.AuthUtils.IS_STUDY_RESEARCHER;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.NEGATIVE_OFFSET_ERROR;
@@ -64,7 +64,7 @@ public class EnrollmentService {
         checkNotNull(appId);
         checkNotNull(studyId);
         
-        checkStudyResearcher(studyId);
+        IS_STUDY_RESEARCHER.checkAndThrow("studyId", studyId);
 
         if (offsetBy != null && offsetBy < 0) {
             throw new BadRequestException(NEGATIVE_OFFSET_ERROR);
@@ -87,7 +87,7 @@ public class EnrollmentService {
         if (account == null) {
             throw new EntityNotFoundException(Account.class);
         }
-        checkSelfOrStudyResearcher(account.getId(), userId);
+        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow("userId", account.getId(), "studyId", userId);
 
         return enrollmentDao.getEnrollmentsForUser(appId, userId);
     }
@@ -99,7 +99,8 @@ public class EnrollmentService {
         Validate.entityThrowingException(INSTANCE, enrollment);
         
         // Verify that the caller has access to this study
-        checkSelfOrStudyResearcher(enrollment.getAccountId(), enrollment.getStudyId());
+        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow(
+                "userId", enrollment.getAccountId(), "studyId", enrollment.getStudyId());
 
         // Because this is an enrollment, we don't want to check the caller's access to the 
         // account based on study, because the account has not been put in a study accessible
@@ -122,7 +123,7 @@ public class EnrollmentService {
         
         Validate.entityThrowingException(INSTANCE, newEnrollment);
         
-        checkSelfOrStudyResearcher(account.getId(), newEnrollment.getStudyId());
+        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow("userId", account.getId(), "studyId", newEnrollment.getStudyId());
 
         for (Enrollment existingEnrollment : account.getEnrollments()) {
             if (existingEnrollment.getStudyId().equals(newEnrollment.getStudyId())) {
@@ -182,7 +183,7 @@ public class EnrollmentService {
         
         Validate.entityThrowingException(INSTANCE, enrollment);
         
-        checkSelfOrStudyResearcher(account.getId(), enrollment.getStudyId());
+        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow("userId", account.getId(), "studyId", enrollment.getStudyId());
         
         // If supplied, this value should be the same timestamp as the withdrewOn
         // value in the signature. Otherwise just set it here. 

--- a/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
@@ -64,7 +64,7 @@ public class EnrollmentService {
         checkNotNull(appId);
         checkNotNull(studyId);
         
-        IS_STUDY_RESEARCHER.checkAndThrow("studyId", studyId);
+        IS_STUDY_RESEARCHER.checkStudyId(studyId);
 
         if (offsetBy != null && offsetBy < 0) {
             throw new BadRequestException(NEGATIVE_OFFSET_ERROR);
@@ -87,7 +87,7 @@ public class EnrollmentService {
         if (account == null) {
             throw new EntityNotFoundException(Account.class);
         }
-        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow("userId", account.getId(), "studyId", userId);
+        IS_SELF_OR_STUDY_RESEARCHER.checkStudyAndUserIds(null, account.getId());
 
         return enrollmentDao.getEnrollmentsForUser(appId, userId);
     }
@@ -99,8 +99,7 @@ public class EnrollmentService {
         Validate.entityThrowingException(INSTANCE, enrollment);
         
         // Verify that the caller has access to this study
-        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow(
-                "userId", enrollment.getAccountId(), "studyId", enrollment.getStudyId());
+        IS_SELF_OR_STUDY_RESEARCHER.checkStudyAndUserIds(enrollment.getStudyId(), enrollment.getAccountId());
 
         // Because this is an enrollment, we don't want to check the caller's access to the 
         // account based on study, because the account has not been put in a study accessible
@@ -123,7 +122,7 @@ public class EnrollmentService {
         
         Validate.entityThrowingException(INSTANCE, newEnrollment);
         
-        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow("userId", account.getId(), "studyId", newEnrollment.getStudyId());
+        IS_SELF_OR_STUDY_RESEARCHER.checkStudyAndUserIds(newEnrollment.getStudyId(), account.getId());
 
         for (Enrollment existingEnrollment : account.getEnrollments()) {
             if (existingEnrollment.getStudyId().equals(newEnrollment.getStudyId())) {
@@ -183,7 +182,8 @@ public class EnrollmentService {
         
         Validate.entityThrowingException(INSTANCE, enrollment);
         
-        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow("userId", account.getId(), "studyId", enrollment.getStudyId());
+        IS_SELF_OR_STUDY_RESEARCHER.checkStudyAndUserIds(
+                enrollment.getStudyId(), account.getId());
         
         // If supplied, this value should be the same timestamp as the withdrewOn
         // value in the signature. Otherwise just set it here. 

--- a/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
@@ -1,6 +1,8 @@
 package org.sagebionetworks.bridge.services;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.STUDY_ID;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.USER_ID;
 import static org.sagebionetworks.bridge.AuthUtils.IS_SELF_OR_STUDY_RESEARCHER;
 import static org.sagebionetworks.bridge.AuthUtils.IS_STUDY_RESEARCHER;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
@@ -64,7 +66,7 @@ public class EnrollmentService {
         checkNotNull(appId);
         checkNotNull(studyId);
         
-        IS_STUDY_RESEARCHER.checkStudyId(studyId);
+        IS_STUDY_RESEARCHER.checkAndThrow(STUDY_ID, studyId);
 
         if (offsetBy != null && offsetBy < 0) {
             throw new BadRequestException(NEGATIVE_OFFSET_ERROR);
@@ -87,7 +89,7 @@ public class EnrollmentService {
         if (account == null) {
             throw new EntityNotFoundException(Account.class);
         }
-        IS_SELF_OR_STUDY_RESEARCHER.checkStudyAndUserIds(null, account.getId());
+        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow(STUDY_ID, null, USER_ID, account.getId());
 
         return enrollmentDao.getEnrollmentsForUser(appId, userId);
     }
@@ -99,7 +101,7 @@ public class EnrollmentService {
         Validate.entityThrowingException(INSTANCE, enrollment);
         
         // Verify that the caller has access to this study
-        IS_SELF_OR_STUDY_RESEARCHER.checkStudyAndUserIds(enrollment.getStudyId(), enrollment.getAccountId());
+        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow(STUDY_ID, enrollment.getStudyId(), USER_ID, enrollment.getAccountId());
 
         // Because this is an enrollment, we don't want to check the caller's access to the 
         // account based on study, because the account has not been put in a study accessible
@@ -122,7 +124,7 @@ public class EnrollmentService {
         
         Validate.entityThrowingException(INSTANCE, newEnrollment);
         
-        IS_SELF_OR_STUDY_RESEARCHER.checkStudyAndUserIds(newEnrollment.getStudyId(), account.getId());
+        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow(STUDY_ID, newEnrollment.getStudyId(), USER_ID, account.getId());
 
         for (Enrollment existingEnrollment : account.getEnrollments()) {
             if (existingEnrollment.getStudyId().equals(newEnrollment.getStudyId())) {
@@ -182,8 +184,7 @@ public class EnrollmentService {
         
         Validate.entityThrowingException(INSTANCE, enrollment);
         
-        IS_SELF_OR_STUDY_RESEARCHER.checkStudyAndUserIds(
-                enrollment.getStudyId(), account.getId());
+        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow(STUDY_ID, enrollment.getStudyId(), USER_ID, account.getId());
         
         // If supplied, this value should be the same timestamp as the withdrewOn
         // value in the signature. Otherwise just set it here. 

--- a/src/main/java/org/sagebionetworks/bridge/services/OrganizationService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/OrganizationService.java
@@ -128,7 +128,7 @@ public class OrganizationService {
     public Organization updateOrganization(Organization organization) {
         checkNotNull(organization);
 
-        IS_ORGADMIN.checkAndThrow("orgId", organization.getIdentifier());
+        IS_ORGADMIN.checkOrgId(organization.getIdentifier());
         
         Validate.entityThrowingException(INSTANCE, organization);
         
@@ -172,7 +172,7 @@ public class OrganizationService {
         checkArgument(isNotBlank(appId));
         checkArgument(isNotBlank(identifier));
         
-        IS_ADMIN.checkAndThrow();
+        IS_ADMIN.check();
         
         Organization existing = orgDao.getOrganization(appId, identifier)
                 .orElseThrow(() -> new EntityNotFoundException(Organization.class));        
@@ -194,7 +194,7 @@ public class OrganizationService {
         checkArgument(isNotBlank(identifier));
         checkNotNull(search);
         
-        IS_ORGADMIN.checkAndThrow("orgId", identifier);
+        IS_ORGADMIN.checkOrgId(identifier);
         
         AccountSummarySearch scopedSearch = new AccountSummarySearch.Builder()
                 .copyOf(search)
@@ -224,7 +224,7 @@ public class OrganizationService {
         checkArgument(isNotBlank(identifier));
         checkNotNull(accountId);
         
-        IS_ORGADMIN.checkAndThrow("orgId", identifier);
+        IS_ORGADMIN.checkOrgId(identifier);
         
         Account account = accountDao.getAccount(accountId)
                 .orElseThrow(() -> new EntityNotFoundException(Account.class));
@@ -244,7 +244,7 @@ public class OrganizationService {
         checkArgument(isNotBlank(identifier));
         checkNotNull(accountId);
         
-        IS_ORGADMIN.checkAndThrow("orgId", identifier);
+        IS_ORGADMIN.checkOrgId(identifier);
         
         Account account = accountDao.getAccount(accountId)
                 .orElseThrow(() -> new EntityNotFoundException(Account.class));

--- a/src/main/java/org/sagebionetworks/bridge/services/OrganizationService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/OrganizationService.java
@@ -3,6 +3,8 @@ package org.sagebionetworks.bridge.services;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.sagebionetworks.bridge.AuthUtils.IS_ADMIN;
+import static org.sagebionetworks.bridge.AuthUtils.IS_ORGADMIN;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.NEGATIVE_OFFSET_ERROR;
@@ -22,7 +24,6 @@ import org.sagebionetworks.bridge.exceptions.ConstraintViolationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import org.sagebionetworks.bridge.AuthUtils;
 import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.cache.CacheKey;
 import org.sagebionetworks.bridge.cache.CacheProvider;
@@ -127,7 +128,7 @@ public class OrganizationService {
     public Organization updateOrganization(Organization organization) {
         checkNotNull(organization);
 
-        AuthUtils.checkOrgMember(organization.getIdentifier());
+        IS_ORGADMIN.checkAndThrow("orgId", organization.getIdentifier());
         
         Validate.entityThrowingException(INSTANCE, organization);
         
@@ -171,7 +172,7 @@ public class OrganizationService {
         checkArgument(isNotBlank(appId));
         checkArgument(isNotBlank(identifier));
         
-        AuthUtils.checkOrgMember(identifier); // or admin
+        IS_ADMIN.checkAndThrow();
         
         Organization existing = orgDao.getOrganization(appId, identifier)
                 .orElseThrow(() -> new EntityNotFoundException(Organization.class));        
@@ -193,7 +194,7 @@ public class OrganizationService {
         checkArgument(isNotBlank(identifier));
         checkNotNull(search);
         
-        AuthUtils.checkOrgMember(identifier);
+        IS_ORGADMIN.checkAndThrow("orgId", identifier);
         
         AccountSummarySearch scopedSearch = new AccountSummarySearch.Builder()
                 .copyOf(search)
@@ -223,7 +224,7 @@ public class OrganizationService {
         checkArgument(isNotBlank(identifier));
         checkNotNull(accountId);
         
-        AuthUtils.checkOrgAdmin(identifier);
+        IS_ORGADMIN.checkAndThrow("orgId", identifier);
         
         Account account = accountDao.getAccount(accountId)
                 .orElseThrow(() -> new EntityNotFoundException(Account.class));
@@ -243,7 +244,7 @@ public class OrganizationService {
         checkArgument(isNotBlank(identifier));
         checkNotNull(accountId);
         
-        AuthUtils.checkOrgMember(identifier);
+        IS_ORGADMIN.checkAndThrow("orgId", identifier);
         
         Account account = accountDao.getAccount(accountId)
                 .orElseThrow(() -> new EntityNotFoundException(Account.class));

--- a/src/main/java/org/sagebionetworks/bridge/services/OrganizationService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/OrganizationService.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.services;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.ORG_ID;
 import static org.sagebionetworks.bridge.AuthUtils.IS_ADMIN;
 import static org.sagebionetworks.bridge.AuthUtils.IS_ORGADMIN;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
@@ -128,7 +129,7 @@ public class OrganizationService {
     public Organization updateOrganization(Organization organization) {
         checkNotNull(organization);
 
-        IS_ORGADMIN.checkOrgId(organization.getIdentifier());
+        IS_ORGADMIN.checkAndThrow(ORG_ID, organization.getIdentifier());
         
         Validate.entityThrowingException(INSTANCE, organization);
         
@@ -172,7 +173,7 @@ public class OrganizationService {
         checkArgument(isNotBlank(appId));
         checkArgument(isNotBlank(identifier));
         
-        IS_ADMIN.check();
+        IS_ADMIN.checkAndThrow();
         
         Organization existing = orgDao.getOrganization(appId, identifier)
                 .orElseThrow(() -> new EntityNotFoundException(Organization.class));        
@@ -194,7 +195,7 @@ public class OrganizationService {
         checkArgument(isNotBlank(identifier));
         checkNotNull(search);
         
-        IS_ORGADMIN.checkOrgId(identifier);
+        IS_ORGADMIN.checkAndThrow(ORG_ID, identifier);
         
         AccountSummarySearch scopedSearch = new AccountSummarySearch.Builder()
                 .copyOf(search)
@@ -224,7 +225,7 @@ public class OrganizationService {
         checkArgument(isNotBlank(identifier));
         checkNotNull(accountId);
         
-        IS_ORGADMIN.checkOrgId(identifier);
+        IS_ORGADMIN.checkAndThrow(ORG_ID, identifier);
         
         Account account = accountDao.getAccount(accountId)
                 .orElseThrow(() -> new EntityNotFoundException(Account.class));
@@ -244,7 +245,7 @@ public class OrganizationService {
         checkArgument(isNotBlank(identifier));
         checkNotNull(accountId);
         
-        IS_ORGADMIN.checkOrgId(identifier);
+        IS_ORGADMIN.checkAndThrow(ORG_ID, identifier);
         
         Account account = accountDao.getAccount(accountId)
                 .orElseThrow(() -> new EntityNotFoundException(Account.class));

--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -437,7 +437,7 @@ public class ParticipantService {
         account.setStatus(UNVERIFIED);
         // Organizational admins create accounts in their organization.
         // Otherwise this field is ignored on create.
-        if (IS_ORGADMIN.check("orgId", participant.getOrgMembership())) {
+        if (IS_ORGADMIN.verifyOrgId(participant.getOrgMembership())) {
             account.setOrgMembership(participant.getOrgMembership());
         }
 
@@ -535,7 +535,7 @@ public class ParticipantService {
     private void updateAccountAndRoles(App app, Account account, StudyParticipant participant, boolean isNew) {
         // Do this much earlier in the call and avoid some expensive operations like password hashing.
         for (String studyId : participant.getExternalIds().keySet()) {
-            if (!IS_STUDY_TEAM_OR_WORKER.check("studyId", studyId)) {
+            if (!IS_STUDY_TEAM_OR_WORKER.verifyStudyId(studyId)) {
                 throw new BadRequestException(studyId + " is not a study of the caller");
             }
         }

--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -5,6 +5,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.sagebionetworks.bridge.AuthUtils.IS_ORGADMIN;
+import static org.sagebionetworks.bridge.AuthUtils.IS_STUDY_TEAM_OR_WORKER;
 import static org.sagebionetworks.bridge.BridgeUtils.studyAssociationsVisibleToCaller;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.CAN_BE_EDITED_BY;
@@ -33,7 +35,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import org.sagebionetworks.bridge.AuthUtils;
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.BridgeUtils.StudyAssociations;
@@ -436,7 +437,7 @@ public class ParticipantService {
         account.setStatus(UNVERIFIED);
         // Organizational admins create accounts in their organization.
         // Otherwise this field is ignored on create.
-        if (AuthUtils.isOrgAdmin(participant.getOrgMembership())) {
+        if (IS_ORGADMIN.check("orgId", participant.getOrgMembership())) {
             account.setOrgMembership(participant.getOrgMembership());
         }
 
@@ -534,7 +535,7 @@ public class ParticipantService {
     private void updateAccountAndRoles(App app, Account account, StudyParticipant participant, boolean isNew) {
         // Do this much earlier in the call and avoid some expensive operations like password hashing.
         for (String studyId : participant.getExternalIds().keySet()) {
-            if (!AuthUtils.isStudyTeamMemberOrWorker(studyId)) {
+            if (!IS_STUDY_TEAM_OR_WORKER.check("studyId", studyId)) {
                 throw new BadRequestException(studyId + " is not a study of the caller");
             }
         }

--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -5,6 +5,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.ORG_ID;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.STUDY_ID;
 import static org.sagebionetworks.bridge.AuthUtils.IS_ORGADMIN;
 import static org.sagebionetworks.bridge.AuthUtils.IS_STUDY_TEAM_OR_WORKER;
 import static org.sagebionetworks.bridge.BridgeUtils.studyAssociationsVisibleToCaller;
@@ -437,7 +439,7 @@ public class ParticipantService {
         account.setStatus(UNVERIFIED);
         // Organizational admins create accounts in their organization.
         // Otherwise this field is ignored on create.
-        if (IS_ORGADMIN.verifyOrgId(participant.getOrgMembership())) {
+        if (IS_ORGADMIN.check(ORG_ID, participant.getOrgMembership())) {
             account.setOrgMembership(participant.getOrgMembership());
         }
 
@@ -535,7 +537,7 @@ public class ParticipantService {
     private void updateAccountAndRoles(App app, Account account, StudyParticipant participant, boolean isNew) {
         // Do this much earlier in the call and avoid some expensive operations like password hashing.
         for (String studyId : participant.getExternalIds().keySet()) {
-            if (!IS_STUDY_TEAM_OR_WORKER.verifyStudyId(studyId)) {
+            if (!IS_STUDY_TEAM_OR_WORKER.check(STUDY_ID, studyId)) {
                 throw new BadRequestException(studyId + " is not a study of the caller");
             }
         }

--- a/src/main/java/org/sagebionetworks/bridge/services/SponsorService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/SponsorService.java
@@ -2,6 +2,7 @@
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.ORG_ID;
 import static org.sagebionetworks.bridge.AuthUtils.IS_ORGADMIN;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
@@ -126,7 +127,7 @@ public class SponsorService {
         checkNotNull(studyId);
         checkNotNull(orgId);
         
-        IS_ORGADMIN.checkOrgId(orgId);
+        IS_ORGADMIN.checkAndThrow(ORG_ID, orgId);
         
         // The database constraints are thrown and converted to EntityNotFoundExceptions
         // if either the organization or the study do not exist, or if the org already
@@ -141,7 +142,7 @@ public class SponsorService {
         checkNotNull(studyId);
         checkNotNull(orgId);
         
-        IS_ORGADMIN.checkOrgId(orgId);
+        IS_ORGADMIN.checkAndThrow(ORG_ID, orgId);
 
         if (sponsorDao.doesOrganizationSponsorStudy(appId, studyId, orgId)) {
             // Currently we allow you to remove the last sponsor from a study. There is no 

--- a/src/main/java/org/sagebionetworks/bridge/services/SponsorService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/SponsorService.java
@@ -2,7 +2,7 @@
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.sagebionetworks.bridge.AuthUtils.checkOrgMember;
+import static org.sagebionetworks.bridge.AuthUtils.IS_ORGADMIN;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.NEGATIVE_OFFSET_ERROR;
@@ -126,7 +126,7 @@ public class SponsorService {
         checkNotNull(studyId);
         checkNotNull(orgId);
         
-        checkOrgMember(orgId);
+        IS_ORGADMIN.checkAndThrow("orgId", orgId);
         
         // The database constraints are thrown and converted to EntityNotFoundExceptions
         // if either the organization or the study do not exist, or if the org already
@@ -141,7 +141,7 @@ public class SponsorService {
         checkNotNull(studyId);
         checkNotNull(orgId);
         
-        checkOrgMember(orgId);
+        IS_ORGADMIN.checkAndThrow("orgId", orgId);
 
         if (sponsorDao.doesOrganizationSponsorStudy(appId, studyId, orgId)) {
             // Currently we allow you to remove the last sponsor from a study. There is no 

--- a/src/main/java/org/sagebionetworks/bridge/services/SponsorService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/SponsorService.java
@@ -126,7 +126,7 @@ public class SponsorService {
         checkNotNull(studyId);
         checkNotNull(orgId);
         
-        IS_ORGADMIN.checkAndThrow("orgId", orgId);
+        IS_ORGADMIN.checkOrgId(orgId);
         
         // The database constraints are thrown and converted to EntityNotFoundExceptions
         // if either the organization or the study do not exist, or if the org already
@@ -141,7 +141,7 @@ public class SponsorService {
         checkNotNull(studyId);
         checkNotNull(orgId);
         
-        IS_ORGADMIN.checkAndThrow("orgId", orgId);
+        IS_ORGADMIN.checkOrgId(orgId);
 
         if (sponsorDao.doesOrganizationSponsorStudy(appId, studyId, orgId)) {
             // Currently we allow you to remove the last sponsor from a study. There is no 

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AccountsController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AccountsController.java
@@ -226,7 +226,7 @@ public class AccountsController extends BaseController  {
     
     public Account verifyOrgAdminIsActingOnOrgMember(String appId, String orgId, String userId) {
         // The caller needs to be an administrator of this organization
-        if (!IS_ORGADMIN.check("orgId", orgId)) {
+        if (!IS_ORGADMIN.verifyOrgId(orgId)) {
             throw new EntityNotFoundException(Account.class);
         }
         // The account (if it exists) must be in the organization. Return account for 

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AccountsController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AccountsController.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
+import static org.sagebionetworks.bridge.AuthUtils.IS_ORGADMIN;
 import static org.sagebionetworks.bridge.BridgeUtils.parseAccountId;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.ORG_ADMIN;
@@ -25,7 +26,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import org.sagebionetworks.bridge.AuthUtils;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.RequestInfo;
@@ -226,7 +226,7 @@ public class AccountsController extends BaseController  {
     
     public Account verifyOrgAdminIsActingOnOrgMember(String appId, String orgId, String userId) {
         // The caller needs to be an administrator of this organization
-        if(!AuthUtils.isOrgAdmin(orgId)) {
+        if (!IS_ORGADMIN.check("orgId", orgId)) {
             throw new EntityNotFoundException(Account.class);
         }
         // The account (if it exists) must be in the organization. Return account for 

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AccountsController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AccountsController.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
+import static org.sagebionetworks.bridge.AuthEvaluatorField.ORG_ID;
 import static org.sagebionetworks.bridge.AuthUtils.IS_ORGADMIN;
 import static org.sagebionetworks.bridge.BridgeUtils.parseAccountId;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
@@ -226,7 +227,7 @@ public class AccountsController extends BaseController  {
     
     public Account verifyOrgAdminIsActingOnOrgMember(String appId, String orgId, String userId) {
         // The caller needs to be an administrator of this organization
-        if (!IS_ORGADMIN.verifyOrgId(orgId)) {
+        if (!IS_ORGADMIN.check(ORG_ID, orgId)) {
             throw new EntityNotFoundException(Account.class);
         }
         // The account (if it exists) must be in the organization. Return account for 

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/MembershipController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/MembershipController.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
+import static org.sagebionetworks.bridge.AuthUtils.IS_ORGADMIN;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.ORG_ADMIN;
 import static org.springframework.http.HttpStatus.CREATED;
@@ -12,7 +13,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import org.sagebionetworks.bridge.AuthUtils;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.models.AccountSummarySearch;
 import org.sagebionetworks.bridge.models.PagedResourceList;
@@ -38,7 +38,7 @@ public class MembershipController extends BaseController {
         // should this just be scoped to any administrative user?
         UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
         
-        AuthUtils.checkOrgMember(orgId);
+        IS_ORGADMIN.checkAndThrow("orgId", orgId);
         
         AccountSummarySearch search = parseJson(AccountSummarySearch.class);
         return organizationService.getMembers(session.getAppId(), orgId, search);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/MembershipController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/MembershipController.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
+import static org.sagebionetworks.bridge.AuthEvaluatorField.ORG_ID;
 import static org.sagebionetworks.bridge.AuthUtils.IS_ORGADMIN;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.ORG_ADMIN;
@@ -38,7 +39,7 @@ public class MembershipController extends BaseController {
         // should this just be scoped to any administrative user?
         UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
         
-        IS_ORGADMIN.checkOrgId(orgId);
+        IS_ORGADMIN.checkAndThrow(ORG_ID, orgId);
         
         AccountSummarySearch search = parseJson(AccountSummarySearch.class);
         return organizationService.getMembers(session.getAppId(), orgId, search);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/MembershipController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/MembershipController.java
@@ -38,7 +38,7 @@ public class MembershipController extends BaseController {
         // should this just be scoped to any administrative user?
         UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
         
-        IS_ORGADMIN.checkAndThrow("orgId", orgId);
+        IS_ORGADMIN.checkOrgId(orgId);
         
         AccountSummarySearch search = parseJson(AccountSummarySearch.class);
         return organizationService.getMembers(session.getAppId(), orgId, search);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
+import static org.sagebionetworks.bridge.AuthEvaluatorField.USER_ID;
 import static org.sagebionetworks.bridge.AuthUtils.IS_SELF_OR_RESEARCHER;
 import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeUtils.getDateTimeOrDefault;
@@ -107,7 +108,7 @@ public class ParticipantController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     public StatusMessage createSmsRegistration(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkUserId(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow(USER_ID, userId);
         
         App app = appService.getApp(session.getAppId());
 
@@ -187,7 +188,7 @@ public class ParticipantController extends BaseController {
     @DeleteMapping("/v3/participants/{userId}")
     public StatusMessage deleteTestParticipant(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkUserId(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow(USER_ID, userId);
         App app = appService.getApp(session.getAppId());
         
         StudyParticipant participant = participantService.getParticipant(app, userId, false);
@@ -381,7 +382,7 @@ public class ParticipantController extends BaseController {
             APPLICATION_JSON_UTF8_VALUE })
     public String getRequestInfo(@PathVariable String userId) throws JsonProcessingException {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkUserId(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow(USER_ID, userId);
         App app = appService.getApp(session.getAppId());
 
         // Verify it's in the same app as the researcher.
@@ -397,7 +398,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}")
     public StatusMessage updateParticipant(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkUserId(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow(USER_ID, userId);
         App app = appService.getApp(session.getAppId());
 
         StudyParticipant participant = parseJson(StudyParticipant.class);
@@ -413,7 +414,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/signOut")
     public StatusMessage signOut(@PathVariable String userId, @RequestParam(required = false) boolean deleteReauthToken) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkUserId(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow(USER_ID, userId);
         App app = appService.getApp(session.getAppId());
 
         participantService.signUserOut(app, userId, deleteReauthToken);
@@ -424,7 +425,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/requestResetPassword")
     public StatusMessage requestResetPassword(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkUserId(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow(USER_ID, userId);
         App app = appService.getApp(session.getAppId());
 
         participantService.requestResetPassword(app, userId);
@@ -439,7 +440,7 @@ public class ParticipantController extends BaseController {
             @RequestParam(required = false) String offsetKey, @RequestParam(required = false) String pageSize)
             throws Exception {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkUserId(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow(USER_ID, userId);
         App app = appService.getApp(session.getAppId());
         
         return getActivityHistoryInternalV2(app, userId, activityGuid, scheduledOnStart,
@@ -452,7 +453,7 @@ public class ParticipantController extends BaseController {
             @RequestParam(required = false) String scheduledOnEnd, @RequestParam(required = false) String offsetKey,
             @RequestParam(required = false) String pageSize) throws Exception {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkUserId(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow(USER_ID, userId);
         App app = appService.getApp(session.getAppId());
         
         return getActivityHistoryV3Internal(app, userId, activityType, referentGuid, scheduledOnStart,
@@ -462,7 +463,7 @@ public class ParticipantController extends BaseController {
     @DeleteMapping("/v3/participants/{userId}/activities")
     public StatusMessage deleteActivities(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkUserId(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow(USER_ID, userId);
         App app = appService.getApp(session.getAppId());
 
         participantService.deleteActivities(app, userId);
@@ -473,7 +474,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/resendEmailVerification")
     public StatusMessage resendEmailVerification(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkUserId(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow(USER_ID, userId);
         App app = appService.getApp(session.getAppId());
 
         participantService.resendVerification(app, ChannelType.EMAIL, userId);
@@ -484,7 +485,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/resendPhoneVerification")
     public StatusMessage resendPhoneVerification(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkUserId(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow(USER_ID, userId);
         App app = appService.getApp(session.getAppId());
 
         participantService.resendVerification(app, ChannelType.PHONE, userId);
@@ -495,7 +496,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/consents/{guid}/resendConsent")
     public StatusMessage resendConsentAgreement(@PathVariable String userId, @PathVariable String guid) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkUserId(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow(USER_ID, userId);
         App app = appService.getApp(session.getAppId());
         
         SubpopulationGuid subpopGuid = SubpopulationGuid.create(guid);
@@ -507,7 +508,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/consents/withdraw")
     public StatusMessage withdrawFromApp(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkUserId(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow(USER_ID, userId);
         App app = appService.getApp(session.getAppId());
         
         Withdrawal withdrawal = parseJson(Withdrawal.class);
@@ -521,7 +522,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/consents/{guid}/withdraw")
     public StatusMessage withdrawConsent(@PathVariable String userId, @PathVariable String guid) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkUserId(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow(USER_ID, userId);
         App app = appService.getApp(session.getAppId());
         
         Withdrawal withdrawal = parseJson(Withdrawal.class);
@@ -538,7 +539,7 @@ public class ParticipantController extends BaseController {
             @RequestParam(required = false) String startTime, @RequestParam(required = false) String endTime,
             @RequestParam(required = false) Integer pageSize, @RequestParam(required = false) String offsetKey) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkUserId(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow(USER_ID, userId);
         App app = appService.getApp(session.getAppId());
         
         DateTime startTimeDate = getDateTimeOrDefault(startTime, null);
@@ -550,7 +551,7 @@ public class ParticipantController extends BaseController {
     @GetMapping("/v3/participants/{userId}/notifications")
     public ResourceList<NotificationRegistration> getNotificationRegistrations(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkUserId(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow(USER_ID, userId);
         App app = appService.getApp(session.getAppId());
         
         List<NotificationRegistration> registrations = participantService.listRegistrations(app, userId);
@@ -562,7 +563,7 @@ public class ParticipantController extends BaseController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public StatusMessage sendNotification(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkUserId(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow(USER_ID, userId);
         App app = appService.getApp(session.getAppId());
         
         NotificationMessage message = parseJson(NotificationMessage.class);
@@ -579,7 +580,7 @@ public class ParticipantController extends BaseController {
     @GetMapping("/v3/participants/{userId}/activityEvents")
     public ResourceList<ActivityEvent> getActivityEvents(@PathVariable String userId) {
         UserSession researcherSession = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkUserId(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow(USER_ID, userId);
         App app = appService.getApp(researcherSession.getAppId());
 
         return new ResourceList<>(participantService.getActivityEvents(app, userId));

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
@@ -1,6 +1,6 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
-import static org.sagebionetworks.bridge.AuthUtils.checkSelfOrResearcher;
+import static org.sagebionetworks.bridge.AuthUtils.IS_SELF_OR_RESEARCHER;
 import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeUtils.getDateTimeOrDefault;
 import static org.sagebionetworks.bridge.BridgeUtils.getIntOrDefault;
@@ -107,7 +107,7 @@ public class ParticipantController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     public StatusMessage createSmsRegistration(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        checkSelfOrResearcher(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
         
         App app = appService.getApp(session.getAppId());
 
@@ -187,7 +187,7 @@ public class ParticipantController extends BaseController {
     @DeleteMapping("/v3/participants/{userId}")
     public StatusMessage deleteTestParticipant(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        checkSelfOrResearcher(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
         App app = appService.getApp(session.getAppId());
         
         StudyParticipant participant = participantService.getParticipant(app, userId, false);
@@ -381,7 +381,7 @@ public class ParticipantController extends BaseController {
             APPLICATION_JSON_UTF8_VALUE })
     public String getRequestInfo(@PathVariable String userId) throws JsonProcessingException {
         UserSession session = getAdministrativeSession();
-        checkSelfOrResearcher(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
         App app = appService.getApp(session.getAppId());
 
         // Verify it's in the same app as the researcher.
@@ -397,7 +397,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}")
     public StatusMessage updateParticipant(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        checkSelfOrResearcher(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
         App app = appService.getApp(session.getAppId());
 
         StudyParticipant participant = parseJson(StudyParticipant.class);
@@ -413,7 +413,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/signOut")
     public StatusMessage signOut(@PathVariable String userId, @RequestParam(required = false) boolean deleteReauthToken) {
         UserSession session = getAdministrativeSession();
-        checkSelfOrResearcher(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
         App app = appService.getApp(session.getAppId());
 
         participantService.signUserOut(app, userId, deleteReauthToken);
@@ -424,7 +424,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/requestResetPassword")
     public StatusMessage requestResetPassword(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        checkSelfOrResearcher(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
         App app = appService.getApp(session.getAppId());
 
         participantService.requestResetPassword(app, userId);
@@ -439,7 +439,7 @@ public class ParticipantController extends BaseController {
             @RequestParam(required = false) String offsetKey, @RequestParam(required = false) String pageSize)
             throws Exception {
         UserSession session = getAdministrativeSession();
-        checkSelfOrResearcher(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
         App app = appService.getApp(session.getAppId());
         
         return getActivityHistoryInternalV2(app, userId, activityGuid, scheduledOnStart,
@@ -452,7 +452,7 @@ public class ParticipantController extends BaseController {
             @RequestParam(required = false) String scheduledOnEnd, @RequestParam(required = false) String offsetKey,
             @RequestParam(required = false) String pageSize) throws Exception {
         UserSession session = getAdministrativeSession();
-        checkSelfOrResearcher(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
         App app = appService.getApp(session.getAppId());
         
         return getActivityHistoryV3Internal(app, userId, activityType, referentGuid, scheduledOnStart,
@@ -462,7 +462,7 @@ public class ParticipantController extends BaseController {
     @DeleteMapping("/v3/participants/{userId}/activities")
     public StatusMessage deleteActivities(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        checkSelfOrResearcher(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
         App app = appService.getApp(session.getAppId());
 
         participantService.deleteActivities(app, userId);
@@ -473,7 +473,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/resendEmailVerification")
     public StatusMessage resendEmailVerification(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        checkSelfOrResearcher(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
         App app = appService.getApp(session.getAppId());
 
         participantService.resendVerification(app, ChannelType.EMAIL, userId);
@@ -484,7 +484,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/resendPhoneVerification")
     public StatusMessage resendPhoneVerification(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        checkSelfOrResearcher(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
         App app = appService.getApp(session.getAppId());
 
         participantService.resendVerification(app, ChannelType.PHONE, userId);
@@ -495,7 +495,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/consents/{guid}/resendConsent")
     public StatusMessage resendConsentAgreement(@PathVariable String userId, @PathVariable String guid) {
         UserSession session = getAdministrativeSession();
-        checkSelfOrResearcher(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
         App app = appService.getApp(session.getAppId());
         
         SubpopulationGuid subpopGuid = SubpopulationGuid.create(guid);
@@ -507,7 +507,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/consents/withdraw")
     public StatusMessage withdrawFromApp(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        checkSelfOrResearcher(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
         App app = appService.getApp(session.getAppId());
         
         Withdrawal withdrawal = parseJson(Withdrawal.class);
@@ -521,7 +521,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/consents/{guid}/withdraw")
     public StatusMessage withdrawConsent(@PathVariable String userId, @PathVariable String guid) {
         UserSession session = getAdministrativeSession();
-        checkSelfOrResearcher(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
         App app = appService.getApp(session.getAppId());
         
         Withdrawal withdrawal = parseJson(Withdrawal.class);
@@ -538,7 +538,7 @@ public class ParticipantController extends BaseController {
             @RequestParam(required = false) String startTime, @RequestParam(required = false) String endTime,
             @RequestParam(required = false) Integer pageSize, @RequestParam(required = false) String offsetKey) {
         UserSession session = getAdministrativeSession();
-        checkSelfOrResearcher(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
         App app = appService.getApp(session.getAppId());
         
         DateTime startTimeDate = getDateTimeOrDefault(startTime, null);
@@ -550,7 +550,7 @@ public class ParticipantController extends BaseController {
     @GetMapping("/v3/participants/{userId}/notifications")
     public ResourceList<NotificationRegistration> getNotificationRegistrations(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        checkSelfOrResearcher(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
         App app = appService.getApp(session.getAppId());
         
         List<NotificationRegistration> registrations = participantService.listRegistrations(app, userId);
@@ -562,7 +562,7 @@ public class ParticipantController extends BaseController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public StatusMessage sendNotification(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        checkSelfOrResearcher(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
         App app = appService.getApp(session.getAppId());
         
         NotificationMessage message = parseJson(NotificationMessage.class);
@@ -579,7 +579,7 @@ public class ParticipantController extends BaseController {
     @GetMapping("/v3/participants/{userId}/activityEvents")
     public ResourceList<ActivityEvent> getActivityEvents(@PathVariable String userId) {
         UserSession researcherSession = getAdministrativeSession();
-        checkSelfOrResearcher(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
         App app = appService.getApp(researcherSession.getAppId());
 
         return new ResourceList<>(participantService.getActivityEvents(app, userId));

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
@@ -107,7 +107,7 @@ public class ParticipantController extends BaseController {
     @ResponseStatus(HttpStatus.CREATED)
     public StatusMessage createSmsRegistration(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
+        IS_SELF_OR_RESEARCHER.checkUserId(userId);
         
         App app = appService.getApp(session.getAppId());
 
@@ -187,7 +187,7 @@ public class ParticipantController extends BaseController {
     @DeleteMapping("/v3/participants/{userId}")
     public StatusMessage deleteTestParticipant(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
+        IS_SELF_OR_RESEARCHER.checkUserId(userId);
         App app = appService.getApp(session.getAppId());
         
         StudyParticipant participant = participantService.getParticipant(app, userId, false);
@@ -381,7 +381,7 @@ public class ParticipantController extends BaseController {
             APPLICATION_JSON_UTF8_VALUE })
     public String getRequestInfo(@PathVariable String userId) throws JsonProcessingException {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
+        IS_SELF_OR_RESEARCHER.checkUserId(userId);
         App app = appService.getApp(session.getAppId());
 
         // Verify it's in the same app as the researcher.
@@ -397,7 +397,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}")
     public StatusMessage updateParticipant(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
+        IS_SELF_OR_RESEARCHER.checkUserId(userId);
         App app = appService.getApp(session.getAppId());
 
         StudyParticipant participant = parseJson(StudyParticipant.class);
@@ -413,7 +413,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/signOut")
     public StatusMessage signOut(@PathVariable String userId, @RequestParam(required = false) boolean deleteReauthToken) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
+        IS_SELF_OR_RESEARCHER.checkUserId(userId);
         App app = appService.getApp(session.getAppId());
 
         participantService.signUserOut(app, userId, deleteReauthToken);
@@ -424,7 +424,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/requestResetPassword")
     public StatusMessage requestResetPassword(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
+        IS_SELF_OR_RESEARCHER.checkUserId(userId);
         App app = appService.getApp(session.getAppId());
 
         participantService.requestResetPassword(app, userId);
@@ -439,7 +439,7 @@ public class ParticipantController extends BaseController {
             @RequestParam(required = false) String offsetKey, @RequestParam(required = false) String pageSize)
             throws Exception {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
+        IS_SELF_OR_RESEARCHER.checkUserId(userId);
         App app = appService.getApp(session.getAppId());
         
         return getActivityHistoryInternalV2(app, userId, activityGuid, scheduledOnStart,
@@ -452,7 +452,7 @@ public class ParticipantController extends BaseController {
             @RequestParam(required = false) String scheduledOnEnd, @RequestParam(required = false) String offsetKey,
             @RequestParam(required = false) String pageSize) throws Exception {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
+        IS_SELF_OR_RESEARCHER.checkUserId(userId);
         App app = appService.getApp(session.getAppId());
         
         return getActivityHistoryV3Internal(app, userId, activityType, referentGuid, scheduledOnStart,
@@ -462,7 +462,7 @@ public class ParticipantController extends BaseController {
     @DeleteMapping("/v3/participants/{userId}/activities")
     public StatusMessage deleteActivities(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
+        IS_SELF_OR_RESEARCHER.checkUserId(userId);
         App app = appService.getApp(session.getAppId());
 
         participantService.deleteActivities(app, userId);
@@ -473,7 +473,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/resendEmailVerification")
     public StatusMessage resendEmailVerification(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
+        IS_SELF_OR_RESEARCHER.checkUserId(userId);
         App app = appService.getApp(session.getAppId());
 
         participantService.resendVerification(app, ChannelType.EMAIL, userId);
@@ -484,7 +484,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/resendPhoneVerification")
     public StatusMessage resendPhoneVerification(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
+        IS_SELF_OR_RESEARCHER.checkUserId(userId);
         App app = appService.getApp(session.getAppId());
 
         participantService.resendVerification(app, ChannelType.PHONE, userId);
@@ -495,7 +495,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/consents/{guid}/resendConsent")
     public StatusMessage resendConsentAgreement(@PathVariable String userId, @PathVariable String guid) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
+        IS_SELF_OR_RESEARCHER.checkUserId(userId);
         App app = appService.getApp(session.getAppId());
         
         SubpopulationGuid subpopGuid = SubpopulationGuid.create(guid);
@@ -507,7 +507,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/consents/withdraw")
     public StatusMessage withdrawFromApp(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
+        IS_SELF_OR_RESEARCHER.checkUserId(userId);
         App app = appService.getApp(session.getAppId());
         
         Withdrawal withdrawal = parseJson(Withdrawal.class);
@@ -521,7 +521,7 @@ public class ParticipantController extends BaseController {
     @PostMapping("/v3/participants/{userId}/consents/{guid}/withdraw")
     public StatusMessage withdrawConsent(@PathVariable String userId, @PathVariable String guid) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
+        IS_SELF_OR_RESEARCHER.checkUserId(userId);
         App app = appService.getApp(session.getAppId());
         
         Withdrawal withdrawal = parseJson(Withdrawal.class);
@@ -538,7 +538,7 @@ public class ParticipantController extends BaseController {
             @RequestParam(required = false) String startTime, @RequestParam(required = false) String endTime,
             @RequestParam(required = false) Integer pageSize, @RequestParam(required = false) String offsetKey) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
+        IS_SELF_OR_RESEARCHER.checkUserId(userId);
         App app = appService.getApp(session.getAppId());
         
         DateTime startTimeDate = getDateTimeOrDefault(startTime, null);
@@ -550,7 +550,7 @@ public class ParticipantController extends BaseController {
     @GetMapping("/v3/participants/{userId}/notifications")
     public ResourceList<NotificationRegistration> getNotificationRegistrations(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
+        IS_SELF_OR_RESEARCHER.checkUserId(userId);
         App app = appService.getApp(session.getAppId());
         
         List<NotificationRegistration> registrations = participantService.listRegistrations(app, userId);
@@ -562,7 +562,7 @@ public class ParticipantController extends BaseController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public StatusMessage sendNotification(@PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
+        IS_SELF_OR_RESEARCHER.checkUserId(userId);
         App app = appService.getApp(session.getAppId());
         
         NotificationMessage message = parseJson(NotificationMessage.class);
@@ -579,7 +579,7 @@ public class ParticipantController extends BaseController {
     @GetMapping("/v3/participants/{userId}/activityEvents")
     public ResourceList<ActivityEvent> getActivityEvents(@PathVariable String userId) {
         UserSession researcherSession = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
+        IS_SELF_OR_RESEARCHER.checkUserId(userId);
         App app = appService.getApp(researcherSession.getAppId());
 
         return new ResourceList<>(participantService.getActivityEvents(app, userId));

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportController.java
@@ -128,7 +128,7 @@ public class ParticipantReportController extends BaseController {
             @PathVariable String identifier, @RequestParam(required = false) String startDate,
             @RequestParam(required = false) String endDate) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
+        IS_SELF_OR_RESEARCHER.checkUserId(userId);
         
         return getParticipantReportInternal(session.getAppId(), userId, identifier, startDate, endDate);
     }
@@ -162,7 +162,7 @@ public class ParticipantReportController extends BaseController {
             @RequestParam(required = false) String endTime, @RequestParam(required = false) String offsetKey,
             @RequestParam(required = false) String pageSize) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
+        IS_SELF_OR_RESEARCHER.checkUserId(userId);
         
         return getParticipantReportInternalV4(session.getAppId(), userId, identifier, 
                 startTime, endTime, offsetKey, pageSize);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportController.java
@@ -1,6 +1,6 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
-import static org.sagebionetworks.bridge.AuthUtils.checkSelfOrResearcher;
+import static org.sagebionetworks.bridge.AuthUtils.IS_SELF_OR_RESEARCHER;
 import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeUtils.getDateTimeOrDefault;
 import static org.sagebionetworks.bridge.BridgeUtils.getIntOrDefault;
@@ -128,7 +128,7 @@ public class ParticipantReportController extends BaseController {
             @PathVariable String identifier, @RequestParam(required = false) String startDate,
             @RequestParam(required = false) String endDate) {
         UserSession session = getAdministrativeSession();
-        checkSelfOrResearcher(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
         
         return getParticipantReportInternal(session.getAppId(), userId, identifier, startDate, endDate);
     }
@@ -162,7 +162,7 @@ public class ParticipantReportController extends BaseController {
             @RequestParam(required = false) String endTime, @RequestParam(required = false) String offsetKey,
             @RequestParam(required = false) String pageSize) {
         UserSession session = getAdministrativeSession();
-        checkSelfOrResearcher(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", userId);
         
         return getParticipantReportInternalV4(session.getAppId(), userId, identifier, 
                 startTime, endTime, offsetKey, pageSize);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportController.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
+import static org.sagebionetworks.bridge.AuthEvaluatorField.USER_ID;
 import static org.sagebionetworks.bridge.AuthUtils.IS_SELF_OR_RESEARCHER;
 import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeUtils.getDateTimeOrDefault;
@@ -128,7 +129,7 @@ public class ParticipantReportController extends BaseController {
             @PathVariable String identifier, @RequestParam(required = false) String startDate,
             @RequestParam(required = false) String endDate) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkUserId(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow(USER_ID, userId);
         
         return getParticipantReportInternal(session.getAppId(), userId, identifier, startDate, endDate);
     }
@@ -162,7 +163,7 @@ public class ParticipantReportController extends BaseController {
             @RequestParam(required = false) String endTime, @RequestParam(required = false) String offsetKey,
             @RequestParam(required = false) String pageSize) {
         UserSession session = getAdministrativeSession();
-        IS_SELF_OR_RESEARCHER.checkUserId(userId);
+        IS_SELF_OR_RESEARCHER.checkAndThrow(USER_ID, userId);
         
         return getParticipantReportInternalV4(session.getAppId(), userId, identifier, 
                 startTime, endTime, offsetKey, pageSize);

--- a/src/main/java/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
@@ -88,7 +88,7 @@ public class StudyParticipantValidator implements Validator {
                 Optional<Organization> opt = organizationService.getOrganizationOpt(app.getIdentifier(), orgId);
                 if (!opt.isPresent()) {
                     errors.rejectValue("orgMembership", "is not a valid organization");
-                } else if (!IS_ORG_MEMBER.check("orgId", orgId)) {
+                } else if (!IS_ORG_MEMBER.verifyOrgId(orgId)) {
                     errors.rejectValue("orgMembership", "cannot be set by caller");
                 }
             }

--- a/src/main/java/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.validators;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.ORG_ID;
 import static org.sagebionetworks.bridge.AuthUtils.IS_ORG_MEMBER;
 
 import java.util.Map;
@@ -88,7 +89,7 @@ public class StudyParticipantValidator implements Validator {
                 Optional<Organization> opt = organizationService.getOrganizationOpt(app.getIdentifier(), orgId);
                 if (!opt.isPresent()) {
                     errors.rejectValue("orgMembership", "is not a valid organization");
-                } else if (!IS_ORG_MEMBER.verifyOrgId(orgId)) {
+                } else if (!IS_ORG_MEMBER.check(ORG_ID, orgId)) {
                     errors.rejectValue("orgMembership", "cannot be set by caller");
                 }
             }

--- a/src/main/java/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.validators;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.sagebionetworks.bridge.AuthUtils.IS_ORG_MEMBER;
 
 import java.util.Map;
 import java.util.Optional;
@@ -12,7 +13,6 @@ import com.google.common.collect.Iterables;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
-import org.sagebionetworks.bridge.AuthUtils;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.models.accounts.Phone;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
@@ -88,7 +88,7 @@ public class StudyParticipantValidator implements Validator {
                 Optional<Organization> opt = organizationService.getOrganizationOpt(app.getIdentifier(), orgId);
                 if (!opt.isPresent()) {
                     errors.rejectValue("orgMembership", "is not a valid organization");
-                } else if (!AuthUtils.isOrgMember(orgId)) {
+                } else if (!IS_ORG_MEMBER.check("orgId", orgId)) {
                     errors.rejectValue("orgMembership", "cannot be set by caller");
                 }
             }

--- a/src/test/java/org/sagebionetworks/bridge/AuthEvaluatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/AuthEvaluatorTest.java
@@ -33,17 +33,17 @@ public class AuthEvaluatorTest {
         
         AuthEvaluator evaluator = new AuthEvaluator().canAccessStudy();
         
-        assertTrue(evaluator.check("studyId", "study2"));
-        assertFalse(evaluator.check());
-        assertFalse(evaluator.check("studyId", "study3"));
-        assertFalse(evaluator.check("userId", "user"));
+        assertTrue(evaluator.verify("studyId", "study2"));
+        assertFalse(evaluator.verify());
+        assertFalse(evaluator.verify("studyId", "study3"));
+        assertFalse(evaluator.verify("userId", "user"));
     }
     
     // This does need to go away
     @Test
     public void callerConsideredGlobal() {
         AuthEvaluator evaluator = new AuthEvaluator().callerConsideredGlobal();
-        assertTrue(evaluator.check("studyId", "study2"));
+        assertTrue(evaluator.verify("studyId", "study2"));
     }
     
     @Test
@@ -52,12 +52,12 @@ public class AuthEvaluatorTest {
                 .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
         
         AuthEvaluator evaluator = new AuthEvaluator().hasAnyRole(DEVELOPER, RESEARCHER);
-        assertTrue(evaluator.check());
-        assertTrue(evaluator.check("studyId", "study3")); // params are just ignored
+        assertTrue(evaluator.verify());
+        assertTrue(evaluator.verify("studyId", "study3")); // params are just ignored
         
         evaluator = new AuthEvaluator().hasAnyRole(WORKER);
-        assertFalse(evaluator.check());
-        assertFalse(evaluator.check("studyId", "study3")); // params are just ignored
+        assertFalse(evaluator.verify());
+        assertFalse(evaluator.verify("studyId", "study3")); // params are just ignored
     }
     
     @Test
@@ -66,11 +66,11 @@ public class AuthEvaluatorTest {
                 .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
         
         AuthEvaluator evaluator = new AuthEvaluator().hasAnyRole();
-        assertTrue(evaluator.check());
+        assertTrue(evaluator.verify());
         
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of()).build());
-        assertFalse(evaluator.check());
+        assertFalse(evaluator.verify());
     }
     
     @Test
@@ -79,7 +79,7 @@ public class AuthEvaluatorTest {
                 .withCallerRoles(ImmutableSet.of(SUPERADMIN)).build());
         
         AuthEvaluator evaluator = new AuthEvaluator().hasAnyRole(RESEARCHER);
-        assertTrue(evaluator.check());
+        assertTrue(evaluator.verify());
     }
     
     @Test
@@ -89,10 +89,10 @@ public class AuthEvaluatorTest {
         
         AuthEvaluator evaluator = new AuthEvaluator().isInApp();
         
-        assertTrue(evaluator.check("appId", TEST_APP_ID));
-        assertFalse(evaluator.check());
-        assertFalse(evaluator.check("appId", "some-other-app-id"));
-        assertFalse(evaluator.check("userId", USER_ID));
+        assertTrue(evaluator.verify("appId", TEST_APP_ID));
+        assertFalse(evaluator.verify());
+        assertFalse(evaluator.verify("appId", "some-other-app-id"));
+        assertFalse(evaluator.verify("userId", USER_ID));
     }
 
     @Test
@@ -102,10 +102,10 @@ public class AuthEvaluatorTest {
         
         AuthEvaluator evaluator = new AuthEvaluator().isInOrg();
         
-        assertTrue(evaluator.check("orgId", TEST_ORG_ID));
-        assertFalse(evaluator.check());
-        assertFalse(evaluator.check("orgId", "some-other-org-id"));
-        assertFalse(evaluator.check("userId", USER_ID));
+        assertTrue(evaluator.verify("orgId", TEST_ORG_ID));
+        assertFalse(evaluator.verify());
+        assertFalse(evaluator.verify("orgId", "some-other-org-id"));
+        assertFalse(evaluator.verify("userId", USER_ID));
     }
     
     @Test
@@ -114,10 +114,10 @@ public class AuthEvaluatorTest {
                 .withCallerUserId(USER_ID).build());
         
         AuthEvaluator evaluator = new AuthEvaluator().isSelf();
-        assertTrue(evaluator.check("userId", USER_ID));
-        assertFalse(evaluator.check());
-        assertFalse(evaluator.check("userId", "another-user-id"));
-        assertFalse(evaluator.check("studyId", USER_ID));
+        assertTrue(evaluator.verify("userId", USER_ID));
+        assertFalse(evaluator.verify());
+        assertFalse(evaluator.verify("userId", "another-user-id"));
+        assertFalse(evaluator.verify("studyId", USER_ID));
     }
     
     @Test
@@ -127,17 +127,17 @@ public class AuthEvaluatorTest {
                 .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
 
         AuthEvaluator evaluator = new AuthEvaluator().isInOrg().hasAnyRole(RESEARCHER);
-        assertTrue(evaluator.check("orgId", TEST_ORG_ID));
+        assertTrue(evaluator.verify("orgId", TEST_ORG_ID));
         
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership("another-org")
                 .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
-        assertFalse(evaluator.check("orgId", TEST_ORG_ID));
+        assertFalse(evaluator.verify("orgId", TEST_ORG_ID));
         
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
-        assertFalse(evaluator.check("orgId", TEST_ORG_ID));
+        assertFalse(evaluator.verify("orgId", TEST_ORG_ID));
     }
     
     @Test
@@ -148,16 +148,16 @@ public class AuthEvaluatorTest {
 
         AuthEvaluator evaluator = new AuthEvaluator().isInOrg().or().isSelf();
         // left side passes
-        assertTrue(evaluator.check("orgId", TEST_ORG_ID, "userId", "wrong-id"));
+        assertTrue(evaluator.verify("orgId", TEST_ORG_ID, "userId", "wrong-id"));
         
         // right side passes
-        assertTrue(evaluator.check("orgId", "wrong-organization", "userId", USER_ID));
+        assertTrue(evaluator.verify("orgId", "wrong-organization", "userId", USER_ID));
         
         // both sides pass
-        assertTrue(evaluator.check("orgId", TEST_ORG_ID, "userId", USER_ID));
+        assertTrue(evaluator.verify("orgId", TEST_ORG_ID, "userId", USER_ID));
         
         // both sides fail
-        assertFalse(evaluator.check("orgId", "wrong-organization", "userId", "wrong-id"));
+        assertFalse(evaluator.verify("orgId", "wrong-organization", "userId", "wrong-id"));
     }
 
     @Test
@@ -167,7 +167,7 @@ public class AuthEvaluatorTest {
 
         AuthEvaluator evaluator = new AuthEvaluator().isInOrg();
         
-        evaluator.checkAndThrow("orgId", TEST_ORG_ID);
+        evaluator.checkOrgId(TEST_ORG_ID);
     }
     
     @Test
@@ -178,7 +178,7 @@ public class AuthEvaluatorTest {
 
         AuthEvaluator evaluator = new AuthEvaluator().isInOrg().isSelf();
         
-        evaluator.checkAndThrow("orgId", TEST_ORG_ID, "userId", USER_ID);
+        evaluator.checkOrgAndUserIds(TEST_ORG_ID, USER_ID);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -188,7 +188,7 @@ public class AuthEvaluatorTest {
 
         AuthEvaluator evaluator = new AuthEvaluator().isInOrg();
         
-        evaluator.checkAndThrow("orgId", "foo");
+        evaluator.checkOrgId("foo");
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -199,6 +199,6 @@ public class AuthEvaluatorTest {
 
         AuthEvaluator evaluator = new AuthEvaluator().isInOrg().isSelf();
         
-        evaluator.checkAndThrow("orgId", "foo", "userId", "foo");
+        evaluator.checkOrgAndUserIds("foo", "foo");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/AuthEvaluatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/AuthEvaluatorTest.java
@@ -1,5 +1,9 @@
 package org.sagebionetworks.bridge;
 
+import static org.sagebionetworks.bridge.AuthEvaluatorField.APP_ID;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.ORG_ID;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.STUDY_ID;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.USER_ID;
 import static org.sagebionetworks.bridge.RequestContext.NULL_INSTANCE;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
@@ -7,7 +11,7 @@ import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
 import static org.sagebionetworks.bridge.Roles.WORKER;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -33,17 +37,17 @@ public class AuthEvaluatorTest {
         
         AuthEvaluator evaluator = new AuthEvaluator().canAccessStudy();
         
-        assertTrue(evaluator.verify("studyId", "study2"));
-        assertFalse(evaluator.verify());
-        assertFalse(evaluator.verify("studyId", "study3"));
-        assertFalse(evaluator.verify("userId", "user"));
+        assertTrue(evaluator.check(STUDY_ID, "study2"));
+        assertFalse(evaluator.check());
+        assertFalse(evaluator.check(STUDY_ID, "study3"));
+        assertFalse(evaluator.check(USER_ID, "user"));
     }
     
     // This does need to go away
     @Test
     public void callerConsideredGlobal() {
         AuthEvaluator evaluator = new AuthEvaluator().callerConsideredGlobal();
-        assertTrue(evaluator.verify("studyId", "study2"));
+        assertTrue(evaluator.check(STUDY_ID, "study2"));
     }
     
     @Test
@@ -52,12 +56,12 @@ public class AuthEvaluatorTest {
                 .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
         
         AuthEvaluator evaluator = new AuthEvaluator().hasAnyRole(DEVELOPER, RESEARCHER);
-        assertTrue(evaluator.verify());
-        assertTrue(evaluator.verify("studyId", "study3")); // params are just ignored
+        assertTrue(evaluator.check());
+        assertTrue(evaluator.check(STUDY_ID, "study3")); // params are just ignored
         
         evaluator = new AuthEvaluator().hasAnyRole(WORKER);
-        assertFalse(evaluator.verify());
-        assertFalse(evaluator.verify("studyId", "study3")); // params are just ignored
+        assertFalse(evaluator.check());
+        assertFalse(evaluator.check(STUDY_ID, "study3")); // params are just ignored
     }
     
     @Test
@@ -66,11 +70,11 @@ public class AuthEvaluatorTest {
                 .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
         
         AuthEvaluator evaluator = new AuthEvaluator().hasAnyRole();
-        assertTrue(evaluator.verify());
+        assertTrue(evaluator.check());
         
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of()).build());
-        assertFalse(evaluator.verify());
+        assertFalse(evaluator.check());
     }
     
     @Test
@@ -79,7 +83,7 @@ public class AuthEvaluatorTest {
                 .withCallerRoles(ImmutableSet.of(SUPERADMIN)).build());
         
         AuthEvaluator evaluator = new AuthEvaluator().hasAnyRole(RESEARCHER);
-        assertTrue(evaluator.verify());
+        assertTrue(evaluator.check());
     }
     
     @Test
@@ -89,10 +93,10 @@ public class AuthEvaluatorTest {
         
         AuthEvaluator evaluator = new AuthEvaluator().isInApp();
         
-        assertTrue(evaluator.verify("appId", TEST_APP_ID));
-        assertFalse(evaluator.verify());
-        assertFalse(evaluator.verify("appId", "some-other-app-id"));
-        assertFalse(evaluator.verify("userId", USER_ID));
+        assertTrue(evaluator.check(APP_ID, TEST_APP_ID));
+        assertFalse(evaluator.check());
+        assertFalse(evaluator.check(APP_ID, "some-other-app-id"));
+        assertFalse(evaluator.check(USER_ID, TEST_USER_ID));
     }
 
     @Test
@@ -102,22 +106,22 @@ public class AuthEvaluatorTest {
         
         AuthEvaluator evaluator = new AuthEvaluator().isInOrg();
         
-        assertTrue(evaluator.verify("orgId", TEST_ORG_ID));
-        assertFalse(evaluator.verify());
-        assertFalse(evaluator.verify("orgId", "some-other-org-id"));
-        assertFalse(evaluator.verify("userId", USER_ID));
+        assertTrue(evaluator.check(ORG_ID, TEST_ORG_ID));
+        assertFalse(evaluator.check());
+        assertFalse(evaluator.check(ORG_ID, "some-other-org-id"));
+        assertFalse(evaluator.check(USER_ID, TEST_USER_ID));
     }
     
     @Test
     public void isSelf() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerUserId(USER_ID).build());
+                .withCallerUserId(TEST_USER_ID).build());
         
         AuthEvaluator evaluator = new AuthEvaluator().isSelf();
-        assertTrue(evaluator.verify("userId", USER_ID));
-        assertFalse(evaluator.verify());
-        assertFalse(evaluator.verify("userId", "another-user-id"));
-        assertFalse(evaluator.verify("studyId", USER_ID));
+        assertTrue(evaluator.check(USER_ID, TEST_USER_ID));
+        assertFalse(evaluator.check());
+        assertFalse(evaluator.check(USER_ID, "another-user-id"));
+        assertFalse(evaluator.check(STUDY_ID, TEST_USER_ID));
     }
     
     @Test
@@ -127,37 +131,37 @@ public class AuthEvaluatorTest {
                 .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
 
         AuthEvaluator evaluator = new AuthEvaluator().isInOrg().hasAnyRole(RESEARCHER);
-        assertTrue(evaluator.verify("orgId", TEST_ORG_ID));
+        assertTrue(evaluator.check(ORG_ID, TEST_ORG_ID));
         
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership("another-org")
                 .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
-        assertFalse(evaluator.verify("orgId", TEST_ORG_ID));
+        assertFalse(evaluator.check(ORG_ID, TEST_ORG_ID));
         
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
-        assertFalse(evaluator.verify("orgId", TEST_ORG_ID));
+        assertFalse(evaluator.check(ORG_ID, TEST_ORG_ID));
     }
     
     @Test
     public void orConditionsEnforced() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID)
-                .withCallerUserId(USER_ID).build());
+                .withCallerUserId(TEST_USER_ID).build());
 
         AuthEvaluator evaluator = new AuthEvaluator().isInOrg().or().isSelf();
         // left side passes
-        assertTrue(evaluator.verify("orgId", TEST_ORG_ID, "userId", "wrong-id"));
+        assertTrue(evaluator.check(ORG_ID, TEST_ORG_ID, USER_ID, "wrong-id"));
         
         // right side passes
-        assertTrue(evaluator.verify("orgId", "wrong-organization", "userId", USER_ID));
+        assertTrue(evaluator.check(ORG_ID, "wrong-organization", USER_ID, TEST_USER_ID));
         
         // both sides pass
-        assertTrue(evaluator.verify("orgId", TEST_ORG_ID, "userId", USER_ID));
+        assertTrue(evaluator.check(ORG_ID, TEST_ORG_ID, USER_ID, TEST_USER_ID));
         
         // both sides fail
-        assertFalse(evaluator.verify("orgId", "wrong-organization", "userId", "wrong-id"));
+        assertFalse(evaluator.check(ORG_ID, "wrong-organization", USER_ID, "wrong-id"));
     }
 
     @Test
@@ -167,18 +171,18 @@ public class AuthEvaluatorTest {
 
         AuthEvaluator evaluator = new AuthEvaluator().isInOrg();
         
-        evaluator.checkOrgId(TEST_ORG_ID);
+        evaluator.checkAndThrow(ORG_ID, TEST_ORG_ID);
     }
     
     @Test
     public void checkAndThrowTwoArgsPasses() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerUserId(USER_ID)
+                .withCallerUserId(TEST_USER_ID)
                 .withCallerOrgMembership(TEST_ORG_ID).build());
 
         AuthEvaluator evaluator = new AuthEvaluator().isInOrg().isSelf();
         
-        evaluator.checkOrgAndUserIds(TEST_ORG_ID, USER_ID);
+        evaluator.checkAndThrow(ORG_ID, TEST_ORG_ID, USER_ID, TEST_USER_ID);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -188,17 +192,17 @@ public class AuthEvaluatorTest {
 
         AuthEvaluator evaluator = new AuthEvaluator().isInOrg();
         
-        evaluator.checkOrgId("foo");
+        evaluator.checkAndThrow(ORG_ID, "foo");
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
     public void checkAndThrowTwoArgsThrows() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerUserId(USER_ID)
+                .withCallerUserId(TEST_USER_ID)
                 .withCallerOrgMembership(TEST_ORG_ID).build());
 
         AuthEvaluator evaluator = new AuthEvaluator().isInOrg().isSelf();
         
-        evaluator.checkOrgAndUserIds("foo", "foo");
+        evaluator.checkAndThrow(ORG_ID, "foo", USER_ID, "foo");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
@@ -1,5 +1,9 @@
 package org.sagebionetworks.bridge;
 
+import static org.sagebionetworks.bridge.AuthEvaluatorField.ORG_ID;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.OWNER_ID;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.STUDY_ID;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.USER_ID;
 import static org.sagebionetworks.bridge.AuthUtils.IS_ORGADMIN;
 import static org.sagebionetworks.bridge.AuthUtils.IS_ORG_MEMBER;
 import static org.sagebionetworks.bridge.AuthUtils.IS_ORG_MEMBER_IN_APP;
@@ -16,11 +20,11 @@ import static org.sagebionetworks.bridge.Roles.ORG_ADMIN;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
 import static org.sagebionetworks.bridge.Roles.WORKER;
-import static org.sagebionetworks.bridge.TestConstants.OWNER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_OWNER_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -35,7 +39,7 @@ import org.testng.annotations.Test;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 
 public class AuthUtilsTest extends Mockito {
-    private static final String SHARED_OWNER_ID = TEST_APP_ID + ":" + OWNER_ID;
+    private static final String SHARED_OWNER_ID = TEST_APP_ID + ":" + TEST_OWNER_ID;
     
     @AfterMethod
     public void afterMethod() {
@@ -44,9 +48,9 @@ public class AuthUtilsTest extends Mockito {
     
     @Test
     public void checkSelfOrStudyResearcherSucceedsForSelf() {
-        RequestContext.set(new RequestContext.Builder().withCallerUserId(USER_ID).build());
+        RequestContext.set(new RequestContext.Builder().withCallerUserId(TEST_USER_ID).build());
         
-        IS_SELF_OR_STUDY_RESEARCHER.checkStudyAndUserIds(TEST_STUDY_ID, USER_ID);
+        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID);
     }
     
     @Test
@@ -56,7 +60,7 @@ public class AuthUtilsTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
                 .build());
         
-        IS_SELF_OR_STUDY_RESEARCHER.checkStudyAndUserIds(TEST_STUDY_ID, USER_ID);
+        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID);
     }
 
     @Test
@@ -65,7 +69,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ADMIN))
                 .build());
         
-        IS_SELF_OR_STUDY_RESEARCHER.checkStudyAndUserIds(TEST_STUDY_ID, USER_ID);
+        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -75,7 +79,7 @@ public class AuthUtilsTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of("someOtherStudy"))
                 .build());
         
-        IS_SELF_OR_STUDY_RESEARCHER.checkStudyAndUserIds(TEST_STUDY_ID, USER_ID);
+        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -85,7 +89,7 @@ public class AuthUtilsTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
                 .build());
         
-        IS_SELF_OR_STUDY_RESEARCHER.checkStudyAndUserIds(TEST_STUDY_ID, USER_ID);
+        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID);
     }
 
     @Test
@@ -93,7 +97,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID).build());
         
-        IS_ORG_MEMBER.checkOrgId(TEST_ORG_ID);
+        IS_ORG_MEMBER.checkAndThrow(ORG_ID, TEST_ORG_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -101,14 +105,14 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership("another-organization").build());
         
-        IS_ORG_MEMBER.checkOrgId(TEST_ORG_ID);
+        IS_ORG_MEMBER.checkAndThrow(ORG_ID, TEST_ORG_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
     public void checkOrgMemberFailsOnNullOrg() {
         RequestContext.set(new RequestContext.Builder().build());
         
-        IS_ORG_MEMBER.checkOrgId(TEST_ORG_ID);
+        IS_ORG_MEMBER.checkAndThrow(ORG_ID, TEST_ORG_ID);
     }
     
     @Test
@@ -116,49 +120,49 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID).build());
         
-        IS_ORG_MEMBER.checkOrgId(TEST_ORG_ID);
+        IS_ORG_MEMBER.checkAndThrow(ORG_ID, TEST_ORG_ID);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
     public void checkOrgMembershipFails() {
         RequestContext.set(new RequestContext.Builder().build());
         
-        IS_ORG_MEMBER.checkOrgId(TEST_ORG_ID);
+        IS_ORG_MEMBER.checkAndThrow(ORG_ID, TEST_ORG_ID);
     }
     
     @Test
     public void checkOrgMemberOfSharedAssessmentOwnerSucceedsForAdmin() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());
-        IS_ORG_MEMBER_IN_APP.checkOwnerId(SHARED_OWNER_ID);
+        IS_ORG_MEMBER_IN_APP.checkAndThrow(OWNER_ID, SHARED_OWNER_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
     public void checkOrgMemberOfSharedAssessmentOwnerFailsForGlobalOwnerId() {
         RequestContext.set(NULL_INSTANCE);
-        IS_ORG_MEMBER_IN_APP.checkOwnerId(OWNER_ID);
+        IS_ORG_MEMBER_IN_APP.checkAndThrow(OWNER_ID, TEST_OWNER_ID);
     }
     
     @Test
     public void checkOrgMemberOfSharedAssessmentOwnerSucceedsForOwner() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerAppId(TEST_APP_ID)
-                .withCallerOrgMembership(OWNER_ID).build());
-        IS_ORG_MEMBER_IN_APP.checkOwnerId(SHARED_OWNER_ID);
+                .withCallerOrgMembership(TEST_OWNER_ID).build());
+        IS_ORG_MEMBER_IN_APP.checkAndThrow(OWNER_ID, SHARED_OWNER_ID);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
     public void checkOrgMemberOfSharedAssessmentOwnerFailsWrongOrgId() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership("notValidOwner").build());
-        IS_ORG_MEMBER_IN_APP.checkOwnerId(SHARED_OWNER_ID);
+        IS_ORG_MEMBER_IN_APP.checkAndThrow(OWNER_ID, SHARED_OWNER_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
     public void checkOrgMemberOfSharedAssessmentOwnerFailsWrongAppId() { 
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_APP_ID).build());
-        IS_ORG_MEMBER_IN_APP.checkOwnerId(SHARED_OWNER_ID);        
+        IS_ORG_MEMBER_IN_APP.checkAndThrow(OWNER_ID, SHARED_OWNER_ID);        
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -166,15 +170,15 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(NULL_INSTANCE);
         // still doesn't pass because the appId must always match (global users must call 
         // this API after associating to the right app context):
-        IS_ORG_MEMBER_IN_APP.checkOwnerId("other:"+OWNER_ID);
+        IS_ORG_MEMBER_IN_APP.checkAndThrow(OWNER_ID, "other:"+TEST_OWNER_ID);
     }
     
     @Test
     public void checkSelfOrResearcherSucceedsForSelf() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerUserId(USER_ID).build());
+                .withCallerUserId(TEST_USER_ID).build());
         
-        IS_SELF_OR_RESEARCHER.checkUserId(USER_ID);
+        IS_SELF_OR_RESEARCHER.checkAndThrow(USER_ID, TEST_USER_ID);
     }
     
     @Test
@@ -183,7 +187,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(RESEARCHER))
                 .withCallerUserId("notUserId").build());
         
-        IS_SELF_OR_RESEARCHER.checkUserId(USER_ID);
+        IS_SELF_OR_RESEARCHER.checkAndThrow(USER_ID, TEST_USER_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -192,7 +196,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(DEVELOPER))
                 .withCallerUserId("notUserId").build());
         
-        IS_SELF_OR_RESEARCHER.checkUserId(USER_ID);
+        IS_SELF_OR_RESEARCHER.checkAndThrow(USER_ID, TEST_USER_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -200,7 +204,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of("studyA", "studyB")).build());
         
-        IS_STUDY_TEAM_OR_WORKER.checkStudyId(TEST_STUDY_ID);
+        IS_STUDY_TEAM_OR_WORKER.checkAndThrow(STUDY_ID, TEST_STUDY_ID);
     }
     
     @Test
@@ -208,7 +212,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
         
-        assertFalse( IS_STUDY_TEAM_OR_WORKER.verify("studyId", TEST_STUDY_ID) );
+        assertFalse( IS_STUDY_TEAM_OR_WORKER.check(STUDY_ID, TEST_STUDY_ID) );
     }
     
     @Test
@@ -216,7 +220,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
         
-        assertFalse( IS_STUDY_TEAM_OR_WORKER.verify("studyId", null) );
+        assertFalse( IS_STUDY_TEAM_OR_WORKER.check(STUDY_ID, null) );
     }
     
     @Test
@@ -225,7 +229,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(WORKER))
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
         
-        assertTrue( IS_STUDY_TEAM_OR_WORKER.verify("studyId", TEST_STUDY_ID) );
+        assertTrue( IS_STUDY_TEAM_OR_WORKER.check(STUDY_ID, TEST_STUDY_ID) );
     }
 
     @Test
@@ -234,7 +238,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ADMIN))
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
         
-        assertTrue( IS_STUDY_TEAM_OR_WORKER.verify("studyId", TEST_STUDY_ID) );
+        assertTrue( IS_STUDY_TEAM_OR_WORKER.check(STUDY_ID, TEST_STUDY_ID) );
     }
     
     @Test
@@ -242,7 +246,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
         
-        assertTrue( IS_STUDY_TEAM_OR_WORKER.verify("studyId", "study2") );
+        assertTrue( IS_STUDY_TEAM_OR_WORKER.check(STUDY_ID, "study2") );
     }
 
     @Test
@@ -282,14 +286,14 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());
 
-        IS_ORG_MEMBER.checkOrgId(TEST_ORG_ID);
+        IS_ORG_MEMBER.checkAndThrow(ORG_ID, TEST_ORG_ID);
     }
     
     @Test
     public void isStudyScopedToCallerSucceedsForGlobalUser() {
         RequestContext.set(new RequestContext.Builder().build());
         
-        IS_STUDY_TEAM_OR_WORKER.checkStudyId(TEST_STUDY_ID);
+        IS_STUDY_TEAM_OR_WORKER.checkAndThrow(STUDY_ID, TEST_STUDY_ID);
     }
     
     @Test
@@ -299,7 +303,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(RESEARCHER))
                 .build());
         
-        IS_STUDY_RESEARCHER.checkStudyId(TEST_STUDY_ID);
+        IS_STUDY_RESEARCHER.checkAndThrow(STUDY_ID, TEST_STUDY_ID);
     }
 
     @Test
@@ -308,7 +312,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ADMIN))
                 .build());
         
-        IS_STUDY_RESEARCHER.checkStudyId(TEST_STUDY_ID);
+        IS_STUDY_RESEARCHER.checkAndThrow(STUDY_ID, TEST_STUDY_ID);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -318,7 +322,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(RESEARCHER))
                 .build());
         
-        IS_STUDY_RESEARCHER.checkStudyId(TEST_STUDY_ID);
+        IS_STUDY_RESEARCHER.checkAndThrow(STUDY_ID, TEST_STUDY_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -328,7 +332,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(DEVELOPER))
                 .build());
         
-        IS_STUDY_RESEARCHER.checkStudyId(TEST_STUDY_ID);
+        IS_STUDY_RESEARCHER.checkAndThrow(STUDY_ID, TEST_STUDY_ID);
     }
     
     @Test
@@ -338,7 +342,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
                 .build());
         
-        IS_ORGADMIN.checkOrgId(TEST_ORG_ID);
+        IS_ORGADMIN.checkAndThrow(ORG_ID, TEST_ORG_ID);
     }
 
     @Test
@@ -347,7 +351,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ADMIN))
                 .build());
         
-        IS_ORGADMIN.checkOrgId(TEST_ORG_ID);
+        IS_ORGADMIN.checkAndThrow(ORG_ID, TEST_ORG_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -357,7 +361,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
                 .build());
         
-        IS_ORGADMIN.checkOrgId(TEST_ORG_ID);
+        IS_ORGADMIN.checkAndThrow(ORG_ID, TEST_ORG_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -367,7 +371,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(DEVELOPER))
                 .build());
         
-        IS_ORGADMIN.checkOrgId(TEST_ORG_ID);
+        IS_ORGADMIN.checkAndThrow(ORG_ID, TEST_ORG_ID);
     }
     
     @Test
@@ -375,7 +379,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID).build());
         
-        assertTrue( IS_ORG_MEMBER.verify("orgId", TEST_ORG_ID) );
+        assertTrue( IS_ORG_MEMBER.check(ORG_ID, TEST_ORG_ID) );
     }
     
     @Test
@@ -383,7 +387,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());
         
-        assertTrue( IS_ORG_MEMBER.verify("orgId", TEST_ORG_ID) );
+        assertTrue( IS_ORG_MEMBER.check(ORG_ID, TEST_ORG_ID) );
     }
     
     @Test
@@ -393,7 +397,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerOrgMembership("wrong-org")
                 .build());
         
-        assertFalse( IS_ORG_MEMBER.verify("orgId", TEST_ORG_ID) );
+        assertFalse( IS_ORG_MEMBER.check(ORG_ID, TEST_ORG_ID) );
     }
     
     @Test
@@ -403,7 +407,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
                 .build());
         
-        assertTrue( IS_ORGADMIN.verify("orgId", TEST_ORG_ID) );
+        assertTrue( IS_ORGADMIN.check(ORG_ID, TEST_ORG_ID) );
     }
 
     @Test
@@ -412,7 +416,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
                 .build());
         
-        assertFalse( IS_ORGADMIN.verify("orgId", TEST_ORG_ID) );
+        assertFalse( IS_ORGADMIN.check(ORG_ID, TEST_ORG_ID) );
     }
 
     @Test
@@ -421,15 +425,15 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .build());
         
-        assertFalse( IS_ORGADMIN.verify("orgId", TEST_ORG_ID) );
+        assertFalse( IS_ORGADMIN.check(ORG_ID, TEST_ORG_ID) );
     }
     
     @Test
     public void isSelfOrStudyTeamMemberOrWorkerSucceesForSelf() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerUserId(USER_ID).build());
+                .withCallerUserId(TEST_USER_ID).build());
         
-        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.verify("studyId", TEST_STUDY_ID, "userId", USER_ID) );
+        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.check(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID) );
     }
 
     @Test
@@ -437,7 +441,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID)).build());
         
-        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.verify("studyId", TEST_STUDY_ID, "userId", USER_ID) );
+        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.check(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID) );
     }
 
     @Test
@@ -445,7 +449,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(WORKER)).build());
         
-        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.verify("studyId", TEST_STUDY_ID, "userId", USER_ID) );
+        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.check(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID) );
     }
 
     @Test
@@ -457,25 +461,25 @@ public class AuthUtilsTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of("study1"))
                 .build());
         
-        assertFalse( IS_SELF_STUDY_TEAM_OR_WORKER.verify("studyId", TEST_STUDY_ID, "userId", USER_ID) );
+        assertFalse( IS_SELF_STUDY_TEAM_OR_WORKER.check(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID) );
     }
     
     @Test
     public void isSelfOrStudyTeamMemberOrWorkerForSelf() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerUserId(USER_ID)
+                .withCallerUserId(TEST_USER_ID)
                 .build());
         
-        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.verify("studyId", TEST_STUDY_ID, "userId", USER_ID) );
+        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.check(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID) );
     }
 
     @Test
     public void isSelfOrStudyTeamMemberOrWorkerForStudyTeamMember() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerUserId(USER_ID)
+                .withCallerUserId(TEST_USER_ID)
                 .build());
         
-        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.verify("studyId", TEST_STUDY_ID, "userId", USER_ID) );
+        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.check(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID) );
     }
 
     @Test
@@ -484,7 +488,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(WORKER))
                 .build());
         
-        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.verify("studyId", TEST_STUDY_ID, "userId", USER_ID) );
+        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.check(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID) );
     }
 
     @Test
@@ -496,16 +500,16 @@ public class AuthUtilsTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of("study1"))
                 .build());
         
-        assertFalse( IS_SELF_ORGADMIN_OR_WORKER.verify("orgId", TEST_ORG_ID, "userId", USER_ID) );
+        assertFalse( IS_SELF_ORGADMIN_OR_WORKER.check(ORG_ID, TEST_ORG_ID, USER_ID, TEST_USER_ID) );
     }
 
     @Test
     public void isSelfWorkerOrOrgAdminForSelf() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerUserId(USER_ID)
+                .withCallerUserId(TEST_USER_ID)
                 .build());
         
-        assertTrue( IS_SELF_ORGADMIN_OR_WORKER.verify("orgId", TEST_ORG_ID, "userId", USER_ID) );
+        assertTrue( IS_SELF_ORGADMIN_OR_WORKER.check(ORG_ID, TEST_ORG_ID, USER_ID, TEST_USER_ID) );
     }
 
     @Test
@@ -514,7 +518,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(WORKER))
                 .build());
         
-        assertTrue( IS_SELF_ORGADMIN_OR_WORKER.verify("orgId", TEST_ORG_ID, "userId", USER_ID) );
+        assertTrue( IS_SELF_ORGADMIN_OR_WORKER.check(ORG_ID, TEST_ORG_ID, USER_ID, TEST_USER_ID) );
     }
 
     @Test
@@ -524,7 +528,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
                 .build());
         
-        assertTrue( IS_SELF_ORGADMIN_OR_WORKER.verify("orgId", TEST_ORG_ID, "userId", USER_ID) );
+        assertTrue( IS_SELF_ORGADMIN_OR_WORKER.check(ORG_ID, TEST_ORG_ID, USER_ID, TEST_USER_ID) );
     }
 
     @Test
@@ -533,7 +537,7 @@ public class AuthUtilsTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
                 .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
         
-        IS_STUDY_RESEARCHER.checkStudyId(TEST_STUDY_ID);
+        IS_STUDY_RESEARCHER.checkAndThrow(STUDY_ID, TEST_STUDY_ID);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -542,6 +546,6 @@ public class AuthUtilsTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of("studyA"))
                 .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
         
-        IS_STUDY_RESEARCHER.checkStudyId(TEST_STUDY_ID);
+        IS_STUDY_RESEARCHER.checkAndThrow(STUDY_ID, TEST_STUDY_ID);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
@@ -46,7 +46,7 @@ public class AuthUtilsTest extends Mockito {
     public void checkSelfOrStudyResearcherSucceedsForSelf() {
         RequestContext.set(new RequestContext.Builder().withCallerUserId(USER_ID).build());
         
-        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow("userId", USER_ID, "studyId", TEST_STUDY_ID);
+        IS_SELF_OR_STUDY_RESEARCHER.checkStudyAndUserIds(TEST_STUDY_ID, USER_ID);
     }
     
     @Test
@@ -56,7 +56,7 @@ public class AuthUtilsTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
                 .build());
         
-        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow("userId", USER_ID, "studyId", TEST_STUDY_ID);
+        IS_SELF_OR_STUDY_RESEARCHER.checkStudyAndUserIds(TEST_STUDY_ID, USER_ID);
     }
 
     @Test
@@ -65,7 +65,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ADMIN))
                 .build());
         
-        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow("userId", USER_ID, "studyId", TEST_STUDY_ID);
+        IS_SELF_OR_STUDY_RESEARCHER.checkStudyAndUserIds(TEST_STUDY_ID, USER_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -75,7 +75,7 @@ public class AuthUtilsTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of("someOtherStudy"))
                 .build());
         
-        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow("userId", USER_ID, "studyId", TEST_STUDY_ID);
+        IS_SELF_OR_STUDY_RESEARCHER.checkStudyAndUserIds(TEST_STUDY_ID, USER_ID);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -85,7 +85,7 @@ public class AuthUtilsTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
                 .build());
         
-        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow("userId", USER_ID, "studyId", TEST_STUDY_ID);
+        IS_SELF_OR_STUDY_RESEARCHER.checkStudyAndUserIds(TEST_STUDY_ID, USER_ID);
     }
 
     @Test
@@ -93,7 +93,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID).build());
         
-        IS_ORG_MEMBER.checkAndThrow("orgId", TEST_ORG_ID);
+        IS_ORG_MEMBER.checkOrgId(TEST_ORG_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -101,14 +101,14 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership("another-organization").build());
         
-        IS_ORG_MEMBER.checkAndThrow("orgId", TEST_ORG_ID);
+        IS_ORG_MEMBER.checkOrgId(TEST_ORG_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
     public void checkOrgMemberFailsOnNullOrg() {
         RequestContext.set(new RequestContext.Builder().build());
         
-        IS_ORG_MEMBER.checkAndThrow("orgId", TEST_ORG_ID);
+        IS_ORG_MEMBER.checkOrgId(TEST_ORG_ID);
     }
     
     @Test
@@ -116,27 +116,27 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID).build());
         
-        IS_ORG_MEMBER.checkAndThrow("orgId", TEST_ORG_ID);
+        IS_ORG_MEMBER.checkOrgId(TEST_ORG_ID);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
     public void checkOrgMembershipFails() {
         RequestContext.set(new RequestContext.Builder().build());
         
-        IS_ORG_MEMBER.checkAndThrow("orgId", TEST_ORG_ID);
+        IS_ORG_MEMBER.checkOrgId(TEST_ORG_ID);
     }
     
     @Test
     public void checkOrgMemberOfSharedAssessmentOwnerSucceedsForAdmin() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());
-        IS_ORG_MEMBER_IN_APP.checkAndThrow("ownerId", SHARED_OWNER_ID);
+        IS_ORG_MEMBER_IN_APP.checkOwnerId(SHARED_OWNER_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
     public void checkOrgMemberOfSharedAssessmentOwnerFailsForGlobalOwnerId() {
         RequestContext.set(NULL_INSTANCE);
-        IS_ORG_MEMBER_IN_APP.checkAndThrow("ownerId", OWNER_ID);
+        IS_ORG_MEMBER_IN_APP.checkOwnerId(OWNER_ID);
     }
     
     @Test
@@ -144,21 +144,21 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerAppId(TEST_APP_ID)
                 .withCallerOrgMembership(OWNER_ID).build());
-        IS_ORG_MEMBER_IN_APP.checkAndThrow("ownerId", SHARED_OWNER_ID);
+        IS_ORG_MEMBER_IN_APP.checkOwnerId(SHARED_OWNER_ID);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
     public void checkOrgMemberOfSharedAssessmentOwnerFailsWrongOrgId() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership("notValidOwner").build());
-        IS_ORG_MEMBER_IN_APP.checkAndThrow("ownerId", SHARED_OWNER_ID);
+        IS_ORG_MEMBER_IN_APP.checkOwnerId(SHARED_OWNER_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
     public void checkOrgMemberOfSharedAssessmentOwnerFailsWrongAppId() { 
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_APP_ID).build());
-        IS_ORG_MEMBER_IN_APP.checkAndThrow("ownerId", SHARED_OWNER_ID);        
+        IS_ORG_MEMBER_IN_APP.checkOwnerId(SHARED_OWNER_ID);        
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -166,7 +166,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(NULL_INSTANCE);
         // still doesn't pass because the appId must always match (global users must call 
         // this API after associating to the right app context):
-        IS_ORG_MEMBER_IN_APP.checkAndThrow("ownerId", "other:"+OWNER_ID);
+        IS_ORG_MEMBER_IN_APP.checkOwnerId("other:"+OWNER_ID);
     }
     
     @Test
@@ -174,7 +174,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId(USER_ID).build());
         
-        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", USER_ID);
+        IS_SELF_OR_RESEARCHER.checkUserId(USER_ID);
     }
     
     @Test
@@ -183,7 +183,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(RESEARCHER))
                 .withCallerUserId("notUserId").build());
         
-        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", USER_ID);
+        IS_SELF_OR_RESEARCHER.checkUserId(USER_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -192,7 +192,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(DEVELOPER))
                 .withCallerUserId("notUserId").build());
         
-        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", USER_ID);
+        IS_SELF_OR_RESEARCHER.checkUserId(USER_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -200,7 +200,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of("studyA", "studyB")).build());
         
-        IS_STUDY_TEAM_OR_WORKER.checkAndThrow("studyId", TEST_STUDY_ID);
+        IS_STUDY_TEAM_OR_WORKER.checkStudyId(TEST_STUDY_ID);
     }
     
     @Test
@@ -208,7 +208,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
         
-        assertFalse( IS_STUDY_TEAM_OR_WORKER.check("studyId", TEST_STUDY_ID) );
+        assertFalse( IS_STUDY_TEAM_OR_WORKER.verify("studyId", TEST_STUDY_ID) );
     }
     
     @Test
@@ -216,7 +216,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
         
-        assertFalse( IS_STUDY_TEAM_OR_WORKER.check("studyId", null) );
+        assertFalse( IS_STUDY_TEAM_OR_WORKER.verify("studyId", null) );
     }
     
     @Test
@@ -225,7 +225,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(WORKER))
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
         
-        assertTrue( IS_STUDY_TEAM_OR_WORKER.check("studyId", TEST_STUDY_ID) );
+        assertTrue( IS_STUDY_TEAM_OR_WORKER.verify("studyId", TEST_STUDY_ID) );
     }
 
     @Test
@@ -234,7 +234,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ADMIN))
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
         
-        assertTrue( IS_STUDY_TEAM_OR_WORKER.check("studyId", TEST_STUDY_ID) );
+        assertTrue( IS_STUDY_TEAM_OR_WORKER.verify("studyId", TEST_STUDY_ID) );
     }
     
     @Test
@@ -242,7 +242,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
         
-        assertTrue( IS_STUDY_TEAM_OR_WORKER.check("studyId", "study2") );
+        assertTrue( IS_STUDY_TEAM_OR_WORKER.verify("studyId", "study2") );
     }
 
     @Test
@@ -282,14 +282,14 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());
 
-        IS_ORG_MEMBER.checkAndThrow("orgId", TEST_ORG_ID);
+        IS_ORG_MEMBER.checkOrgId(TEST_ORG_ID);
     }
     
     @Test
     public void isStudyScopedToCallerSucceedsForGlobalUser() {
         RequestContext.set(new RequestContext.Builder().build());
         
-        IS_STUDY_TEAM_OR_WORKER.checkAndThrow("studyId", TEST_STUDY_ID);
+        IS_STUDY_TEAM_OR_WORKER.checkStudyId(TEST_STUDY_ID);
     }
     
     @Test
@@ -299,7 +299,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(RESEARCHER))
                 .build());
         
-        IS_STUDY_RESEARCHER.checkAndThrow("studyId", TEST_STUDY_ID);
+        IS_STUDY_RESEARCHER.checkStudyId(TEST_STUDY_ID);
     }
 
     @Test
@@ -308,7 +308,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ADMIN))
                 .build());
         
-        IS_STUDY_RESEARCHER.checkAndThrow("studyId", TEST_STUDY_ID);
+        IS_STUDY_RESEARCHER.checkStudyId(TEST_STUDY_ID);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -318,7 +318,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(RESEARCHER))
                 .build());
         
-        IS_STUDY_RESEARCHER.checkAndThrow("studyId", TEST_STUDY_ID);
+        IS_STUDY_RESEARCHER.checkStudyId(TEST_STUDY_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -328,7 +328,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(DEVELOPER))
                 .build());
         
-        IS_STUDY_RESEARCHER.checkAndThrow("studyId", TEST_STUDY_ID);
+        IS_STUDY_RESEARCHER.checkStudyId(TEST_STUDY_ID);
     }
     
     @Test
@@ -338,7 +338,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
                 .build());
         
-        IS_ORGADMIN.checkAndThrow("orgId", TEST_ORG_ID);
+        IS_ORGADMIN.checkOrgId(TEST_ORG_ID);
     }
 
     @Test
@@ -347,7 +347,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ADMIN))
                 .build());
         
-        IS_ORGADMIN.checkAndThrow("orgId", TEST_ORG_ID);
+        IS_ORGADMIN.checkOrgId(TEST_ORG_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -357,7 +357,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
                 .build());
         
-        IS_ORGADMIN.checkAndThrow("orgId", TEST_ORG_ID);
+        IS_ORGADMIN.checkOrgId(TEST_ORG_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -367,7 +367,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(DEVELOPER))
                 .build());
         
-        IS_ORGADMIN.checkAndThrow("orgId", TEST_ORG_ID);
+        IS_ORGADMIN.checkOrgId(TEST_ORG_ID);
     }
     
     @Test
@@ -375,7 +375,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID).build());
         
-        assertTrue( IS_ORG_MEMBER.check("orgId", TEST_ORG_ID) );
+        assertTrue( IS_ORG_MEMBER.verify("orgId", TEST_ORG_ID) );
     }
     
     @Test
@@ -383,7 +383,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());
         
-        assertTrue( IS_ORG_MEMBER.check("orgId", TEST_ORG_ID) );
+        assertTrue( IS_ORG_MEMBER.verify("orgId", TEST_ORG_ID) );
     }
     
     @Test
@@ -393,7 +393,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerOrgMembership("wrong-org")
                 .build());
         
-        assertFalse( IS_ORG_MEMBER.check("orgId", TEST_ORG_ID) );
+        assertFalse( IS_ORG_MEMBER.verify("orgId", TEST_ORG_ID) );
     }
     
     @Test
@@ -403,7 +403,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
                 .build());
         
-        assertTrue( IS_ORGADMIN.check("orgId", TEST_ORG_ID) );
+        assertTrue( IS_ORGADMIN.verify("orgId", TEST_ORG_ID) );
     }
 
     @Test
@@ -412,7 +412,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
                 .build());
         
-        assertFalse( IS_ORGADMIN.check("orgId", TEST_ORG_ID) );
+        assertFalse( IS_ORGADMIN.verify("orgId", TEST_ORG_ID) );
     }
 
     @Test
@@ -421,7 +421,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .build());
         
-        assertFalse( IS_ORGADMIN.check("orgId", TEST_ORG_ID) );
+        assertFalse( IS_ORGADMIN.verify("orgId", TEST_ORG_ID) );
     }
     
     @Test
@@ -429,7 +429,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId(USER_ID).build());
         
-        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.check("studyId", TEST_STUDY_ID, "userId", USER_ID) );
+        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.verify("studyId", TEST_STUDY_ID, "userId", USER_ID) );
     }
 
     @Test
@@ -437,7 +437,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID)).build());
         
-        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.check("studyId", TEST_STUDY_ID, "userId", USER_ID) );
+        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.verify("studyId", TEST_STUDY_ID, "userId", USER_ID) );
     }
 
     @Test
@@ -445,7 +445,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(WORKER)).build());
         
-        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.check("studyId", TEST_STUDY_ID, "userId", USER_ID) );
+        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.verify("studyId", TEST_STUDY_ID, "userId", USER_ID) );
     }
 
     @Test
@@ -457,7 +457,7 @@ public class AuthUtilsTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of("study1"))
                 .build());
         
-        assertFalse( IS_SELF_STUDY_TEAM_OR_WORKER.check("studyId", TEST_STUDY_ID, "userId", USER_ID) );
+        assertFalse( IS_SELF_STUDY_TEAM_OR_WORKER.verify("studyId", TEST_STUDY_ID, "userId", USER_ID) );
     }
     
     @Test
@@ -466,7 +466,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerUserId(USER_ID)
                 .build());
         
-        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.check("studyId", TEST_STUDY_ID, "userId", USER_ID) );
+        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.verify("studyId", TEST_STUDY_ID, "userId", USER_ID) );
     }
 
     @Test
@@ -475,7 +475,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerUserId(USER_ID)
                 .build());
         
-        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.check("studyId", TEST_STUDY_ID, "userId", USER_ID) );
+        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.verify("studyId", TEST_STUDY_ID, "userId", USER_ID) );
     }
 
     @Test
@@ -484,7 +484,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(WORKER))
                 .build());
         
-        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.check("studyId", TEST_STUDY_ID, "userId", USER_ID) );
+        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.verify("studyId", TEST_STUDY_ID, "userId", USER_ID) );
     }
 
     @Test
@@ -496,7 +496,7 @@ public class AuthUtilsTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of("study1"))
                 .build());
         
-        assertFalse( IS_SELF_ORGADMIN_OR_WORKER.check("orgId", TEST_ORG_ID, "userId", USER_ID) );
+        assertFalse( IS_SELF_ORGADMIN_OR_WORKER.verify("orgId", TEST_ORG_ID, "userId", USER_ID) );
     }
 
     @Test
@@ -505,7 +505,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerUserId(USER_ID)
                 .build());
         
-        assertTrue( IS_SELF_ORGADMIN_OR_WORKER.check("orgId", TEST_ORG_ID, "userId", USER_ID) );
+        assertTrue( IS_SELF_ORGADMIN_OR_WORKER.verify("orgId", TEST_ORG_ID, "userId", USER_ID) );
     }
 
     @Test
@@ -514,7 +514,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(WORKER))
                 .build());
         
-        assertTrue( IS_SELF_ORGADMIN_OR_WORKER.check("orgId", TEST_ORG_ID, "userId", USER_ID) );
+        assertTrue( IS_SELF_ORGADMIN_OR_WORKER.verify("orgId", TEST_ORG_ID, "userId", USER_ID) );
     }
 
     @Test
@@ -524,7 +524,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
                 .build());
         
-        assertTrue( IS_SELF_ORGADMIN_OR_WORKER.check("orgId", TEST_ORG_ID, "userId", USER_ID) );
+        assertTrue( IS_SELF_ORGADMIN_OR_WORKER.verify("orgId", TEST_ORG_ID, "userId", USER_ID) );
     }
 
     @Test
@@ -533,7 +533,7 @@ public class AuthUtilsTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
                 .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
         
-        IS_STUDY_RESEARCHER.checkAndThrow("studyId", TEST_STUDY_ID);
+        IS_STUDY_RESEARCHER.checkStudyId(TEST_STUDY_ID);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -542,6 +542,6 @@ public class AuthUtilsTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of("studyA"))
                 .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
         
-        IS_STUDY_RESEARCHER.checkAndThrow("studyId", TEST_STUDY_ID);
+        IS_STUDY_RESEARCHER.checkStudyId(TEST_STUDY_ID);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
@@ -1,5 +1,14 @@
 package org.sagebionetworks.bridge;
 
+import static org.sagebionetworks.bridge.AuthUtils.IS_ORGADMIN;
+import static org.sagebionetworks.bridge.AuthUtils.IS_ORG_MEMBER;
+import static org.sagebionetworks.bridge.AuthUtils.IS_ORG_MEMBER_IN_APP;
+import static org.sagebionetworks.bridge.AuthUtils.IS_SELF_OR_RESEARCHER;
+import static org.sagebionetworks.bridge.AuthUtils.IS_SELF_OR_STUDY_RESEARCHER;
+import static org.sagebionetworks.bridge.AuthUtils.IS_SELF_STUDY_TEAM_OR_WORKER;
+import static org.sagebionetworks.bridge.AuthUtils.IS_SELF_ORGADMIN_OR_WORKER;
+import static org.sagebionetworks.bridge.AuthUtils.IS_STUDY_RESEARCHER;
+import static org.sagebionetworks.bridge.AuthUtils.IS_STUDY_TEAM_OR_WORKER;
 import static org.sagebionetworks.bridge.RequestContext.NULL_INSTANCE;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
@@ -7,7 +16,6 @@ import static org.sagebionetworks.bridge.Roles.ORG_ADMIN;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
 import static org.sagebionetworks.bridge.Roles.WORKER;
-import static org.sagebionetworks.bridge.TestConstants.GUID;
 import static org.sagebionetworks.bridge.TestConstants.OWNER_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
@@ -38,7 +46,7 @@ public class AuthUtilsTest extends Mockito {
     public void checkSelfOrStudyResearcherSucceedsForSelf() {
         RequestContext.set(new RequestContext.Builder().withCallerUserId(USER_ID).build());
         
-        AuthUtils.checkSelfOrStudyResearcher(USER_ID, TEST_STUDY_ID);
+        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow("userId", USER_ID, "studyId", TEST_STUDY_ID);
     }
     
     @Test
@@ -48,7 +56,7 @@ public class AuthUtilsTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
                 .build());
         
-        AuthUtils.checkSelfOrStudyResearcher(USER_ID, TEST_STUDY_ID);
+        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow("userId", USER_ID, "studyId", TEST_STUDY_ID);
     }
 
     @Test
@@ -57,7 +65,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ADMIN))
                 .build());
         
-        AuthUtils.checkSelfOrStudyResearcher(USER_ID, TEST_STUDY_ID);
+        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow("userId", USER_ID, "studyId", TEST_STUDY_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -67,7 +75,7 @@ public class AuthUtilsTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of("someOtherStudy"))
                 .build());
         
-        AuthUtils.checkSelfOrStudyResearcher(USER_ID, TEST_STUDY_ID);
+        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow("userId", USER_ID, "studyId", TEST_STUDY_ID);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -77,7 +85,7 @@ public class AuthUtilsTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
                 .build());
         
-        AuthUtils.checkSelfOrStudyResearcher(USER_ID, TEST_STUDY_ID);
+        IS_SELF_OR_STUDY_RESEARCHER.checkAndThrow("userId", USER_ID, "studyId", TEST_STUDY_ID);
     }
 
     @Test
@@ -85,7 +93,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID).build());
         
-        AuthUtils.checkOrgMember(TEST_ORG_ID);
+        IS_ORG_MEMBER.checkAndThrow("orgId", TEST_ORG_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -93,14 +101,14 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership("another-organization").build());
         
-        AuthUtils.checkOrgMember(TEST_ORG_ID);
+        IS_ORG_MEMBER.checkAndThrow("orgId", TEST_ORG_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
     public void checkOrgMemberFailsOnNullOrg() {
         RequestContext.set(new RequestContext.Builder().build());
         
-        AuthUtils.checkOrgMember(TEST_ORG_ID);
+        IS_ORG_MEMBER.checkAndThrow("orgId", TEST_ORG_ID);
     }
     
     @Test
@@ -108,27 +116,27 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID).build());
         
-        AuthUtils.checkOrgMember(TEST_ORG_ID);
+        IS_ORG_MEMBER.checkAndThrow("orgId", TEST_ORG_ID);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
     public void checkOrgMembershipFails() {
         RequestContext.set(new RequestContext.Builder().build());
         
-        AuthUtils.checkOrgMember(TEST_ORG_ID);
+        IS_ORG_MEMBER.checkAndThrow("orgId", TEST_ORG_ID);
     }
     
     @Test
     public void checkOrgMemberOfSharedAssessmentOwnerSucceedsForAdmin() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());
-        AuthUtils.checkOrgMemberOfSharedAssessmentOwner(TEST_APP_ID, GUID, SHARED_OWNER_ID);
+        IS_ORG_MEMBER_IN_APP.checkAndThrow("ownerId", SHARED_OWNER_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
     public void checkOrgMemberOfSharedAssessmentOwnerFailsForGlobalOwnerId() {
         RequestContext.set(NULL_INSTANCE);
-        AuthUtils.checkOrgMemberOfSharedAssessmentOwner(TEST_APP_ID, GUID, OWNER_ID);
+        IS_ORG_MEMBER_IN_APP.checkAndThrow("ownerId", OWNER_ID);
     }
     
     @Test
@@ -136,21 +144,21 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerAppId(TEST_APP_ID)
                 .withCallerOrgMembership(OWNER_ID).build());
-        AuthUtils.checkOrgMemberOfSharedAssessmentOwner(TEST_APP_ID, GUID, SHARED_OWNER_ID);
+        IS_ORG_MEMBER_IN_APP.checkAndThrow("ownerId", SHARED_OWNER_ID);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
     public void checkOrgMemberOfSharedAssessmentOwnerFailsWrongOrgId() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership("notValidOwner").build());
-        AuthUtils.checkOrgMemberOfSharedAssessmentOwner(TEST_APP_ID, GUID, SHARED_OWNER_ID);
+        IS_ORG_MEMBER_IN_APP.checkAndThrow("ownerId", SHARED_OWNER_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
     public void checkOrgMemberOfSharedAssessmentOwnerFailsWrongAppId() { 
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_APP_ID).build());
-        AuthUtils.checkOrgMemberOfSharedAssessmentOwner(TEST_APP_ID, GUID, "other:"+OWNER_ID);        
+        IS_ORG_MEMBER_IN_APP.checkAndThrow("ownerId", SHARED_OWNER_ID);        
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -158,7 +166,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(NULL_INSTANCE);
         // still doesn't pass because the appId must always match (global users must call 
         // this API after associating to the right app context):
-        AuthUtils.checkOrgMemberOfSharedAssessmentOwner(TEST_APP_ID, GUID, "other:"+OWNER_ID);        
+        IS_ORG_MEMBER_IN_APP.checkAndThrow("ownerId", "other:"+OWNER_ID);
     }
     
     @Test
@@ -166,7 +174,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId(USER_ID).build());
         
-        AuthUtils.checkSelfOrResearcher(USER_ID);
+        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", USER_ID);
     }
     
     @Test
@@ -175,7 +183,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(RESEARCHER))
                 .withCallerUserId("notUserId").build());
         
-        AuthUtils.checkSelfOrResearcher(USER_ID);
+        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", USER_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -184,7 +192,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(DEVELOPER))
                 .withCallerUserId("notUserId").build());
         
-        AuthUtils.checkSelfOrResearcher(USER_ID);
+        IS_SELF_OR_RESEARCHER.checkAndThrow("userId", USER_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -192,7 +200,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of("studyA", "studyB")).build());
         
-        AuthUtils.checkStudyTeamMemberOrWorker(TEST_STUDY_ID);
+        IS_STUDY_TEAM_OR_WORKER.checkAndThrow("studyId", TEST_STUDY_ID);
     }
     
     @Test
@@ -200,7 +208,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
         
-        assertFalse( AuthUtils.isStudyTeamMemberOrWorker(TEST_STUDY_ID) );
+        assertFalse( IS_STUDY_TEAM_OR_WORKER.check("studyId", TEST_STUDY_ID) );
     }
     
     @Test
@@ -208,7 +216,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
         
-        assertFalse( AuthUtils.isStudyTeamMemberOrWorker(null) );
+        assertFalse( IS_STUDY_TEAM_OR_WORKER.check("studyId", null) );
     }
     
     @Test
@@ -217,7 +225,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(WORKER))
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
         
-        assertTrue( AuthUtils.isStudyTeamMemberOrWorker(TEST_STUDY_ID) );
+        assertTrue( IS_STUDY_TEAM_OR_WORKER.check("studyId", TEST_STUDY_ID) );
     }
 
     @Test
@@ -226,7 +234,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ADMIN))
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
         
-        assertTrue( AuthUtils.isStudyTeamMemberOrWorker(TEST_STUDY_ID) );
+        assertTrue( IS_STUDY_TEAM_OR_WORKER.check("studyId", TEST_STUDY_ID) );
     }
     
     @Test
@@ -234,7 +242,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
         
-        assertTrue( AuthUtils.isStudyTeamMemberOrWorker("study2") );
+        assertTrue( IS_STUDY_TEAM_OR_WORKER.check("studyId", "study2") );
     }
 
     @Test
@@ -274,14 +282,14 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());
 
-        AuthUtils.checkOrgMember(TEST_ORG_ID);
+        IS_ORG_MEMBER.checkAndThrow("orgId", TEST_ORG_ID);
     }
     
     @Test
     public void isStudyScopedToCallerSucceedsForGlobalUser() {
         RequestContext.set(new RequestContext.Builder().build());
         
-        AuthUtils.checkStudyTeamMemberOrWorker(TEST_STUDY_ID);
+        IS_STUDY_TEAM_OR_WORKER.checkAndThrow("studyId", TEST_STUDY_ID);
     }
     
     @Test
@@ -291,7 +299,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(RESEARCHER))
                 .build());
         
-        AuthUtils.checkStudyResearcher(TEST_STUDY_ID);
+        IS_STUDY_RESEARCHER.checkAndThrow("studyId", TEST_STUDY_ID);
     }
 
     @Test
@@ -300,7 +308,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ADMIN))
                 .build());
         
-        AuthUtils.checkStudyResearcher(TEST_STUDY_ID);
+        IS_STUDY_RESEARCHER.checkAndThrow("studyId", TEST_STUDY_ID);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -310,7 +318,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(RESEARCHER))
                 .build());
         
-        AuthUtils.checkStudyResearcher(TEST_STUDY_ID);
+        IS_STUDY_RESEARCHER.checkAndThrow("studyId", TEST_STUDY_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -320,7 +328,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(DEVELOPER))
                 .build());
         
-        AuthUtils.checkStudyResearcher(TEST_STUDY_ID);
+        IS_STUDY_RESEARCHER.checkAndThrow("studyId", TEST_STUDY_ID);
     }
     
     @Test
@@ -330,7 +338,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
                 .build());
         
-        AuthUtils.checkOrgAdmin(TEST_ORG_ID);
+        IS_ORGADMIN.checkAndThrow("orgId", TEST_ORG_ID);
     }
 
     @Test
@@ -339,7 +347,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ADMIN))
                 .build());
         
-        AuthUtils.checkOrgAdmin(TEST_ORG_ID);
+        IS_ORGADMIN.checkAndThrow("orgId", TEST_ORG_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -349,7 +357,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
                 .build());
         
-        AuthUtils.checkOrgAdmin(TEST_ORG_ID);
+        IS_ORGADMIN.checkAndThrow("orgId", TEST_ORG_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -359,7 +367,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(DEVELOPER))
                 .build());
         
-        AuthUtils.checkOrgAdmin(TEST_ORG_ID);
+        IS_ORGADMIN.checkAndThrow("orgId", TEST_ORG_ID);
     }
     
     @Test
@@ -367,7 +375,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID).build());
         
-        assertTrue( AuthUtils.isOrgMember(TEST_ORG_ID) );
+        assertTrue( IS_ORG_MEMBER.check("orgId", TEST_ORG_ID) );
     }
     
     @Test
@@ -375,7 +383,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());
         
-        assertTrue( AuthUtils.isOrgMember(TEST_ORG_ID) );
+        assertTrue( IS_ORG_MEMBER.check("orgId", TEST_ORG_ID) );
     }
     
     @Test
@@ -385,7 +393,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerOrgMembership("wrong-org")
                 .build());
         
-        assertFalse( AuthUtils.isOrgMember(TEST_ORG_ID) );
+        assertFalse( IS_ORG_MEMBER.check("orgId", TEST_ORG_ID) );
     }
     
     @Test
@@ -395,7 +403,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
                 .build());
         
-        assertTrue( AuthUtils.isOrgAdmin(TEST_ORG_ID) );
+        assertTrue( IS_ORGADMIN.check("orgId", TEST_ORG_ID) );
     }
 
     @Test
@@ -404,7 +412,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
                 .build());
         
-        assertFalse( AuthUtils.isOrgAdmin(TEST_ORG_ID) );
+        assertFalse( IS_ORGADMIN.check("orgId", TEST_ORG_ID) );
     }
 
     @Test
@@ -413,7 +421,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .build());
         
-        assertFalse( AuthUtils.isOrgAdmin(TEST_ORG_ID) );
+        assertFalse( IS_ORGADMIN.check("orgId", TEST_ORG_ID) );
     }
     
     @Test
@@ -421,7 +429,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId(USER_ID).build());
         
-        assertTrue( AuthUtils.isSelfOrStudyTeamMemberOrWorker(TEST_STUDY_ID, USER_ID) );
+        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.check("studyId", TEST_STUDY_ID, "userId", USER_ID) );
     }
 
     @Test
@@ -429,7 +437,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID)).build());
         
-        assertTrue( AuthUtils.isSelfOrStudyTeamMemberOrWorker(TEST_STUDY_ID, USER_ID) );
+        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.check("studyId", TEST_STUDY_ID, "userId", USER_ID) );
     }
 
     @Test
@@ -437,7 +445,7 @@ public class AuthUtilsTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(WORKER)).build());
         
-        assertTrue( AuthUtils.isSelfOrStudyTeamMemberOrWorker(TEST_STUDY_ID, USER_ID) );
+        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.check("studyId", TEST_STUDY_ID, "userId", USER_ID) );
     }
 
     @Test
@@ -449,7 +457,7 @@ public class AuthUtilsTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of("study1"))
                 .build());
         
-        assertFalse( AuthUtils.isSelfOrStudyTeamMemberOrWorker(TEST_STUDY_ID, USER_ID) );
+        assertFalse( IS_SELF_STUDY_TEAM_OR_WORKER.check("studyId", TEST_STUDY_ID, "userId", USER_ID) );
     }
     
     @Test
@@ -458,7 +466,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerUserId(USER_ID)
                 .build());
         
-        assertTrue( AuthUtils.isSelfOrStudyTeamMemberOrWorker(TEST_STUDY_ID, USER_ID) );
+        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.check("studyId", TEST_STUDY_ID, "userId", USER_ID) );
     }
 
     @Test
@@ -467,7 +475,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerUserId(USER_ID)
                 .build());
         
-        assertTrue( AuthUtils.isSelfOrStudyTeamMemberOrWorker(TEST_STUDY_ID, USER_ID) );
+        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.check("studyId", TEST_STUDY_ID, "userId", USER_ID) );
     }
 
     @Test
@@ -476,7 +484,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(WORKER))
                 .build());
         
-        assertTrue( AuthUtils.isSelfOrStudyTeamMemberOrWorker(TEST_STUDY_ID, USER_ID) );
+        assertTrue( IS_SELF_STUDY_TEAM_OR_WORKER.check("studyId", TEST_STUDY_ID, "userId", USER_ID) );
     }
 
     @Test
@@ -488,7 +496,7 @@ public class AuthUtilsTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of("study1"))
                 .build());
         
-        assertFalse( AuthUtils.isSelfWorkerOrOrgAdmin(TEST_ORG_ID, USER_ID) );
+        assertFalse( IS_SELF_ORGADMIN_OR_WORKER.check("orgId", TEST_ORG_ID, "userId", USER_ID) );
     }
 
     @Test
@@ -497,7 +505,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerUserId(USER_ID)
                 .build());
         
-        assertTrue( AuthUtils.isSelfWorkerOrOrgAdmin(TEST_ORG_ID, USER_ID) );
+        assertTrue( IS_SELF_ORGADMIN_OR_WORKER.check("orgId", TEST_ORG_ID, "userId", USER_ID) );
     }
 
     @Test
@@ -506,7 +514,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(WORKER))
                 .build());
         
-        assertTrue( AuthUtils.isSelfWorkerOrOrgAdmin(TEST_ORG_ID, USER_ID) );
+        assertTrue( IS_SELF_ORGADMIN_OR_WORKER.check("orgId", TEST_ORG_ID, "userId", USER_ID) );
     }
 
     @Test
@@ -516,7 +524,7 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
                 .build());
         
-        assertTrue( AuthUtils.isSelfWorkerOrOrgAdmin(TEST_ORG_ID, USER_ID) );
+        assertTrue( IS_SELF_ORGADMIN_OR_WORKER.check("orgId", TEST_ORG_ID, "userId", USER_ID) );
     }
 
     @Test
@@ -525,7 +533,7 @@ public class AuthUtilsTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
                 .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
         
-        AuthUtils.checkStudyResearcher(TEST_STUDY_ID);
+        IS_STUDY_RESEARCHER.checkAndThrow("studyId", TEST_STUDY_ID);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -534,6 +542,6 @@ public class AuthUtilsTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of("studyA"))
                 .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
         
-        AuthUtils.checkStudyResearcher(TEST_STUDY_ID);
+        IS_STUDY_RESEARCHER.checkAndThrow("studyId", TEST_STUDY_ID);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -3,7 +3,7 @@ package org.sagebionetworks.bridge;
 import static java.util.stream.Collectors.toSet;
 import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.models.assessments.ResourceCategory.LICENSE;
 import static org.sagebionetworks.bridge.models.assessments.ResourceCategory.PUBLICATION;
 import static org.sagebionetworks.bridge.models.templates.TemplateType.EMAIL_SIGNED_CONSENT;
@@ -342,18 +342,18 @@ public class BridgeUtilsTest {
     
     @Test
     public void filterForStudyAccountReturnsSelfAccount() {
-        RequestContext.set(new RequestContext.Builder().withCallerUserId(USER_ID)
+        RequestContext.set(new RequestContext.Builder().withCallerUserId(TEST_USER_ID)
                 .withOrgSponsoredStudies(ImmutableSet.of("A")).build());
         
         Account account = Account.create();
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         
         assertNotNull(BridgeUtils.filterForStudy(account));
     }
 
     @Test
     public void filterForStudyAccountNotSelfReturnsNull() {
-        RequestContext.set(new RequestContext.Builder().withCallerUserId(USER_ID)
+        RequestContext.set(new RequestContext.Builder().withCallerUserId(TEST_USER_ID)
                 .withOrgSponsoredStudies(ImmutableSet.of("A")).build());
         
         Account account = Account.create();

--- a/src/test/java/org/sagebionetworks/bridge/RequestContextTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/RequestContextTest.java
@@ -9,7 +9,7 @@ import static org.sagebionetworks.bridge.Roles.WORKER;
 import static org.sagebionetworks.bridge.TestConstants.LANGUAGES;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestConstants.USER_STUDY_IDS;
 import static org.sagebionetworks.bridge.models.ClientInfo.UNKNOWN_CLIENT;
 import static org.testng.Assert.assertEquals;
@@ -108,7 +108,7 @@ public class RequestContextTest extends Mockito {
         ClientInfo clientInfo = ClientInfo.fromUserAgentCache("Asthma/26 (Unknown iPhone; iPhone OS/9.1) BridgeSDK/4");
         
         RequestContext context = new RequestContext.Builder().withRequestId(REQUEST_ID).withCallerEnrolledStudies(STUDIES)
-                .withCallerAppId(TEST_APP_ID).withMetrics(metrics).withCallerRoles(ROLES).withCallerUserId(USER_ID)
+                .withCallerAppId(TEST_APP_ID).withMetrics(metrics).withCallerRoles(ROLES).withCallerUserId(TEST_USER_ID)
                 .withCallerLanguages(LANGUAGES).withCallerClientInfo(clientInfo).withCallerOrgMembership(TEST_ORG_ID)
                 .withOrgSponsoredStudies(USER_STUDY_IDS).build();
 
@@ -116,7 +116,7 @@ public class RequestContextTest extends Mockito {
         assertEquals(context.getCallerAppId(), TEST_APP_ID);
         assertEquals(context.getCallerEnrolledStudies(), STUDIES);
         assertEquals(context.getCallerRoles(), ROLES);
-        assertEquals(context.getCallerUserId(), USER_ID);
+        assertEquals(context.getCallerUserId(), TEST_USER_ID);
         assertEquals(context.getCallerLanguages(), LANGUAGES);
         assertEquals(context.getCallerClientInfo(), clientInfo);
         assertEquals(context.getMetrics(), metrics);
@@ -132,7 +132,7 @@ public class RequestContextTest extends Mockito {
         ClientInfo clientInfo = ClientInfo.fromUserAgentCache("Asthma/26 (Unknown iPhone; iPhone OS/9.1) BridgeSDK/4");
         
         RequestContext context = new RequestContext.Builder().withRequestId(REQUEST_ID).withCallerAppId(TEST_APP_ID)
-                .withCallerEnrolledStudies(STUDIES).withMetrics(metrics).withCallerRoles(ROLES).withCallerUserId(USER_ID)
+                .withCallerEnrolledStudies(STUDIES).withMetrics(metrics).withCallerRoles(ROLES).withCallerUserId(TEST_USER_ID)
                 .withCallerLanguages(LANGUAGES).withCallerClientInfo(clientInfo).withCallerOrgMembership(TEST_ORG_ID)
                 .withOrgSponsoredStudies(USER_STUDY_IDS).build();
         
@@ -142,7 +142,7 @@ public class RequestContextTest extends Mockito {
         assertEquals(copy.getCallerAppId(), TEST_APP_ID);
         assertEquals(copy.getCallerEnrolledStudies(), STUDIES);
         assertEquals(copy.getCallerRoles(), ROLES);
-        assertEquals(copy.getCallerUserId(), USER_ID);
+        assertEquals(copy.getCallerUserId(), TEST_USER_ID);
         assertEquals(copy.getCallerLanguages(), LANGUAGES);
         assertEquals(copy.getCallerClientInfo(), clientInfo);
         assertEquals(copy.getMetrics(), metrics);
@@ -213,7 +213,7 @@ public class RequestContextTest extends Mockito {
         when(mockSponsorService.getSponsoredStudyIds(TEST_APP_ID, TEST_ORG_ID)).thenReturn(USER_STUDY_IDS);
         
         UserSession session = new UserSession(new StudyParticipant.Builder().withStudyIds(USER_STUDY_IDS)
-                .withRoles(ImmutableSet.of(DEVELOPER)).withId(USER_ID).withOrgMembership(TEST_ORG_ID)
+                .withRoles(ImmutableSet.of(DEVELOPER)).withId(TEST_USER_ID).withOrgMembership(TEST_ORG_ID)
                 .withLanguages(LANGUAGES).build());
         session.setAuthenticated(true);
         session.setAppId(TEST_APP_ID);
@@ -225,7 +225,7 @@ public class RequestContextTest extends Mockito {
         assertEquals(retValue.getOrgSponsoredStudies(), USER_STUDY_IDS);
         assertTrue(retValue.isAdministrator());
         assertTrue(retValue.isInRole(DEVELOPER));
-        assertEquals(retValue.getCallerUserId(), USER_ID);
+        assertEquals(retValue.getCallerUserId(), TEST_USER_ID);
         assertEquals(retValue.getCallerOrgMembership(), TEST_ORG_ID);
         assertEquals(retValue.getCallerLanguages(), LANGUAGES);
         
@@ -241,7 +241,7 @@ public class RequestContextTest extends Mockito {
         when(mockSponsorService.getSponsoredStudyIds(TEST_APP_ID, TEST_ORG_ID)).thenReturn(USER_STUDY_IDS);
         
         UserSession session = new UserSession(new StudyParticipant.Builder().withStudyIds(USER_STUDY_IDS)
-                .withRoles(ImmutableSet.of(DEVELOPER)).withId(USER_ID).withLanguages(LANGUAGES).build());
+                .withRoles(ImmutableSet.of(DEVELOPER)).withId(TEST_USER_ID).withLanguages(LANGUAGES).build());
         session.setAuthenticated(true);
         session.setAppId(TEST_APP_ID);
         
@@ -261,7 +261,7 @@ public class RequestContextTest extends Mockito {
         when(mockSponsorService.getSponsoredStudyIds(TEST_APP_ID, TEST_ORG_ID)).thenReturn(USER_STUDY_IDS);
         
         UserSession session = new UserSession(new StudyParticipant.Builder().withStudyIds(USER_STUDY_IDS)
-                .withRoles(ImmutableSet.of(ADMIN)).withOrgMembership(TEST_ORG_ID).withId(USER_ID)
+                .withRoles(ImmutableSet.of(ADMIN)).withOrgMembership(TEST_ORG_ID).withId(TEST_USER_ID)
                 .withLanguages(LANGUAGES).build());
         session.setAuthenticated(true);
         session.setAppId(TEST_APP_ID);
@@ -283,7 +283,7 @@ public class RequestContextTest extends Mockito {
         RequestContext.set(context);
         
         UserSession session = new UserSession(new StudyParticipant.Builder().withStudyIds(USER_STUDY_IDS)
-                .withRoles(ImmutableSet.of(DEVELOPER)).withId(USER_ID).withOrgMembership(TEST_ORG_ID)
+                .withRoles(ImmutableSet.of(DEVELOPER)).withId(TEST_USER_ID).withOrgMembership(TEST_ORG_ID)
                 .withLanguages(LANGUAGES).build());
         session.setAuthenticated(true);
         session.setAppId(TEST_APP_ID);
@@ -295,7 +295,7 @@ public class RequestContextTest extends Mockito {
         assertEquals(retValue.getOrgSponsoredStudies(), ImmutableSet.of());
         assertTrue(retValue.isAdministrator());
         assertTrue(retValue.isInRole(DEVELOPER));
-        assertEquals(retValue.getCallerUserId(), USER_ID);
+        assertEquals(retValue.getCallerUserId(), TEST_USER_ID);
         assertEquals(retValue.getCallerOrgMembership(), TEST_ORG_ID);
         assertEquals(retValue.getCallerLanguages(), LANGUAGES);
         

--- a/src/test/java/org/sagebionetworks/bridge/TestConstants.java
+++ b/src/test/java/org/sagebionetworks/bridge/TestConstants.java
@@ -47,7 +47,7 @@ public class TestConstants {
     public static final String REQUEST_ID = "request-id";
     public static final String UA = "Asthma/26 (Unknown iPhone; iPhone OS/9.1) BridgeSDK/4";
     public static final String IP_ADDRESS = "2.3.4.5";
-    public static final String USER_ID = "userId";
+    public static final String TEST_USER_ID = "userId";
     public static final String SYNAPSE_USER_ID = "12345";
     public static final DateTimeZone TIMEZONE_MSK = DateTimeZone.forOffsetHours(3);
 
@@ -60,7 +60,7 @@ public class TestConstants {
     public static final byte[] MOCK_MD5 = { -104, 10, -30, -37, 25, -113, 92, -9, 69, -118, -46, -87, 11, -14, 38, -61 };
     public static final String MOCK_MD5_HEX_ENCODED = "980ae2db198f5cf7458ad2a90bf226c3";
 
-    public static final AccountId ACCOUNT_ID = AccountId.forId(TEST_APP_ID, USER_ID);
+    public static final AccountId ACCOUNT_ID = AccountId.forId(TEST_APP_ID, TEST_USER_ID);
     public static final CriteriaContext TEST_CONTEXT = new CriteriaContext.Builder()
             .withUserId("user-id").withAppId(TEST_APP_ID).build();
 
@@ -161,7 +161,7 @@ public class TestConstants {
     public static final Activity ACTIVITY_3 = new Activity.Builder().withLabel("Activity3").withGuid("AAA")
             .withTask("tapTest").build();
 
-    public static final String OWNER_ID = "oneOwnerId";
+    public static final String TEST_OWNER_ID = "oneOwnerId";
     public static final String IDENTIFIER = "oneIdentifier";
     public static final Set<String> STRING_TAGS = ImmutableSet.of("tag1", "tag2");
     public static final Set<Tag> TAGS = TagUtils.toTagSet(STRING_TAGS);

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/AccountPersistenceExceptionConverterTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/AccountPersistenceExceptionConverterTest.java
@@ -4,7 +4,7 @@ import static org.sagebionetworks.bridge.TestConstants.EMAIL;
 import static org.sagebionetworks.bridge.TestConstants.PHONE;
 import static org.sagebionetworks.bridge.TestConstants.SYNAPSE_USER_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
 
@@ -72,7 +72,7 @@ public class AccountPersistenceExceptionConverterTest extends Mockito {
         account.setEmail(EMAIL);
         
         Account existing = Account.create();
-        existing.setId(USER_ID);
+        existing.setId(TEST_USER_ID);
         existing.setAppId(TEST_APP_ID);
         existing.setEmail(EMAIL);
         
@@ -86,7 +86,7 @@ public class AccountPersistenceExceptionConverterTest extends Mockito {
         RuntimeException result = converter.convert(pe, account);
         assertEquals(result.getClass(), EntityAlreadyExistsException.class);
         assertEquals(result.getMessage(), "Email address has already been used by another account.");
-        assertEquals(((EntityAlreadyExistsException)result).getEntityKeys().get("userId"), USER_ID);
+        assertEquals(((EntityAlreadyExistsException)result).getEntityKeys().get("userId"), TEST_USER_ID);
     }
     
     @Test
@@ -96,7 +96,7 @@ public class AccountPersistenceExceptionConverterTest extends Mockito {
         account.setPhone(PHONE);
         
         Account existing = Account.create();
-        existing.setId(USER_ID);
+        existing.setId(TEST_USER_ID);
         existing.setAppId(TEST_APP_ID);
         existing.setPhone(PHONE);
         
@@ -110,19 +110,19 @@ public class AccountPersistenceExceptionConverterTest extends Mockito {
         RuntimeException result = converter.convert(pe, account);
         assertEquals(result.getClass(), EntityAlreadyExistsException.class);
         assertEquals(result.getMessage(), "Phone number has already been used by another account.");
-        assertEquals(((EntityAlreadyExistsException)result).getEntityKeys().get("userId"), USER_ID);
+        assertEquals(((EntityAlreadyExistsException)result).getEntityKeys().get("userId"), TEST_USER_ID);
     }
 
     @Test
     public void entityAlreadyExistsForExternalId() {
-        Enrollment enrollment = Enrollment.create(TEST_APP_ID, "something", USER_ID, "ext");
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, "something", TEST_USER_ID, "ext");
         
         HibernateAccount account = new HibernateAccount();
         account.setAppId(TEST_APP_ID);
         account.setEnrollments(ImmutableSet.of(enrollment));
         
         Account existing = Account.create();
-        existing.setId(USER_ID);
+        existing.setId(TEST_USER_ID);
         existing.setAppId(TEST_APP_ID);
         existing.setEnrollments(ImmutableSet.of(enrollment));
         
@@ -135,19 +135,19 @@ public class AccountPersistenceExceptionConverterTest extends Mockito {
         RuntimeException result = converter.convert(pe, account);
         assertEquals(result.getClass(), EntityAlreadyExistsException.class);
         assertEquals(result.getMessage(), "External ID has already been used by another account.");
-        assertEquals(((EntityAlreadyExistsException)result).getEntityKeys().get("userId"), USER_ID);
+        assertEquals(((EntityAlreadyExistsException)result).getEntityKeys().get("userId"), TEST_USER_ID);
     }
     
     @Test
     public void entityAlreadyExistsForExternalIdWhenThereAreMultiple() {
         HibernateAccount account = new HibernateAccount();
         account.setAppId(TEST_APP_ID);
-        Enrollment en1 = Enrollment.create(TEST_APP_ID, "studyA", USER_ID, "externalIdA");
-        Enrollment en2 = Enrollment.create(TEST_APP_ID, "studyB", USER_ID, "externalIdB");
+        Enrollment en1 = Enrollment.create(TEST_APP_ID, "studyA", TEST_USER_ID, "externalIdA");
+        Enrollment en2 = Enrollment.create(TEST_APP_ID, "studyB", TEST_USER_ID, "externalIdB");
         account.setEnrollments(ImmutableSet.of(en1, en2));
         
         Account existing = Account.create();
-        existing.setId(USER_ID);
+        existing.setId(TEST_USER_ID);
         existing.setAppId(TEST_APP_ID);
         
         when(accountDao.getAccount(AccountId.forExternalId(TEST_APP_ID, "externalIdB")))
@@ -160,7 +160,7 @@ public class AccountPersistenceExceptionConverterTest extends Mockito {
         RuntimeException result = converter.convert(pe, account);
         assertEquals(result.getClass(), EntityAlreadyExistsException.class);
         assertEquals(result.getMessage(), "External ID has already been used by another account.");
-        assertEquals(((EntityAlreadyExistsException)result).getEntityKeys().get("userId"), USER_ID);
+        assertEquals(((EntityAlreadyExistsException)result).getEntityKeys().get("userId"), TEST_USER_ID);
     }
     
     @Test
@@ -170,12 +170,12 @@ public class AccountPersistenceExceptionConverterTest extends Mockito {
         
         HibernateAccount account = new HibernateAccount();
         account.setAppId(TEST_APP_ID);
-        Enrollment en1 = Enrollment.create(TEST_APP_ID, "studyA", USER_ID, "externalIdA");
-        Enrollment en2 = Enrollment.create(TEST_APP_ID, "studyB", USER_ID, "externalIdB");
+        Enrollment en1 = Enrollment.create(TEST_APP_ID, "studyA", TEST_USER_ID, "externalIdA");
+        Enrollment en2 = Enrollment.create(TEST_APP_ID, "studyB", TEST_USER_ID, "externalIdB");
         account.setEnrollments(ImmutableSet.of(en1, en2));
         
         Account existing = Account.create();
-        existing.setId(USER_ID);
+        existing.setId(TEST_USER_ID);
         existing.setAppId(TEST_APP_ID);
         
         // Accept anything here, but verify that it is externalIdB still (the first that would match
@@ -189,7 +189,7 @@ public class AccountPersistenceExceptionConverterTest extends Mockito {
         RuntimeException result = converter.convert(pe, account);
         assertEquals(result.getClass(), EntityAlreadyExistsException.class);
         assertEquals(result.getMessage(), "External ID has already been used by another account.");
-        assertEquals(((EntityAlreadyExistsException)result).getEntityKeys().get("userId"), USER_ID);
+        assertEquals(((EntityAlreadyExistsException)result).getEntityKeys().get("userId"), TEST_USER_ID);
         
         verify(accountDao).getAccount(AccountId.forExternalId(TEST_APP_ID, "externalIdA"));
     }
@@ -201,11 +201,11 @@ public class AccountPersistenceExceptionConverterTest extends Mockito {
         
         HibernateAccount account = new HibernateAccount();
         account.setAppId(TEST_APP_ID);
-        Enrollment as1 = Enrollment.create(TEST_APP_ID, "studyA", USER_ID, "externalIdA");
+        Enrollment as1 = Enrollment.create(TEST_APP_ID, "studyA", TEST_USER_ID, "externalIdA");
         account.setEnrollments(ImmutableSet.of(as1));
         
         Account existing = Account.create();
-        existing.setId(USER_ID);
+        existing.setId(TEST_USER_ID);
         existing.setAppId(TEST_APP_ID);
         
         // Accept anything here, but verify that it is externalIdA (which won't match user calling method)
@@ -254,7 +254,7 @@ public class AccountPersistenceExceptionConverterTest extends Mockito {
     public void entityAlreadyExistsForSynapseUserId() {
         Account account = Account.create();
         account.setSynapseUserId(SYNAPSE_USER_ID);
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         account.setAppId(TEST_APP_ID);
         
         when(accountDao.getAccount(AccountId.forSynapseUserId(TEST_APP_ID, SYNAPSE_USER_ID)))
@@ -272,7 +272,7 @@ public class AccountPersistenceExceptionConverterTest extends Mockito {
     @Test
     public void entityAlreadyExistsForDuplicateExternalIdInApp() {
         Account account = Account.create();
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         account.setAppId(TEST_APP_ID);
         
         when(accountDao.getAccount(AccountId.forExternalId(TEST_APP_ID, "CCC")))

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountTest.java
@@ -14,7 +14,7 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_EXTERNAL_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
 import static org.sagebionetworks.bridge.TestConstants.USER_DATA_GROUPS;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.models.accounts.AccountStatus.DISABLED;
 import static org.sagebionetworks.bridge.models.accounts.AccountStatus.ENABLED;
@@ -56,7 +56,7 @@ import com.google.common.collect.Sets;
 
 public class HibernateAccountTest {
     private static final Set<Enrollment> ENROLLMENTS = ImmutableSet
-            .of(Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID, TEST_EXTERNAL_ID));
+            .of(Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID, TEST_EXTERNAL_ID));
     
     private static final SubpopulationGuid GUID1 = SubpopulationGuid.create("guid1");
     private static final SubpopulationGuid GUID2 = SubpopulationGuid.create("guid2");
@@ -104,8 +104,8 @@ public class HibernateAccountTest {
         account.setNotifyByEmail(true);
         account.setMigrationVersion(3);
         
-        Enrollment en1 = Enrollment.create(TEST_APP_ID, "studyA", USER_ID);
-        Enrollment en2 = Enrollment.create(TEST_APP_ID, "studyB", USER_ID);
+        Enrollment en1 = Enrollment.create(TEST_APP_ID, "studyA", TEST_USER_ID);
+        Enrollment en2 = Enrollment.create(TEST_APP_ID, "studyB", TEST_USER_ID);
         account.setEnrollments(ImmutableSet.of(en1, en2));
         
         // Do this just to verify it is not included in the serialization.
@@ -401,9 +401,9 @@ public class HibernateAccountTest {
     
     @Test
     public void getActiveEnrollments() {
-        Enrollment en1 = Enrollment.create(TEST_APP_ID, "studyA", USER_ID);
-        Enrollment en2 = Enrollment.create(TEST_APP_ID, "studyB", USER_ID);
-        Enrollment en3 = Enrollment.create(TEST_APP_ID, "studyC", USER_ID);
+        Enrollment en1 = Enrollment.create(TEST_APP_ID, "studyA", TEST_USER_ID);
+        Enrollment en2 = Enrollment.create(TEST_APP_ID, "studyB", TEST_USER_ID);
+        Enrollment en3 = Enrollment.create(TEST_APP_ID, "studyC", TEST_USER_ID);
         en2.setWithdrawnOn(CREATED_ON);
         Set<Enrollment> enrollments = ImmutableSet.of(en1, en2, en3);
         

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateEnrollmentDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateEnrollmentDaoTest.java
@@ -3,7 +3,7 @@ package org.sagebionetworks.bridge.hibernate;
 import static org.sagebionetworks.bridge.BridgeConstants.TEST_USER_GROUP;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.hibernate.HibernateEnrollmentDao.REF_QUERY;
 import static org.sagebionetworks.bridge.models.studies.EnrollmentFilter.ENROLLED;
 import static org.testng.Assert.assertEquals;
@@ -209,7 +209,7 @@ public class HibernateEnrollmentDaoTest extends Mockito {
         when(mockHelper.queryGet(eq(REF_QUERY), any(), isNull(), eq(1), eq(HibernateAccount.class)))
             .thenReturn(ImmutableList.of(account1), ImmutableList.of(account2), ImmutableList.of(account3));
         
-        List<EnrollmentDetail> retValue = dao.getEnrollmentsForUser(TEST_APP_ID, USER_ID);
+        List<EnrollmentDetail> retValue = dao.getEnrollmentsForUser(TEST_APP_ID, TEST_USER_ID);
         EnrollmentDetail detail1 = retValue.get(0);
         assertEquals(detail1.getParticipant().getLastName(), "account1");
         assertEquals(detail1.getEnrolledBy().getLastName(), "account2");
@@ -220,7 +220,7 @@ public class HibernateEnrollmentDaoTest extends Mockito {
         
         assertEquals(queryCaptor.getValue(), "FROM HibernateEnrollment WHERE appId = :appId AND accountId = :userId");
         assertEquals(paramsCaptor.getValue().get("appId"), TEST_APP_ID);
-        assertEquals(paramsCaptor.getValue().get("userId"), USER_ID);
+        assertEquals(paramsCaptor.getValue().get("userId"), TEST_USER_ID);
     }
 
 }

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateExternalIdDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateExternalIdDaoTest.java
@@ -2,7 +2,7 @@ package org.sagebionetworks.bridge.hibernate;
 
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -147,7 +147,7 @@ public class HibernateExternalIdDaoTest extends Mockito {
 
     @Test
     public void deleteExternalId() {
-        Enrollment en = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment en = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         en.setExternalId(EXTERNAL_ID);
         
         Account account = Account.create();
@@ -185,7 +185,7 @@ public class HibernateExternalIdDaoTest extends Mockito {
 
     @Test
     public void deleteExternalIdEnrollmentNotFound() {
-        Enrollment en = Enrollment.create(TEST_APP_ID, "anotherStudy", USER_ID);
+        Enrollment en = Enrollment.create(TEST_APP_ID, "anotherStudy", TEST_USER_ID);
         
         Account account = Account.create();
         account.setEnrollments(ImmutableSet.of(en));
@@ -215,10 +215,10 @@ public class HibernateExternalIdDaoTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of("studyA")).build());
         
         // The enrollment has the external ID the caller is looking for, but it's not in study A
-        Enrollment en = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID, EXTERNAL_ID);
+        Enrollment en = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID, EXTERNAL_ID);
         
         Account account = Account.create();
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         account.setEnrollments(Sets.newHashSet(en));
         
         AccountId accountId = AccountId.forExternalId(TEST_APP_ID, EXTERNAL_ID);

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateRequestInfoDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateRequestInfoDaoTest.java
@@ -1,6 +1,6 @@
 package org.sagebionetworks.bridge.hibernate;
 
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.testng.Assert.assertNotNull;
 
 import org.joda.time.DateTime;
@@ -33,8 +33,8 @@ public class HibernateRequestInfoDaoTest extends Mockito {
     
     @Test
     public void updateRequestInfoNoExistingObject() {
-        RequestInfo newInfo = new RequestInfo.Builder().withUserId(USER_ID).build();
-        when(mockHelper.getById(RequestInfo.class, USER_ID)).thenReturn(null);
+        RequestInfo newInfo = new RequestInfo.Builder().withUserId(TEST_USER_ID).build();
+        when(mockHelper.getById(RequestInfo.class, TEST_USER_ID)).thenReturn(null);
         
         dao.updateRequestInfo(newInfo);
 
@@ -43,11 +43,11 @@ public class HibernateRequestInfoDaoTest extends Mockito {
     
     @Test
     public void updateRequestInfoMergedWithExistingObject() {
-        RequestInfo newInfo = new RequestInfo.Builder().withUserId(USER_ID)
+        RequestInfo newInfo = new RequestInfo.Builder().withUserId(TEST_USER_ID)
                 .withActivitiesAccessedOn(DateTime.now()).build();
-        RequestInfo existingInfo = new RequestInfo.Builder().withUserId(USER_ID)
+        RequestInfo existingInfo = new RequestInfo.Builder().withUserId(TEST_USER_ID)
                 .withSignedInOn(DateTime.now()).build();
-        when(mockHelper.getById(RequestInfo.class, USER_ID)).thenReturn(existingInfo);
+        when(mockHelper.getById(RequestInfo.class, TEST_USER_ID)).thenReturn(existingInfo);
         
         dao.updateRequestInfo(newInfo);
 
@@ -60,23 +60,23 @@ public class HibernateRequestInfoDaoTest extends Mockito {
 
     @Test
     public void getRequestInfo() {
-        dao.getRequestInfo(USER_ID);
-        verify(mockHelper).getById(RequestInfo.class, USER_ID);
+        dao.getRequestInfo(TEST_USER_ID);
+        verify(mockHelper).getById(RequestInfo.class, TEST_USER_ID);
     }
 
     @Test
     public void removeRequestInfo() {
-        RequestInfo existingInfo = new RequestInfo.Builder().withUserId(USER_ID)
+        RequestInfo existingInfo = new RequestInfo.Builder().withUserId(TEST_USER_ID)
                 .withSignedInOn(DateTime.now()).build();
-        when(mockHelper.getById(RequestInfo.class, USER_ID)).thenReturn(existingInfo);
+        when(mockHelper.getById(RequestInfo.class, TEST_USER_ID)).thenReturn(existingInfo);
         
-        dao.removeRequestInfo(USER_ID);
-        verify(mockHelper).deleteById(RequestInfo.class, USER_ID);
+        dao.removeRequestInfo(TEST_USER_ID);
+        verify(mockHelper).deleteById(RequestInfo.class, TEST_USER_ID);
     }       
     
     @Test
     public void removeRequestInfoNoObject() {
-        dao.removeRequestInfo(USER_ID);
+        dao.removeRequestInfo(TEST_USER_ID);
         verify(mockHelper, never()).deleteById(any(), any());
     }       
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/AccountIdTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/AccountIdTest.java
@@ -4,7 +4,7 @@ import static org.sagebionetworks.bridge.TestConstants.EMAIL;
 import static org.sagebionetworks.bridge.TestConstants.PHONE;
 import static org.sagebionetworks.bridge.TestConstants.SYNAPSE_USER_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -25,8 +25,8 @@ public class AccountIdTest {
     
     @Test
     public void twoAccountIdsAreTheSameWithTheSameData() {
-        assertTrue(AccountId.forId(TEST_APP_ID, USER_ID)
-                .equals(AccountId.forId(TEST_APP_ID, USER_ID)));
+        assertTrue(AccountId.forId(TEST_APP_ID, TEST_USER_ID)
+                .equals(AccountId.forId(TEST_APP_ID, TEST_USER_ID)));
         
         assertTrue(AccountId.forPhone(TEST_APP_ID, PHONE)
                 .equals(AccountId.forPhone(TEST_APP_ID, PHONE)));
@@ -46,7 +46,7 @@ public class AccountIdTest {
     
     @Test
     public void testToString() {
-        assertEquals(AccountId.forId(TEST_APP_ID, USER_ID).toString(), "AccountId [appId="+TEST_APP_ID+", credential="+ USER_ID + "]");
+        assertEquals(AccountId.forId(TEST_APP_ID, TEST_USER_ID).toString(), "AccountId [appId="+TEST_APP_ID+", credential="+ TEST_USER_ID + "]");
         
         assertEquals(AccountId.forPhone(TEST_APP_ID, PHONE).toString(), "AccountId [appId="+TEST_APP_ID+", credential=Phone [regionCode=US, number=9712486796]]");
         
@@ -62,7 +62,7 @@ public class AccountIdTest {
     @Test
     public void factoryMethodsWork() {
         String number = PHONE.getNumber();
-        assertEquals(AccountId.forId(TEST_APP_ID, USER_ID).getId(), USER_ID);
+        assertEquals(AccountId.forId(TEST_APP_ID, TEST_USER_ID).getId(), TEST_USER_ID);
         assertEquals(AccountId.forEmail(TEST_APP_ID, "one").getEmail(), "one");
         assertEquals(AccountId.forPhone(TEST_APP_ID, PHONE).getPhone().getNumber(), number);
         assertEquals(AccountId.forHealthCode(TEST_APP_ID, "ABC-DEF").getHealthCode(), "ABC-DEF");
@@ -77,12 +77,12 @@ public class AccountIdTest {
     
     @Test(expectedExceptions = NullPointerException.class)
     public void emailAccessorThrows() {
-        AccountId.forId(TEST_APP_ID, USER_ID).getEmail();
+        AccountId.forId(TEST_APP_ID, TEST_USER_ID).getEmail();
     }
     
     @Test(expectedExceptions = NullPointerException.class)
     public void phoneAccessorThrows() {
-        AccountId.forId(TEST_APP_ID, USER_ID).getPhone();
+        AccountId.forId(TEST_APP_ID, TEST_USER_ID).getPhone();
     }
     
     @Test(expectedExceptions = NullPointerException.class)
@@ -132,7 +132,7 @@ public class AccountIdTest {
     
     @Test(expectedExceptions = NullPointerException.class)
     public void cannotCreateIdObjectWithNoAppId() {
-        AccountId.forId(null, USER_ID);
+        AccountId.forId(null, TEST_USER_ID);
     }
 
     @Test(expectedExceptions = NullPointerException.class)
@@ -152,11 +152,11 @@ public class AccountIdTest {
     
     @Test
     public void getValuesWithoutGuards() {
-        AccountId id = AccountId.forId(TEST_APP_ID, USER_ID);
+        AccountId id = AccountId.forId(TEST_APP_ID, TEST_USER_ID);
         
         AccountId accountId = id.getUnguardedAccountId();
         assertEquals(accountId.getAppId(), TEST_APP_ID);
-        assertEquals(accountId.getId(), USER_ID);
+        assertEquals(accountId.getId(), TEST_USER_ID);
         assertNull(accountId.getEmail());
         assertNull(accountId.getPhone());
         assertNull(accountId.getHealthCode());

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/AccountRefTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/AccountRefTest.java
@@ -10,7 +10,7 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.TestConstants.USER_DATA_GROUPS;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.models.accounts.AccountStatus.DISABLED;
 import static org.sagebionetworks.bridge.models.accounts.PasswordAlgorithm.BCRYPT;
 import static org.sagebionetworks.bridge.models.accounts.SharingScope.ALL_QUALIFIED_RESEARCHERS;
@@ -46,7 +46,7 @@ public class AccountRefTest {
         account.setAppId(TEST_APP_ID);
         account.setOrgMembership(TEST_ORG_ID);
         account.setRoles(ImmutableSet.of(DEVELOPER));
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         account.setCreatedOn(CREATED_ON);
         account.setModifiedOn(MODIFIED_ON);
         account.setClientData(TestUtils.getClientData());
@@ -60,7 +60,7 @@ public class AccountRefTest {
         account.setPasswordHash("passwordHash");
         account.setPasswordModifiedOn(MODIFIED_ON);
         account.setPasswordAlgorithm(BCRYPT);
-        account.setEnrollments(ImmutableSet.of(Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID)));
+        account.setEnrollments(ImmutableSet.of(Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID)));
         
         AccountRef ref = new AccountRef(account);
         
@@ -72,7 +72,7 @@ public class AccountRefTest {
         assertEquals(node.get("phone").get("number").textValue(), PHONE.getNumber());
         assertEquals(node.get("synapseUserId").textValue(), "synapseUserId");
         assertEquals(node.get("orgMembership").textValue(), TEST_ORG_ID);
-        assertEquals(node.get("identifier").textValue(), USER_ID);
+        assertEquals(node.get("identifier").textValue(), TEST_USER_ID);
         assertEquals(node.get("type").textValue(), "AccountRef");
         
         // This reference object is never deserialized on the server.

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/VerificationDataTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/VerificationDataTest.java
@@ -2,7 +2,7 @@ package org.sagebionetworks.bridge.models.accounts;
 
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TIMESTAMP;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -20,44 +20,44 @@ public class VerificationDataTest {
         VerificationData data = new VerificationData.Builder()
                 .withAppId(TEST_APP_ID)
                 .withType(ChannelType.PHONE)
-                .withUserId(USER_ID)
+                .withUserId(TEST_USER_ID)
                 .withExpiresOn(TIMESTAMP.getMillis()).build();
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(data);
         assertEquals(node.get("appId").textValue(), TEST_APP_ID);
         assertEquals(node.get("type").textValue(), "phone");
-        assertEquals(node.get("userId").textValue(), USER_ID);
+        assertEquals(node.get("userId").textValue(), TEST_USER_ID);
         assertEquals(node.get("expiresOn").longValue(), TIMESTAMP.getMillis());
         
         VerificationData deser = BridgeObjectMapper.get().readValue(node.toString(),
                 VerificationData.class);
         assertEquals(deser.getAppId(), TEST_APP_ID);
         assertEquals(deser.getType(), ChannelType.PHONE);
-        assertEquals(deser.getUserId(), USER_ID);
+        assertEquals(deser.getUserId(), TEST_USER_ID);
         assertEquals(deser.getExpiresOn(), TIMESTAMP.getMillis());
     }
     
     @Test
     public void restoreVerificationDataWithStudyId() throws Exception {
         String json = TestUtils.createJson("{'studyId':'"+TEST_APP_ID+"','type':'email','userId':'"+
-                USER_ID+"',"+"'expiresOn':1422319112486}");
+                TEST_USER_ID+"',"+"'expiresOn':1422319112486}");
         VerificationData deser = BridgeObjectMapper.get().readValue(json,
                 VerificationData.class);
         assertEquals(deser.getAppId(), TEST_APP_ID);
         assertEquals(deser.getType(), ChannelType.EMAIL);
-        assertEquals(deser.getUserId(), USER_ID);
+        assertEquals(deser.getUserId(), TEST_USER_ID);
         assertEquals(deser.getExpiresOn(), TIMESTAMP.getMillis());
     }
     
     @Test
     public void restoreVerificationDataWithAppId() throws Exception {
         String json = TestUtils.createJson("{'appId':'"+TEST_APP_ID+"','type':'email','userId':'"+
-                USER_ID+"',"+"'expiresOn':1422319112486}");
+                TEST_USER_ID+"',"+"'expiresOn':1422319112486}");
         VerificationData deser = BridgeObjectMapper.get().readValue(json,
                 VerificationData.class);
         assertEquals(deser.getAppId(), TEST_APP_ID);
         assertEquals(deser.getType(), ChannelType.EMAIL);
-        assertEquals(deser.getUserId(), USER_ID);
+        assertEquals(deser.getUserId(), TEST_USER_ID);
         assertEquals(deser.getExpiresOn(), TIMESTAMP.getMillis());
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/assessments/AssessmentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/assessments/AssessmentTest.java
@@ -5,7 +5,7 @@ import static org.sagebionetworks.bridge.TestConstants.CUSTOMIZATION_FIELDS;
 import static org.sagebionetworks.bridge.TestConstants.GUID;
 import static org.sagebionetworks.bridge.TestConstants.IDENTIFIER;
 import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
-import static org.sagebionetworks.bridge.TestConstants.OWNER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_OWNER_ID;
 import static org.sagebionetworks.bridge.TestConstants.STRING_TAGS;
 import static org.sagebionetworks.bridge.TestConstants.TAGS;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
@@ -44,7 +44,7 @@ public class AssessmentTest {
         assessment.setGuid(GUID);
         assessment.setIdentifier(IDENTIFIER);
         assessment.setRevision(5);
-        assessment.setOwnerId(OWNER_ID);
+        assessment.setOwnerId(TEST_OWNER_ID);
         assessment.setTitle("title");
         assessment.setSummary("summary");
         assessment.setOsName(ANDROID);
@@ -82,7 +82,7 @@ public class AssessmentTest {
         assertEquals(node.get("guid").textValue(), GUID);
         assertEquals(node.get("identifier").textValue(), IDENTIFIER);
         assertEquals(node.get("revision").intValue(), 5);
-        assertEquals(node.get("ownerId").textValue(), OWNER_ID);
+        assertEquals(node.get("ownerId").textValue(), TEST_OWNER_ID);
         assertEquals(node.get("title").textValue(), "title");
         assertEquals(node.get("summary").textValue(), "summary");
         assertEquals(node.get("osName").textValue(), ANDROID);
@@ -127,7 +127,7 @@ public class AssessmentTest {
         dto.setGuid(GUID);
         dto.setIdentifier(IDENTIFIER);
         dto.setRevision(5);
-        dto.setOwnerId(OWNER_ID);
+        dto.setOwnerId(TEST_OWNER_ID);
         dto.setTitle("title");
         dto.setSummary("summary");
         dto.setOsName(ANDROID);
@@ -148,7 +148,7 @@ public class AssessmentTest {
         assertEquals(assessment.getGuid(), GUID);
         assertEquals(assessment.getIdentifier(), IDENTIFIER);
         assertEquals(assessment.getRevision(), 5);
-        assertEquals(assessment.getOwnerId(), OWNER_ID);
+        assertEquals(assessment.getOwnerId(), TEST_OWNER_ID);
         assertEquals(assessment.getTitle(), "title");
         assertEquals(assessment.getSummary(), "summary");
         assertEquals(assessment.getOsName(), ANDROID);

--- a/src/test/java/org/sagebionetworks/bridge/models/assessments/HibernateAssessmentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/assessments/HibernateAssessmentTest.java
@@ -5,7 +5,7 @@ import static org.sagebionetworks.bridge.TestConstants.CUSTOMIZATION_FIELDS;
 import static org.sagebionetworks.bridge.TestConstants.GUID;
 import static org.sagebionetworks.bridge.TestConstants.IDENTIFIER;
 import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
-import static org.sagebionetworks.bridge.TestConstants.OWNER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_OWNER_ID;
 import static org.sagebionetworks.bridge.TestConstants.TAGS;
 import static org.sagebionetworks.bridge.models.OperatingSystem.ANDROID;
 import static org.testng.Assert.assertEquals;
@@ -46,7 +46,7 @@ public class HibernateAssessmentTest {
         assessment.setMinutesToComplete(10);
         assessment.setOsName(ANDROID);
         assessment.setOriginGuid("originGuid");
-        assessment.setOwnerId(OWNER_ID);
+        assessment.setOwnerId(TEST_OWNER_ID);
         assessment.setTags(TAGS);
         assessment.setCustomizationFields(CUSTOMIZATION_FIELDS);
         assessment.setCreatedOn(CREATED_ON);
@@ -68,7 +68,7 @@ public class HibernateAssessmentTest {
         assertEquals(assessment.getMinutesToComplete(), new Integer(10));
         assertEquals(assessment.getOsName(), ANDROID);
         assertEquals(assessment.getOriginGuid(), "originGuid");
-        assertEquals(assessment.getOwnerId(), OWNER_ID);
+        assertEquals(assessment.getOwnerId(), TEST_OWNER_ID);
         assertEquals(assessment.getTags(), TAGS);
         assertEquals(assessment.getCustomizationFields(), CUSTOMIZATION_FIELDS);
         assertEquals(assessment.getCreatedOn(), CREATED_ON);

--- a/src/test/java/org/sagebionetworks/bridge/models/studies/EnrollmentDetailTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/studies/EnrollmentDetailTest.java
@@ -2,7 +2,7 @@ package org.sagebionetworks.bridge.models.studies;
 
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -30,7 +30,7 @@ public class EnrollmentDetailTest {
         account3.setEmail("email3@email.com");
         AccountRef ref3 = new AccountRef(account3);
         
-        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         enrollment.setExternalId("anExternalId");
         enrollment.setConsentRequired(true);
 

--- a/src/test/java/org/sagebionetworks/bridge/models/studies/EnrollmentMigrationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/studies/EnrollmentMigrationTest.java
@@ -4,7 +4,7 @@ import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
 import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -19,7 +19,7 @@ public class EnrollmentMigrationTest {
         EnrollmentMigration enrollment = new EnrollmentMigration(); 
         enrollment.setAppId(TEST_APP_ID);
         enrollment.setStudyId(TEST_STUDY_ID);
-        enrollment.setUserId(USER_ID);
+        enrollment.setUserId(TEST_USER_ID);
         enrollment.setExternalId("externalId");
         enrollment.setEnrolledOn(CREATED_ON);
         enrollment.setWithdrawnOn(MODIFIED_ON);
@@ -33,7 +33,7 @@ public class EnrollmentMigrationTest {
         
         assertEquals(em.getAppId(), TEST_APP_ID);
         assertEquals(em.getStudyId(), TEST_STUDY_ID);
-        assertEquals(em.getUserId(), USER_ID);
+        assertEquals(em.getUserId(), TEST_USER_ID);
         assertEquals(em.getExternalId(), "externalId");
         assertEquals(em.getEnrolledOn(), CREATED_ON);
         assertEquals(em.getWithdrawnOn(), MODIFIED_ON);
@@ -45,7 +45,7 @@ public class EnrollmentMigrationTest {
         Enrollment en = em.asEnrollment();
         assertEquals(en.getAppId(), TEST_APP_ID);
         assertEquals(en.getStudyId(), TEST_STUDY_ID);
-        assertEquals(en.getAccountId(), USER_ID);
+        assertEquals(en.getAccountId(), TEST_USER_ID);
         assertEquals(en.getExternalId(), "externalId");
         assertEquals(en.getEnrolledOn(), CREATED_ON);
         assertEquals(en.getWithdrawnOn(), MODIFIED_ON);

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
@@ -9,7 +9,7 @@ import static org.sagebionetworks.bridge.TestConstants.PHONE;
 import static org.sagebionetworks.bridge.TestConstants.SYNAPSE_USER_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.dao.AccountDao.MIGRATION_VERSION;
 import static org.sagebionetworks.bridge.models.AccountSummarySearch.EMPTY_SEARCH;
 import static org.sagebionetworks.bridge.models.accounts.AccountSecretType.REAUTH;
@@ -71,7 +71,7 @@ import org.sagebionetworks.bridge.services.AuthenticationService.ChannelType;
 
 public class AccountServiceTest extends Mockito {
 
-    private static final AccountId ACCOUNT_ID = AccountId.forId(TEST_APP_ID, USER_ID);
+    private static final AccountId ACCOUNT_ID = AccountId.forId(TEST_APP_ID, TEST_USER_ID);
     private static final AccountId ACCOUNT_ID_WITH_EMAIL = AccountId.forEmail(TEST_APP_ID, EMAIL);
     private static final SignIn SIGN_IN = new SignIn.Builder().withAppId(TEST_APP_ID).withEmail(EMAIL)
             .withReauthToken("reauthToken").build();
@@ -85,7 +85,7 @@ public class AccountServiceTest extends Mockito {
     private static final String STUDY_A = "studyA";
     private static final String STUDY_B = "studyB";
     private static final Set<Enrollment> ACCOUNT_ENROLLMENTS = ImmutableSet
-            .of(Enrollment.create(TEST_APP_ID, STUDY_A, USER_ID));
+            .of(Enrollment.create(TEST_APP_ID, STUDY_A, TEST_USER_ID));
     private static final ImmutableSet<String> CALLER_STUDIES = ImmutableSet.of(STUDY_B);
     
     private static final SignIn PASSWORD_SIGNIN = new SignIn.Builder().withAppId(TEST_APP_ID).withEmail(EMAIL)
@@ -194,7 +194,7 @@ public class AccountServiceTest extends Mockito {
         app.setReauthenticationEnabled(true);
         
         Account account = mockGetAccountById(ACCOUNT_ID_WITH_EMAIL, false);
-        when(mockAccountSecretDao.verifySecret(REAUTH, USER_ID, "reauthToken", ROTATIONS))
+        when(mockAccountSecretDao.verifySecret(REAUTH, TEST_USER_ID, "reauthToken", ROTATIONS))
                 .thenReturn(Optional.of(mockSecret));
 
         Account returnVal = service.reauthenticate(app, SIGN_IN);
@@ -207,7 +207,7 @@ public class AccountServiceTest extends Mockito {
         mockGetAccountById(ACCOUNT_ID, false);
 
         service.deleteReauthToken(ACCOUNT_ID);
-        verify(mockAccountSecretDao).removeSecrets(REAUTH, USER_ID);
+        verify(mockAccountSecretDao).removeSecrets(REAUTH, TEST_USER_ID);
     }
 
     @Test
@@ -216,7 +216,7 @@ public class AccountServiceTest extends Mockito {
         app.setIdentifier(TEST_APP_ID);
         
         Account account = Account.create();
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         account.setEmail(EMAIL);
         account.setStatus(UNVERIFIED);
         account.setAppId("wrong-app");
@@ -225,7 +225,7 @@ public class AccountServiceTest extends Mockito {
         verify(mockAccountDao).createAccount(eq(app), accountCaptor.capture());
         
         Account createdAccount = accountCaptor.getValue();
-        assertEquals(createdAccount.getId(), USER_ID);
+        assertEquals(createdAccount.getId(), TEST_USER_ID);
         assertEquals(createdAccount.getAppId(), TEST_APP_ID);
         assertEquals(createdAccount.getCreatedOn().getMillis(), MOCK_DATETIME.getMillis());
         assertEquals(createdAccount.getModifiedOn().getMillis(), MOCK_DATETIME.getMillis());
@@ -248,7 +248,7 @@ public class AccountServiceTest extends Mockito {
         // mock hibernate
         Account account = Account.create();
         account.setAppId(TEST_APP_ID);
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         when(mockAccountDao.getAccount(any())).thenReturn(Optional.empty());
         
         // execute
@@ -294,7 +294,7 @@ public class AccountServiceTest extends Mockito {
         mockGetAccountById(ACCOUNT_ID, false);
 
         service.deleteAccount(ACCOUNT_ID);
-        verify(mockAccountDao).deleteAccount(USER_ID);
+        verify(mockAccountDao).deleteAccount(TEST_USER_ID);
     }
     
     @Test
@@ -335,7 +335,7 @@ public class AccountServiceTest extends Mockito {
     public void verifyEmailUsingToken() {
         Account account = Account.create();
         account.setAppId(TEST_APP_ID);
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         account.setEmail(EMAIL);
         account.setStatus(UNVERIFIED);
         account.setEmailVerified(FALSE);
@@ -354,7 +354,7 @@ public class AccountServiceTest extends Mockito {
     @Test
     public void verifyEmailUsingAccountNoChangeNecessary() {
         Account account = Account.create();
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         account.setStatus(ENABLED);
         account.setEmailVerified(TRUE);
 
@@ -378,7 +378,7 @@ public class AccountServiceTest extends Mockito {
     public void verifyPhoneUsingToken() {
         Account account = Account.create();
         account.setAppId(TEST_APP_ID);
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         account.setPhone(PHONE);
         account.setStatus(UNVERIFIED);
         account.setPhoneVerified(FALSE);
@@ -398,7 +398,7 @@ public class AccountServiceTest extends Mockito {
     @Test
     public void verifyPhoneUsingAccountNoChangeNecessary() {
         Account account = Account.create();
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         account.setStatus(ENABLED);
         account.setPhoneVerified(TRUE);
 
@@ -421,7 +421,7 @@ public class AccountServiceTest extends Mockito {
         // Set up test account
         Account account = Account.create();
         account.setAppId(TEST_APP_ID);
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         account.setEmail(EMAIL);
         account.setStatus(UNVERIFIED);
 
@@ -430,7 +430,7 @@ public class AccountServiceTest extends Mockito {
         verify(mockAccountDao).updateAccount(accountCaptor.capture());
 
         Account updatedAccount = accountCaptor.getValue();
-        assertEquals(updatedAccount.getId(), USER_ID);
+        assertEquals(updatedAccount.getId(), TEST_USER_ID);
         assertEquals(updatedAccount.getModifiedOn().getMillis(), MOCK_DATETIME.getMillis());
         assertEquals(updatedAccount.getPasswordAlgorithm(), PasswordAlgorithm.DEFAULT_PASSWORD_ALGORITHM);
         assertEquals(updatedAccount.getPasswordModifiedOn().getMillis(), MOCK_DATETIME.getMillis());
@@ -447,7 +447,7 @@ public class AccountServiceTest extends Mockito {
         // Set up test account
         Account account = Account.create();
         account.setAppId(TEST_APP_ID);
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         account.setPhone(PHONE);
         account.setStatus(UNVERIFIED);
 
@@ -464,13 +464,13 @@ public class AccountServiceTest extends Mockito {
     
     @Test
     public void changePasswordForExternalId() {
-        Enrollment en = Enrollment.create(TEST_APP_ID, STUDY_A, USER_ID);
+        Enrollment en = Enrollment.create(TEST_APP_ID, STUDY_A, TEST_USER_ID);
         en.setExternalId("anExternalId");
         
         // Set up test account
         Account account = Account.create();
         account.setAppId(TEST_APP_ID);
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         account.setStatus(UNVERIFIED);
         account.getEnrollments().add(en);
 
@@ -492,7 +492,7 @@ public class AccountServiceTest extends Mockito {
         App app = App.create();
 
         Account account = service.authenticate(app, PASSWORD_SIGNIN);
-        assertEquals(account.getId(), USER_ID);
+        assertEquals(account.getId(), TEST_USER_ID);
         assertEquals(account.getAppId(), TEST_APP_ID);
         assertEquals(account.getEmail(), EMAIL);
         assertEquals(account.getHealthCode(), HEALTH_CODE);
@@ -596,14 +596,14 @@ public class AccountServiceTest extends Mockito {
         mockGetAccountById(ACCOUNT_ID_WITH_EMAIL, false);
 
         AccountSecret secret = AccountSecret.create();
-        when(mockAccountSecretDao.verifySecret(REAUTH, USER_ID, REAUTH_TOKEN, ROTATIONS))
+        when(mockAccountSecretDao.verifySecret(REAUTH, TEST_USER_ID, REAUTH_TOKEN, ROTATIONS))
                 .thenReturn(Optional.of(secret));
 
         App app = App.create();
         app.setReauthenticationEnabled(true);
 
         Account account = service.reauthenticate(app, REAUTH_SIGNIN);
-        assertEquals(account.getId(), USER_ID);
+        assertEquals(account.getId(), TEST_USER_ID);
         assertEquals(account.getAppId(), TEST_APP_ID);
         assertEquals(account.getEmail(), EMAIL);
         // Version has not been incremented by an update
@@ -614,7 +614,7 @@ public class AccountServiceTest extends Mockito {
         verify(mockAccountDao, never()).updateAccount(any());
 
         // verify token verification
-        verify(mockAccountSecretDao).verifySecret(REAUTH, USER_ID, REAUTH_TOKEN, 3);
+        verify(mockAccountSecretDao).verifySecret(REAUTH, TEST_USER_ID, REAUTH_TOKEN, 3);
     }
 
     @Test
@@ -664,7 +664,7 @@ public class AccountServiceTest extends Mockito {
         persistedAccount.setEmailVerified(false);
 
         AccountSecret secret = AccountSecret.create();
-        when(mockAccountSecretDao.verifySecret(REAUTH, USER_ID, REAUTH_TOKEN, ROTATIONS))
+        when(mockAccountSecretDao.verifySecret(REAUTH, TEST_USER_ID, REAUTH_TOKEN, ROTATIONS))
                 .thenReturn(Optional.of(secret));
 
         App app = App.create();
@@ -680,7 +680,7 @@ public class AccountServiceTest extends Mockito {
         persistedAccount.setEmailVerified(false);
 
         AccountSecret secret = AccountSecret.create();
-        when(mockAccountSecretDao.verifySecret(REAUTH, USER_ID, REAUTH_TOKEN, ROTATIONS))
+        when(mockAccountSecretDao.verifySecret(REAUTH, TEST_USER_ID, REAUTH_TOKEN, ROTATIONS))
                 .thenReturn(Optional.of(secret));
 
         App app = App.create();
@@ -696,7 +696,7 @@ public class AccountServiceTest extends Mockito {
         persistedAccount.setStatus(DISABLED);
 
         AccountSecret secret = AccountSecret.create();
-        when(mockAccountSecretDao.verifySecret(REAUTH, USER_ID, REAUTH_TOKEN, ROTATIONS))
+        when(mockAccountSecretDao.verifySecret(REAUTH, TEST_USER_ID, REAUTH_TOKEN, ROTATIONS))
                 .thenReturn(Optional.of(secret));
 
         App app = App.create();
@@ -758,7 +758,7 @@ public class AccountServiceTest extends Mockito {
 
         service.deleteReauthToken(ACCOUNT_ID_WITH_EMAIL);
 
-        verify(mockAccountSecretDao).removeSecrets(REAUTH, USER_ID);
+        verify(mockAccountSecretDao).removeSecrets(REAUTH, TEST_USER_ID);
     }
 
     @Test
@@ -771,7 +771,7 @@ public class AccountServiceTest extends Mockito {
         verify(mockAccountDao, never()).updateAccount(any());
 
         // But we do always call this.
-        verify(mockAccountSecretDao).removeSecrets(REAUTH, USER_ID);
+        verify(mockAccountSecretDao).removeSecrets(REAUTH, TEST_USER_ID);
     }
 
     @Test
@@ -780,7 +780,7 @@ public class AccountServiceTest extends Mockito {
         service.deleteReauthToken(ACCOUNT_ID_WITH_EMAIL);
 
         verify(mockAccountDao, never()).updateAccount(any());
-        verify(mockAccountSecretDao, never()).removeSecrets(AccountSecretType.REAUTH, USER_ID);
+        verify(mockAccountSecretDao, never()).removeSecrets(AccountSecretType.REAUTH, TEST_USER_ID);
     }
 
     @Test
@@ -798,7 +798,7 @@ public class AccountServiceTest extends Mockito {
         verify(mockAccountDao).createAccount(eq(app), accountCaptor.capture());
 
         Account createdAccount = accountCaptor.getValue();
-        assertEquals(createdAccount.getId(), USER_ID);
+        assertEquals(createdAccount.getId(), TEST_USER_ID);
         assertEquals(createdAccount.getAppId(), TEST_APP_ID);
         assertEquals(createdAccount.getCreatedOn().getMillis(), MOCK_DATETIME.getMillis());
         assertEquals(createdAccount.getModifiedOn().getMillis(), MOCK_DATETIME.getMillis());
@@ -811,7 +811,7 @@ public class AccountServiceTest extends Mockito {
         // Some fields can't be modified. Create the persisted account and set the base fields so we can verify they
         // weren't modified.
         Account persistedAccount = Account.create();
-        persistedAccount.setId(USER_ID);
+        persistedAccount.setId(TEST_USER_ID);
         persistedAccount.setAppId(TEST_APP_ID);
         persistedAccount.setCreatedOn(MOCK_DATETIME);
         persistedAccount.setEmailVerified(TRUE);
@@ -833,7 +833,7 @@ public class AccountServiceTest extends Mockito {
 
         Account account = Account.create();
         account.setAppId(TEST_APP_ID);
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         account.setCreatedOn(MOCK_DATETIME.plusDays(4));
         account.setEmail(OTHER_EMAIL);
         account.setPhone(OTHER_PHONE);
@@ -850,7 +850,7 @@ public class AccountServiceTest extends Mockito {
         verify(mockAccountDao).updateAccount(accountCaptor.capture());
         Account updatedAccount = accountCaptor.getValue();
         assertEquals(updatedAccount.getAppId(), TEST_APP_ID);
-        assertEquals(updatedAccount.getId(), USER_ID);
+        assertEquals(updatedAccount.getId(), TEST_USER_ID);
         assertEquals(updatedAccount.getCreatedOn().getMillis(), MOCK_DATETIME.getMillis());
         assertEquals(updatedAccount.getEmail(), OTHER_EMAIL);
         assertEquals(updatedAccount.getPhone(), OTHER_PHONE);
@@ -868,7 +868,7 @@ public class AccountServiceTest extends Mockito {
         
         Account account = Account.create();
         account.setAppId(TEST_APP_ID);
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         account.setPasswordAlgorithm(STORMPATH_HMAC_SHA_256);
         account.setPasswordHash("bad password hash");
         account.setPasswordModifiedOn(MOCK_DATETIME);
@@ -891,7 +891,7 @@ public class AccountServiceTest extends Mockito {
         
         Account account = Account.create();
         account.setAppId(TEST_APP_ID);
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         account.setOrgMembership("some other nonsense");
 
         service.updateAccount(account);
@@ -1029,7 +1029,7 @@ public class AccountServiceTest extends Mockito {
     private Account mockGetAccountById(AccountId accountId, boolean generatePasswordHash) throws Exception {
         Account account = Account.create();
         account.setAppId(TEST_APP_ID);
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         account.setEmail(EMAIL);
         account.setEmailVerified(TRUE);
         account.setHealthCode(HEALTH_CODE);

--- a/src/test/java/org/sagebionetworks/bridge/services/AssessmentConfigServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AssessmentConfigServiceTest.java
@@ -7,7 +7,7 @@ import static org.sagebionetworks.bridge.RequestContext.NULL_INSTANCE;
 import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
 import static org.sagebionetworks.bridge.TestConstants.GUID;
 import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
-import static org.sagebionetworks.bridge.TestConstants.OWNER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_OWNER_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
 import static org.testng.Assert.assertEquals;
@@ -146,10 +146,10 @@ public class AssessmentConfigServiceTest extends Mockito {
     @Test
     public void updateAssessmentConfig() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerOrgMembership(OWNER_ID).build());
+                .withCallerOrgMembership(TEST_OWNER_ID).build());
         
         Assessment assessment = AssessmentTest.createAssessment();
-        assessment.setOwnerId(OWNER_ID);
+        assessment.setOwnerId(TEST_OWNER_ID);
         assessment.setOriginGuid(GUID);
         when(mockAssessmentService.getAssessmentByGuid(TEST_APP_ID, GUID))
             .thenReturn(assessment);
@@ -181,7 +181,7 @@ public class AssessmentConfigServiceTest extends Mockito {
             expectedExceptionsMessageRegExp = ".*config is required.*")
     public void updateAssessmentConfigInvalid() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerOrgMembership(OWNER_ID).build());
+                .withCallerOrgMembership(TEST_OWNER_ID).build());
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setOriginGuid(GUID);
         when(mockAssessmentService.getAssessmentByGuid(TEST_APP_ID, GUID))
@@ -201,10 +201,10 @@ public class AssessmentConfigServiceTest extends Mockito {
     @Test
     public void customizeAssessmentConfig() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerOrgMembership(OWNER_ID).build());
+                .withCallerOrgMembership(TEST_OWNER_ID).build());
         
         Assessment assessment = AssessmentTest.createAssessment();
-        assessment.setOwnerId(OWNER_ID);
+        assessment.setOwnerId(TEST_OWNER_ID);
         assessment.setCustomizationFields(ImmutableMap.of("anIdentifier", ImmutableSet.of(
                 new PropertyInfo.Builder().withPropName("stringValue").build(),
                 new PropertyInfo.Builder().withPropName("intValue").build(),
@@ -242,7 +242,7 @@ public class AssessmentConfigServiceTest extends Mockito {
             expectedExceptionsMessageRegExp = ".*identifier is missing.*")
     public void customizeAssessmentConfigInvalid() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerOrgMembership(OWNER_ID).build());
+                .withCallerOrgMembership(TEST_OWNER_ID).build());
         
         AssessmentConfigValidator val = new AssessmentConfigValidator.Builder()
                 .addValidator("*", new AbstractValidator() {
@@ -256,7 +256,7 @@ public class AssessmentConfigServiceTest extends Mockito {
         doReturn(val).when(service).getValidator();
         
         Assessment assessment = AssessmentTest.createAssessment();
-        assessment.setOwnerId(OWNER_ID);
+        assessment.setOwnerId(TEST_OWNER_ID);
         assessment.setCustomizationFields(ImmutableMap.of("anIdentifier", ImmutableSet.of(
                 new PropertyInfo.Builder().withPropName("stringValue").build(),
                 new PropertyInfo.Builder().withPropName("intValue").build(),
@@ -283,10 +283,10 @@ public class AssessmentConfigServiceTest extends Mockito {
     @Test
     public void customizeAssessmentConfigUnchanged() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerOrgMembership(OWNER_ID).build());
+                .withCallerOrgMembership(TEST_OWNER_ID).build());
         
         Assessment assessment = AssessmentTest.createAssessment();
-        assessment.setOwnerId(OWNER_ID);
+        assessment.setOwnerId(TEST_OWNER_ID);
         assessment.setCustomizationFields(ImmutableMap.of("anIdentifier", ImmutableSet.of(
                 new PropertyInfo.Builder().withPropName("stringValue").build()
         )));

--- a/src/test/java/org/sagebionetworks/bridge/services/AssessmentResourceServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AssessmentResourceServiceTest.java
@@ -7,7 +7,7 @@ import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
 import static org.sagebionetworks.bridge.TestConstants.GUID;
 import static org.sagebionetworks.bridge.TestConstants.IDENTIFIER;
 import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
-import static org.sagebionetworks.bridge.TestConstants.OWNER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_OWNER_ID;
 import static org.sagebionetworks.bridge.TestConstants.RESOURCE_CATEGORIES;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
@@ -89,7 +89,7 @@ public class AssessmentResourceServiceTest extends Mockito {
         
         RequestContext.set(new RequestContext.Builder()
                 .withCallerAppId(TEST_APP_ID)
-                .withCallerOrgMembership(OWNER_ID).build());
+                .withCallerOrgMembership(TEST_OWNER_ID).build());
     }
     
     @AfterMethod
@@ -348,7 +348,7 @@ public class AssessmentResourceServiceTest extends Mockito {
     @Test
     public void updateSharedResource() { 
         Assessment assessment = AssessmentTest.createAssessment();
-        assessment.setOwnerId(TEST_APP_ID + ":" + OWNER_ID);
+        assessment.setOwnerId(TEST_APP_ID + ":" + TEST_OWNER_ID);
         when(mockAssessmentService.getLatestAssessment(SHARED_APP_ID, ASSESSMENT_ID)).thenReturn(assessment);
         
         AssessmentResource existing = AssessmentResourceTest.createAssessmentResource();
@@ -588,10 +588,10 @@ public class AssessmentResourceServiceTest extends Mockito {
     @Test
     public void importAssessmentResourcesCallerCorrectOrg() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerOrgMembership(OWNER_ID).build());
+                .withCallerOrgMembership(TEST_OWNER_ID).build());
 
         Assessment assessment = AssessmentTest.createAssessment();
-        assessment.setOwnerId(OWNER_ID);
+        assessment.setOwnerId(TEST_OWNER_ID);
         when(mockAssessmentService.getLatestAssessment(TEST_APP_ID, ASSESSMENT_ID)).thenReturn(assessment);
         
         Set<String> guids = ImmutableSet.of("guid1", "guid2", "guid3");
@@ -619,7 +619,7 @@ public class AssessmentResourceServiceTest extends Mockito {
     @Test
     public void publishAssessmentResources() {
         Assessment assessment = AssessmentTest.createAssessment();
-        assessment.setOwnerId(TEST_APP_ID+":"+OWNER_ID);
+        assessment.setOwnerId(TEST_APP_ID+":"+TEST_OWNER_ID);
         when(mockAssessmentService.getLatestAssessment(SHARED_APP_ID, ASSESSMENT_ID)).thenReturn(assessment);
         
         Set<String> guids = ImmutableSet.of("guid1", "guid2", "guid3");
@@ -638,10 +638,10 @@ public class AssessmentResourceServiceTest extends Mockito {
     public void publishAssessmentResourcesOwnerInOrg() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerAppId(TEST_APP_ID)
-                .withCallerOrgMembership(OWNER_ID).build());
+                .withCallerOrgMembership(TEST_OWNER_ID).build());
         
         Assessment assessment = AssessmentTest.createAssessment();
-        assessment.setOwnerId(TEST_APP_ID+":"+OWNER_ID);
+        assessment.setOwnerId(TEST_APP_ID+":"+TEST_OWNER_ID);
         when(mockAssessmentService.getLatestAssessment(SHARED_APP_ID, ASSESSMENT_ID)).thenReturn(assessment);
         
         Set<String> guids = ImmutableSet.of("guid1", "guid2", "guid3");
@@ -661,7 +661,7 @@ public class AssessmentResourceServiceTest extends Mockito {
                 .withCallerOrgMembership("wrongOwnerId").build());
         
         Assessment assessment = AssessmentTest.createAssessment();
-        assessment.setOwnerId(TEST_APP_ID+":"+OWNER_ID);
+        assessment.setOwnerId(TEST_APP_ID+":"+TEST_OWNER_ID);
         when(mockAssessmentService.getLatestAssessment(SHARED_APP_ID, ASSESSMENT_ID)).thenReturn(assessment);
         
         Set<String> guids = ImmutableSet.of("guid1", "guid2", "guid3");
@@ -672,10 +672,10 @@ public class AssessmentResourceServiceTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class)
     public void publishAssessmentResourcesCallerWrongAppContext() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerEnrolledStudies(ImmutableSet.of(OWNER_ID)).build());
+                .withCallerEnrolledStudies(ImmutableSet.of(TEST_OWNER_ID)).build());
         
         Assessment assessment = AssessmentTest.createAssessment();
-        assessment.setOwnerId(TEST_APP_ID+":"+OWNER_ID);
+        assessment.setOwnerId(TEST_APP_ID+":"+TEST_OWNER_ID);
         when(mockAssessmentService.getLatestAssessment(SHARED_APP_ID, ASSESSMENT_ID)).thenReturn(assessment);
         
         Set<String> guids = ImmutableSet.of("guid1", "guid2", "guid3");

--- a/src/test/java/org/sagebionetworks/bridge/services/AssessmentServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AssessmentServiceTest.java
@@ -12,7 +12,7 @@ import static org.sagebionetworks.bridge.TestConstants.GUID;
 import static org.sagebionetworks.bridge.TestConstants.IDENTIFIER;
 import static org.sagebionetworks.bridge.TestConstants.INFO1;
 import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
-import static org.sagebionetworks.bridge.TestConstants.OWNER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_OWNER_ID;
 import static org.sagebionetworks.bridge.TestConstants.STRING_TAGS;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.models.OperatingSystem.ANDROID;
@@ -104,7 +104,7 @@ public class AssessmentServiceTest extends Mockito {
         // you are an administrator). 
         RequestContext.set(new RequestContext.Builder()
                 .withCallerAppId(TEST_APP_ID)
-                .withCallerOrgMembership(OWNER_ID).build());
+                .withCallerOrgMembership(TEST_OWNER_ID).build());
     }
     
     @AfterMethod
@@ -149,7 +149,7 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void createAssessment() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
                 .thenReturn(mockOrganization);
         when(mockDao.getAssessmentRevisions(any(), any(), anyInt(), anyInt(), anyBoolean()))
             .thenReturn(EMPTY_LIST);
@@ -163,7 +163,7 @@ public class AssessmentServiceTest extends Mockito {
         verify(mockDao).createAssessment(eq(TEST_APP_ID), eq(assessment), configCaptor.capture());
         
         assertEquals(assessment.getGuid(), GUID);
-        assertEquals(assessment.getOwnerId(), OWNER_ID);
+        assertEquals(assessment.getOwnerId(), TEST_OWNER_ID);
         // Same timestamp on create
         assertEquals(assessment.getCreatedOn(), CREATED_ON);
         assertEquals(assessment.getModifiedOn(), CREATED_ON);
@@ -177,7 +177,7 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void createAssessmentAdjustsOsNameAlias() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
             .thenReturn(mockOrganization);
         when(mockDao.getAssessmentRevisions(any(), any(), anyInt(), anyInt(), anyBoolean()))
             .thenReturn(EMPTY_LIST);
@@ -198,7 +198,7 @@ public class AssessmentServiceTest extends Mockito {
         when(mockDao.getAssessmentRevisions(TEST_APP_ID, IDENTIFIER, 0, 1, true))
             .thenReturn(new PagedResourceList<>(ImmutableList.of(), 0));
         
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
             .thenReturn(mockOrganization);
         
         Assessment assessment = AssessmentTest.createAssessment();
@@ -211,7 +211,7 @@ public class AssessmentServiceTest extends Mockito {
         assessment.setGuid(null);
         assessment.setDeleted(false);
         
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
             .thenReturn(mockOrganization);
         when(mockDao.getAssessmentRevisions(any(), any(), anyInt(), anyInt(), anyBoolean()))
             .thenReturn(new PagedResourceList<>(ImmutableList.of(assessment), 1));
@@ -222,7 +222,7 @@ public class AssessmentServiceTest extends Mockito {
     @Test(expectedExceptions = InvalidEntityException.class,
             expectedExceptionsMessageRegExp = ".*identifier cannot be missing.*")
     public void createAssessmentInvalid() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
             .thenReturn(mockOrganization);
         when(mockDao.getAssessmentRevisions(any(), any(), anyInt(), anyInt(), anyBoolean()))
             .thenReturn(EMPTY_LIST);
@@ -235,7 +235,7 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void createAssessmentScrubsMarkup() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
             .thenReturn(mockOrganization);
         when(mockDao.getAssessmentRevisions(any(), any(), anyInt(), anyInt(), anyBoolean()))
             .thenReturn(EMPTY_LIST);
@@ -250,7 +250,7 @@ public class AssessmentServiceTest extends Mockito {
 
     @Test
     public void createAssessmentRevision() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
                 .thenReturn(mockOrganization);
         when(mockDao.getAssessment(TEST_APP_ID, GUID))
             .thenReturn(Optional.of(AssessmentTest.createAssessment()));
@@ -266,7 +266,7 @@ public class AssessmentServiceTest extends Mockito {
         
         assertEquals(assessment.getGuid(), GUID);
         assertEquals(assessment.getIdentifier(), IDENTIFIER);
-        assertEquals(assessment.getOwnerId(), OWNER_ID);
+        assertEquals(assessment.getOwnerId(), TEST_OWNER_ID);
         // same timestamp on creation
         assertEquals(assessment.getCreatedOn(), CREATED_ON);
         assertEquals(assessment.getModifiedOn(), CREATED_ON);
@@ -283,15 +283,15 @@ public class AssessmentServiceTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerEnrolledStudies(ImmutableSet.of("studyD")).build());
         
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
             .thenReturn(mockOrganization);
         
         Assessment existing = AssessmentTest.createAssessment();
-        existing.setOwnerId(OWNER_ID);
+        existing.setOwnerId(TEST_OWNER_ID);
         when(mockDao.getAssessment(TEST_APP_ID, GUID)).thenReturn(Optional.of(existing));
         
         Assessment assessment = AssessmentTest.createAssessment();
-        assessment.setOwnerId(OWNER_ID);
+        assessment.setOwnerId(TEST_OWNER_ID);
         service.createAssessmentRevision(TEST_APP_ID, GUID, assessment);
     }
 
@@ -301,7 +301,7 @@ public class AssessmentServiceTest extends Mockito {
         assessment.setGuid(null);
         assessment.setDeleted(false);
         
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
             .thenReturn(mockOrganization);
         when(mockDao.getAssessmentRevisions(any(), any(), anyInt(), anyInt(), anyBoolean()))
             .thenReturn(new PagedResourceList<>(ImmutableList.of(), 0));
@@ -312,7 +312,7 @@ public class AssessmentServiceTest extends Mockito {
     @Test(expectedExceptions = InvalidEntityException.class,
             expectedExceptionsMessageRegExp = ".*identifier cannot be missing.*")
     public void createAssessmentRevisionInvalid() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
             .thenReturn(mockOrganization);
         when(mockDao.getAssessment(TEST_APP_ID, GUID))
             .thenReturn(Optional.of(new Assessment()));
@@ -325,7 +325,7 @@ public class AssessmentServiceTest extends Mockito {
 
     @Test
     public void createAssessmentRevisionScrubsMarkup() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
             .thenReturn(mockOrganization);
         Assessment existing = AssessmentTest.createAssessment();
         when(mockDao.getAssessment(TEST_APP_ID, GUID))
@@ -341,7 +341,7 @@ public class AssessmentServiceTest extends Mockito {
 
     @Test
     public void updateAssessment() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID)).thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID)).thenReturn(mockOrganization);
         
         // Fill out only the fields needed to pass validation, leaving the rest to be
         // filled in by the existing assessment
@@ -359,7 +359,7 @@ public class AssessmentServiceTest extends Mockito {
         assertSame(retValue, assessment);
         
         assertEquals(retValue.getIdentifier(), IDENTIFIER);
-        assertEquals(retValue.getOwnerId(), OWNER_ID);
+        assertEquals(retValue.getOwnerId(), TEST_OWNER_ID);
         assertEquals(retValue.getOriginGuid(), "originGuid");
         assertEquals(retValue.getCreatedOn(), CREATED_ON);
         assertEquals(retValue.getModifiedOn(), MODIFIED_ON);
@@ -369,7 +369,7 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void updateAssessmentAdjustsOsNameAlias() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID)).thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID)).thenReturn(mockOrganization);
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setOsName("Both");
@@ -386,7 +386,7 @@ public class AssessmentServiceTest extends Mockito {
 
     @Test
     public void updateAssessmentSomeFieldsImmutable() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID)).thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID)).thenReturn(mockOrganization);
         
         Assessment existing = AssessmentTest.createAssessment();
         when(mockDao.getAssessment(TEST_APP_ID, GUID))
@@ -404,7 +404,7 @@ public class AssessmentServiceTest extends Mockito {
         
         Assessment retValue = service.updateAssessment(TEST_APP_ID, assessment);
         assertEquals(retValue.getIdentifier(), IDENTIFIER);
-        assertEquals(retValue.getOwnerId(), OWNER_ID);
+        assertEquals(retValue.getOwnerId(), TEST_OWNER_ID);
         assertEquals(retValue.getOriginGuid(), "originGuid");
         assertEquals(retValue.getCreatedOn(), CREATED_ON);
         assertEquals(retValue.getModifiedOn(), MODIFIED_ON);
@@ -412,7 +412,7 @@ public class AssessmentServiceTest extends Mockito {
         verify(mockDao).updateAssessment(eq(TEST_APP_ID), assessmentCaptor.capture());
         Assessment saved = assessmentCaptor.getValue();
         assertEquals(saved.getIdentifier(), IDENTIFIER);
-        assertEquals(saved.getOwnerId(), OWNER_ID);
+        assertEquals(saved.getOwnerId(), TEST_OWNER_ID);
         assertEquals(saved.getOriginGuid(), "originGuid");
         assertEquals(saved.getCreatedOn(), CREATED_ON);
         assertEquals(saved.getModifiedOn(), MODIFIED_ON);
@@ -430,7 +430,7 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void updateAssessmentCanDelete() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID)).thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID)).thenReturn(mockOrganization);
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setDeleted(true);
@@ -447,7 +447,7 @@ public class AssessmentServiceTest extends Mockito {
 
     @Test
     public void updateAssessmentCanUndelete() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID)).thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID)).thenReturn(mockOrganization);
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setDeleted(false);
@@ -478,7 +478,7 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void updateAssessmentScrubsMarkup() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID)).thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID)).thenReturn(mockOrganization);
 
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setDeleted(false);
@@ -496,15 +496,15 @@ public class AssessmentServiceTest extends Mockito {
     public void updateSharedAssessment() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerAppId(TEST_APP_ID)
-                .withCallerOrgMembership(OWNER_ID).build());
+                .withCallerOrgMembership(TEST_OWNER_ID).build());
         
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
             .thenReturn(Organization.create());
         
         Assessment existing = AssessmentTest.createAssessment();
         existing.setOriginGuid("unusualGuid");
         existing.setDeleted(false);
-        existing.setOwnerId(TEST_APP_ID + ":" + OWNER_ID);
+        existing.setOwnerId(TEST_APP_ID + ":" + TEST_OWNER_ID);
         when(mockDao.getAssessment(SHARED_APP_ID, GUID))
             .thenReturn(Optional.of(existing));
         
@@ -514,7 +514,7 @@ public class AssessmentServiceTest extends Mockito {
         verify(mockDao).updateAssessment(SHARED_APP_ID, assessment);
         
         assertEquals(assessment.getIdentifier(), IDENTIFIER);
-        assertEquals(TEST_APP_ID + ":" + OWNER_ID, assessment.getOwnerId());
+        assertEquals(TEST_APP_ID + ":" + TEST_OWNER_ID, assessment.getOwnerId());
         assertEquals(assessment.getOriginGuid(), "unusualGuid");
         assertEquals(assessment.getCreatedOn(), CREATED_ON);
         assertEquals(assessment.getModifiedOn(), MODIFIED_ON);
@@ -524,14 +524,14 @@ public class AssessmentServiceTest extends Mockito {
     public void updateSharedAssessmentAdjustsOsNameAlias() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerAppId(TEST_APP_ID)
-                .withCallerOrgMembership(OWNER_ID).build());
+                .withCallerOrgMembership(TEST_OWNER_ID).build());
         
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
             .thenReturn(Organization.create());
         
         Assessment existing = AssessmentTest.createAssessment();
         existing.setDeleted(false);
-        existing.setOwnerId(TEST_APP_ID + ":" + OWNER_ID);
+        existing.setOwnerId(TEST_APP_ID + ":" + TEST_OWNER_ID);
         when(mockDao.getAssessment(SHARED_APP_ID, GUID))
             .thenReturn(Optional.of(existing));
         
@@ -544,13 +544,13 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void updateSharedAssessmentSomeFieldsImmutable() {
-        String ownerIdInShared = TEST_APP_ID + ":" + OWNER_ID;
+        String ownerIdInShared = TEST_APP_ID + ":" + TEST_OWNER_ID;
         
         RequestContext.set(new RequestContext.Builder()
                 .withCallerAppId(TEST_APP_ID)
-                .withCallerOrgMembership(OWNER_ID).build());
+                .withCallerOrgMembership(TEST_OWNER_ID).build());
         
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
             .thenReturn(Organization.create());
         
         Assessment existing = AssessmentTest.createAssessment();
@@ -589,11 +589,11 @@ public class AssessmentServiceTest extends Mockito {
     public void updateSharedAssessmentUnauthorizedApp() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerAppId(TEST_APP_ID)
-                .withCallerOrgMembership(OWNER_ID).build());
+                .withCallerOrgMembership(TEST_OWNER_ID).build());
         
         Assessment existing = AssessmentTest.createAssessment();
         existing.setDeleted(false);
-        existing.setOwnerId("wrong-app:" + OWNER_ID);
+        existing.setOwnerId("wrong-app:" + TEST_OWNER_ID);
         when(mockDao.getAssessment(SHARED_APP_ID, GUID))
             .thenReturn(Optional.of(existing));
         
@@ -605,7 +605,7 @@ public class AssessmentServiceTest extends Mockito {
     public void updateSharedAssessmentUnauthorizedOrg() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerAppId(TEST_APP_ID)
-                .withCallerOrgMembership(OWNER_ID).build());
+                .withCallerOrgMembership(TEST_OWNER_ID).build());
         
         Assessment existing = AssessmentTest.createAssessment();
         existing.setDeleted(false);
@@ -623,11 +623,11 @@ public class AssessmentServiceTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(SUPERADMIN))
                 .withCallerAppId(TEST_APP_ID).build());
         when(mockOrganizationService.getOrganization(
-                TEST_APP_ID, OWNER_ID)).thenReturn(Organization.create());
+                TEST_APP_ID, TEST_OWNER_ID)).thenReturn(Organization.create());
         
         Assessment existing = AssessmentTest.createAssessment();
         existing.setDeleted(false);
-        existing.setOwnerId(TEST_APP_ID + ":" + OWNER_ID);
+        existing.setOwnerId(TEST_APP_ID + ":" + TEST_OWNER_ID);
         when(mockDao.getAssessment(SHARED_APP_ID, GUID))
             .thenReturn(Optional.of(existing));
         
@@ -658,13 +658,13 @@ public class AssessmentServiceTest extends Mockito {
 
     @Test
     public void updateSharedAssessmentCanDelete() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID)).thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID)).thenReturn(mockOrganization);
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setDeleted(true);
         
         Assessment existing = AssessmentTest.createAssessment();
-        existing.setOwnerId(TEST_APP_ID + ":" + OWNER_ID);
+        existing.setOwnerId(TEST_APP_ID + ":" + TEST_OWNER_ID);
         existing.setDeleted(false);
         
         when(mockDao.getAssessment(SHARED_APP_ID, assessment.getGuid()))
@@ -677,13 +677,13 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void updateSharedAssessmentCanUndelete() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID)).thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID)).thenReturn(mockOrganization);
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setDeleted(false);
         
         Assessment existing = AssessmentTest.createAssessment();
-        existing.setOwnerId(TEST_APP_ID + ":" + OWNER_ID);
+        existing.setOwnerId(TEST_APP_ID + ":" + TEST_OWNER_ID);
         existing.setDeleted(true);
         
         when(mockDao.getAssessment(SHARED_APP_ID, assessment.getGuid()))
@@ -873,7 +873,7 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void publishAssessment() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
             .thenReturn(mockOrganization);
         
         Assessment existing =  AssessmentTest.createAssessment();
@@ -881,7 +881,7 @@ public class AssessmentServiceTest extends Mockito {
         existing.setGuid("oldGuid");
         existing.setRevision(-1);
         existing.setOriginGuid(null);
-        existing.setOwnerId(OWNER_ID);
+        existing.setOwnerId(TEST_OWNER_ID);
         existing.setVersion(-1L);        
         
         when(mockDao.getAssessment(TEST_APP_ID, "oldGuid")).thenReturn(Optional.of(existing));
@@ -905,7 +905,7 @@ public class AssessmentServiceTest extends Mockito {
         assertEquals(assessmentToPublish.getGuid(), GUID); // has been reset
         assertEquals(assessmentToPublish.getRevision(), 1);
         assertNull(assessmentToPublish.getOriginGuid());
-        assertEquals(assessmentToPublish.getOwnerId(), TEST_APP_ID + ":" + OWNER_ID);
+        assertEquals(assessmentToPublish.getOwnerId(), TEST_APP_ID + ":" + TEST_OWNER_ID);
         assertEquals(assessmentToPublish.getVersion(), 0);
         // verify that a fuller copy also occurred
         assertEquals(assessmentToPublish.getTitle(), existing.getTitle());
@@ -914,7 +914,7 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void publishAssessmentWithNewIdentifier() { 
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID)).thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID)).thenReturn(mockOrganization);
     
         Assessment existing =  AssessmentTest.createAssessment();
     
@@ -954,7 +954,7 @@ public class AssessmentServiceTest extends Mockito {
 
     @Test
     public void publishAssessmentPriorPublishedVersion() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
             .thenReturn(mockOrganization);
         
         Assessment local = AssessmentTest.createAssessment();
@@ -967,7 +967,7 @@ public class AssessmentServiceTest extends Mockito {
         // shared library
         Assessment revision = AssessmentTest.createAssessment();
         revision.setRevision(10);
-        revision.setOwnerId(TEST_APP_ID + ":" + OWNER_ID);
+        revision.setOwnerId(TEST_APP_ID + ":" + TEST_OWNER_ID);
         PagedResourceList<Assessment> page = new PagedResourceList<>(ImmutableList.of(revision), 1);
         when(mockDao.getAssessmentRevisions(SHARED_APP_ID, IDENTIFIER, 0, 1, true)).thenReturn(page);        
         
@@ -985,7 +985,7 @@ public class AssessmentServiceTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class, 
             expectedExceptionsMessageRegExp = ".*Assessment exists in shared library.*")
     public void publishAssessmentPriorPublishedVersionDifferentOwner() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
             .thenReturn(mockOrganization);
         
         Assessment local = AssessmentTest.createAssessment();
@@ -995,7 +995,7 @@ public class AssessmentServiceTest extends Mockito {
         // shared library
         Assessment revision = AssessmentTest.createAssessment();
         revision.setRevision(10);
-        revision.setOwnerId("otherApp:" + OWNER_ID);
+        revision.setOwnerId("otherApp:" + TEST_OWNER_ID);
         PagedResourceList<Assessment> page = new PagedResourceList<>(ImmutableList.of(revision), 1);
         when(mockDao.getAssessmentRevisions(SHARED_APP_ID, IDENTIFIER, 0, 1, true)).thenReturn(page);        
         
@@ -1018,11 +1018,11 @@ public class AssessmentServiceTest extends Mockito {
         when(mockDao.importAssessment(TEST_APP_ID, sharedAssessment, sharedConfig))
             .thenReturn(sharedAssessment);
         
-        Assessment retValue = service.importAssessment(TEST_APP_ID, OWNER_ID, null, GUID);
+        Assessment retValue = service.importAssessment(TEST_APP_ID, TEST_OWNER_ID, null, GUID);
         assertSame(retValue, sharedAssessment);
         assertEquals(retValue.getRevision(), 1);
         assertEquals(retValue.getOriginGuid(), "sharedGuid");
-        assertEquals(retValue.getOwnerId(), OWNER_ID);
+        assertEquals(retValue.getOwnerId(), TEST_OWNER_ID);
         
         verify(mockDao).importAssessment(TEST_APP_ID, sharedAssessment, sharedConfig);
     }
@@ -1034,10 +1034,10 @@ public class AssessmentServiceTest extends Mockito {
 
         when(mockDao.getAssessmentRevisions(TEST_APP_ID, NEW_IDENTIFIER, 0, 1, true))
             .thenReturn(new PagedResourceList<>(ImmutableList.of(), 0));
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
             .thenReturn(mockOrganization);
         
-        service.importAssessment(TEST_APP_ID, OWNER_ID, NEW_IDENTIFIER, GUID);
+        service.importAssessment(TEST_APP_ID, TEST_OWNER_ID, NEW_IDENTIFIER, GUID);
         
         verify(mockDao).importAssessment(eq(TEST_APP_ID), assessmentCaptor.capture(), configCaptor.capture());
         
@@ -1056,7 +1056,7 @@ public class AssessmentServiceTest extends Mockito {
 
         when(mockDao.getAssessmentRevisions(TEST_APP_ID, IDENTIFIER, 0, 1, true))
             .thenReturn(new PagedResourceList<>(ImmutableList.of(), 0));
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
             .thenReturn(mockOrganization);
         
         service.importAssessment(TEST_APP_ID, "new-owner-id", null, GUID);
@@ -1119,14 +1119,14 @@ public class AssessmentServiceTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership("notTheOwnerId").build());
 
-        service.importAssessment(TEST_APP_ID, OWNER_ID, null, GUID);
+        service.importAssessment(TEST_APP_ID, TEST_OWNER_ID, null, GUID);
     }
     
     @Test(expectedExceptions = EntityNotFoundException.class)
     public void importAssessmentNotFoundException() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
             .thenReturn(mockOrganization);
-        service.importAssessment(TEST_APP_ID, OWNER_ID, null, GUID);
+        service.importAssessment(TEST_APP_ID, TEST_OWNER_ID, null, GUID);
     }
     
     @Test
@@ -1149,20 +1149,20 @@ public class AssessmentServiceTest extends Mockito {
         
         when(mockDao.importAssessment(TEST_APP_ID, sharedAssessment, sharedConfig)).thenReturn(sharedAssessment);
         
-        Assessment retValue = service.importAssessment(TEST_APP_ID, OWNER_ID, null, GUID);
+        Assessment retValue = service.importAssessment(TEST_APP_ID, TEST_OWNER_ID, null, GUID);
         assertSame(retValue, sharedAssessment);
         assertEquals(retValue.getRevision(), 4); // 1 higher than 3
         assertEquals(retValue.getOriginGuid(), "sharedGuid");
-        assertEquals(retValue.getOwnerId(), OWNER_ID);
+        assertEquals(retValue.getOwnerId(), TEST_OWNER_ID);
     }
         
     @Test
     public void deleteAssessment() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
             .thenReturn(Organization.create());
         
         Assessment assessment = new Assessment();
-        assessment.setOwnerId(OWNER_ID);
+        assessment.setOwnerId(TEST_OWNER_ID);
         when(mockDao.getAssessment(TEST_APP_ID, GUID)).thenReturn(Optional.of(assessment));
         
         service.deleteAssessment(TEST_APP_ID, GUID);
@@ -1222,7 +1222,7 @@ public class AssessmentServiceTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership("orgD").build());
         
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
             .thenReturn(mockOrganization);
         
         when(mockDao.getAssessmentRevisions(TEST_APP_ID, IDENTIFIER, 0, 1, true))
@@ -1238,7 +1238,7 @@ public class AssessmentServiceTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership("orgD").build());
         
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID))
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
             .thenReturn(mockOrganization);
         
         Assessment existing = AssessmentTest.createAssessment();
@@ -1277,7 +1277,7 @@ public class AssessmentServiceTest extends Mockito {
     public void importAssessmentChecksOwnership() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership("orgD").build());
-        service.importAssessment(TEST_APP_ID, OWNER_ID, null, GUID);
+        service.importAssessment(TEST_APP_ID, TEST_OWNER_ID, null, GUID);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)

--- a/src/test/java/org/sagebionetworks/bridge/services/EnrollmentServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/EnrollmentServiceTest.java
@@ -11,7 +11,7 @@ import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.models.ResourceList.ENROLLMENT_FILTER;
 import static org.sagebionetworks.bridge.models.ResourceList.OFFSET_BY;
 import static org.sagebionetworks.bridge.models.ResourceList.PAGE_SIZE;
@@ -146,48 +146,48 @@ public class EnrollmentServiceTest extends Mockito {
     
     @Test
     public void getEnrollmentsForUser() {
-        AccountId accountId = AccountId.forId(TEST_APP_ID, USER_ID);
+        AccountId accountId = AccountId.forId(TEST_APP_ID, TEST_USER_ID);
         when(mockAccountService.getAccount(accountId)).thenReturn(Account.create());
         
         List<EnrollmentDetail> details = ImmutableList.of();
-        when(mockEnrollmentDao.getEnrollmentsForUser(TEST_APP_ID, USER_ID)).thenReturn(details);
+        when(mockEnrollmentDao.getEnrollmentsForUser(TEST_APP_ID, TEST_USER_ID)).thenReturn(details);
         
-        List<EnrollmentDetail> retValue = service.getEnrollmentsForUser(TEST_APP_ID, USER_ID);
+        List<EnrollmentDetail> retValue = service.getEnrollmentsForUser(TEST_APP_ID, TEST_USER_ID);
         assertSame(retValue, details);
         
-        verify(mockEnrollmentDao).getEnrollmentsForUser(TEST_APP_ID, USER_ID);
+        verify(mockEnrollmentDao).getEnrollmentsForUser(TEST_APP_ID, TEST_USER_ID);
     }
     
     @Test(expectedExceptions = EntityNotFoundException.class)
     public void getEnrollmentsForUserNotFound() {
-        service.getEnrollmentsForUser(TEST_APP_ID, USER_ID);
+        service.getEnrollmentsForUser(TEST_APP_ID, TEST_USER_ID);
     }
     
     @Test
     public void enrollBySelf() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerUserId(USER_ID)
+                .withCallerUserId(TEST_USER_ID)
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());
         
         // This should not effect the behavior of the enrollment.
-        Enrollment otherStudy = Enrollment.create(TEST_APP_ID, "otherStudy", USER_ID);
+        Enrollment otherStudy = Enrollment.create(TEST_APP_ID, "otherStudy", TEST_USER_ID);
         
         Account account = Account.create();
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         account.setEnrollments(Sets.newHashSet(otherStudy));
         when(mockAccountService.getAccountNoFilter(ACCOUNT_ID))
             .thenReturn(Optional.of(account));
         
         DateTime timestamp = DateTime.now();
         
-        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         enrollment.setExternalId("extId");
         enrollment.setEnrolledOn(timestamp);
 
         Enrollment retValue = service.enroll(enrollment);
         assertEquals(retValue.getAppId(), TEST_APP_ID);
         assertEquals(retValue.getStudyId(), TEST_STUDY_ID);
-        assertEquals(retValue.getAccountId(), USER_ID);
+        assertEquals(retValue.getAccountId(), TEST_USER_ID);
         assertEquals(retValue.getExternalId(), "extId");
         assertEquals(retValue.getEnrolledOn(), timestamp);
         assertNull(retValue.getEnrolledBy());
@@ -206,14 +206,14 @@ public class EnrollmentServiceTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());
         
         Account account = Account.create();
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         when(mockAccountService.getAccountNoFilter(ACCOUNT_ID))
             .thenReturn(Optional.of(account));
         
-        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
 
         Enrollment retValue = service.enroll(enrollment);
-        assertEquals(retValue.getAccountId(), USER_ID);
+        assertEquals(retValue.getAccountId(), TEST_USER_ID);
         assertEquals(retValue.getEnrolledBy(), "adminUser");
     }
     
@@ -227,14 +227,14 @@ public class EnrollmentServiceTest extends Mockito {
         when(mockSponsorService.isStudySponsoredBy(TEST_STUDY_ID, TEST_ORG_ID)).thenReturn(Boolean.TRUE);
         
         Account account = Account.create();
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         when(mockAccountService.getAccountNoFilter(ACCOUNT_ID))
             .thenReturn(Optional.of(account));
         
-        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
 
         Enrollment retValue = service.enroll(enrollment);
-        assertEquals(retValue.getAccountId(), USER_ID);
+        assertEquals(retValue.getAccountId(), TEST_USER_ID);
         assertEquals(retValue.getEnrolledBy(), "adminUser");
     }
     
@@ -242,20 +242,20 @@ public class EnrollmentServiceTest extends Mockito {
     @Test
     public void enrollAlreadyExists() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerUserId(USER_ID)
+                .withCallerUserId(TEST_USER_ID)
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());
         
         Account account = Account.create();
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         
-        Enrollment existing = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
-        Enrollment otherStudy = Enrollment.create(TEST_APP_ID, "otherStudy", USER_ID);
+        Enrollment existing = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
+        Enrollment otherStudy = Enrollment.create(TEST_APP_ID, "otherStudy", TEST_USER_ID);
         account.setEnrollments(ImmutableSet.of(existing, otherStudy));
         
         when(mockAccountService.getAccountNoFilter(ACCOUNT_ID))
             .thenReturn(Optional.of(account));
         
-        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         service.enroll(enrollment);
     }
     
@@ -263,10 +263,10 @@ public class EnrollmentServiceTest extends Mockito {
             expectedExceptionsMessageRegExp = "Account not found.")
     public void enrollAccountNotFound() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerUserId(USER_ID)
+                .withCallerUserId(TEST_USER_ID)
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());
         
-        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         enrollment.setExternalId("extId");
 
         service.enroll(enrollment);
@@ -275,15 +275,15 @@ public class EnrollmentServiceTest extends Mockito {
     @Test
     public void enrollAlreadyExistsButIsWithdrawn() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerUserId(USER_ID)
+                .withCallerUserId(TEST_USER_ID)
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());
         
         Account account = Account.create();
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         
-        Enrollment unrelatedEnrollment = Enrollment.create(TEST_APP_ID, "someOtherStudy", USER_ID);
+        Enrollment unrelatedEnrollment = Enrollment.create(TEST_APP_ID, "someOtherStudy", TEST_USER_ID);
         
-        Enrollment existing = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment existing = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         // This should cause the enrollment to be recreated.
         existing.setWithdrawnOn(MODIFIED_ON);
         account.setEnrollments(Sets.newHashSet(unrelatedEnrollment, existing));
@@ -291,13 +291,13 @@ public class EnrollmentServiceTest extends Mockito {
         when(mockAccountService.getAccountNoFilter(ACCOUNT_ID))
             .thenReturn(Optional.of(account));
         
-        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         enrollment.setExternalId("extId");
         
         Enrollment retValue = service.enroll(enrollment);
         assertEquals(retValue.getAppId(), TEST_APP_ID);
         assertEquals(retValue.getStudyId(), TEST_STUDY_ID);
-        assertEquals(retValue.getAccountId(), USER_ID);
+        assertEquals(retValue.getAccountId(), TEST_USER_ID);
         assertEquals(retValue.getExternalId(), "extId");
         assertEquals(retValue.getEnrolledOn(), CREATED_ON);
         assertNull(retValue.getEnrolledBy());
@@ -314,11 +314,11 @@ public class EnrollmentServiceTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
         
         Account account = Account.create();
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         when(mockAccountService.getAccountNoFilter(ACCOUNT_ID))
             .thenReturn(Optional.of(account));
         
-        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
 
         service.enroll(enrollment);
     }
@@ -333,17 +333,17 @@ public class EnrollmentServiceTest extends Mockito {
         // the call to sponsorService returns null
         
         Account account = Account.create();
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
         
-        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
 
         service.enroll(enrollment);
     }
     
     @Test(expectedExceptions = InvalidEntityException.class)
     public void enrollInvalidEnrollment() {
-        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         enrollment.setAccountId(null);
 
         service.enroll(enrollment);
@@ -352,17 +352,17 @@ public class EnrollmentServiceTest extends Mockito {
     @Test
     public void unenrollBySelf() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerUserId(USER_ID).build());
+                .withCallerUserId(TEST_USER_ID).build());
                 
-        Enrollment existing = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
-        Enrollment otherStudy = Enrollment.create(TEST_APP_ID, "otherStudy", USER_ID);
+        Enrollment existing = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
+        Enrollment otherStudy = Enrollment.create(TEST_APP_ID, "otherStudy", TEST_USER_ID);
         
         Account account = Account.create();
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         account.setEnrollments(Sets.newHashSet(otherStudy, existing));
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
         
-        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         enrollment.setWithdrawnOn(MODIFIED_ON.minusHours(1));
         enrollment.setWithdrawalNote("Withdrawal reason");
         
@@ -381,16 +381,16 @@ public class EnrollmentServiceTest extends Mockito {
     @Test
     public void unenrollBySelfDefaultsWithdrawnOn() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerUserId(USER_ID).build());
+                .withCallerUserId(TEST_USER_ID).build());
                 
-        Enrollment existing = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment existing = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         
         Account account = Account.create();
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         account.setEnrollments(Sets.newHashSet(existing));
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
         
-        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         enrollment.setWithdrawalNote("Withdrawal reason");
         
         Enrollment retValue = service.unenroll(enrollment);
@@ -407,14 +407,14 @@ public class EnrollmentServiceTest extends Mockito {
                 .withCallerUserId("adminUser")
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());
                 
-        Enrollment existing = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment existing = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         
         Account account = Account.create();
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         account.setEnrollments(Sets.newHashSet(existing));
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
         
-        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         enrollment.setWithdrawnOn(MODIFIED_ON);
         enrollment.setWithdrawalNote("Withdrawal reason");
         
@@ -439,14 +439,14 @@ public class EnrollmentServiceTest extends Mockito {
         
         when(mockSponsorService.isStudySponsoredBy(TEST_STUDY_ID, TEST_ORG_ID)).thenReturn(Boolean.TRUE);
                 
-        Enrollment existing = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment existing = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         
         Account account = Account.create();
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         account.setEnrollments(Sets.newHashSet(existing));
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
         
-        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         enrollment.setWithdrawnOn(MODIFIED_ON);
         enrollment.setWithdrawalNote("Withdrawal reason");
         
@@ -468,10 +468,10 @@ public class EnrollmentServiceTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());
         
         Account account = Account.create();
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
         
-        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         service.unenroll(enrollment);
     }
     
@@ -481,7 +481,7 @@ public class EnrollmentServiceTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());
         
-        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         service.unenroll(enrollment);
     }
     
@@ -493,15 +493,15 @@ public class EnrollmentServiceTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());
         
-        Enrollment existing = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment existing = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         existing.setWithdrawnOn(MODIFIED_ON);
         
         Account account = Account.create();
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         account.setEnrollments(Sets.newHashSet(existing));
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
         
-        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         service.unenroll(enrollment);
     }
     
@@ -512,10 +512,10 @@ public class EnrollmentServiceTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
         
         Account account = Account.create();
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
         
-        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         service.unenroll(enrollment);
     }
     
@@ -529,16 +529,16 @@ public class EnrollmentServiceTest extends Mockito {
         when(mockSponsorService.isStudySponsoredBy(TEST_STUDY_ID, TEST_ORG_ID)).thenReturn(Boolean.FALSE);
 
         Account account = Account.create();
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
 
-        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         service.unenroll(enrollment);
     }
     
     @Test(expectedExceptions = InvalidEntityException.class)
     public void unenrollInvalidEnrollment() {
-        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         enrollment.setAccountId(null);
 
         service.unenroll(enrollment);

--- a/src/test/java/org/sagebionetworks/bridge/services/NotificationsServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/NotificationsServiceTest.java
@@ -2,7 +2,7 @@ package org.sagebionetworks.bridge.services;
 
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestUtils.getNotificationMessage;
 import static org.sagebionetworks.bridge.TestUtils.getNotificationRegistration;
 import static org.testng.Assert.assertEquals;
@@ -51,7 +51,7 @@ public class NotificationsServiceTest {
     private static final String PLATFORM_ARN = "arn:platform";
 
     private static final CriteriaContext DUMMY_CONTEXT = new CriteriaContext.Builder().withAppId(TEST_APP_ID)
-            .withUserId(USER_ID).build();
+            .withUserId(TEST_USER_ID).build();
 
     @Mock
     private NotificationTopicService mockNotificationTopicService;
@@ -142,9 +142,9 @@ public class NotificationsServiceTest {
         when(mockRegistrationDao.createRegistration(registration)).thenReturn(registration);
 
         // Mock participant DAO w/ phone number.
-        StudyParticipant participant = new StudyParticipant.Builder().withId(USER_ID).withPhone(TestConstants.PHONE)
+        StudyParticipant participant = new StudyParticipant.Builder().withId(TEST_USER_ID).withPhone(TestConstants.PHONE)
                 .withPhoneVerified(true).build();
-        when(mockParticipantService.getParticipant(mockApp, USER_ID, false)).thenReturn(participant);
+        when(mockParticipantService.getParticipant(mockApp, TEST_USER_ID, false)).thenReturn(participant);
 
         // Execute and validate.
         NotificationRegistration result = service.createRegistration(TEST_APP_ID, DUMMY_CONTEXT, registration);
@@ -158,9 +158,9 @@ public class NotificationsServiceTest {
     @Test(expectedExceptions = BadRequestException.class)
     public void createRegistration_SmsNotificationPhoneNotVerified() {
         // Mock participant DAO w/ unverified phone number.
-        StudyParticipant participant = new StudyParticipant.Builder().withId(USER_ID).withPhone(TestConstants.PHONE)
+        StudyParticipant participant = new StudyParticipant.Builder().withId(TEST_USER_ID).withPhone(TestConstants.PHONE)
                 .withPhoneVerified(null).build();
-        when(mockParticipantService.getParticipant(mockApp, USER_ID, false)).thenReturn(participant);
+        when(mockParticipantService.getParticipant(mockApp, TEST_USER_ID, false)).thenReturn(participant);
 
         // Execute and validate.
         service.createRegistration(TEST_APP_ID, DUMMY_CONTEXT, getSmsNotificationRegistration());
@@ -169,9 +169,9 @@ public class NotificationsServiceTest {
     @Test(expectedExceptions = BadRequestException.class)
     public void createRegistration_SmsNotificationPhoneDoesNotMatch() {
         // Mock participant DAO w/ wrong phone number.
-        StudyParticipant participant = new StudyParticipant.Builder().withId(USER_ID).withPhone(TestConstants.PHONE)
+        StudyParticipant participant = new StudyParticipant.Builder().withId(TEST_USER_ID).withPhone(TestConstants.PHONE)
                 .withPhoneVerified(true).build();
-        when(mockParticipantService.getParticipant(mockApp, USER_ID, false)).thenReturn(participant);
+        when(mockParticipantService.getParticipant(mockApp, TEST_USER_ID, false)).thenReturn(participant);
 
         // Execute and validate.
         NotificationRegistration registration = getSmsNotificationRegistration();

--- a/src/test/java/org/sagebionetworks/bridge/services/OrganizationServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/OrganizationServiceTest.java
@@ -180,7 +180,8 @@ public class OrganizationServiceTest extends Mockito {
     @Test
     public void updateOrganization() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerOrgMembership(IDENTIFIER).build());
+                .withCallerOrgMembership(IDENTIFIER)
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         Organization org = Organization.create();
         org.setAppId(TEST_APP_ID);
         org.setIdentifier(IDENTIFIER);
@@ -206,7 +207,8 @@ public class OrganizationServiceTest extends Mockito {
             expectedExceptionsMessageRegExp = "Organization not found.")
     public void updateOrganizationNotFound() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerOrgMembership(IDENTIFIER).build());
+                .withCallerOrgMembership(IDENTIFIER)
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         when(mockOrgDao.getOrganization(TEST_APP_ID, IDENTIFIER)).thenReturn(Optional.empty());
         
         Organization org = Organization.create();
@@ -220,7 +222,8 @@ public class OrganizationServiceTest extends Mockito {
     @Test(expectedExceptions = InvalidEntityException.class)
     public void updateOrganizationNotValid() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerOrgMembership(IDENTIFIER).build());
+                .withCallerOrgMembership(IDENTIFIER)
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         Organization org = Organization.create();
         org.setIdentifier(IDENTIFIER);
         
@@ -260,7 +263,7 @@ public class OrganizationServiceTest extends Mockito {
     @Test
     public void deleteOrganization() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerOrgMembership(IDENTIFIER).build());
+                .withCallerRoles(ImmutableSet.of(ADMIN)).build());
         Organization org = Organization.create();
         when(mockOrgDao.getOrganization(TEST_APP_ID, IDENTIFIER)).thenReturn(Optional.of(org));
         
@@ -297,7 +300,7 @@ public class OrganizationServiceTest extends Mockito {
             expectedExceptionsMessageRegExp = "Organization not found.")
     public void deleteOrganizationNotFound() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerOrgMembership(IDENTIFIER).build());
+                .withCallerRoles(ImmutableSet.of(ADMIN)).build());
         when(mockOrgDao.getOrganization(TEST_APP_ID, IDENTIFIER)).thenReturn(Optional.empty());
         
         service.deleteOrganization(TEST_APP_ID, IDENTIFIER);
@@ -306,7 +309,8 @@ public class OrganizationServiceTest extends Mockito {
     @Test
     public void getMembers() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerOrgMembership(IDENTIFIER).build());
+                .withCallerOrgMembership(IDENTIFIER)
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         
         when(mockOrgDao.getOrganization(TEST_APP_ID, IDENTIFIER)).thenReturn(Optional.of(Organization.create()));
         
@@ -453,7 +457,8 @@ public class OrganizationServiceTest extends Mockito {
     @Test
     public void removeMember() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerOrgMembership(IDENTIFIER).build());
+                .withCallerOrgMembership(IDENTIFIER)
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         
         Account account = Account.create();
         account.setOrgMembership(IDENTIFIER);

--- a/src/test/java/org/sagebionetworks/bridge/services/OrganizationServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/OrganizationServiceTest.java
@@ -11,7 +11,7 @@ import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
 import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.USER_DATA_GROUPS;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
@@ -363,7 +363,7 @@ public class OrganizationServiceTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         
         Account account = Account.create();
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         when(mockAccountDao.getAccount(ACCOUNT_ID)).thenReturn(Optional.of(account));
         
         service.addMember(TEST_APP_ID, IDENTIFIER, ACCOUNT_ID);
@@ -371,7 +371,7 @@ public class OrganizationServiceTest extends Mockito {
         verify(mockAccountDao).updateAccount(accountCaptor.capture());
         assertEquals(accountCaptor.getValue().getOrgMembership(), IDENTIFIER);
         
-        verify(mockSessionUpdateService).updateOrgMembership(USER_ID, IDENTIFIER);
+        verify(mockSessionUpdateService).updateOrgMembership(TEST_USER_ID, IDENTIFIER);
     }
     
     @Test
@@ -462,7 +462,7 @@ public class OrganizationServiceTest extends Mockito {
         
         Account account = Account.create();
         account.setOrgMembership(IDENTIFIER);
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         when(mockAccountDao.getAccount(ACCOUNT_ID)).thenReturn(Optional.of(account));
 
         service.removeMember(TEST_APP_ID, IDENTIFIER, ACCOUNT_ID);
@@ -470,7 +470,7 @@ public class OrganizationServiceTest extends Mockito {
         verify(mockAccountDao).updateAccount(accountCaptor.capture());
         assertNull(accountCaptor.getValue().getOrgMembership());
         
-        verify(mockSessionUpdateService).updateOrgMembership(USER_ID, null);
+        verify(mockSessionUpdateService).updateOrgMembership(TEST_USER_ID, null);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -15,7 +15,7 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.TestConstants.TIMESTAMP;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestConstants.USER_STUDY_IDS;
 import static org.sagebionetworks.bridge.models.accounts.AccountStatus.DISABLED;
 import static org.sagebionetworks.bridge.models.accounts.AccountStatus.UNVERIFIED;
@@ -2390,10 +2390,10 @@ public class ParticipantServiceTest extends Mockito {
                 .withEventKey("anEvent")
                 .withTimestamp(TIMESTAMP).build();
         
-        AccountId accountId = AccountId.forId(APP.getIdentifier(), USER_ID);
+        AccountId accountId = AccountId.forId(APP.getIdentifier(), TEST_USER_ID);
         when(accountService.getAccount(accountId)).thenReturn(account);
         
-        participantService.createCustomActivityEvent(APP, USER_ID, request);
+        participantService.createCustomActivityEvent(APP, TEST_USER_ID, request);
         
         verify(activityEventService).publishCustomEvent(APP, HEALTH_CODE, "anEvent", TIMESTAMP);
     }
@@ -2405,7 +2405,7 @@ public class ParticipantServiceTest extends Mockito {
                 .withEventKey("anEvent")
                 .withTimestamp(TIMESTAMP).build();
         
-        participantService.createCustomActivityEvent(APP, USER_ID, request);
+        participantService.createCustomActivityEvent(APP, TEST_USER_ID, request);
     }
     
     // getPagedAccountSummaries() filters studies in the query itself, as this is the only 

--- a/src/test/java/org/sagebionetworks/bridge/services/RequestInfoServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/RequestInfoServiceTest.java
@@ -1,6 +1,6 @@
 package org.sagebionetworks.bridge.services;
 
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 
@@ -42,9 +42,9 @@ public class RequestInfoServiceTest extends Mockito {
     @Test
     public void getRequestInfoFromDatabase() {
         RequestInfo info = new RequestInfo.Builder().build();
-        when(mockRequestInfoDao.getRequestInfo(USER_ID)).thenReturn(info);
+        when(mockRequestInfoDao.getRequestInfo(TEST_USER_ID)).thenReturn(info);
         
-        RequestInfo retrieved = service.getRequestInfo(USER_ID);
+        RequestInfo retrieved = service.getRequestInfo(TEST_USER_ID);
         assertSame(retrieved, info);
         
         // No need to execute this path
@@ -55,9 +55,9 @@ public class RequestInfoServiceTest extends Mockito {
     @Test
     public void getRequestInfoFromCache() {
         RequestInfo info = new RequestInfo.Builder().build();
-        when(mockCacheProvider.getRequestInfo(USER_ID)).thenReturn(info);
+        when(mockCacheProvider.getRequestInfo(TEST_USER_ID)).thenReturn(info);
         
-        RequestInfo retrieved = service.getRequestInfo(USER_ID);
+        RequestInfo retrieved = service.getRequestInfo(TEST_USER_ID);
         assertSame(retrieved, info);
         
         // And it was saved
@@ -66,15 +66,15 @@ public class RequestInfoServiceTest extends Mockito {
     
     @Test
     public void getRequestInfoReturnsNothing() {
-        RequestInfo retrieved = service.getRequestInfo(USER_ID);
+        RequestInfo retrieved = service.getRequestInfo(TEST_USER_ID);
         assertNull(retrieved);
         verify(mockRequestInfoDao, never()).updateRequestInfo(any());
     }
     
     @Test
     public void removeRequestInfo() {
-        service.removeRequestInfo(USER_ID);
-        verify(mockRequestInfoDao).removeRequestInfo(USER_ID);
-        verify(mockCacheProvider).removeRequestInfo(USER_ID);
+        service.removeRequestInfo(TEST_USER_ID);
+        verify(mockRequestInfoDao).removeRequestInfo(TEST_USER_ID);
+        verify(mockCacheProvider).removeRequestInfo(TEST_USER_ID);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/SessionUpdateServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/SessionUpdateServiceTest.java
@@ -5,7 +5,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.models.accounts.SharingScope.ALL_QUALIFIED_RESEARCHERS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
@@ -232,11 +232,11 @@ public class SessionUpdateServiceTest {
     public void updateOrgMembershipAddMembership() {
         UserSession session = new UserSession();
         session.setParticipant(new StudyParticipant.Builder().withOrgMembership("test").build());
-        when(mockCacheProvider.getUserSessionByUserId(USER_ID)).thenReturn(session);
+        when(mockCacheProvider.getUserSessionByUserId(TEST_USER_ID)).thenReturn(session);
         
         ArgumentCaptor<UserSession> sessionCaptor = ArgumentCaptor.forClass(UserSession.class);
         
-        service.updateOrgMembership(USER_ID, "newOrgId");
+        service.updateOrgMembership(TEST_USER_ID, "newOrgId");
         
         verify(mockCacheProvider).setUserSession(sessionCaptor.capture());
         assertEquals("newOrgId", sessionCaptor.getValue().getParticipant().getOrgMembership());
@@ -246,11 +246,11 @@ public class SessionUpdateServiceTest {
     public void updateOrgMembershipRemoveMembership() {
         UserSession session = new UserSession();
         session.setParticipant(new StudyParticipant.Builder().withOrgMembership("test").build());
-        when(mockCacheProvider.getUserSessionByUserId(USER_ID)).thenReturn(session);
+        when(mockCacheProvider.getUserSessionByUserId(TEST_USER_ID)).thenReturn(session);
         
         ArgumentCaptor<UserSession> sessionCaptor = ArgumentCaptor.forClass(UserSession.class);
         
-        service.updateOrgMembership(USER_ID, null);
+        service.updateOrgMembership(TEST_USER_ID, null);
         
         verify(mockCacheProvider).setUserSession(sessionCaptor.capture());
         assertNull(sessionCaptor.getValue().getParticipant().getOrgMembership());

--- a/src/test/java/org/sagebionetworks/bridge/services/SponsorServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/SponsorServiceTest.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.services;
 import static org.sagebionetworks.bridge.BridgeConstants.NEGATIVE_OFFSET_ERROR;
 import static org.sagebionetworks.bridge.BridgeConstants.PAGE_SIZE_ERROR;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
+import static org.sagebionetworks.bridge.Roles.ORG_ADMIN;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
@@ -161,9 +162,10 @@ public class SponsorServiceTest extends Mockito {
     }
 
     @Test
-    public void addStudySponsorAsOrgMember() {
+    public void addStudySponsorAsOrgAdmin() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerOrgMembership(TEST_ORG_ID).build());
+                .withCallerOrgMembership(TEST_ORG_ID)
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         
         service.addStudySponsor(TEST_APP_ID, TEST_STUDY_ID, TEST_ORG_ID);
         
@@ -193,9 +195,10 @@ public class SponsorServiceTest extends Mockito {
     }
     
     @Test
-    public void removeStudySponsorAsOrgMember() {
+    public void removeStudySponsorAsOrgAdmin() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerOrgMembership(TEST_ORG_ID).build());
+                .withCallerOrgMembership(TEST_ORG_ID)
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
 
         when(mockSponsorDao.doesOrganizationSponsorStudy(
                 TEST_APP_ID, TEST_STUDY_ID, TEST_ORG_ID)).thenReturn(true);

--- a/src/test/java/org/sagebionetworks/bridge/services/TemplateRevisionServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/TemplateRevisionServiceTest.java
@@ -4,7 +4,7 @@ import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TIMESTAMP;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.models.apps.MimeType.TEXT;
 import static org.sagebionetworks.bridge.models.templates.TemplateType.SMS_PHONE_SIGN_IN;
 import static org.testng.Assert.assertEquals;
@@ -66,7 +66,7 @@ public class TemplateRevisionServiceTest extends Mockito {
         MockitoAnnotations.initMocks(this);
         
         when(service.getDateTime()).thenReturn(TIMESTAMP);
-        when(service.getUserId()).thenReturn(USER_ID);
+        when(service.getUserId()).thenReturn(TEST_USER_ID);
     }
 
     @Test
@@ -136,7 +136,7 @@ public class TemplateRevisionServiceTest extends Mockito {
         
         assertEquals(captured.getTemplateGuid(), TEMPLATE_GUID);
         assertEquals(captured.getCreatedOn(), CREATED_ON);
-        assertEquals(captured.getCreatedBy(), USER_ID);
+        assertEquals(captured.getCreatedBy(), TEST_USER_ID);
         assertEquals(captured.getStoragePath(), STORAGE_PATH);
         assertEquals(captured.getDocumentContent(), DOCUMENT_CONTENT);
         assertEquals(captured.getMimeType(), TEXT);

--- a/src/test/java/org/sagebionetworks/bridge/services/TemplateServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/TemplateServiceTest.java
@@ -6,7 +6,7 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TIMESTAMP;
 import static org.sagebionetworks.bridge.TestConstants.UA;
 import static org.sagebionetworks.bridge.TestConstants.USER_DATA_GROUPS;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestConstants.USER_STUDY_IDS;
 import static org.sagebionetworks.bridge.models.apps.MimeType.HTML;
 import static org.sagebionetworks.bridge.models.templates.TemplateType.EMAIL_ACCOUNT_EXISTS;
@@ -130,7 +130,7 @@ public class TemplateServiceTest extends Mockito {
         service.makeDefaultTemplateMap();
         when(service.generateGuid()).thenReturn(GUID1);
         when(service.getTimestamp()).thenReturn(TIMESTAMP);
-        when(service.getUserId()).thenReturn(USER_ID);
+        when(service.getUserId()).thenReturn(TEST_USER_ID);
         
         app = App.create();
         app.setIdentifier(TEST_APP_ID);
@@ -419,7 +419,7 @@ public class TemplateServiceTest extends Mockito {
         verify(mockTemplateDao).createTemplate(template);
         
         TemplateRevision revision = revisionCaptor.getValue();
-        assertEquals(revision.getCreatedBy(), USER_ID);
+        assertEquals(revision.getCreatedBy(), TEST_USER_ID);
         assertEquals(revision.getCreatedOn(), TIMESTAMP);
         assertEquals(revision.getTemplateGuid(), GUID1);
         assertEquals(revision.getStoragePath(), GUID1 + "." + TIMESTAMP.getMillis());

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AccountsControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AccountsControllerTest.java
@@ -10,7 +10,7 @@ import static org.sagebionetworks.bridge.TestConstants.PHONE;
 import static org.sagebionetworks.bridge.TestConstants.SYNAPSE_USER_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertCreate;
 import static org.sagebionetworks.bridge.TestUtils.assertDelete;
 import static org.sagebionetworks.bridge.TestUtils.assertGet;
@@ -68,8 +68,8 @@ import org.sagebionetworks.bridge.services.UserAdminService;
 
 public class AccountsControllerTest extends Mockito {
     
-    private static final IdentifierHolder ID = new IdentifierHolder(USER_ID);
-    private static final AccountId ACCOUNT_ID = AccountId.forId(TEST_APP_ID, USER_ID);
+    private static final IdentifierHolder ID = new IdentifierHolder(TEST_USER_ID);
+    private static final AccountId ACCOUNT_ID = AccountId.forId(TEST_APP_ID, TEST_USER_ID);
     private static final Set<Roles> CALLER_ROLES = ImmutableSet.of(RESEARCHER);
     private static final Set<String> CALLER_STUDIES = ImmutableSet.of("studyA");
     private static final SignIn EMAIL_PASSWORD_SIGN_IN_REQUEST = new SignIn.Builder()
@@ -194,7 +194,7 @@ public class AccountsControllerTest extends Mockito {
         mockRequestBody(mockRequest, participant);
         
         IdentifierHolder retValue = controller.createAccount();
-        assertEquals(retValue.getIdentifier(), USER_ID);
+        assertEquals(retValue.getIdentifier(), TEST_USER_ID);
         
         verify(mockParticipantService)
             .createParticipant(eq(app), participantCaptor.capture(), eq(true));
@@ -214,7 +214,7 @@ public class AccountsControllerTest extends Mockito {
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
 
-        Account retValue = controller.getAccount(USER_ID);
+        Account retValue = controller.getAccount(TEST_USER_ID);
         assertSame(retValue, account);
     }
     
@@ -236,15 +236,15 @@ public class AccountsControllerTest extends Mockito {
         mockRequestBody(mockRequest, submitted);
 
         StudyParticipant persisted = new StudyParticipant.Builder()
-                .withId(USER_ID)
+                .withId(TEST_USER_ID)
                 .withOrgMembership(TEST_ORG_ID).build();
         when(mockParticipantService.getParticipant(app, account, false)).thenReturn(persisted);
         
-        StatusMessage retValue = controller.updateAccount(USER_ID);
+        StatusMessage retValue = controller.updateAccount(TEST_USER_ID);
         assertEquals(retValue.getMessage(), "Member updated.");
         
         verify(mockParticipantService).updateParticipant(eq(app), participantCaptor.capture());
-        assertEquals(participantCaptor.getValue().getId(), USER_ID);
+        assertEquals(participantCaptor.getValue().getId(), TEST_USER_ID);
         assertEquals(participantCaptor.getValue().getOrgMembership(), TEST_ORG_ID);
     }
     
@@ -261,12 +261,12 @@ public class AccountsControllerTest extends Mockito {
         StudyParticipant existing = new StudyParticipant.Builder()
                 .withOrgMembership(TEST_ORG_ID)
                 .build();
-        when(mockParticipantService.getParticipant(app, USER_ID, false)).thenReturn(existing);
+        when(mockParticipantService.getParticipant(app, TEST_USER_ID, false)).thenReturn(existing);
 
-        StatusMessage retValue = controller.deleteAccount(USER_ID);
+        StatusMessage retValue = controller.deleteAccount(TEST_USER_ID);
         assertEquals(retValue.getMessage(), "Member account deleted.");
         
-        verify(mockUserAdminService).deleteUser(app, USER_ID);
+        verify(mockUserAdminService).deleteUser(app, TEST_USER_ID);
     }
     
     @Test
@@ -281,9 +281,9 @@ public class AccountsControllerTest extends Mockito {
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
         
         RequestInfo requestInfo = new RequestInfo.Builder().withAppId(TEST_APP_ID).build();
-        when(mockRequestInfoService.getRequestInfo(USER_ID)).thenReturn(requestInfo);
+        when(mockRequestInfoService.getRequestInfo(TEST_USER_ID)).thenReturn(requestInfo);
         
-        String retValue = controller.getRequestInfo(USER_ID);
+        String retValue = controller.getRequestInfo(TEST_USER_ID);
         assertEquals(retValue, RequestInfo.REQUEST_INFO_WRITER.writeValueAsString(requestInfo));
     }
     
@@ -298,9 +298,9 @@ public class AccountsControllerTest extends Mockito {
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
         
-        when(mockRequestInfoService.getRequestInfo(USER_ID)).thenReturn(null);
+        when(mockRequestInfoService.getRequestInfo(TEST_USER_ID)).thenReturn(null);
         
-        String retValue = controller.getRequestInfo(USER_ID);
+        String retValue = controller.getRequestInfo(TEST_USER_ID);
         assertEquals(retValue, RequestInfo.REQUEST_INFO_WRITER
                 .writeValueAsString(new RequestInfo.Builder().build()));
     }
@@ -316,10 +316,10 @@ public class AccountsControllerTest extends Mockito {
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
 
-        StatusMessage retValue = controller.requestResetPassword(USER_ID);
+        StatusMessage retValue = controller.requestResetPassword(TEST_USER_ID);
         assertEquals(retValue.getMessage(), "Request to reset password sent to user.");
         
-        verify(mockParticipantService).requestResetPassword(app, USER_ID);
+        verify(mockParticipantService).requestResetPassword(app, TEST_USER_ID);
     }
     
     @Test
@@ -333,9 +333,9 @@ public class AccountsControllerTest extends Mockito {
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
         
-        controller.resendEmailVerification(USER_ID);
+        controller.resendEmailVerification(TEST_USER_ID);
         
-        verify(mockParticipantService).resendVerification(app, ChannelType.EMAIL, USER_ID);
+        verify(mockParticipantService).resendVerification(app, ChannelType.EMAIL, TEST_USER_ID);
     }
     
     @Test
@@ -349,9 +349,9 @@ public class AccountsControllerTest extends Mockito {
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
         
-        controller.resendPhoneVerification(USER_ID);
+        controller.resendPhoneVerification(TEST_USER_ID);
         
-        verify(mockParticipantService).resendVerification(app, ChannelType.PHONE, USER_ID);        
+        verify(mockParticipantService).resendVerification(app, ChannelType.PHONE, TEST_USER_ID);        
     }
     
     @Test
@@ -365,9 +365,9 @@ public class AccountsControllerTest extends Mockito {
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
         
-        controller.signOut(USER_ID, true);
+        controller.signOut(TEST_USER_ID, true);
         
-        verify(mockParticipantService).signUserOut(app, USER_ID, true);
+        verify(mockParticipantService).signUserOut(app, TEST_USER_ID, true);
     }
     
     @Test
@@ -383,7 +383,7 @@ public class AccountsControllerTest extends Mockito {
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
         
         Account retValue = controller.verifyOrgAdminIsActingOnOrgMember(
-                TEST_APP_ID, TEST_ORG_ID, USER_ID);
+                TEST_APP_ID, TEST_ORG_ID, TEST_USER_ID);
         assertSame(retValue, account);
     }
     
@@ -399,7 +399,7 @@ public class AccountsControllerTest extends Mockito {
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(null);
         
         controller.verifyOrgAdminIsActingOnOrgMember(
-                TEST_APP_ID, TEST_ORG_ID, USER_ID);
+                TEST_APP_ID, TEST_ORG_ID, TEST_USER_ID);
     }
 
     @Test(expectedExceptions = EntityNotFoundException.class, 
@@ -417,7 +417,7 @@ public class AccountsControllerTest extends Mockito {
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
         
         Account retValue = controller.verifyOrgAdminIsActingOnOrgMember(
-                TEST_APP_ID, TEST_ORG_ID, USER_ID);
+                TEST_APP_ID, TEST_ORG_ID, TEST_USER_ID);
        
         assertSame(retValue, account);
     }
@@ -435,7 +435,7 @@ public class AccountsControllerTest extends Mockito {
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
         
         Account retValue = controller.verifyOrgAdminIsActingOnOrgMember(
-                TEST_APP_ID, TEST_ORG_ID, USER_ID);
+                TEST_APP_ID, TEST_ORG_ID, TEST_USER_ID);
         assertSame(retValue, account);
     }
 
@@ -453,7 +453,7 @@ public class AccountsControllerTest extends Mockito {
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
         
         Account retValue = controller.verifyOrgAdminIsActingOnOrgMember(
-                TEST_APP_ID, TEST_ORG_ID, USER_ID);
+                TEST_APP_ID, TEST_ORG_ID, TEST_USER_ID);
         assertSame(retValue, account);
     }
     
@@ -464,13 +464,13 @@ public class AccountsControllerTest extends Mockito {
         doReturn(session).when(controller).getAuthenticatedSession();
         
         StudyParticipant participant = new StudyParticipant.Builder().withRoles(CALLER_ROLES).withStudyIds(CALLER_STUDIES)
-                .withId(USER_ID).build();
+                .withId(TEST_USER_ID).build();
 
         when(mockParticipantService.updateIdentifiers(eq(app), any(), any())).thenReturn(participant);
 
         JsonNode result = controller.updateIdentifiers();
 
-        assertEquals(result.get("id").textValue(), USER_ID);
+        assertEquals(result.get("id").textValue(), TEST_USER_ID);
 
         verify(mockParticipantService).updateIdentifiers(eq(app), contextCaptor.capture(),
                 identifierUpdateCaptor.capture());
@@ -491,13 +491,13 @@ public class AccountsControllerTest extends Mockito {
         doReturn(session).when(controller).getAuthenticatedSession();
         
         StudyParticipant participant = new StudyParticipant.Builder().withRoles(CALLER_ROLES).withStudyIds(CALLER_STUDIES)
-                .withId(USER_ID).build();
+                .withId(TEST_USER_ID).build();
         
         when(mockParticipantService.updateIdentifiers(eq(app), any(), any())).thenReturn(participant);
 
         JsonNode result = controller.updateIdentifiers();
 
-        assertEquals(result.get("id").textValue(), USER_ID);
+        assertEquals(result.get("id").textValue(), TEST_USER_ID);
 
         verify(mockParticipantService).updateIdentifiers(eq(app), contextCaptor.capture(),
                 identifierUpdateCaptor.capture());
@@ -516,13 +516,13 @@ public class AccountsControllerTest extends Mockito {
         doReturn(session).when(controller).getAuthenticatedSession();
         
         StudyParticipant participant = new StudyParticipant.Builder().withRoles(CALLER_ROLES).withStudyIds(CALLER_STUDIES)
-                .withId(USER_ID).build();
+                .withId(TEST_USER_ID).build();
         
         when(mockParticipantService.updateIdentifiers(eq(app), any(), any())).thenReturn(participant);
 
         JsonNode result = controller.updateIdentifiers();
 
-        assertEquals(result.get("id").textValue(), USER_ID);
+        assertEquals(result.get("id").textValue(), TEST_USER_ID);
 
         verify(mockParticipantService).updateIdentifiers(eq(app), contextCaptor.capture(),
                 identifierUpdateCaptor.capture());

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AppControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AppControllerTest.java
@@ -12,7 +12,6 @@ import static org.sagebionetworks.bridge.TestConstants.EMAIL;
 import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
 import static org.sagebionetworks.bridge.TestConstants.SYNAPSE_USER_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertCreate;
 import static org.sagebionetworks.bridge.TestUtils.assertCrossOrigin;
 import static org.sagebionetworks.bridge.TestUtils.assertDelete;
@@ -148,7 +147,7 @@ public class AppControllerTest extends Mockito {
         
         // mock session with appId
         when(mockSession.getAppId()).thenReturn(TEST_APP_ID);
-        when(mockSession.getId()).thenReturn(USER_ID);
+        when(mockSession.getId()).thenReturn(TEST_USER_ID);
         
         app = new DynamoApp();
         app.setSupportEmail(EMAIL_ADDRESS);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AssessmentControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AssessmentControllerTest.java
@@ -11,7 +11,7 @@ import static org.sagebionetworks.bridge.TestConstants.CUSTOMIZATION_FIELDS;
 import static org.sagebionetworks.bridge.TestConstants.GUID;
 import static org.sagebionetworks.bridge.TestConstants.IDENTIFIER;
 import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
-import static org.sagebionetworks.bridge.TestConstants.OWNER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_OWNER_ID;
 import static org.sagebionetworks.bridge.TestConstants.STRING_TAGS;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertCreate;
@@ -174,7 +174,7 @@ public class AssessmentControllerTest extends Mockito {
         assertEquals(captured.getNormingStatus(), "normingStatus");
         assertEquals(captured.getOsName(), ANDROID);
         assertEquals(captured.getOriginGuid(), "originGuid");
-        assertEquals(captured.getOwnerId(), OWNER_ID);
+        assertEquals(captured.getOwnerId(), TEST_OWNER_ID);
         assertEquals(captured.getTags(), STRING_TAGS);
         assertEquals(captured.getCustomizationFields(), CUSTOMIZATION_FIELDS);
         assertEquals(captured.getCreatedOn(), CREATED_ON);
@@ -241,7 +241,7 @@ public class AssessmentControllerTest extends Mockito {
         assertEquals(retValue.getNormingStatus(), "normingStatus");
         assertEquals(retValue.getOsName(), ANDROID);
         assertEquals(retValue.getOriginGuid(), "originGuid");
-        assertEquals(retValue.getOwnerId(), OWNER_ID);
+        assertEquals(retValue.getOwnerId(), TEST_OWNER_ID);
         assertEquals(retValue.getTags(), STRING_TAGS);
         assertEquals(retValue.getCustomizationFields(), CUSTOMIZATION_FIELDS);
         assertEquals(retValue.getCreatedOn(), CREATED_ON);
@@ -276,7 +276,7 @@ public class AssessmentControllerTest extends Mockito {
         assertEquals(retValue.getNormingStatus(), "normingStatus");
         assertEquals(retValue.getOsName(), ANDROID);
         assertEquals(retValue.getOriginGuid(), "originGuid");
-        assertEquals(retValue.getOwnerId(), OWNER_ID);
+        assertEquals(retValue.getOwnerId(), TEST_OWNER_ID);
         assertEquals(retValue.getTags(), STRING_TAGS);
         assertEquals(retValue.getCustomizationFields(), CUSTOMIZATION_FIELDS);
         assertEquals(retValue.getCreatedOn(), CREATED_ON);
@@ -422,7 +422,7 @@ public class AssessmentControllerTest extends Mockito {
         assertEquals(captured.getNormingStatus(), "normingStatus");
         assertEquals(captured.getOsName(), ANDROID);
         assertEquals(captured.getOriginGuid(), "originGuid");
-        assertEquals(captured.getOwnerId(), OWNER_ID);
+        assertEquals(captured.getOwnerId(), TEST_OWNER_ID);
         assertEquals(captured.getTags(), STRING_TAGS);
         assertEquals(captured.getCustomizationFields(), CUSTOMIZATION_FIELDS);
         assertEquals(captured.getCreatedOn(), CREATED_ON);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/BaseControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/BaseControllerTest.java
@@ -20,7 +20,7 @@ import static org.sagebionetworks.bridge.TestConstants.TIMEZONE_MSK;
 import static org.sagebionetworks.bridge.TestConstants.UA;
 import static org.sagebionetworks.bridge.TestConstants.UNCONSENTED_STATUS_MAP;
 import static org.sagebionetworks.bridge.TestConstants.USER_DATA_GROUPS;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestConstants.USER_STUDY_IDS;
 import static org.sagebionetworks.bridge.models.ClientInfo.UNKNOWN_CLIENT;
 import static org.springframework.http.HttpHeaders.ACCEPT_LANGUAGE;
@@ -405,14 +405,14 @@ public class BaseControllerTest extends Mockito {
         session.setIpAddress(IP_ADDRESS);
         session.setParticipant(new StudyParticipant.Builder()
                 .withDataGroups(USER_DATA_GROUPS).withStudyIds(USER_STUDY_IDS)
-                .withLanguages(LANGUAGES).withHealthCode(HEALTH_CODE).withId(USER_ID).build());
+                .withLanguages(LANGUAGES).withHealthCode(HEALTH_CODE).withId(TEST_USER_ID).build());
         
         CriteriaContext context = controller.getCriteriaContext(session);
         
         assertEquals(context.getLanguages(), LANGUAGES);
         assertEquals(context.getClientInfo(), ClientInfo.fromUserAgentCache(UA));
         assertEquals(context.getHealthCode(), HEALTH_CODE);
-        assertEquals(context.getUserId(), USER_ID);
+        assertEquals(context.getUserId(), TEST_USER_ID);
         assertEquals(context.getUserDataGroups(), USER_DATA_GROUPS);
         assertEquals(context.getUserStudyIds(), USER_STUDY_IDS);
         assertEquals(context.getAppId(), TEST_APP_ID);
@@ -489,17 +489,17 @@ public class BaseControllerTest extends Mockito {
     @Test
     public void getRequestInfoBuilder() {
         RequestInfo existingInfo = new RequestInfo.Builder().withActivitiesAccessedOn(TIMESTAMP).build();
-        when(requestInfoService.getRequestInfo(USER_ID)).thenReturn(existingInfo);
+        when(requestInfoService.getRequestInfo(TEST_USER_ID)).thenReturn(existingInfo);
         when(mockRequest.getHeader(USER_AGENT)).thenReturn(UA);
         
         session.setAppId(TEST_APP_ID);
-        session.setParticipant(new StudyParticipant.Builder().withId(USER_ID).withLanguages(LANGUAGES)
+        session.setParticipant(new StudyParticipant.Builder().withId(TEST_USER_ID).withLanguages(LANGUAGES)
                 .withDataGroups(USER_DATA_GROUPS).withStudyIds(USER_STUDY_IDS)
                 .withTimeZone(TIMEZONE_MSK).build());
 
         RequestInfo info = controller.getRequestInfoBuilder(session).build();
         assertEquals(info.getActivitiesAccessedOn(), TIMESTAMP.withZone(TIMEZONE_MSK));
-        assertEquals(info.getUserId(), USER_ID);
+        assertEquals(info.getUserId(), TEST_USER_ID);
         assertEquals(info.getClientInfo(), ClientInfo.fromUserAgentCache(UA));
         assertEquals(info.getUserAgent(), UA);
         assertEquals(info.getLanguages(), LANGUAGES);
@@ -773,7 +773,7 @@ public class BaseControllerTest extends Mockito {
         session.setAppId(TEST_APP_ID);
         session.setIpAddress("1.2.3.4");
         session.setParticipant(new StudyParticipant.Builder()
-                .withId(USER_ID)
+                .withId(TEST_USER_ID)
                 .withOrgMembership(TEST_ORG_ID)
                 .withLanguages(LANGUAGES)
                 .withStudyIds(USER_STUDY_IDS)
@@ -797,7 +797,7 @@ public class BaseControllerTest extends Mockito {
         assertEquals(context.getCallerEnrolledStudies(), USER_STUDY_IDS);
         assertEquals(context.getOrgSponsoredStudies(), orgStudies);
         assertTrue(context.isAdministrator()); 
-        assertEquals(context.getCallerUserId(), USER_ID); 
+        assertEquals(context.getCallerUserId(), TEST_USER_ID); 
         assertEquals(context.getCallerClientInfo(), UNKNOWN_CLIENT);
         assertEquals(context.getCallerLanguages(), LANGUAGES);
         assertEquals(context.getCallerIpAddress(), "1.2.3.4");

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/CRCControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/CRCControllerTest.java
@@ -10,7 +10,7 @@ import static org.sagebionetworks.bridge.TestConstants.EMAIL;
 import static org.sagebionetworks.bridge.TestConstants.PHONE;
 import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
 import static org.sagebionetworks.bridge.TestConstants.TIMESTAMP;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestConstants.USER_STUDY_IDS;
 import static org.sagebionetworks.bridge.TestUtils.createJson;
 import static org.sagebionetworks.bridge.TestUtils.mockRequestBody;
@@ -116,9 +116,9 @@ public class CRCControllerTest extends Mockito {
     String AUTHORIZATION_HEADER_VALUE = "Basic "
             + new String(Base64.getEncoder().encode(CREDENTIALS.getBytes()));
     
-    static final Enrollment ENROLLMENT1 = Enrollment.create(APP_ID, "studyA", USER_ID);
-    static final Enrollment ENROLLMENT2 = Enrollment.create(APP_ID, "studyB", USER_ID);
-    static final AccountId ACCOUNT_ID = AccountId.forId(APP_ID, USER_ID);
+    static final Enrollment ENROLLMENT1 = Enrollment.create(APP_ID, "studyA", TEST_USER_ID);
+    static final Enrollment ENROLLMENT2 = Enrollment.create(APP_ID, "studyB", TEST_USER_ID);
+    static final AccountId ACCOUNT_ID = AccountId.forId(APP_ID, TEST_USER_ID);
     static final AccountId ACCOUNT_ID_FOR_HC = AccountId.forHealthCode(APP_ID, HEALTH_CODE);
     static final String LOCATION_JSON = TestUtils.createJson("{ 'id':'4b72216e-f638-4eb0-b901-e23ca2aa69de', "
             +"'meta':{ 'lastUpdated':'2020-08-20T12:41:26Z' }, 'resourceType':'Bundle', 'type':'searchset', "
@@ -316,7 +316,7 @@ public class CRCControllerTest extends Mockito {
 
         account = Account.create();
         account.setHealthCode(HEALTH_CODE);
-        account.setId(USER_ID);
+        account.setId(TEST_USER_ID);
         account.setEnrollments(ImmutableSet.of(ENROLLMENT1, ENROLLMENT2));
         account.setDataGroups(ImmutableSet.of("group1", TEST_USER_GROUP));
         
@@ -524,7 +524,7 @@ public class CRCControllerTest extends Mockito {
         appointment.setStatus(BOOKED);
         // add a wrong participant to verify we go through them all and look for ours
         addAppointmentParticipantComponent(appointment, "Location/foo");
-        addAppointmentSageId(appointment, USER_ID);
+        addAppointmentSageId(appointment, TEST_USER_ID);
         
         String json = FHIR_CONTEXT.newJsonParser().encodeResourceToString(appointment);
         mockRequestBody(mockRequest, json);
@@ -576,7 +576,7 @@ public class CRCControllerTest extends Mockito {
         appointment.setStatus(BOOKED);
         // add a wrong participant to verify we go through them all and look for ours
         addAppointmentParticipantComponent(appointment, LOCATION_NS + "foo");
-        addAppointmentSageId(appointment, USER_ID);
+        addAppointmentSageId(appointment, TEST_USER_ID);
         
         String json = FHIR_CONTEXT.newJsonParser().encodeResourceToString(appointment);
         mockRequestBody(mockRequest, json);
@@ -614,7 +614,7 @@ public class CRCControllerTest extends Mockito {
         Appointment appointment = new Appointment();
         appointment.setStatus(CANCELLED);
         addAppointmentParticipantComponent(appointment, LOCATION_NS + "foo");
-        addAppointmentSageId(appointment, USER_ID);
+        addAppointmentSageId(appointment, TEST_USER_ID);
         
         String json = FHIR_CONTEXT.newJsonParser().encodeResourceToString(appointment);
         mockRequestBody(mockRequest, json);
@@ -643,7 +643,7 @@ public class CRCControllerTest extends Mockito {
         Appointment appointment = new Appointment();
         appointment.setStatus(ENTEREDINERROR);
         addAppointmentParticipantComponent(appointment, LOCATION_NS + "foo");
-        addAppointmentSageId(appointment, USER_ID);
+        addAppointmentSageId(appointment, TEST_USER_ID);
         
         String json = FHIR_CONTEXT.newJsonParser().encodeResourceToString(appointment);
         mockRequestBody(mockRequest, json);
@@ -675,7 +675,7 @@ public class CRCControllerTest extends Mockito {
         appointment.setStatus(BOOKED);
         // add a wrong participant to verify we go through them all and look for ours
         addAppointmentParticipantComponent(appointment, "Location/foo");
-        addAppointmentSageId(appointment, USER_ID);
+        addAppointmentSageId(appointment, TEST_USER_ID);
         
         String json = FHIR_CONTEXT.newJsonParser().encodeResourceToString(appointment);
         mockRequestBody(mockRequest, json);
@@ -715,7 +715,7 @@ public class CRCControllerTest extends Mockito {
 
         Appointment appointment = new Appointment();
         appointment.setStatus(BOOKED);
-        addAppointmentSageId(appointment, USER_ID);
+        addAppointmentSageId(appointment, TEST_USER_ID);
         
         String json = FHIR_CONTEXT.newJsonParser().encodeResourceToString(appointment);
         mockRequestBody(mockRequest, json);
@@ -923,7 +923,7 @@ public class CRCControllerTest extends Mockito {
         String ns = node.get("subject").get("identifier").get("system").textValue();
         String value = node.get("subject").get("identifier").get("value").textValue();
         assertEquals(ns, USER_ID_VALUE_NS); 
-        assertEquals(value, USER_ID);
+        assertEquals(value, TEST_USER_ID);
     }
     
     @Test
@@ -1067,7 +1067,7 @@ public class CRCControllerTest extends Mockito {
         Patient patient = controller.createPatient(account);
         
         assertTrue(patient.getActive());
-        assertEquals(patient.getIdentifier().get(0).getValue(), USER_ID);
+        assertEquals(patient.getIdentifier().get(0).getValue(), TEST_USER_ID);
         assertEquals(patient.getIdentifier().get(0).getSystem(), USER_ID_VALUE_NS);
         assertEquals(patient.getName().get(0).getGivenAsSingleString(), "Test");
         assertEquals(patient.getName().get(0).getFamily(), "User");
@@ -1147,7 +1147,7 @@ public class CRCControllerTest extends Mockito {
         
         Identifier identifier = new Identifier();
         identifier.setSystem("wrong-system");
-        identifier.setValue(USER_ID);
+        identifier.setValue(TEST_USER_ID);
         ProcedureRequest procedure = new ProcedureRequest();
         procedure.addIdentifier(identifier);
         String json = FHIR_CONTEXT.newJsonParser().encodeResourceToString(procedure);
@@ -1179,7 +1179,7 @@ public class CRCControllerTest extends Mockito {
         
         Identifier identifier = new Identifier();
         identifier.setSystem("wrong-system");
-        identifier.setValue(USER_ID);
+        identifier.setValue(TEST_USER_ID);
         Observation observation = new Observation();
         observation.addIdentifier(identifier);
         String json = FHIR_CONTEXT.newJsonParser().encodeResourceToString(observation);
@@ -1194,7 +1194,7 @@ public class CRCControllerTest extends Mockito {
         when(mockRequest.getHeader(AUTHORIZATION)).thenReturn(AUTHORIZATION_HEADER_VALUE);
         when(mockAccountService.authenticate(any(), any())).thenReturn(account);
         when(mockAccountService.getAccount(any())).thenReturn(null);
-        mockRequestBody(mockRequest, makeAppointment(USER_ID, BOOKED));
+        mockRequestBody(mockRequest, makeAppointment(TEST_USER_ID, BOOKED));
         mockGetLocation(LOCATION_JSON);
         
         controller.postAppointment();
@@ -1204,7 +1204,7 @@ public class CRCControllerTest extends Mockito {
     public void callerUserNameIncorrect() throws Exception {
         String auth = new String(Base64.getEncoder().encode(("foo:dummy-password").getBytes()));
         when(mockRequest.getHeader(AUTHORIZATION)).thenReturn("Basic " + auth);
-        mockRequestBody(mockRequest, makeAppointment(USER_ID, BOOKED));
+        mockRequestBody(mockRequest, makeAppointment(TEST_USER_ID, BOOKED));
         
         controller.postProcedureRequest();
     }
@@ -1417,7 +1417,7 @@ public class CRCControllerTest extends Mockito {
             if (node.get("actor").has("identifier")) {
                 String ns = node.get("actor").get("identifier").get("system").textValue();
                 String value = node.get("actor").get("identifier").get("value").textValue();
-                if (value.equals(USER_ID) && USER_ID_VALUE_NS.equals(ns)) {
+                if (value.equals(TEST_USER_ID) && USER_ID_VALUE_NS.equals(ns)) {
                     return;
                 }
             }
@@ -1444,7 +1444,7 @@ public class CRCControllerTest extends Mockito {
         
         Identifier id = new Identifier();
         id.setSystem(USER_ID_VALUE_NS);
-        id.setValue(USER_ID);
+        id.setValue(TEST_USER_ID);
         
         Reference ref = new Reference();
         ref.setIdentifier(id);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/CacheAdminControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/CacheAdminControllerTest.java
@@ -4,7 +4,7 @@ import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
 import static org.sagebionetworks.bridge.TestConstants.ACCOUNT_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertCrossOrigin;
 import static org.sagebionetworks.bridge.TestUtils.assertDelete;
 import static org.sagebionetworks.bridge.TestUtils.assertGet;
@@ -59,7 +59,7 @@ public class CacheAdminControllerTest extends Mockito {
         
         session = new UserSession();
         session.setParticipant(new StudyParticipant.Builder()
-                .withRoles(ImmutableSet.of(SUPERADMIN)).withId(USER_ID).build());
+                .withRoles(ImmutableSet.of(SUPERADMIN)).withId(TEST_USER_ID).build());
         doAnswer(answer -> {
             if (session.isInRole(SUPERADMIN)) {
                 return session;
@@ -96,7 +96,7 @@ public class CacheAdminControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class)
     public void listItemsRejectsAppAdmin() throws Exception {
         session.setParticipant(new StudyParticipant.Builder()
-                .withRoles(ImmutableSet.of(ADMIN)).withId(USER_ID).build());
+                .withRoles(ImmutableSet.of(ADMIN)).withId(TEST_USER_ID).build());
         
         Set<String> items = ImmutableSet.of("A", "B", "C");
         when(mockCacheAdminService.listItems()).thenReturn(items);
@@ -119,7 +119,7 @@ public class CacheAdminControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class)
     public void removeItemRejectsAppAdmin() throws Exception {
         session.setParticipant(new StudyParticipant.Builder()
-                .withRoles(ImmutableSet.of(ADMIN)).withId(USER_ID).build());
+                .withRoles(ImmutableSet.of(ADMIN)).withId(TEST_USER_ID).build());
         
         controller.removeItem("cacheKey");
     }    

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ConsentControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ConsentControllerTest.java
@@ -6,7 +6,7 @@ import static org.sagebionetworks.bridge.TestConstants.SIGNATURE;
 import static org.sagebionetworks.bridge.TestConstants.SUBPOP_GUID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TIMESTAMP;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestConstants.WITHDRAWAL;
 import static org.sagebionetworks.bridge.TestUtils.assertCreate;
 import static org.sagebionetworks.bridge.TestUtils.assertCrossOrigin;
@@ -116,7 +116,7 @@ public class ConsentControllerTest extends Mockito {
         when(mockAppService.getApp(TEST_APP_ID)).thenReturn(app);
 
         StudyParticipant participant = new StudyParticipant.Builder()
-                .withHealthCode(HEALTH_CODE).withId(USER_ID).build();
+                .withHealthCode(HEALTH_CODE).withId(TEST_USER_ID).build();
         session = new UserSession(participant);
         session.setAppId(TEST_APP_ID);
         session.setSessionToken(ORIGINAL_SESSION_TOKEN);
@@ -183,7 +183,7 @@ public class ConsentControllerTest extends Mockito {
     @Test
     public void getConsentSignatureV1() throws Exception {
         SubpopulationGuid defaultGuid = SubpopulationGuid.create(TEST_APP_ID);
-        when(mockConsentService.getConsentSignature(app, defaultGuid, USER_ID)).thenReturn(SIGNATURE);
+        when(mockConsentService.getConsentSignature(app, defaultGuid, TEST_USER_ID)).thenReturn(SIGNATURE);
         
         String result = controller.getConsentSignature();
         
@@ -191,12 +191,12 @@ public class ConsentControllerTest extends Mockito {
         assertEquals(SIGNATURE.getName(), retrieved.getName());
         assertEquals(SIGNATURE.getBirthdate(), retrieved.getBirthdate());
         
-        verify(mockConsentService).getConsentSignature(app, defaultGuid, USER_ID);
+        verify(mockConsentService).getConsentSignature(app, defaultGuid, TEST_USER_ID);
     }
     
     @Test
     public void getConsentSignatureV2() throws Exception {
-        when(mockConsentService.getConsentSignature(app, SUBPOP_GUID, USER_ID)).thenReturn(SIGNATURE);
+        when(mockConsentService.getConsentSignature(app, SUBPOP_GUID, TEST_USER_ID)).thenReturn(SIGNATURE);
         
         String result = controller.getConsentSignatureV2(SUBPOP_GUID.getGuid());
         
@@ -204,7 +204,7 @@ public class ConsentControllerTest extends Mockito {
         assertEquals(SIGNATURE.getName(), retrieved.getName());
         assertEquals(SIGNATURE.getBirthdate(), retrieved.getBirthdate());
         
-        verify(mockConsentService).getConsentSignature(app, SUBPOP_GUID, USER_ID);
+        verify(mockConsentService).getConsentSignature(app, SUBPOP_GUID, TEST_USER_ID);
     }
     
     @SuppressWarnings("deprecation")

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentControllerTest.java
@@ -8,7 +8,7 @@ import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
 import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertCreate;
 import static org.sagebionetworks.bridge.TestUtils.assertCrossOrigin;
 import static org.sagebionetworks.bridge.TestUtils.assertDelete;
@@ -127,7 +127,7 @@ public class EnrollmentControllerTest extends Mockito {
         Enrollment enrollment = new HibernateEnrollment();
         enrollment.setEnrolledOn(CREATED_ON);
         enrollment.setExternalId("anExternalId");
-        enrollment.setAccountId(USER_ID);
+        enrollment.setAccountId(TEST_USER_ID);
         enrollment.setConsentRequired(true);
         
         TestUtils.mockRequestBody(mockRequest, enrollment);
@@ -145,7 +145,7 @@ public class EnrollmentControllerTest extends Mockito {
         assertEquals(value.getStudyId(), TEST_STUDY_ID);
         assertEquals(value.getEnrolledOn(), CREATED_ON);
         assertEquals(value.getExternalId(), "anExternalId");
-        assertEquals(value.getAccountId(), USER_ID);
+        assertEquals(value.getAccountId(), TEST_USER_ID);
         assertTrue(value.isConsentRequired());
     }
 
@@ -154,7 +154,7 @@ public class EnrollmentControllerTest extends Mockito {
         Enrollment completed = new HibernateEnrollment();
         when(mockService.unenroll(any())).thenReturn(completed);
 
-        Enrollment retValue = controller.unenroll(TEST_STUDY_ID, USER_ID, "This is a note");
+        Enrollment retValue = controller.unenroll(TEST_STUDY_ID, TEST_USER_ID, "This is a note");
         assertSame(retValue, completed);
         
         verify(mockService).unenroll(enrollmentCaptor.capture());
@@ -163,7 +163,7 @@ public class EnrollmentControllerTest extends Mockito {
         assertEquals(value.getWithdrawalNote(), "This is a note");
         assertEquals(value.getAppId(), TEST_APP_ID);
         assertEquals(value.getStudyId(), TEST_STUDY_ID);
-        assertEquals(value.getAccountId(), USER_ID);
+        assertEquals(value.getAccountId(), TEST_USER_ID);
     }
     
     @Test
@@ -172,14 +172,14 @@ public class EnrollmentControllerTest extends Mockito {
         session.setAppId(TEST_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(SUPERADMIN);
         
-        AccountId accountId = AccountId.forId(TEST_APP_ID, USER_ID);
+        AccountId accountId = AccountId.forId(TEST_APP_ID, TEST_USER_ID);
         
         AccountService mockAccountService = mock(AccountService.class);
         controller.setAccountService(mockAccountService);
         
         Account account = Account.create();
-        Enrollment en1 = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID, "externalId");
-        Enrollment en2 = Enrollment.create(TEST_APP_ID, "anotherStudy", USER_ID);
+        Enrollment en1 = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID, "externalId");
+        Enrollment en2 = Enrollment.create(TEST_APP_ID, "anotherStudy", TEST_USER_ID);
         en2.setConsentRequired(true);
         en2.setEnrolledOn(CREATED_ON);
         en2.setWithdrawnOn(MODIFIED_ON);
@@ -189,7 +189,7 @@ public class EnrollmentControllerTest extends Mockito {
         account.setEnrollments(ImmutableSet.of(en1, en2));
         when(mockAccountService.getAccount(accountId)).thenReturn(account);
         
-        List<EnrollmentMigration> returnValue = controller.getUserEnrollments(USER_ID);
+        List<EnrollmentMigration> returnValue = controller.getUserEnrollments(TEST_USER_ID);
         assertEquals(returnValue.size(), 2);
         assertEquals(returnValue.stream().map(m -> m.getStudyId()).collect(toSet()), 
                 ImmutableSet.of(TEST_STUDY_ID, "anotherStudy"));
@@ -206,7 +206,7 @@ public class EnrollmentControllerTest extends Mockito {
         
         when(mockAccountService.getAccount(any())).thenReturn(null);
         
-        controller.getUserEnrollments(USER_ID);
+        controller.getUserEnrollments(TEST_USER_ID);
     }
     
     @Test
@@ -215,23 +215,23 @@ public class EnrollmentControllerTest extends Mockito {
         session.setAppId(TEST_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(SUPERADMIN);
 
-        Enrollment newEnrollment = Enrollment.create(TEST_APP_ID, "anotherStudy", USER_ID);
+        Enrollment newEnrollment = Enrollment.create(TEST_APP_ID, "anotherStudy", TEST_USER_ID);
         mockRequestBody(mockRequest, ImmutableSet.of(EnrollmentMigration.create(newEnrollment)));
         
-        AccountId accountId = AccountId.forHealthCode(TEST_APP_ID, USER_ID);
+        AccountId accountId = AccountId.forHealthCode(TEST_APP_ID, TEST_USER_ID);
         
         AccountService mockAccountService = mock(AccountService.class);
         controller.setAccountService(mockAccountService);
         
         Account mockAccount = mock(Account.class);
-        Enrollment en1 = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID, "externalId");
+        Enrollment en1 = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID, "externalId");
         Set<Enrollment> enrollments = Sets.newHashSet(en1);
         when(mockAccount.getEnrollments()).thenReturn(enrollments);
         when(mockAccountService.getAccount(accountId)).thenReturn(mockAccount);
         
         mockEditAccount(mockAccountService, mockAccount);
         
-        StatusMessage message = controller.updateUserEnrollments("healthcode:"+USER_ID);
+        StatusMessage message = controller.updateUserEnrollments("healthcode:"+TEST_USER_ID);
         assertEquals(message.getMessage(), "Enrollments updated.");
         
         verify(mockAccount, times(2)).getEnrollments();
@@ -244,7 +244,7 @@ public class EnrollmentControllerTest extends Mockito {
         session.setAppId(TEST_APP_ID);
         doReturn(session).when(controller).getAuthenticatedSession(SUPERADMIN);
 
-        Enrollment newEnrollment = Enrollment.create(TEST_APP_ID, "anotherStudy", USER_ID);
+        Enrollment newEnrollment = Enrollment.create(TEST_APP_ID, "anotherStudy", TEST_USER_ID);
         mockRequestBody(mockRequest, ImmutableSet.of(EnrollmentMigration.create(newEnrollment)));
         
         AccountService mockAccountService = mock(AccountService.class);
@@ -252,7 +252,7 @@ public class EnrollmentControllerTest extends Mockito {
         
         when(mockAccountService.getAccount(any())).thenReturn(null);
         
-        controller.updateUserEnrollments(USER_ID);
+        controller.updateUserEnrollments(TEST_USER_ID);
     }
     
     @Test
@@ -263,20 +263,20 @@ public class EnrollmentControllerTest extends Mockito {
 
         mockRequestBody(mockRequest, ImmutableSet.of());
         
-        AccountId accountId = AccountId.forHealthCode(TEST_APP_ID, USER_ID);
+        AccountId accountId = AccountId.forHealthCode(TEST_APP_ID, TEST_USER_ID);
         
         AccountService mockAccountService = mock(AccountService.class);
         controller.setAccountService(mockAccountService);
         
         Account mockAccount = mock(Account.class);
-        Enrollment en1 = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID, "externalId");
+        Enrollment en1 = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID, "externalId");
         Set<Enrollment> enrollments = Sets.newHashSet(en1);
         when(mockAccount.getEnrollments()).thenReturn(enrollments);
         when(mockAccountService.getAccount(accountId)).thenReturn(mockAccount);
         
         mockEditAccount(mockAccountService, mockAccount);
         
-        controller.updateUserEnrollments("healthcode:"+USER_ID);
+        controller.updateUserEnrollments("healthcode:"+TEST_USER_ID);
         
         verify(mockAccount, times(2)).getEnrollments();
         assertTrue(enrollments.isEmpty());

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/FPHSControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/FPHSControllerTest.java
@@ -2,7 +2,7 @@ package org.sagebionetworks.bridge.spring.controllers;
 
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertCreate;
 import static org.sagebionetworks.bridge.TestUtils.assertCrossOrigin;
 import static org.sagebionetworks.bridge.TestUtils.assertGet;
@@ -106,7 +106,7 @@ public class FPHSControllerTest extends Mockito {
     }
     
     private UserSession setUserSession() {
-        StudyParticipant participant = new StudyParticipant.Builder().withId(USER_ID).withHealthCode("BBB").build();
+        StudyParticipant participant = new StudyParticipant.Builder().withId(TEST_USER_ID).withHealthCode("BBB").build();
         
         UserSession session = new UserSession(participant);
         session.setAppId(FPHS_ID);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/HealthDataEx3ControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/HealthDataEx3ControllerTest.java
@@ -114,14 +114,14 @@ public class HealthDataEx3ControllerTest {
     public void deleteRecordsForUser() {
         when(mockAccountService.getHealthCodeForAccount(any())).thenReturn(TestConstants.HEALTH_CODE);
 
-        StatusMessage statusMessage = controller.deleteRecordsForUser(TestConstants.USER_ID);
+        StatusMessage statusMessage = controller.deleteRecordsForUser(TestConstants.TEST_USER_ID);
         assertEquals(statusMessage.getMessage(), "Health data has been deleted for participant");
 
         ArgumentCaptor<AccountId> accountIdCaptor = ArgumentCaptor.forClass(AccountId.class);
         verify(mockAccountService).getHealthCodeForAccount(accountIdCaptor.capture());
         AccountId accountId = accountIdCaptor.getValue();
         assertEquals(accountId.getAppId(), TestConstants.TEST_APP_ID);
-        assertEquals(accountId.getId(), TestConstants.USER_ID);
+        assertEquals(accountId.getId(), TestConstants.TEST_USER_ID);
 
         verify(mockHealthDataEx3Service).deleteRecordsForHealthCode(TestConstants.HEALTH_CODE);
     }
@@ -129,7 +129,7 @@ public class HealthDataEx3ControllerTest {
     @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteRecordsForUser_UserNotFound() {
         when(mockAccountService.getHealthCodeForAccount(any())).thenReturn(null);
-        controller.deleteRecordsForUser(TestConstants.USER_ID);
+        controller.deleteRecordsForUser(TestConstants.TEST_USER_ID);
     }
 
     @Test
@@ -160,11 +160,11 @@ public class HealthDataEx3ControllerTest {
         when(mockHealthDataEx3Service.getRecordsForHealthCode(TestConstants.HEALTH_CODE, CREATED_ON_START,
                 CREATED_ON_END, BridgeConstants.API_DEFAULT_PAGE_SIZE, OFFSET_KEY)).thenReturn(recordList);
 
-        ResourceList<HealthDataRecordEx3> outputList = controller.getRecordsForUser(TestConstants.USER_ID,
+        ResourceList<HealthDataRecordEx3> outputList = controller.getRecordsForUser(TestConstants.TEST_USER_ID,
                 CREATED_ON_START_STRING, CREATED_ON_END_STRING, PAGE_SIZE_STRING, OFFSET_KEY);
         assertSame(outputList, recordList);
         assertEquals(outputList.getRequestParams().size(), 6);
-        assertEquals(outputList.getRequestParams().get("userId"), TestConstants.USER_ID);
+        assertEquals(outputList.getRequestParams().get("userId"), TestConstants.TEST_USER_ID);
         assertEquals(outputList.getRequestParams().get(ResourceList.START_TIME), CREATED_ON_START_STRING);
         assertEquals(outputList.getRequestParams().get(ResourceList.END_TIME), CREATED_ON_END_STRING);
         assertEquals(outputList.getRequestParams().get(ResourceList.PAGE_SIZE), BridgeConstants.API_DEFAULT_PAGE_SIZE);
@@ -175,7 +175,7 @@ public class HealthDataEx3ControllerTest {
         verify(mockAccountService).getHealthCodeForAccount(accountIdCaptor.capture());
         AccountId accountId = accountIdCaptor.getValue();
         assertEquals(accountId.getAppId(), TestConstants.TEST_APP_ID);
-        assertEquals(accountId.getId(), TestConstants.USER_ID);
+        assertEquals(accountId.getId(), TestConstants.TEST_USER_ID);
 
         verify(mockHealthDataEx3Service).getRecordsForHealthCode(TestConstants.HEALTH_CODE, CREATED_ON_START,
                 CREATED_ON_END, BridgeConstants.API_DEFAULT_PAGE_SIZE, OFFSET_KEY);
@@ -184,7 +184,7 @@ public class HealthDataEx3ControllerTest {
     @Test(expectedExceptions = EntityNotFoundException.class)
     public void getRecordsForUser_UserNotFound() {
         when(mockAccountService.getHealthCodeForAccount(any())).thenReturn(null);
-        controller.getRecordsForUser(TestConstants.USER_ID, CREATED_ON_START_STRING, CREATED_ON_END_STRING,
+        controller.getRecordsForUser(TestConstants.TEST_USER_ID, CREATED_ON_START_STRING, CREATED_ON_END_STRING,
                 PAGE_SIZE_STRING, OFFSET_KEY);
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/MasterSchedulerControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/MasterSchedulerControllerTest.java
@@ -12,7 +12,7 @@ import javax.servlet.http.HttpServletResponse;
 import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
 import static org.sagebionetworks.bridge.TestConstants.ACCOUNT_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertCreate;
 import static org.sagebionetworks.bridge.TestUtils.assertCrossOrigin;
 import static org.sagebionetworks.bridge.TestUtils.assertDelete;
@@ -90,7 +90,7 @@ public class MasterSchedulerControllerTest extends Mockito {
         mockSession = new UserSession();
         mockSession.setAppId(TEST_APP_ID);
         mockSession.setAuthenticated(true);
-        mockSession.setParticipant(new StudyParticipant.Builder().withId(USER_ID).build());
+        mockSession.setParticipant(new StudyParticipant.Builder().withId(TEST_USER_ID).build());
         doReturn(mockSession).when(controller).getAuthenticatedSession(SUPERADMIN);
         
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(Account.create());

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/MembershipControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/MembershipControllerTest.java
@@ -7,7 +7,7 @@ import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.ORG_ADMIN;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertCreate;
 import static org.sagebionetworks.bridge.TestUtils.assertDelete;
 import static org.sagebionetworks.bridge.TestUtils.assertPost;
@@ -125,24 +125,24 @@ public class MembershipControllerTest extends Mockito {
     public void addMember() {
         doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
         
-        controller.addMember(TEST_ORG_ID, USER_ID);
+        controller.addMember(TEST_ORG_ID, TEST_USER_ID);
         
         verify(mockOrganizationService).addMember(eq(TEST_APP_ID), eq(TEST_ORG_ID), accountIdCaptor.capture());
         AccountId accountId = accountIdCaptor.getValue();
         assertEquals(TEST_APP_ID, accountId.getAppId());
-        assertEquals(USER_ID, accountId.getId());
+        assertEquals(TEST_USER_ID, accountId.getId());
     }
 
     @Test
     public void removeMember() {
         doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
         
-        controller.removeMember(TEST_ORG_ID, USER_ID);
+        controller.removeMember(TEST_ORG_ID, TEST_USER_ID);
         
         verify(mockOrganizationService).removeMember(eq(TEST_APP_ID), eq(TEST_ORG_ID), accountIdCaptor.capture());
         AccountId accountId = accountIdCaptor.getValue();
         assertEquals(TEST_APP_ID, accountId.getAppId());
-        assertEquals(USER_ID, accountId.getId());
+        assertEquals(TEST_USER_ID, accountId.getId());
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
@@ -23,7 +23,7 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TIMESTAMP;
 import static org.sagebionetworks.bridge.TestConstants.UNENCRYPTED_HEALTH_CODE;
 import static org.sagebionetworks.bridge.TestConstants.USER_DATA_GROUPS;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestConstants.USER_STUDY_IDS;
 import static org.sagebionetworks.bridge.TestUtils.assertAccept;
 import static org.sagebionetworks.bridge.TestUtils.assertCreate;
@@ -254,7 +254,7 @@ public class ParticipantControllerTest extends Mockito {
         app.setIdentifier(TEST_APP_ID);
 
         participant = new StudyParticipant.Builder().withRoles(CALLER_ROLES).withStudyIds(CALLER_STUDIES)
-                .withId(USER_ID).build();
+                .withId(TEST_USER_ID).build();
 
         session = new UserSession(participant);
         session.setAuthenticated(true);
@@ -331,11 +331,11 @@ public class ParticipantControllerTest extends Mockito {
                 new StudyParticipant.Builder().copyOf(session.getParticipant()).withRoles(CALLER_ROLES).build());
 
         // Execute.
-        StatusMessage result = controller.createSmsRegistration(USER_ID);
+        StatusMessage result = controller.createSmsRegistration(TEST_USER_ID);
         assertEquals(result.getMessage(), "SMS notification registration created");
 
         // Verify dependent services.
-        verify(mockParticipantService).createSmsRegistration(app, USER_ID);
+        verify(mockParticipantService).createSmsRegistration(app, TEST_USER_ID);
     }
 
     @SuppressWarnings("deprecation")
@@ -427,7 +427,7 @@ public class ParticipantControllerTest extends Mockito {
     @Test
     public void getParticipantReturnsNoHealthCodeForDeveloper() throws Exception {
         participant = new StudyParticipant.Builder().withRoles(ImmutableSet.of(DEVELOPER, RESEARCHER))
-                .withStudyIds(CALLER_STUDIES).withId(USER_ID).build();
+                .withStudyIds(CALLER_STUDIES).withId(TEST_USER_ID).build();
         session.setParticipant(participant);
         
         app.setHealthCodeExportEnabled(false);
@@ -447,7 +447,7 @@ public class ParticipantControllerTest extends Mockito {
     @Test
     public void getParticipantReturnsHealthCodeForAdmin() throws Exception {
         participant = new StudyParticipant.Builder().withRoles(ImmutableSet.of(ADMIN, RESEARCHER))
-                .withId(USER_ID).withStudyIds(CALLER_STUDIES).withId(USER_ID).build();
+                .withId(TEST_USER_ID).withStudyIds(CALLER_STUDIES).withId(TEST_USER_ID).build();
         session.setParticipant(participant);
 
         app.setHealthCodeExportEnabled(false);
@@ -467,7 +467,7 @@ public class ParticipantControllerTest extends Mockito {
     public void getParticipantWhereHealthCodeIsPrevented() throws Exception {
         app.setHealthCodeExportEnabled(false);
         
-        controller.getParticipant("healthCode:"+USER_ID, true);
+        controller.getParticipant("healthCode:"+TEST_USER_ID, true);
     }
     
     @Test
@@ -478,7 +478,7 @@ public class ParticipantControllerTest extends Mockito {
         
         app.setHealthCodeExportEnabled(false);
         
-        controller.getParticipant("healthCode:"+USER_ID, true);
+        controller.getParticipant("healthCode:"+TEST_USER_ID, true);
     }
     
     @Test
@@ -492,19 +492,19 @@ public class ParticipantControllerTest extends Mockito {
         
         StudyParticipant studyParticipant = new StudyParticipant.Builder().withFirstName("Test")
                 .withHealthCode(HEALTH_CODE).build();
-        when(mockParticipantService.getParticipant(app, "healthCode:" + USER_ID, true)).thenReturn(studyParticipant);
+        when(mockParticipantService.getParticipant(app, "healthCode:" + TEST_USER_ID, true)).thenReturn(studyParticipant);
         
         // You can still retrieve the user with a health code
-        String result = controller.getParticipantForWorker(TEST_APP_ID, "healthCode:"+USER_ID, true);
+        String result = controller.getParticipantForWorker(TEST_APP_ID, "healthCode:"+TEST_USER_ID, true);
         assertNotNull(result);
     }
 
     @Test
     public void signUserOut() throws Exception {
-        StatusMessage result = controller.signOut(USER_ID, false);
+        StatusMessage result = controller.signOut(TEST_USER_ID, false);
         assertEquals(result.getMessage(), "User signed out.");
 
-        verify(mockParticipantService).signUserOut(app, USER_ID, false);
+        verify(mockParticipantService).signUserOut(app, TEST_USER_ID, false);
     }
 
     
@@ -519,14 +519,14 @@ public class ParticipantControllerTest extends Mockito {
 
         mockRequestBody(mockRequest, json);
 
-        StatusMessage result = controller.updateParticipant(USER_ID);
+        StatusMessage result = controller.updateParticipant(TEST_USER_ID);
         assertEquals(result.getMessage(), "Participant updated.");
 
         // Both the caller roles and the caller's studies are passed to participantService
         verify(mockParticipantService).updateParticipant(eq(app), participantCaptor.capture());
 
         StudyParticipant participant = participantCaptor.getValue();
-        assertEquals(participant.getId(), USER_ID);
+        assertEquals(participant.getId(), TEST_USER_ID);
         assertEquals(participant.getFirstName(), "firstName");
         assertEquals(participant.getLastName(), "lastName");
         assertEquals(participant.getEmail(), EMAIL);
@@ -566,7 +566,7 @@ public class ParticipantControllerTest extends Mockito {
 
         IdentifierHolder result = controller.createParticipant();
 
-        assertEquals(result.getIdentifier(), USER_ID);
+        assertEquals(result.getIdentifier(), TEST_USER_ID);
 
         verify(mockParticipantService).createParticipant(eq(app), participantCaptor.capture(), eq(true));
 
@@ -618,7 +618,7 @@ public class ParticipantControllerTest extends Mockito {
 
     @Test(expectedExceptions = UnauthorizedException.class)
     public void getParticipantRequestInfoForWorkerOnly() throws Exception {
-        controller.getRequestInfoForWorker(app.getIdentifier(), USER_ID);
+        controller.getRequestInfoForWorker(app.getIdentifier(), TEST_USER_ID);
     }
     
     @Test
@@ -662,7 +662,7 @@ public class ParticipantControllerTest extends Mockito {
     }
     
     private IdentifierHolder setUpCreateParticipant() throws Exception {
-        IdentifierHolder holder = new IdentifierHolder(USER_ID);
+        IdentifierHolder holder = new IdentifierHolder(TEST_USER_ID);
 
         app.getUserProfileAttributes().add("phone");
         String json = createJson("{'firstName':'firstName'," + "'lastName':'lastName'," + "'email':'email@email.com',"
@@ -689,14 +689,14 @@ public class ParticipantControllerTest extends Mockito {
 
     @Test
     public void getSelfParticipantNoConsentHistories() throws Exception {
-        StudyParticipant studyParticipant = new StudyParticipant.Builder().withId(USER_ID)
+        StudyParticipant studyParticipant = new StudyParticipant.Builder().withId(TEST_USER_ID)
                 .withEncryptedHealthCode(ENCRYPTED_HEALTH_CODE).withFirstName("Test").build();
         when(mockParticipantService.getSelfParticipant(eq(app), any(), eq(false))).thenReturn(studyParticipant);
 
         String result = controller.getSelfParticipant(false);
         
         verify(mockParticipantService).getSelfParticipant(eq(app), contextCaptor.capture(), eq(false));
-        assertEquals(contextCaptor.getValue().getUserId(), USER_ID);
+        assertEquals(contextCaptor.getValue().getUserId(), TEST_USER_ID);
 
         JsonNode node = MAPPER.readTree(result);
         assertEquals(node.get("firstName").textValue(), "Test");
@@ -759,7 +759,7 @@ public class ParticipantControllerTest extends Mockito {
     public void getSelfParticipantReturnsNoHealthCode() throws Exception {
         session.setParticipant(new StudyParticipant.Builder().copyOf(participant).withRoles(ImmutableSet.of()).build());
         
-        StudyParticipant studyParticipant = new StudyParticipant.Builder().withId(USER_ID)
+        StudyParticipant studyParticipant = new StudyParticipant.Builder().withId(TEST_USER_ID)
                 .withEncryptedHealthCode(ENCRYPTED_HEALTH_CODE).withFirstName("Test").build();
         when(mockParticipantService.getSelfParticipant(eq(app), any(), eq(false))).thenReturn(studyParticipant);
 
@@ -772,7 +772,7 @@ public class ParticipantControllerTest extends Mockito {
     
     @Test
     public void getSelfParticipantReturnsHealthCodeForAdmins() throws Exception {
-        StudyParticipant studyParticipant = new StudyParticipant.Builder().withId(USER_ID)
+        StudyParticipant studyParticipant = new StudyParticipant.Builder().withId(TEST_USER_ID)
                 .withEncryptedHealthCode(ENCRYPTED_HEALTH_CODE).withFirstName("Test").build();
         when(mockParticipantService.getSelfParticipant(eq(app), any(), eq(false))).thenReturn(studyParticipant);
 
@@ -789,14 +789,14 @@ public class ParticipantControllerTest extends Mockito {
 
         // All values should be copied over here, also add a healthCode to verify it is not unset.
         StudyParticipant participant = new StudyParticipant.Builder()
-                .copyOf(TestUtils.getStudyParticipant(ParticipantControllerTest.class)).withId(USER_ID)
+                .copyOf(TestUtils.getStudyParticipant(ParticipantControllerTest.class)).withId(TEST_USER_ID)
                 .withLanguages(LANGUAGES).withRoles(ImmutableSet.of(DEVELOPER)) // <-- should not be passed along
                 .withDataGroups(USER_DATA_GROUPS).withStudyIds(USER_STUDY_IDS)
                 .withHealthCode(HEALTH_CODE).build();
         session.setParticipant(participant);
         session.setIpAddress(IP_ADDRESS); // if this is not the same as request, you get an authentication error
 
-        doReturn(participant).when(mockParticipantService).getParticipant(eq(app), eq(USER_ID), anyBoolean());
+        doReturn(participant).when(mockParticipantService).getParticipant(eq(app), eq(TEST_USER_ID), anyBoolean());
 
         String json = MAPPER.writeValueAsString(participant);
         mockRequestBody(mockRequest, json);
@@ -810,14 +810,14 @@ public class ParticipantControllerTest extends Mockito {
         verify(mockCacheProvider).setUserSession(any());
         
         InOrder inOrder = inOrder(mockParticipantService);
-        inOrder.verify(mockParticipantService).getParticipant(app, USER_ID, false);
+        inOrder.verify(mockParticipantService).getParticipant(app, TEST_USER_ID, false);
         // No roles are passed in this method, and the studies of the user are passed
         inOrder.verify(mockParticipantService).updateParticipant(eq(app), participantCaptor.capture());
-        inOrder.verify(mockParticipantService).getParticipant(app, USER_ID, true);
+        inOrder.verify(mockParticipantService).getParticipant(app, TEST_USER_ID, true);
         
         // Just test the different types and verify they are there.
         StudyParticipant captured = participantCaptor.getValue();
-        assertEquals(captured.getId(), USER_ID);
+        assertEquals(captured.getId(), TEST_USER_ID);
         assertEquals(captured.getFirstName(), "FirstName");
         assertEquals(captured.getSharingScope(), ALL_QUALIFIED_RESEARCHERS);
         assertTrue(captured.isNotifyByEmail());
@@ -829,7 +829,7 @@ public class ParticipantControllerTest extends Mockito {
         CriteriaContext context = contextCaptor.getValue();
         assertEquals(context.getAppId(), TEST_APP_ID);
         assertEquals(context.getHealthCode(), HEALTH_CODE);
-        assertEquals(context.getUserId(), USER_ID);
+        assertEquals(context.getUserId(), TEST_USER_ID);
         assertEquals(context.getClientInfo(), ClientInfo.UNKNOWN_CLIENT);
         assertEquals(context.getUserDataGroups(), USER_DATA_GROUPS);
         assertEquals(context.getUserStudyIds(), USER_STUDY_IDS);
@@ -859,7 +859,7 @@ public class ParticipantControllerTest extends Mockito {
                 .withDataGroups(ImmutableSet.of("group1", "group2")).withAttributes(attrs)
                 .withLanguages(ImmutableList.of("en")).withStatus(AccountStatus.DISABLED).withExternalId("POWERS")
                 .build();
-        doReturn(participant).when(mockParticipantService).getParticipant(eq(app), eq(USER_ID), anyBoolean());
+        doReturn(participant).when(mockParticipantService).getParticipant(eq(app), eq(TEST_USER_ID), anyBoolean());
 
         String json = createJson("{'externalId':'simpleStringChange'," + "'sharingScope':'no_sharing',"
                 + "'notifyByEmail':false," + "'attributes':{'baz':'belgium'}," + "'languages':['fr'],"
@@ -871,7 +871,7 @@ public class ParticipantControllerTest extends Mockito {
 
         verify(mockParticipantService).updateParticipant(eq(app), participantCaptor.capture());
         StudyParticipant captured = participantCaptor.getValue();
-        assertEquals(captured.getId(), USER_ID);
+        assertEquals(captured.getId(), TEST_USER_ID);
         assertEquals(captured.getFirstName(), "firstName");
         assertEquals(captured.getLastName(), "lastName");
         assertEquals(captured.getEmail(), "email@email.com");
@@ -889,7 +889,7 @@ public class ParticipantControllerTest extends Mockito {
     @Test
     public void participantUpdateSelfCannotToggleSharingWhenUnconsented() throws Exception {
         StudyParticipant participant = new StudyParticipant.Builder().withSharingScope(NO_SHARING).build();
-        doReturn(participant).when(mockParticipantService).getParticipant(eq(app), eq(USER_ID), anyBoolean());
+        doReturn(participant).when(mockParticipantService).getParticipant(eq(app), eq(TEST_USER_ID), anyBoolean());
 
         String json = createJson("{'sharingScope':'all_qualified_researchers'}");
         mockRequestBody(mockRequest, json);
@@ -906,7 +906,7 @@ public class ParticipantControllerTest extends Mockito {
         session.setConsentStatuses(CONSENTED_STATUS_MAP);
         
         StudyParticipant participant = new StudyParticipant.Builder().withSharingScope(ALL_QUALIFIED_RESEARCHERS).build();
-        doReturn(participant).when(mockParticipantService).getParticipant(eq(app), eq(USER_ID), anyBoolean());
+        doReturn(participant).when(mockParticipantService).getParticipant(eq(app), eq(TEST_USER_ID), anyBoolean());
 
         String json = createJson("{}");
         mockRequestBody(mockRequest, json);
@@ -919,10 +919,10 @@ public class ParticipantControllerTest extends Mockito {
     
     @Test
     public void requestResetPassword() throws Exception {
-        StatusMessage result = controller.requestResetPassword(USER_ID);
+        StatusMessage result = controller.requestResetPassword(TEST_USER_ID);
         assertEquals(result.getMessage(), "Request to reset password sent to user.");
 
-        verify(mockParticipantService).requestResetPassword(app, USER_ID);
+        verify(mockParticipantService).requestResetPassword(app, TEST_USER_ID);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -931,15 +931,15 @@ public class ParticipantControllerTest extends Mockito {
                 .withId("notUserId").withRoles(ImmutableSet.of(DEVELOPER)).build();
         session.setParticipant(participant);
 
-        controller.requestResetPassword(USER_ID);
+        controller.requestResetPassword(TEST_USER_ID);
     }
 
     @Test
     public void updateSelfCallCannotChangeIdToSomeoneElse() throws Exception {
         // All values should be copied over here.
         StudyParticipant participant = TestUtils.getStudyParticipant(ParticipantControllerTest.class);
-        participant = new StudyParticipant.Builder().copyOf(participant).withId(USER_ID).build();
-        doReturn(participant).when(mockParticipantService).getParticipant(eq(app), eq(USER_ID), anyBoolean());
+        participant = new StudyParticipant.Builder().copyOf(participant).withId(TEST_USER_ID).build();
+        doReturn(participant).when(mockParticipantService).getParticipant(eq(app), eq(TEST_USER_ID), anyBoolean());
 
         // Now change to some other ID
         participant = new StudyParticipant.Builder().copyOf(participant).withId("someOtherId").build();
@@ -954,15 +954,15 @@ public class ParticipantControllerTest extends Mockito {
 
         // The ID was changed back to the session's participant user ID, not the one provided.
         StudyParticipant captured = participantCaptor.getValue();
-        assertEquals(captured.getId(), USER_ID);
+        assertEquals(captured.getId(), TEST_USER_ID);
     }
 
     @Test
     public void canGetActivityHistoryV2() throws Exception {
         doReturn(createActivityResultsV2("200", 77)).when(mockParticipantService).getActivityHistory(eq(app),
-                eq(USER_ID), eq(ACTIVITY_GUID), any(), any(), eq("200"), eq(77));
+                eq(TEST_USER_ID), eq(ACTIVITY_GUID), any(), any(), eq("200"), eq(77));
 
-        JsonNode result = controller.getActivityHistoryV2(USER_ID, ACTIVITY_GUID, START_TIME.toString(),
+        JsonNode result = controller.getActivityHistoryV2(TEST_USER_ID, ACTIVITY_GUID, START_TIME.toString(),
                 END_TIME.toString(), "200", null, "77");
         ForwardCursorPagedResourceList<ScheduledActivity> page = MAPPER.readValue(result.toString(),
                 FORWARD_CURSOR_PAGED_ACTIVITIES_REF);
@@ -976,7 +976,7 @@ public class ParticipantControllerTest extends Mockito {
         assertEquals(page.getRequestParams().get("pageSize"), 77);
         assertEquals(page.getRequestParams().get("offsetKey"), "200");
 
-        verify(mockParticipantService).getActivityHistory(eq(app), eq(USER_ID), eq(ACTIVITY_GUID),
+        verify(mockParticipantService).getActivityHistory(eq(app), eq(TEST_USER_ID), eq(ACTIVITY_GUID),
                 startsOnCaptor.capture(), endsOnCaptor.capture(), eq("200"), eq(77));
         assertTrue(START_TIME.isEqual(startsOnCaptor.getValue()));
         assertTrue(END_TIME.isEqual(endsOnCaptor.getValue()));
@@ -985,9 +985,9 @@ public class ParticipantControllerTest extends Mockito {
     @Test
     public void canGetActivityHistoryV2WithOffsetKey() throws Exception {
         doReturn(createActivityResultsV2("200", 77)).when(mockParticipantService).getActivityHistory(eq(app),
-                eq(USER_ID), eq(ACTIVITY_GUID), any(), any(), eq("200"), eq(77));
+                eq(TEST_USER_ID), eq(ACTIVITY_GUID), any(), any(), eq("200"), eq(77));
 
-        JsonNode result = controller.getActivityHistoryV2(USER_ID, ACTIVITY_GUID, START_TIME.toString(),
+        JsonNode result = controller.getActivityHistoryV2(TEST_USER_ID, ACTIVITY_GUID, START_TIME.toString(),
                 END_TIME.toString(), null, "200", "77");
         ForwardCursorPagedResourceList<ScheduledActivity> page = MAPPER.readValue(result.toString(),
                 FORWARD_CURSOR_PAGED_ACTIVITIES_REF);
@@ -1000,7 +1000,7 @@ public class ParticipantControllerTest extends Mockito {
         assertEquals(page.getRequestParams().get("pageSize"), 77);
         assertEquals(page.getRequestParams().get("offsetKey"), "200");
 
-        verify(mockParticipantService).getActivityHistory(eq(app), eq(USER_ID), eq(ACTIVITY_GUID),
+        verify(mockParticipantService).getActivityHistory(eq(app), eq(TEST_USER_ID), eq(ACTIVITY_GUID),
                 startsOnCaptor.capture(), endsOnCaptor.capture(), eq("200"), eq(77));
         assertTrue(START_TIME.isEqual(startsOnCaptor.getValue()));
         assertTrue(END_TIME.isEqual(endsOnCaptor.getValue()));
@@ -1009,9 +1009,9 @@ public class ParticipantControllerTest extends Mockito {
     @Test
     public void canGetActivityV2WithNullValues() throws Exception {
         doReturn(createActivityResultsV2(null, API_DEFAULT_PAGE_SIZE)).when(mockParticipantService).getActivityHistory(
-                eq(app), eq(USER_ID), eq(ACTIVITY_GUID), any(), any(), eq(null), eq(API_DEFAULT_PAGE_SIZE));
+                eq(app), eq(TEST_USER_ID), eq(ACTIVITY_GUID), any(), any(), eq(null), eq(API_DEFAULT_PAGE_SIZE));
 
-        JsonNode result = controller.getActivityHistoryV2(USER_ID, ACTIVITY_GUID, null, null, null, null, null);
+        JsonNode result = controller.getActivityHistoryV2(TEST_USER_ID, ACTIVITY_GUID, null, null, null, null, null);
         ForwardCursorPagedResourceList<ScheduledActivity> page = MAPPER.readValue(result.toString(),
                 FORWARD_CURSOR_PAGED_ACTIVITIES_REF);
 
@@ -1021,40 +1021,40 @@ public class ParticipantControllerTest extends Mockito {
         assertEquals(page.getItems().size(), 1); // have not mocked out these items, but the list is there.
         assertEquals(page.getRequestParams().get("pageSize"), API_DEFAULT_PAGE_SIZE);
 
-        verify(mockParticipantService).getActivityHistory(eq(app), eq(USER_ID), eq(ACTIVITY_GUID), eq(null), eq(null),
+        verify(mockParticipantService).getActivityHistory(eq(app), eq(TEST_USER_ID), eq(ACTIVITY_GUID), eq(null), eq(null),
                 eq(null), eq(API_DEFAULT_PAGE_SIZE));
     }
 
     @Test
     public void deleteActivities() throws Exception {
-        StatusMessage result = controller.deleteActivities(USER_ID);
+        StatusMessage result = controller.deleteActivities(TEST_USER_ID);
         assertEquals(result.getMessage(), "Scheduled activities deleted.");
 
-        verify(mockParticipantService).deleteActivities(app, USER_ID);
+        verify(mockParticipantService).deleteActivities(app, TEST_USER_ID);
     }
 
     @Test
     public void resendEmailVerification() throws Exception {
-        StatusMessage result = controller.resendEmailVerification(USER_ID);
+        StatusMessage result = controller.resendEmailVerification(TEST_USER_ID);
         assertEquals(result.getMessage(), "Email verification request has been resent to user.");
 
-        verify(mockParticipantService).resendVerification(app, ChannelType.EMAIL, USER_ID);
+        verify(mockParticipantService).resendVerification(app, ChannelType.EMAIL, TEST_USER_ID);
     }
 
     @Test
     public void resendPhoneVerification() throws Exception {
-        StatusMessage result = controller.resendPhoneVerification(USER_ID);
+        StatusMessage result = controller.resendPhoneVerification(TEST_USER_ID);
         assertEquals(result.getMessage(), "Phone verification request has been resent to user.");
 
-        verify(mockParticipantService).resendVerification(app, ChannelType.PHONE, USER_ID);
+        verify(mockParticipantService).resendVerification(app, ChannelType.PHONE, TEST_USER_ID);
     }
 
     @Test
     public void resendConsentAgreement() throws Exception {
-        StatusMessage result = controller.resendConsentAgreement(USER_ID, SUBPOP_GUID.getGuid());
+        StatusMessage result = controller.resendConsentAgreement(TEST_USER_ID, SUBPOP_GUID.getGuid());
         assertEquals(result.getMessage(), "Consent agreement resent to user.");
 
-        verify(mockParticipantService).resendConsentAgreement(app, SUBPOP_GUID, USER_ID);
+        verify(mockParticipantService).resendConsentAgreement(app, SUBPOP_GUID, TEST_USER_ID);
     }
 
     @Test
@@ -1064,9 +1064,9 @@ public class ParticipantControllerTest extends Mockito {
             String json = "{\"reason\":\"Because, reasons.\"}";
             mockRequestBody(mockRequest, json);
 
-            controller.withdrawFromApp(USER_ID);
+            controller.withdrawFromApp(TEST_USER_ID);
 
-            verify(mockParticipantService).withdrawFromApp(app, USER_ID, new Withdrawal("Because, reasons."),
+            verify(mockParticipantService).withdrawFromApp(app, TEST_USER_ID, new Withdrawal("Because, reasons."),
                     20000);
         } finally {
             DateTimeUtils.setCurrentMillisSystem();
@@ -1080,9 +1080,9 @@ public class ParticipantControllerTest extends Mockito {
             String json = "{\"reason\":\"Because, reasons.\"}";
             mockRequestBody(mockRequest, json);
 
-            controller.withdrawConsent(USER_ID, SUBPOP_GUID.getGuid());
+            controller.withdrawConsent(TEST_USER_ID, SUBPOP_GUID.getGuid());
 
-            verify(mockParticipantService).withdrawConsent(app, USER_ID, SUBPOP_GUID,
+            verify(mockParticipantService).withdrawConsent(app, TEST_USER_ID, SUBPOP_GUID,
                     new Withdrawal("Because, reasons."), 20000);
         } finally {
             DateTimeUtils.setCurrentMillisSystem();
@@ -1099,12 +1099,12 @@ public class ParticipantControllerTest extends Mockito {
         ForwardCursorPagedResourceList<? extends Upload> uploads = new ForwardCursorPagedResourceList<>(list, "abc")
                 .withRequestParam("pageSize", API_MAXIMUM_PAGE_SIZE).withRequestParam("startTime", startTime)
                 .withRequestParam("endTime", endTime);
-        doReturn(uploads).when(mockParticipantService).getUploads(app, USER_ID, startTime, endTime, 10, "abc");
+        doReturn(uploads).when(mockParticipantService).getUploads(app, TEST_USER_ID, startTime, endTime, 10, "abc");
 
-        ForwardCursorPagedResourceList<UploadView> result = controller.getUploads(USER_ID, startTime.toString(),
+        ForwardCursorPagedResourceList<UploadView> result = controller.getUploads(TEST_USER_ID, startTime.toString(),
                 endTime.toString(), 10, "abc");
 
-        verify(mockParticipantService).getUploads(app, USER_ID, startTime, endTime, 10, "abc");
+        verify(mockParticipantService).getUploads(app, TEST_USER_ID, startTime, endTime, 10, "abc");
 
         // in other words, it's the object we mocked out from the service, we were returned the value.
         assertEquals(result.getRequestParams().get("startTime"), startTime.toString());
@@ -1117,36 +1117,36 @@ public class ParticipantControllerTest extends Mockito {
 
         ForwardCursorPagedResourceList<Upload> uploads = new ForwardCursorPagedResourceList<>(list, null)
                 .withRequestParam("pageSize", API_MAXIMUM_PAGE_SIZE);
-        doReturn(uploads).when(mockParticipantService).getUploads(app, USER_ID, null, null, null, null);
+        doReturn(uploads).when(mockParticipantService).getUploads(app, TEST_USER_ID, null, null, null, null);
 
-        controller.getUploads(USER_ID, null, null, null, null);
+        controller.getUploads(TEST_USER_ID, null, null, null, null);
 
-        verify(mockParticipantService).getUploads(app, USER_ID, null, null, null, null);
+        verify(mockParticipantService).getUploads(app, TEST_USER_ID, null, null, null, null);
     }
 
     @Test
     public void getNotificationRegistrations() throws Exception {
         List<NotificationRegistration> list = ImmutableList.of();
-        doReturn(list).when(mockParticipantService).listRegistrations(app, USER_ID);
+        doReturn(list).when(mockParticipantService).listRegistrations(app, TEST_USER_ID);
 
-        ResourceList<NotificationRegistration> result = controller.getNotificationRegistrations(USER_ID);
+        ResourceList<NotificationRegistration> result = controller.getNotificationRegistrations(TEST_USER_ID);
 
         JsonNode node = MAPPER.valueToTree(result);
         assertEquals(node.get("items").size(), 0);
         assertEquals(node.get("type").asText(), "ResourceList");
 
-        verify(mockParticipantService).listRegistrations(app, USER_ID);
+        verify(mockParticipantService).listRegistrations(app, TEST_USER_ID);
     }
 
     @Test
     public void sendMessage() throws Exception {
         mockRequestBody(mockRequest, NOTIFICATION_MESSAGE);
 
-        StatusMessage result = controller.sendNotification(USER_ID);
+        StatusMessage result = controller.sendNotification(TEST_USER_ID);
 
         assertEquals(result.getMessage(), "Message has been sent to external notification service.");
 
-        verify(mockParticipantService).sendNotification(eq(app), eq(USER_ID), messageCaptor.capture());
+        verify(mockParticipantService).sendNotification(eq(app), eq(TEST_USER_ID), messageCaptor.capture());
 
         NotificationMessage captured = messageCaptor.getValue();
         assertEquals(captured.getSubject(), "a subject");
@@ -1156,11 +1156,11 @@ public class ParticipantControllerTest extends Mockito {
     @Test
     public void sendMessageWithSomeErrors() throws Exception {
         Set<String> erroredRegistrations = ImmutableSet.of("123", "456");
-        when(mockParticipantService.sendNotification(app, USER_ID, NOTIFICATION_MESSAGE))
+        when(mockParticipantService.sendNotification(app, TEST_USER_ID, NOTIFICATION_MESSAGE))
                 .thenReturn(erroredRegistrations);
         mockRequestBody(mockRequest, NOTIFICATION_MESSAGE);
 
-        StatusMessage result = controller.sendNotification(USER_ID);
+        StatusMessage result = controller.sendNotification(TEST_USER_ID);
 
         assertEquals(result.getMessage(),
                 "Message has been sent to external notification service. Some registrations returned errors: 123, 456.");
@@ -1178,7 +1178,7 @@ public class ParticipantControllerTest extends Mockito {
 
     @Test(expectedExceptions = UnauthorizedException.class)
     public void getParticipantForWorkerOnly() throws Exception {
-        controller.getParticipantForWorker(app.getIdentifier(), USER_ID, true);
+        controller.getParticipantForWorker(app.getIdentifier(), TEST_USER_ID, true);
     }
 
     @SuppressWarnings("deprecation")
@@ -1242,28 +1242,28 @@ public class ParticipantControllerTest extends Mockito {
         session.setParticipant(new StudyParticipant.Builder().copyOf(session.getParticipant())
                 .withRoles(ImmutableSet.of(Roles.WORKER)).build());
 
-        StudyParticipant foundParticipant = new StudyParticipant.Builder().withId(USER_ID).withHealthCode(HEALTH_CODE)
+        StudyParticipant foundParticipant = new StudyParticipant.Builder().withId(TEST_USER_ID).withHealthCode(HEALTH_CODE)
                 .build();
 
         when(mockAppService.getApp(app.getIdentifier())).thenReturn(app);
-        when(mockParticipantService.getParticipant(app, USER_ID, true)).thenReturn(foundParticipant);
+        when(mockParticipantService.getParticipant(app, TEST_USER_ID, true)).thenReturn(foundParticipant);
 
-        String result = controller.getParticipantForWorker(app.getIdentifier(), USER_ID, true);
+        String result = controller.getParticipantForWorker(app.getIdentifier(), TEST_USER_ID, true);
 
         JsonNode participantNode = MAPPER.readTree(result);
         assertEquals(participantNode.get("healthCode").textValue(), HEALTH_CODE);
         assertNull(participantNode.get("encryptedHealthCode"));
-        assertEquals(participantNode.get("id").textValue(), USER_ID);
+        assertEquals(participantNode.get("id").textValue(), TEST_USER_ID);
 
-        verify(mockParticipantService).getParticipant(app, USER_ID, true);
+        verify(mockParticipantService).getParticipant(app, TEST_USER_ID, true);
     }
 
     @Test
     public void getActivityHistoryV3() throws Exception {
         doReturn(createActivityResultsV2("offsetKey", 15)).when(mockParticipantService).getActivityHistory(eq(app),
-                eq(USER_ID), eq(ActivityType.SURVEY), eq("referentGuid"), any(), any(), eq("offsetKey"), eq(15));
+                eq(TEST_USER_ID), eq(ActivityType.SURVEY), eq("referentGuid"), any(), any(), eq("offsetKey"), eq(15));
 
-        String result = controller.getActivityHistoryV3(USER_ID, "surveys", "referentGuid", START_TIME.toString(),
+        String result = controller.getActivityHistoryV3(TEST_USER_ID, "surveys", "referentGuid", START_TIME.toString(),
                 END_TIME.toString(), "offsetKey", "15");
 
         JsonNode node = MAPPER.readTree(result);
@@ -1275,7 +1275,7 @@ public class ParticipantControllerTest extends Mockito {
                 FORWARD_CURSOR_PAGED_ACTIVITIES_REF);
         assertEquals((int) page.getRequestParams().get("pageSize"), 15);
 
-        verify(mockParticipantService).getActivityHistory(eq(app), eq(USER_ID), eq(ActivityType.SURVEY),
+        verify(mockParticipantService).getActivityHistory(eq(app), eq(TEST_USER_ID), eq(ActivityType.SURVEY),
                 eq("referentGuid"), startTimeCaptor.capture(), endTimeCaptor.capture(), eq("offsetKey"), eq(15));
         assertEquals(startTimeCaptor.getValue().toString(), START_TIME.toString());
         assertEquals(endTimeCaptor.getValue().toString(), END_TIME.toString());
@@ -1283,9 +1283,9 @@ public class ParticipantControllerTest extends Mockito {
 
     @Test
     public void getActivityHistoryV3DefaultsToNulls() throws Exception {
-        controller.getActivityHistoryV3(USER_ID, "badtypes", null, null, null, null, null);
+        controller.getActivityHistoryV3(TEST_USER_ID, "badtypes", null, null, null, null, null);
 
-        verify(mockParticipantService).getActivityHistory(eq(app), eq(USER_ID), eq(null), eq(null),
+        verify(mockParticipantService).getActivityHistory(eq(app), eq(TEST_USER_ID), eq(null), eq(null),
                 startTimeCaptor.capture(), endTimeCaptor.capture(), eq(null),
                 eq(BridgeConstants.API_DEFAULT_PAGE_SIZE));
         assertNull(startTimeCaptor.getValue());
@@ -1300,7 +1300,7 @@ public class ParticipantControllerTest extends Mockito {
 
         JsonNode result = controller.updateIdentifiers();
 
-        assertEquals(result.get("id").textValue(), USER_ID);
+        assertEquals(result.get("id").textValue(), TEST_USER_ID);
 
         verify(mockParticipantService).updateIdentifiers(eq(app), contextCaptor.capture(),
                 identifierUpdateCaptor.capture());
@@ -1322,7 +1322,7 @@ public class ParticipantControllerTest extends Mockito {
 
         JsonNode result = controller.updateIdentifiers();
 
-        assertEquals(result.get("id").textValue(), USER_ID);
+        assertEquals(result.get("id").textValue(), TEST_USER_ID);
 
         verify(mockParticipantService).updateIdentifiers(eq(app), contextCaptor.capture(),
                 identifierUpdateCaptor.capture());
@@ -1342,7 +1342,7 @@ public class ParticipantControllerTest extends Mockito {
 
         JsonNode result = controller.updateIdentifiers();
 
-        assertEquals(result.get("id").textValue(), USER_ID);
+        assertEquals(result.get("id").textValue(), TEST_USER_ID);
 
         verify(mockParticipantService).updateIdentifiers(eq(app), contextCaptor.capture(),
                 identifierUpdateCaptor.capture());
@@ -1378,14 +1378,14 @@ public class ParticipantControllerTest extends Mockito {
         session.setParticipant(new StudyParticipant.Builder().copyOf(session.getParticipant())
                 .withRoles(ImmutableSet.of(Roles.WORKER)).build());
 
-        StudyParticipant foundParticipant = new StudyParticipant.Builder().withId(USER_ID).build();
+        StudyParticipant foundParticipant = new StudyParticipant.Builder().withId(TEST_USER_ID).build();
 
         when(mockAppService.getApp(app.getIdentifier())).thenReturn(app);
-        when(mockParticipantService.getParticipant(app, USER_ID, false)).thenReturn(foundParticipant);
+        when(mockParticipantService.getParticipant(app, TEST_USER_ID, false)).thenReturn(foundParticipant);
 
-        controller.getParticipantForWorker(app.getIdentifier(), USER_ID, false);
+        controller.getParticipantForWorker(app.getIdentifier(), TEST_USER_ID, false);
 
-        verify(mockParticipantService).getParticipant(app, USER_ID, false);
+        verify(mockParticipantService).getParticipant(app, TEST_USER_ID, false);
     }
 
     @Test
@@ -1395,10 +1395,10 @@ public class ParticipantControllerTest extends Mockito {
 
         mockRequestBody(mockRequest, new SmsTemplate("This is a message"));
 
-        StatusMessage result = controller.sendSmsMessageForWorker(TEST_APP_ID, USER_ID);
+        StatusMessage result = controller.sendSmsMessageForWorker(TEST_APP_ID, TEST_USER_ID);
 
         assertEquals(result.getMessage(), "Message sent.");
-        verify(mockParticipantService).sendSmsMessage(eq(app), eq(USER_ID), templateCaptor.capture());
+        verify(mockParticipantService).sendSmsMessage(eq(app), eq(TEST_USER_ID), templateCaptor.capture());
 
         SmsTemplate resultTemplate = templateCaptor.getValue();
         assertEquals(resultTemplate.getMessage(), "This is a message");
@@ -1411,11 +1411,11 @@ public class ParticipantControllerTest extends Mockito {
         DynamoActivityEvent anEvent = new DynamoActivityEvent();
         anEvent.setEventId("event-id");
         List<ActivityEvent> events = ImmutableList.of(anEvent);
-        when(mockParticipantService.getActivityEvents(app, USER_ID)).thenReturn(events);
+        when(mockParticipantService.getActivityEvents(app, TEST_USER_ID)).thenReturn(events);
 
-        ResourceList<ActivityEvent> result = controller.getActivityEventsForWorker(TEST_APP_ID, USER_ID);
+        ResourceList<ActivityEvent> result = controller.getActivityEventsForWorker(TEST_APP_ID, TEST_USER_ID);
 
-        verify(mockParticipantService).getActivityEvents(app, USER_ID);
+        verify(mockParticipantService).getActivityEvents(app, TEST_USER_ID);
         assertEquals(result.getItems().get(0).getEventId(), "event-id");
     }
 
@@ -1426,13 +1426,13 @@ public class ParticipantControllerTest extends Mockito {
 
         ForwardCursorPagedResourceList<ScheduledActivity> cursor = new ForwardCursorPagedResourceList<>(
                 ImmutableList.of(ScheduledActivity.create()), "asdf");
-        when(mockParticipantService.getActivityHistory(eq(app), eq(USER_ID), eq("activityGuid"), any(), any(), eq("asdf"),
+        when(mockParticipantService.getActivityHistory(eq(app), eq(TEST_USER_ID), eq("activityGuid"), any(), any(), eq("asdf"),
                 eq(50))).thenReturn(cursor);
 
-        JsonNode result = controller.getActivityHistoryForWorkerV2(TEST_APP_ID, USER_ID,
+        JsonNode result = controller.getActivityHistoryForWorkerV2(TEST_APP_ID, TEST_USER_ID,
                 "activityGuid", START_TIME.toString(), END_TIME.toString(), null, "asdf", "50");
 
-        verify(mockParticipantService).getActivityHistory(eq(app), eq(USER_ID), eq("activityGuid"), any(), any(),
+        verify(mockParticipantService).getActivityHistory(eq(app), eq(TEST_USER_ID), eq("activityGuid"), any(), any(),
                 eq("asdf"), eq(50));
 
         ForwardCursorPagedResourceList<ScheduledActivity> retrieved = MAPPER
@@ -1447,13 +1447,13 @@ public class ParticipantControllerTest extends Mockito {
 
         ForwardCursorPagedResourceList<ScheduledActivity> cursor = new ForwardCursorPagedResourceList<>(
                 ImmutableList.of(ScheduledActivity.create()), "asdf");
-        when(mockParticipantService.getActivityHistory(eq(app), eq(USER_ID), eq(ActivityType.TASK), any(), any(),
+        when(mockParticipantService.getActivityHistory(eq(app), eq(TEST_USER_ID), eq(ActivityType.TASK), any(), any(),
                 any(), eq("asdf"), eq(50))).thenReturn(cursor);
 
-        String result = controller.getActivityHistoryForWorkerV3(TEST_APP_ID, USER_ID, "tasks",
+        String result = controller.getActivityHistoryForWorkerV3(TEST_APP_ID, TEST_USER_ID, "tasks",
                 START_TIME.toString(), END_TIME.toString(), null, "asdf", "50");
 
-        verify(mockParticipantService).getActivityHistory(eq(app), eq(USER_ID), eq(ActivityType.TASK), any(), any(),
+        verify(mockParticipantService).getActivityHistory(eq(app), eq(TEST_USER_ID), eq(ActivityType.TASK), any(), any(),
                 any(), eq("asdf"), eq(50));
 
         ForwardCursorPagedResourceList<ScheduledActivity> retrieved = MAPPER.readValue(result,
@@ -1466,10 +1466,10 @@ public class ParticipantControllerTest extends Mockito {
         participant = new StudyParticipant.Builder().copyOf(participant).withDataGroups(ImmutableSet.of("test_user"))
                 .build();
 
-        when(mockParticipantService.getParticipant(app, USER_ID, false)).thenReturn(participant);
-        controller.deleteTestParticipant(USER_ID);
+        when(mockParticipantService.getParticipant(app, TEST_USER_ID, false)).thenReturn(participant);
+        controller.deleteTestParticipant(TEST_USER_ID);
 
-        verify(mockUserAdminService).deleteUser(app, USER_ID);
+        verify(mockUserAdminService).deleteUser(app, TEST_USER_ID);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -1478,15 +1478,15 @@ public class ParticipantControllerTest extends Mockito {
                 .withId("notUserId").build();
         session.setParticipant(participant);
 
-        controller.deleteTestParticipant(USER_ID);
+        controller.deleteTestParticipant(TEST_USER_ID);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
     public void deleteTestUserNotATestAccount() {
         participant = new StudyParticipant.Builder().copyOf(participant).withDataGroups(EMPTY_SET).build();
 
-        when(mockParticipantService.getParticipant(app, USER_ID, false)).thenReturn(participant);
-        controller.deleteTestParticipant(USER_ID);
+        when(mockParticipantService.getParticipant(app, TEST_USER_ID, false)).thenReturn(participant);
+        controller.deleteTestParticipant(TEST_USER_ID);
     }
 
     @SuppressWarnings("deprecation")
@@ -1550,22 +1550,22 @@ public class ParticipantControllerTest extends Mockito {
         doReturn(session).when(controller).getAuthenticatedSession(false, RESEARCHER);
         
         List<EnrollmentDetail> list = ImmutableList.of();
-        when(mockEnrollmentService.getEnrollmentsForUser(TEST_APP_ID, USER_ID)).thenReturn(list);
+        when(mockEnrollmentService.getEnrollmentsForUser(TEST_APP_ID, TEST_USER_ID)).thenReturn(list);
         
-        List<EnrollmentDetail> retValue = controller.getEnrollments(USER_ID);
+        List<EnrollmentDetail> retValue = controller.getEnrollments(TEST_USER_ID);
         assertSame(retValue, list);
     }
     
     @Test
     public void getActivityEvents() {
         List<ActivityEvent> events = ImmutableList.of(new DynamoActivityEvent(), new DynamoActivityEvent());
-        when(mockParticipantService.getActivityEvents(app, USER_ID)).thenReturn(events);        
+        when(mockParticipantService.getActivityEvents(app, TEST_USER_ID)).thenReturn(events);        
         
-        ResourceList<ActivityEvent> retValue = controller.getActivityEvents(USER_ID);
+        ResourceList<ActivityEvent> retValue = controller.getActivityEvents(TEST_USER_ID);
         assertNotNull(retValue);
         assertSame(retValue.getItems(), events);
         
-        verify(mockParticipantService).getActivityEvents(app, USER_ID);
+        verify(mockParticipantService).getActivityEvents(app, TEST_USER_ID);
     }
     
     @Test
@@ -1575,11 +1575,11 @@ public class ParticipantControllerTest extends Mockito {
                 .withTimestamp(TIMESTAMP).build();
         mockRequestBody(mockRequest, request);
         
-        StatusMessage retValue = controller.createCustomActivityEvent(USER_ID);
+        StatusMessage retValue = controller.createCustomActivityEvent(TEST_USER_ID);
         assertEquals(retValue.getMessage(), "Event recorded.");
         
         verify(mockParticipantService).createCustomActivityEvent(
-                eq(app), eq(USER_ID), eventRequestCaptor.capture());
+                eq(app), eq(TEST_USER_ID), eventRequestCaptor.capture());
         CustomActivityEventRequest captured = eventRequestCaptor.getValue();
         assertEquals(captured.getEventKey(), "eventKey");
         assertEquals(captured.getTimestamp(), TIMESTAMP);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportControllerTest.java
@@ -6,7 +6,7 @@ import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.WORKER;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestConstants.USER_STUDY_IDS;
 import static org.sagebionetworks.bridge.TestUtils.assertCreate;
 import static org.sagebionetworks.bridge.TestUtils.assertCrossOrigin;
@@ -405,7 +405,7 @@ public class ParticipantReportControllerTest extends Mockito {
     public void saveParticipantReportForWorkerBadJson() throws Exception {
         mockRequestBody(mockRequest, "\"+1234567890\"");
         
-        controller.saveParticipantReport(USER_ID, REPORT_ID);
+        controller.saveParticipantReport(TEST_USER_ID, REPORT_ID);
     }
     
     // This should be legal
@@ -537,7 +537,7 @@ public class ParticipantReportControllerTest extends Mockito {
         
         doReturn(session).when(controller).getAdministrativeSession();
         reset(mockAccountService);
-        controller.getParticipantReport(USER_ID, REPORT_ID, null, null);
+        controller.getParticipantReport(TEST_USER_ID, REPORT_ID, null, null);
     }
     
     @Test(expectedExceptions = EntityNotFoundException.class, 
@@ -545,7 +545,7 @@ public class ParticipantReportControllerTest extends Mockito {
     public void getParticipantReportForWorkerAccountNotFound() {
         doReturn(session).when(controller).getAuthenticatedSession(WORKER);
         reset(mockAccountService);
-        controller.getParticipantReportForWorker(TEST_APP_ID, USER_ID, REPORT_ID, null, null);
+        controller.getParticipantReportForWorker(TEST_APP_ID, TEST_USER_ID, REPORT_ID, null, null);
     }
     
     @Test(expectedExceptions = EntityNotFoundException.class, 
@@ -553,7 +553,7 @@ public class ParticipantReportControllerTest extends Mockito {
     public void saveParticipantReportAccountNotFound() {
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         reset(mockAccountService);
-        controller.saveParticipantReport(USER_ID, REPORT_ID);
+        controller.saveParticipantReport(TEST_USER_ID, REPORT_ID);
     }
     
     @Test(expectedExceptions = EntityNotFoundException.class, 
@@ -561,7 +561,7 @@ public class ParticipantReportControllerTest extends Mockito {
     public void deleteParticipantReportAccountNotFound() {
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, WORKER);
         reset(mockAccountService);
-        controller.deleteParticipantReport(USER_ID, REPORT_ID);
+        controller.deleteParticipantReport(TEST_USER_ID, REPORT_ID);
     }
     
     @Test(expectedExceptions = EntityNotFoundException.class, 
@@ -569,7 +569,7 @@ public class ParticipantReportControllerTest extends Mockito {
     public void deleteParticipantReportRecordAccountNotFound() {
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, WORKER);
         reset(mockAccountService);
-        controller.deleteParticipantReportRecord(USER_ID, REPORT_ID, null);
+        controller.deleteParticipantReportRecord(TEST_USER_ID, REPORT_ID, null);
     }
     
     @Test(expectedExceptions = EntityNotFoundException.class, 
@@ -580,7 +580,7 @@ public class ParticipantReportControllerTest extends Mockito {
         
         doReturn(session).when(controller).getAdministrativeSession();
         reset(mockAccountService);
-        controller.getParticipantReportV4(USER_ID, REPORT_ID, null, null, null, null);
+        controller.getParticipantReportV4(TEST_USER_ID, REPORT_ID, null, null, null, null);
     }
     
     @Test(expectedExceptions = EntityNotFoundException.class, 
@@ -588,7 +588,7 @@ public class ParticipantReportControllerTest extends Mockito {
     public void getParticipantReportForWorkerV4AccountNotFound() {
         doReturn(session).when(controller).getAuthenticatedSession(WORKER);
         reset(mockAccountService);
-        controller.getParticipantReportForWorkerV4(TEST_APP_ID, USER_ID, REPORT_ID, null, null, null, null);
+        controller.getParticipantReportForWorkerV4(TEST_APP_ID, TEST_USER_ID, REPORT_ID, null, null, null, null);
     }
     
     private void assertResultContent(LocalDate expectedStartDate, LocalDate expectedEndDate,

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/SharedAssessmentControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/SharedAssessmentControllerTest.java
@@ -7,7 +7,7 @@ import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
 import static org.sagebionetworks.bridge.TestConstants.GUID;
 import static org.sagebionetworks.bridge.TestConstants.IDENTIFIER;
-import static org.sagebionetworks.bridge.TestConstants.OWNER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_OWNER_ID;
 import static org.sagebionetworks.bridge.TestConstants.STRING_TAGS;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestUtils.mockRequestBody;
@@ -70,12 +70,12 @@ public class SharedAssessmentControllerTest extends Mockito {
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
 
         Assessment assessment = AssessmentTest.createAssessment();
-        when(mockService.importAssessment(TEST_APP_ID, OWNER_ID, null, GUID)).thenReturn(assessment);
+        when(mockService.importAssessment(TEST_APP_ID, TEST_OWNER_ID, null, GUID)).thenReturn(assessment);
 
-        Assessment retValue = controller.importAssessment(GUID, OWNER_ID, null);
+        Assessment retValue = controller.importAssessment(GUID, TEST_OWNER_ID, null);
         assertSame(retValue, assessment);
 
-        verify(mockService).importAssessment(TEST_APP_ID, OWNER_ID, null, GUID);
+        verify(mockService).importAssessment(TEST_APP_ID, TEST_OWNER_ID, null, GUID);
     }
 
     @Test
@@ -85,12 +85,12 @@ public class SharedAssessmentControllerTest extends Mockito {
         doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
 
         Assessment assessment = AssessmentTest.createAssessment();
-        when(mockService.importAssessment(TEST_APP_ID, OWNER_ID, NEW_ID, GUID)).thenReturn(assessment);
+        when(mockService.importAssessment(TEST_APP_ID, TEST_OWNER_ID, NEW_ID, GUID)).thenReturn(assessment);
 
-        Assessment retValue = controller.importAssessment(GUID, OWNER_ID, NEW_ID);
+        Assessment retValue = controller.importAssessment(GUID, TEST_OWNER_ID, NEW_ID);
         assertSame(retValue, assessment);
 
-        verify(mockService).importAssessment(TEST_APP_ID, OWNER_ID, NEW_ID, GUID);
+        verify(mockService).importAssessment(TEST_APP_ID, TEST_OWNER_ID, NEW_ID, GUID);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/SmsControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/SmsControllerTest.java
@@ -3,7 +3,7 @@ package org.sagebionetworks.bridge.spring.controllers;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.TestConstants.PHONE;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertCrossOrigin;
 import static org.sagebionetworks.bridge.TestUtils.assertGet;
 import static org.testng.Assert.assertEquals;
@@ -24,9 +24,9 @@ import org.sagebionetworks.bridge.services.AppService;
 public class SmsControllerTest extends Mockito {
     private static final String MESSAGE_ID = "my-message-id";
 
-    private static final StudyParticipant PARTICIPANT_WITH_NO_PHONE = new StudyParticipant.Builder().withId(USER_ID)
+    private static final StudyParticipant PARTICIPANT_WITH_NO_PHONE = new StudyParticipant.Builder().withId(TEST_USER_ID)
             .build();
-    private static final StudyParticipant PARTICIPANT_WITH_PHONE = new StudyParticipant.Builder().withId(USER_ID)
+    private static final StudyParticipant PARTICIPANT_WITH_PHONE = new StudyParticipant.Builder().withId(TEST_USER_ID)
             .withPhone(PHONE).build();
 
     private static final App DUMMY_APP;
@@ -69,15 +69,15 @@ public class SmsControllerTest extends Mockito {
 
     @Test(expectedExceptions = BadRequestException.class)
     public void getMostRecentMessage_ParticipantWithNoPhone() {
-        when(mockParticipantService.getParticipant(DUMMY_APP, USER_ID, false)).thenReturn(
+        when(mockParticipantService.getParticipant(DUMMY_APP, TEST_USER_ID, false)).thenReturn(
                 PARTICIPANT_WITH_NO_PHONE);
-        controller.getMostRecentMessage(USER_ID);
+        controller.getMostRecentMessage(TEST_USER_ID);
     }
 
     @Test
     public void getMostRecentMessage_ParticipantWithPhone() throws Exception {
         // Mock participant service.
-        when(mockParticipantService.getParticipant(DUMMY_APP, USER_ID, false)).thenReturn(
+        when(mockParticipantService.getParticipant(DUMMY_APP, TEST_USER_ID, false)).thenReturn(
                 PARTICIPANT_WITH_PHONE);
 
         // Setup test. This method is a passthrough for SmsMessage, so just verify one attribute.
@@ -86,7 +86,7 @@ public class SmsControllerTest extends Mockito {
         when(mockSmsService.getMostRecentMessage(PHONE.getNumber())).thenReturn(svcOutput);
 
         // Execute and verify.
-        SmsMessage result = controller.getMostRecentMessage(USER_ID);
+        SmsMessage result = controller.getMostRecentMessage(TEST_USER_ID);
 
         assertEquals(result.getMessageId(), MESSAGE_ID);
     }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/UploadControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/UploadControllerTest.java
@@ -7,7 +7,7 @@ import static org.sagebionetworks.bridge.Roles.WORKER;
 import static org.sagebionetworks.bridge.TestConstants.ACCOUNT_ID;
 import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestUtils.createJson;
 import static org.sagebionetworks.bridge.TestUtils.mockRequestBody;
 import static org.testng.Assert.assertEquals;
@@ -397,7 +397,7 @@ public class UploadControllerTest extends Mockito {
     
     @Test
     public void getUploadByRecordId() throws Exception {
-        doReturn(USER_ID).when(mockResearcherSession).getId();
+        doReturn(TEST_USER_ID).when(mockResearcherSession).getId();
         doReturn(TEST_APP_ID).when(mockResearcherSession).getAppId();
         doReturn(true).when(mockResearcherSession).isInRole(EnumSet.of(SUPERADMIN, WORKER));
         doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN, WORKER);
@@ -428,7 +428,7 @@ public class UploadControllerTest extends Mockito {
     public void getUploadByRecordIdRejectsAppAdmin() throws Exception {
         doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN, WORKER);
         doReturn(true).when(mockResearcherSession).isInRole(ADMIN);
-        doReturn(USER_ID).when(mockResearcherSession).getId();
+        doReturn(TEST_USER_ID).when(mockResearcherSession).getId();
         when(mockResearcherSession.getAppId()).thenReturn(TEST_APP_ID);
 
         HealthDataRecord record = HealthDataRecord.create();

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserManagementControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserManagementControllerTest.java
@@ -10,7 +10,7 @@ import static org.sagebionetworks.bridge.TestConstants.EMAIL;
 import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
 import static org.sagebionetworks.bridge.TestConstants.PASSWORD;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertCreate;
 import static org.sagebionetworks.bridge.TestUtils.assertCrossOrigin;
 import static org.sagebionetworks.bridge.TestUtils.assertDelete;
@@ -107,7 +107,7 @@ public class UserManagementControllerTest extends Mockito {
         MockitoAnnotations.initMocks(this);
 
         StudyParticipant participant = new StudyParticipant.Builder().withHealthCode(HEALTH_CODE)
-                .withId(USER_ID).withRoles(ImmutableSet.of(SUPERADMIN)).withEmail(EMAIL).build();
+                .withId(TEST_USER_ID).withRoles(ImmutableSet.of(SUPERADMIN)).withEmail(EMAIL).build();
 
         session = new UserSession(participant);
         session.setAppId(TEST_APP_ID);
@@ -189,7 +189,7 @@ public class UserManagementControllerTest extends Mockito {
     public void changeStudyForAdmin() throws Exception {
         doReturn(session).when(controller).getAuthenticatedSession(SUPERADMIN);
         
-        AccountId accountId = AccountId.forId(TEST_APP_ID, USER_ID);
+        AccountId accountId = AccountId.forId(TEST_APP_ID, TEST_USER_ID);
         when(mockAccountService.getAccount(accountId)).thenReturn(Account.create());
 
         SignIn signIn = new SignIn.Builder().withAppId("nextStudy").build();
@@ -271,9 +271,9 @@ public class UserManagementControllerTest extends Mockito {
         mockRequestBody(mockRequest, "{}");
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn("AAA");
 
-        StatusMessage result = controller.deleteUser(USER_ID);
+        StatusMessage result = controller.deleteUser(TEST_USER_ID);
         assertEquals(result, UserManagementController.DELETED_MSG);
 
-        verify(mockUserAdminService).deleteUser(mockApp, USER_ID);
+        verify(mockUserAdminService).deleteUser(mockApp, TEST_USER_ID);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserProfileControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/UserProfileControllerTest.java
@@ -6,7 +6,7 @@ import static org.sagebionetworks.bridge.TestConstants.EMAIL;
 import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.USER_DATA_GROUPS;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestConstants.USER_STUDY_IDS;
 import static org.sagebionetworks.bridge.TestUtils.assertCrossOrigin;
 import static org.sagebionetworks.bridge.TestUtils.assertGet;
@@ -150,7 +150,7 @@ public class UserProfileControllerTest extends Mockito {
         
         session = new UserSession(new StudyParticipant.Builder()
                 .withHealthCode(HEALTH_CODE)
-                .withId(USER_ID)
+                .withId(TEST_USER_ID)
                 .build());
         session.setAppId(TEST_APP_ID);
         
@@ -181,12 +181,12 @@ public class UserProfileControllerTest extends Mockito {
         StudyParticipant participant = new StudyParticipant.Builder().withLastName("Last")
                 .withFirstName("First").withEmail(EMAIL).withAttributes(attributes).build();
         
-        doReturn(participant).when(mockParticipantService).getParticipant(app, USER_ID, false);
+        doReturn(participant).when(mockParticipantService).getParticipant(app, TEST_USER_ID, false);
         
         String result = controller.getUserProfile();
         JsonNode node = BridgeObjectMapper.get().readTree(result);
         
-        verify(mockParticipantService).getParticipant(app, USER_ID, false);
+        verify(mockParticipantService).getParticipant(app, TEST_USER_ID, false);
         
         assertEquals(node.get("firstName").textValue(), "First");
         assertEquals("Last", node.get("lastName").textValue());
@@ -204,12 +204,12 @@ public class UserProfileControllerTest extends Mockito {
         StudyParticipant participant = new StudyParticipant.Builder().withEmail(EMAIL).withAttributes(attributes)
                 .build();
         
-        doReturn(participant).when(mockParticipantService).getParticipant(app, USER_ID, false);
+        doReturn(participant).when(mockParticipantService).getParticipant(app, TEST_USER_ID, false);
         
         String result = controller.getUserProfile();
         JsonNode node = BridgeObjectMapper.get().readTree(result);
         
-        verify(mockParticipantService).getParticipant(app, USER_ID, false);
+        verify(mockParticipantService).getParticipant(app, TEST_USER_ID, false);
         
         assertFalse(node.has("firstName"));
         assertFalse(node.has("lastName"));
@@ -231,14 +231,14 @@ public class UserProfileControllerTest extends Mockito {
                 .withFirstName("OldFirstName")
                 .withLastName("OldLastName")
                 .withStudyIds(ImmutableSet.of("studyA"))
-                .withId(USER_ID).build();
+                .withId(TEST_USER_ID).build();
         
         StudyParticipant updatedParticipant = new StudyParticipant.Builder()
                 .copyOf(participant)
                 .withFirstName("First")
                 .withLastName("Last").build();
         
-        doReturn(participant, updatedParticipant).when(mockParticipantService).getParticipant(eq(app), eq(USER_ID), anyBoolean());
+        doReturn(participant, updatedParticipant).when(mockParticipantService).getParticipant(eq(app), eq(TEST_USER_ID), anyBoolean());
         
         // This has a field that should not be passed to the StudyParticipant, because it didn't exist before
         // (externalId)
@@ -253,14 +253,14 @@ public class UserProfileControllerTest extends Mockito {
                 
         // Verify that existing user information (health code) has been retrieved and used when updating session
         InOrder inOrder = inOrder(mockParticipantService);
-        inOrder.verify(mockParticipantService).getParticipant(app, USER_ID, false);
+        inOrder.verify(mockParticipantService).getParticipant(app, TEST_USER_ID, false);
         inOrder.verify(mockParticipantService).updateParticipant(eq(app), participantCaptor.capture());
-        inOrder.verify(mockParticipantService).getParticipant(app, USER_ID, true);
+        inOrder.verify(mockParticipantService).getParticipant(app, TEST_USER_ID, true);
         
         StudyParticipant persisted = participantCaptor.getValue();
         assertEquals(persisted.getHealthCode(), "existingHealthCode");
         assertEquals(persisted.getExternalId(), "originalId");
-        assertEquals(persisted.getId(), USER_ID);
+        assertEquals(persisted.getId(), TEST_USER_ID);
         assertEquals(persisted.getFirstName(), "First");
         assertEquals(persisted.getLastName(), "Last");
         assertEquals(persisted.getAttributes().get("foo"), "belgium");
@@ -276,10 +276,10 @@ public class UserProfileControllerTest extends Mockito {
         // that healthCode (as well as something like firstName) are in the session. 
         StudyParticipant existing = new StudyParticipant.Builder()
                 .withHealthCode(HEALTH_CODE)
-                .withId(USER_ID)
+                .withId(TEST_USER_ID)
                 .withStudyIds(USER_STUDY_IDS) // which includes studyA
                 .withFirstName("First").build();
-        doReturn(existing).when(mockParticipantService).getParticipant(app, USER_ID, false);
+        doReturn(existing).when(mockParticipantService).getParticipant(app, TEST_USER_ID, false);
         session.setParticipant(existing);
         
         Set<String> dataGroupSet = ImmutableSet.of("group1");
@@ -294,7 +294,7 @@ public class UserProfileControllerTest extends Mockito {
         verify(mockConsentService).getConsentStatuses(contextCaptor.capture());
         
         StudyParticipant participant = participantCaptor.getValue();
-        assertEquals(participant.getId(), USER_ID);
+        assertEquals(participant.getId(), TEST_USER_ID);
         assertEquals(participant.getDataGroups(), dataGroupSet);
         assertEquals(participant.getFirstName(), "First");
         assertEquals(participant.getStudyIds(), USER_STUDY_IDS);
@@ -314,7 +314,7 @@ public class UserProfileControllerTest extends Mockito {
     @SuppressWarnings("deprecation")
     public void invalidDataGroupsRejected() throws Exception {
         StudyParticipant existing = new StudyParticipant.Builder().withFirstName("First").build();
-        doReturn(existing).when(mockParticipantService).getParticipant(app, USER_ID, false);
+        doReturn(existing).when(mockParticipantService).getParticipant(app, TEST_USER_ID, false);
         doThrow(new InvalidEntityException("Invalid data groups")).when(mockParticipantService).updateParticipant(eq(app),
                 any());
         
@@ -350,10 +350,10 @@ public class UserProfileControllerTest extends Mockito {
         
         StudyParticipant existing = new StudyParticipant.Builder()
                 .withHealthCode(HEALTH_CODE)
-                .withId(USER_ID)
+                .withId(TEST_USER_ID)
                 .withStudyIds(ImmutableSet.of("studyA"))
                 .withFirstName("First").build();
-        doReturn(existing).when(mockParticipantService).getParticipant(app, USER_ID, false);
+        doReturn(existing).when(mockParticipantService).getParticipant(app, TEST_USER_ID, false);
         session.setParticipant(existing);
         
         mockRequestBody(mockRequest, "{}");
@@ -365,7 +365,7 @@ public class UserProfileControllerTest extends Mockito {
         verify(mockParticipantService).updateParticipant(eq(app), participantCaptor.capture());
         
         StudyParticipant updated = participantCaptor.getValue();
-        assertEquals(updated.getId(), USER_ID);
+        assertEquals(updated.getId(), TEST_USER_ID);
         assertTrue(updated.getDataGroups().isEmpty());
         assertEquals(updated.getFirstName(), "First");
     }

--- a/src/test/java/org/sagebionetworks/bridge/validators/AssessmentValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/AssessmentValidatorTest.java
@@ -3,7 +3,7 @@ package org.sagebionetworks.bridge.validators;
 import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_EVENT_ID_ERROR;
 import static org.sagebionetworks.bridge.BridgeConstants.SHARED_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.IDENTIFIER;
-import static org.sagebionetworks.bridge.TestConstants.OWNER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_OWNER_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
@@ -63,9 +63,9 @@ public class AssessmentValidatorTest extends Mockito {
     @Test
     public void validSharedAssessment() {
         validator = new AssessmentValidator(SHARED_APP_ID, mockOrganizationService);
-        assessment.setOwnerId(TEST_APP_ID + ":" + OWNER_ID);
+        assessment.setOwnerId(TEST_APP_ID + ":" + TEST_OWNER_ID);
         
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, OWNER_ID)).thenReturn(Organization.create());
+        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID)).thenReturn(Organization.create());
     
         Validate.entityThrowingException(validator, assessment);
     }

--- a/src/test/java/org/sagebionetworks/bridge/validators/EnrollmentValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/EnrollmentValidatorTest.java
@@ -4,7 +4,7 @@ import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
 import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 import static org.sagebionetworks.bridge.validators.EnrollmentValidator.INSTANCE;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL_OR_EMPTY;
@@ -16,12 +16,12 @@ import org.sagebionetworks.bridge.models.studies.Enrollment;
 public class EnrollmentValidatorTest {
     
     Enrollment getEnrollment() {
-        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, USER_ID);
+        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         enrollment.setExternalId("anExternalId");
         enrollment.setConsentRequired(true);
         enrollment.setEnrolledOn(CREATED_ON);
         enrollment.setWithdrawnOn(MODIFIED_ON);
-        enrollment.setEnrolledBy(USER_ID);
+        enrollment.setEnrolledBy(TEST_USER_ID);
         enrollment.setWithdrawnBy("withdrawnBy");
         enrollment.setWithdrawalNote("withdrawal note");
         return enrollment;

--- a/src/test/java/org/sagebionetworks/bridge/validators/TemplateRevisionValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/TemplateRevisionValidatorTest.java
@@ -2,7 +2,7 @@ package org.sagebionetworks.bridge.validators;
 
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.sagebionetworks.bridge.TestConstants.TIMESTAMP;
-import static org.sagebionetworks.bridge.TestConstants.USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 import static org.sagebionetworks.bridge.models.apps.MimeType.HTML;
 import static org.sagebionetworks.bridge.models.templates.TemplateType.EMAIL_ACCOUNT_EXISTS;
@@ -147,7 +147,7 @@ public class TemplateRevisionValidatorTest {
         revision.setDocumentContent(BODY);
         revision.setTemplateGuid(TEMPLATE_GUID);
         revision.setCreatedOn(TIMESTAMP);
-        revision.setCreatedBy(USER_ID);
+        revision.setCreatedBy(TEST_USER_ID);
         revision.setStoragePath(STORAGE_PATH);
         revision.setMimeType(HTML);
         return revision;


### PR DESCRIPTION
Remove the static method wrappers around the evaluators so it's easier to track what is being enforced, and where.