### PR TITLE
Need to be selective when using external ID as the one allowed credential.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/UserAdminService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/UserAdminService.java
@@ -121,10 +121,14 @@ public class UserAdminService {
         checkNotNull(participant, "Participant cannot be null");
         
         // Validate app + email or phone or external ID. This is the minimum we need to create a functional account.
-        SignIn signIn = new SignIn.Builder().withAppId(app.getIdentifier()).withEmail(participant.getEmail())
-                .withPhone(participant.getPhone()).withExternalId(participant.getExternalId())
-                .withPassword(participant.getPassword()).build();
-        Validate.entityThrowingException(SignInValidator.MINIMAL, signIn);
+        // Note that some tests add email/phone and external ID which we need to catch for sign in (where only one
+        // credential is allowed).
+        SignIn.Builder signInBuilder = new SignIn.Builder().withAppId(app.getIdentifier()).withEmail(participant.getEmail())
+                .withPhone(participant.getPhone()).withPassword(participant.getPassword());
+        if (participant.getEmail() == null && participant.getPhone() == null) {
+            signInBuilder.withExternalId(participant.getExternalId());
+        }
+        Validate.entityThrowingException(SignInValidator.MINIMAL, signInBuilder.build());
         
         IdentifierHolder identifier = null;
         try {
@@ -157,7 +161,7 @@ public class UserAdminService {
                 // We do ignore consent state here as our intention may be to create a user who is signed in but not
                 // consented.
                 try {
-                    return authenticationService.signIn(app, context, signIn);    
+                    return authenticationService.signIn(app, context, signInBuilder.build());    
                 } catch(ConsentRequiredException e) {
                     return e.getUserSession();
                 }


### PR DESCRIPTION
Some tests set both email and external ID and then the sign in fails validation. Allow email or phone to be the credential for sign in unless we really only have external ID.