### PR TITLE
Enrollment events

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/dao/ActivityEventDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dao/ActivityEventDao.java
@@ -6,6 +6,11 @@ import org.joda.time.DateTime;
 import org.sagebionetworks.bridge.models.activities.ActivityEvent;
 
 public interface ActivityEventDao {
+    
+    /**
+     * Remove a custom event.
+     */
+    boolean deleteCustomEvent(ActivityEvent event);
 
     /**
      * Publish an event into this user's event stream. This event becomes available 

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoActivityEvent.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoActivityEvent.java
@@ -10,8 +10,6 @@ import org.sagebionetworks.bridge.json.DateTimeToLongSerializer;
 import org.sagebionetworks.bridge.models.activities.ActivityEvent;
 import org.sagebionetworks.bridge.models.activities.ActivityEventObjectType;
 import org.sagebionetworks.bridge.models.activities.ActivityEventType;
-import org.sagebionetworks.bridge.validators.ActivityEventValidator;
-import org.sagebionetworks.bridge.validators.Validate;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
@@ -34,7 +32,7 @@ public class DynamoActivityEvent implements ActivityEvent {
     @DynamoDBHashKey
     @Override
     public String getHealthCode() {
-        if (studyId == null || healthCode == null) {
+        if (studyId == null || healthCode == null || healthCode.endsWith(":" + studyId)) {
             return healthCode;
         }
         return (healthCode + ":" + studyId);
@@ -135,9 +133,6 @@ public class DynamoActivityEvent implements ActivityEvent {
             event.setTimestamp(timestamp);
             event.setEventId(getEventId());
             event.setAnswerValue(answerValue);
-
-            Validate.entityThrowingException(ActivityEventValidator.INSTANCE, event);
-            
             return event;
         }
     }

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoActivityEvent.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoActivityEvent.java
@@ -34,7 +34,10 @@ public class DynamoActivityEvent implements ActivityEvent {
     @DynamoDBHashKey
     @Override
     public String getHealthCode() {
-        return (studyId == null) ? healthCode : (healthCode + ":" + studyId);
+        if (studyId == null || healthCode == null) {
+            return healthCode;
+        }
+        return (healthCode + ":" + studyId);
     }
     public void setHealthCode(String healthCode) {
         this.healthCode = healthCode;

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoActivityEventDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoActivityEventDao.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import javax.annotation.Resource;
 
@@ -14,7 +13,6 @@ import org.joda.time.DateTimeZone;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.ActivityEventDao;
 import org.sagebionetworks.bridge.models.activities.ActivityEvent;
-import org.sagebionetworks.bridge.models.activities.ActivityEventObjectType;
 import org.sagebionetworks.bridge.models.activities.ActivityEventType;
 import org.springframework.stereotype.Component;
 
@@ -24,22 +22,34 @@ import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper.FailedBatch;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 
 @Component
 public class DynamoActivityEventDao implements ActivityEventDao {
 
     private static final String ANSWERED_EVENT_POSTFIX = ":"+ActivityEventType.ANSWERED.name().toLowerCase();
-    private static final Set<String> IMMUTABLE_EVENTS = ImmutableSet.of(
-            ActivityEventObjectType.ENROLLMENT.name().toLowerCase(),
-            ActivityEventObjectType.ACTIVITIES_RETRIEVED.name().toLowerCase(),
-            ActivityEventObjectType.CREATED_ON.name().toLowerCase() );
     private DynamoDBMapper mapper;
 
     @Resource(name = "activityEventDdbMapper")
     public final void setDdbMapper(DynamoDBMapper mapper) {
         this.mapper = mapper;
+    }
+
+    @Override
+    public boolean deleteCustomEvent(ActivityEvent event) {
+        checkNotNull(event);
+        
+        DynamoActivityEvent hashKey = new DynamoActivityEvent();
+        hashKey.setHealthCode(event.getHealthCode());
+        hashKey.setStudyId(event.getStudyId());
+        hashKey.setEventId(event.getEventId());
+
+        ActivityEvent savedEvent = mapper.load(hashKey);
+        if (savedEvent != null) {
+            mapper.delete(savedEvent);
+            return true;
+        }
+        return false;
     }
     
     @Override
@@ -52,11 +62,7 @@ public class DynamoActivityEventDao implements ActivityEventDao {
         hashKey.setEventId(event.getEventId());
         
         ActivityEvent savedEvent = mapper.load(hashKey);
-        
-        if (event.getTimestamp() == null) {
-            mapper.delete(event);
-            return true;
-        } else if (isNewOrMutable(savedEvent, event) && isLater(savedEvent, event)) {
+        if (savedEvent == null || isLater(savedEvent, event)) {
             mapper.save(event);
             return true;
         }
@@ -103,20 +109,11 @@ public class DynamoActivityEventDao implements ActivityEventDao {
         }
     }
     
-    // Some events can only be recorded once. 
-    private boolean isNewOrMutable(ActivityEvent savedEvent, ActivityEvent event) {
-        if (savedEvent == null) {
-            return true;
-        }
-        return (!IMMUTABLE_EVENTS.contains(event.getEventId()));
-    }
-    
-    // Events cannot be recorded unless the timestamp submitted is later than the currently
-    // recorded timestamp.
+    /**
+     * Events cannot be recorded unless the timestamp submitted is later than the currently
+     * recorded timestamp.
+     */
     private boolean isLater(ActivityEvent savedEvent, ActivityEvent event) {
-        if (savedEvent == null) {
-            return true;
-        }
         return event.getTimestamp() > savedEvent.getTimestamp();
     }
 

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoActivityEventDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoActivityEventDao.java
@@ -52,7 +52,11 @@ public class DynamoActivityEventDao implements ActivityEventDao {
         hashKey.setEventId(event.getEventId());
         
         ActivityEvent savedEvent = mapper.load(hashKey);
-        if (isNewOrMutable(savedEvent, event) && isLater(savedEvent, event)) {
+        
+        if (event.getTimestamp() == null) {
+            mapper.delete(event);
+            return true;
+        } else if (isNewOrMutable(savedEvent, event) && isLater(savedEvent, event)) {
             mapper.save(event);
             return true;
         }

--- a/src/main/java/org/sagebionetworks/bridge/models/activities/ActivityEvent.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/activities/ActivityEvent.java
@@ -1,22 +1,16 @@
 package org.sagebionetworks.bridge.models.activities;
 
-import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
 import org.sagebionetworks.bridge.dynamodb.DynamoActivityEvent;
-import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.BridgeEntity;
 
 @JsonDeserialize(as = DynamoActivityEvent.class)
 public interface ActivityEvent extends BridgeEntity {
-    ObjectWriter ACTIVITY_EVENT_WRITER = new BridgeObjectMapper().writer(
-            new SimpleFilterProvider().addFilter("filter",
-                    SimpleBeanPropertyFilter.serializeAllExcept("healthCode")));
-
     String getStudyId();
-    
+
+    @JsonIgnore
     String getHealthCode();
 
     String getEventId();

--- a/src/main/java/org/sagebionetworks/bridge/models/activities/CustomActivityEventRequest.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/activities/CustomActivityEventRequest.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.models.activities;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.joda.time.DateTime;
@@ -38,7 +39,11 @@ public class CustomActivityEventRequest {
         private String eventKey;
         private DateTime timestamp;
 
-        /** @see CustomActivityEventRequest#getEventKey */
+        /** 
+         * @see CustomActivityEventRequest#getEventKey. This is returned as eventId, so it's odd that
+         * it needs to be submitted as eventKey. Both are now supported with aliasing. 
+         */
+        @JsonAlias("eventId") 
         public Builder withEventKey(String eventKey) {
             this.eventKey = eventKey;
             return this;

--- a/src/main/java/org/sagebionetworks/bridge/models/subpopulations/ConsentSignature.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/subpopulations/ConsentSignature.java
@@ -8,13 +8,17 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.json.DateTimeToLongDeserializer;
 import org.sagebionetworks.bridge.json.DateTimeToLongSerializer;
 import org.sagebionetworks.bridge.json.JsonUtils;
 import org.sagebionetworks.bridge.models.BridgeEntity;
 
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIgnore;
 import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -93,6 +97,12 @@ public final class ConsentSignature implements BridgeEntity {
     @JsonSerialize(using = DateTimeToLongSerializer.class)
     public @Nonnull long getSignedOn() {
         return signedOn;
+    }
+    
+    @JsonIgnore
+    @DynamoDBIgnore
+    public DateTime getSignedOnAsDateTime() {
+        return new DateTime(signedOn, DateTimeZone.UTC);
     }
     
     /** The date and time the user withdrew this consent (can be null if active). */

--- a/src/main/java/org/sagebionetworks/bridge/services/ActivityEventService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ActivityEventService.java
@@ -75,8 +75,8 @@ public class ActivityEventService {
      * defined in the app (either in activityEventKeys or in AutomaticCustomEvents).
      */
     public void publishCustomEvent(App app, String studyId, String healthCode, String eventKey, DateTime timestamp) {
+        checkNotNull(app);
         checkNotNull(healthCode);
-        checkNotNull(eventKey);
 
         if (!app.getActivityEventKeys().contains(eventKey)
                 && !app.getAutomaticCustomEvents().containsKey(eventKey)) {
@@ -129,8 +129,8 @@ public class ActivityEventService {
     }
     
     public void publishActivitiesRetrieved(App app, String studyId, String healthCode, DateTime timestamp) {
+        checkNotNull(app);
         checkNotNull(healthCode);
-        checkNotNull(timestamp);
         
         ActivityEvent globalEvent = new DynamoActivityEvent.Builder()
             .withHealthCode(healthCode)
@@ -160,7 +160,6 @@ public class ActivityEventService {
      */
     public void publishQuestionAnsweredEvent(String healthCode, SurveyAnswer answer) {
         checkNotNull(healthCode);
-        checkNotNull(answer);
         
         ActivityEvent event = new DynamoActivityEvent.Builder()
             .withHealthCode(healthCode)
@@ -223,7 +222,9 @@ public class ActivityEventService {
     * Gets the activity events times for a specific user in order to schedule against them.
     */
     public Map<String, DateTime> getActivityEventMap(String appId, String studyId, String healthCode) {
+        checkNotNull(appId);
         checkNotNull(healthCode);
+        
         Map<String, DateTime> activityMap = activityEventDao.getActivityEventMap(healthCode, studyId);
         
         Builder<String, DateTime> builder = ImmutableMap.<String, DateTime>builder();
@@ -251,6 +252,9 @@ public class ActivityEventService {
     }
     
     public List<ActivityEvent> getActivityEventList(String appId, String studyId, String healthCode) {
+        checkNotNull(appId);
+        checkNotNull(healthCode);
+        
         Map<String, DateTime> activityEvents = getActivityEventMap(appId, studyId, healthCode);
 
         List<ActivityEvent> activityEventList = Lists.newArrayList();

--- a/src/main/java/org/sagebionetworks/bridge/services/ConsentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ConsentService.java
@@ -76,7 +76,6 @@ public class ConsentService {
     private SmsService smsService;
     private NotificationsService notificationsService;
     private StudyConsentService studyConsentService;
-    private ActivityEventService activityEventService;
     private SubpopulationService subpopService;
     private String xmlTemplateWithSignatureBlock;
     private S3Helper s3Helper;
@@ -110,10 +109,6 @@ public class ConsentService {
     @Autowired
     final void setStudyConsentService(StudyConsentService studyConsentService) {
         this.studyConsentService = studyConsentService;
-    }
-    @Autowired
-    final void setActivityEventService(ActivityEventService activityEventService) {
-        this.activityEventService = activityEventService;
     }
     @Autowired
     final void setSubpopulationService(SubpopulationService subpopService) {
@@ -206,15 +201,10 @@ public class ConsentService {
         account.setSharingScope(sharingScope);
         
         account.getDataGroups().addAll(subpop.getDataGroupsAssignedWhileConsented());
-        for (String studyId : subpop.getStudyIdsAssignedOnConsent()) {
-            Enrollment newEnrollment = Enrollment.create(app.getIdentifier(), studyId, account.getId());
-            enrollmentService.enroll(account, newEnrollment);
-        }
+        Enrollment newEnrollment = Enrollment.create(app.getIdentifier(), subpop.getStudyId(), account.getId());
+        enrollmentService.addEnrollment(account, newEnrollment);
+
         accountService.updateAccount(account);
-        
-        // Publish an enrollment event, set sharing scope 
-        activityEventService.publishEnrollmentEvent(app, subpop.getStudyId(), 
-                participant.getHealthCode(), withConsentCreatedOnSignature);
 
         // Administrative actions, almost exclusively for testing, will send no consent documents
         if (sendSignedConsent) {

--- a/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
@@ -112,15 +112,16 @@ public class EnrollmentService {
         Account account = accountService.getAccountNoFilter(accountId)
                 .orElseThrow(() -> new EntityNotFoundException(Account.class));
         
-        enrollment = enroll(account, enrollment);
+        enrollment = addEnrollment(account, enrollment);
         accountService.updateAccount(account);
         return enrollment;
     }
     
     /**
-     * For methods that are going to save the account, this method handles enrollment but does not persist it.
+     * For methods that are going to save the account, this method adds an enrollment correctly
+     * to an account, but does not persist it or fire an enrollment event.
      */
-    public Enrollment enroll(Account account, Enrollment newEnrollment) {
+    public Enrollment addEnrollment(Account account, Enrollment newEnrollment) {
         checkNotNull(account);
         checkNotNull(newEnrollment);
         

--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -562,7 +562,7 @@ public class ParticipantService {
                 String externalId = entry.getValue();
                 
                 Enrollment enrollment = Enrollment.create(account.getAppId(), studyId, account.getId(), externalId);
-                enrollmentService.enroll(account, enrollment);
+                enrollmentService.addEnrollment(account, enrollment);
             }
         }
         

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ActivityEventController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ActivityEventController.java
@@ -1,15 +1,14 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
-import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
-
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,7 +22,6 @@ import org.sagebionetworks.bridge.services.ActivityEventService;
 
 @CrossOrigin
 @RestController
-@RequestMapping("/v1/activityevents")
 public class ActivityEventController extends BaseController {
 
     private ActivityEventService activityEventService;
@@ -33,7 +31,7 @@ public class ActivityEventController extends BaseController {
         this.activityEventService = activityEventService;
     }
 
-    @PostMapping
+    @PostMapping("/v1/activityevents")
     @ResponseStatus(HttpStatus.CREATED)
     public StatusMessage createCustomActivityEvent() {
         UserSession session = getAuthenticatedAndConsentedSession();
@@ -45,8 +43,18 @@ public class ActivityEventController extends BaseController {
         
         return new StatusMessage("Event recorded");
     }
+    
+    @DeleteMapping("/v1/activityevents/{eventId}")
+    public StatusMessage deleteCustomActivityEvent(@PathVariable String eventId) {
+        UserSession session = getAuthenticatedAndConsentedSession();
 
-    @GetMapping(produces={APPLICATION_JSON_UTF8_VALUE})
+        App app = appService.getApp(session.getAppId());
+        activityEventService.deleteCustomEvent(app, null, session.getHealthCode(), eventId);
+        
+        return new StatusMessage("Event recorded");
+    }
+
+    @GetMapping("/v1/activityevents")
     public ResourceList<ActivityEvent> getSelfActivityEvents() throws Exception {
         UserSession session = getAuthenticatedAndConsentedSession();
         

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ActivityEventController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ActivityEventController.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
-import static org.sagebionetworks.bridge.models.activities.ActivityEvent.ACTIVITY_EVENT_WRITER;
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
 
 import java.util.List;
@@ -48,15 +47,12 @@ public class ActivityEventController extends BaseController {
     }
 
     @GetMapping(produces={APPLICATION_JSON_UTF8_VALUE})
-    public String getSelfActivityEvents() throws Exception {
+    public ResourceList<ActivityEvent> getSelfActivityEvents() throws Exception {
         UserSession session = getAuthenticatedAndConsentedSession();
         
         List<ActivityEvent> activityEvents = activityEventService.getActivityEventList(session.getAppId(),
                 null, session.getHealthCode());
         
-        // I do not like the fact we are serializing in the controller, but that's the only way to access
-        // the ObjectWriter and that's currently how we suppress healthCode.
-        return ACTIVITY_EVENT_WRITER
-                .writeValueAsString(new ResourceList<>(activityEvents));
+        return new ResourceList<>(activityEvents);
     }    
 }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
@@ -584,14 +584,13 @@ public class ParticipantController extends BaseController {
 
     @GetMapping(path = {"/v3/participants/{userId}/activityEvents"}, produces = {
             APPLICATION_JSON_UTF8_VALUE })
-    public String getActivityEvents(@PathVariable String userId) throws JsonProcessingException {
+    public ResourceList<ActivityEvent> getActivityEvents(@PathVariable String userId) throws JsonProcessingException {
         UserSession researcherSession = getAdministrativeSession();
         IS_SELF_OR_RESEARCHER.checkAndThrow(USER_ID, userId);
         App app = appService.getApp(researcherSession.getAppId());
 
         List<ActivityEvent> events = participantService.getActivityEvents(app, null, userId);
-        return ActivityEvent.ACTIVITY_EVENT_WRITER
-                .writeValueAsString(new ResourceList<>(events));
+        return new ResourceList<>(events);
     }
 
     @PostMapping(path = {"/v1/apps/{appId}/participants/{userId}/sendSmsMessage",

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantController.java
@@ -104,11 +104,11 @@ public class StudyParticipantController extends BaseController {
     @GetMapping("/v5/studies/{studyId}/participants/{userId}/enrollments")
     public PagedResourceList<EnrollmentDetail> getEnrollmentsForUser(@PathVariable String studyId, @PathVariable String userId) {
         UserSession session = getAdministrativeSession();
+        Account account = getValidAccountInStudy(session.getAppId(), studyId, userId);
         
         IS_COORD_OR_RESEARCHER.checkAndThrow(STUDY_ID, studyId);
-        checkAccountInStudy(session.getAppId(), studyId, userId);
         
-        List<EnrollmentDetail> list = enrollmentService.getEnrollmentsForUser(session.getAppId(), studyId, userId); 
+        List<EnrollmentDetail> list = enrollmentService.getEnrollmentsForUser(session.getAppId(), studyId, account.getId()); 
         return new PagedResourceList<>(list, list.size(), true);
     }
     
@@ -151,9 +151,9 @@ public class StudyParticipantController extends BaseController {
     public String getParticipant(@PathVariable String studyId, @PathVariable String userId,
             @RequestParam(defaultValue = "true") boolean consents) throws Exception {
         UserSession session = getAdministrativeSession();
+        Account account = getValidAccountInStudy(session.getAppId(), studyId, userId);
         
         IS_COORD_OR_RESEARCHER.checkAndThrow(STUDY_ID, studyId);
-        checkAccountInStudy(session.getAppId(), studyId, userId);
 
         App app = appService.getApp(session.getAppId());
 
@@ -164,7 +164,7 @@ public class StudyParticipantController extends BaseController {
             throw new EntityNotFoundException(Account.class);
         }
         
-        StudyParticipant participant = participantService.getParticipant(app, userId, consents);
+        StudyParticipant participant = participantService.getParticipant(app, account, consents);
         
         ObjectWriter writer = (app.isHealthCodeExportEnabled() || session.isInRole(ADMIN)) ?
                 StudyParticipant.API_WITH_HEALTH_CODE_WRITER :
@@ -176,13 +176,13 @@ public class StudyParticipantController extends BaseController {
             APPLICATION_JSON_UTF8_VALUE })
     public String getRequestInfo(@PathVariable String studyId, @PathVariable String userId) throws JsonProcessingException {
         UserSession session = getAdministrativeSession();
+        Account account = getValidAccountInStudy(session.getAppId(), studyId, userId);
         
         IS_COORD_OR_RESEARCHER.checkAndThrow(STUDY_ID, studyId);
-        checkAccountInStudy(session.getAppId(), studyId, userId);
         
         App app = appService.getApp(session.getAppId());
         // Verify it's in the same app as the researcher.
-        RequestInfo requestInfo = requestInfoService.getRequestInfo(userId);
+        RequestInfo requestInfo = requestInfoService.getRequestInfo(account.getId());
         if (requestInfo == null) {
             requestInfo = new RequestInfo.Builder().build();
         } else if (!app.getIdentifier().equals(requestInfo.getAppId())) {
@@ -194,14 +194,14 @@ public class StudyParticipantController extends BaseController {
     @PostMapping("/v5/studies/{studyId}/participants/{userId}")
     public StatusMessage updateParticipant(@PathVariable String studyId, @PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-
+        Account account = getValidAccountInStudy(session.getAppId(), studyId, userId);
+        
         IS_COORD_OR_RESEARCHER.checkAndThrow(STUDY_ID, studyId);
-        checkAccountInStudy(session.getAppId(), studyId, userId);
         
         StudyParticipant participant = parseJson(StudyParticipant.class);
  
         // Force userId of the URL
-        participant = new StudyParticipant.Builder().copyOf(participant).withId(userId).build();
+        participant = new StudyParticipant.Builder().copyOf(participant).withId(account.getId()).build();
         
         App app = appService.getApp(session.getAppId());
         participantService.updateParticipant(app, participant);
@@ -213,12 +213,12 @@ public class StudyParticipantController extends BaseController {
     public StatusMessage signOut(@PathVariable String studyId, @PathVariable String userId,
             @RequestParam(required = false) boolean deleteReauthToken) {
         UserSession session = getAdministrativeSession();
+        Account account = getValidAccountInStudy(session.getAppId(), studyId, userId);
 
         IS_COORD_OR_RESEARCHER.checkAndThrow(STUDY_ID, studyId);
-        checkAccountInStudy(session.getAppId(), studyId, userId);
         
         App app = appService.getApp(session.getAppId());
-        participantService.signUserOut(app, userId, deleteReauthToken);
+        participantService.signUserOut(app, account.getId(), deleteReauthToken);
 
         return SIGN_OUT_MSG;
     }
@@ -226,12 +226,12 @@ public class StudyParticipantController extends BaseController {
     @PostMapping("/v5/studies/{studyId}/participants/{userId}/requestResetPassword")
     public StatusMessage requestResetPassword(@PathVariable String studyId, @PathVariable String userId) {
         UserSession session = getAdministrativeSession();
+        Account account = getValidAccountInStudy(session.getAppId(), studyId, userId);
 
         IS_COORD_OR_RESEARCHER.checkAndThrow(STUDY_ID, studyId);
-        checkAccountInStudy(session.getAppId(), studyId, userId);
         
         App app = appService.getApp(session.getAppId());
-        participantService.requestResetPassword(app, userId);
+        participantService.requestResetPassword(app, account.getId());
         
         return RESET_PWD_MSG;
     }
@@ -239,12 +239,12 @@ public class StudyParticipantController extends BaseController {
     @PostMapping("/v5/studies/{studyId}/participants/{userId}/resendEmailVerification")
     public StatusMessage resendEmailVerification(@PathVariable String studyId, @PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-
+        Account account = getValidAccountInStudy(session.getAppId(), studyId, userId);
+        
         IS_COORD_OR_RESEARCHER.checkAndThrow(STUDY_ID, studyId);
-        checkAccountInStudy(session.getAppId(), studyId, userId);
         
         App app = appService.getApp(session.getAppId());
-        participantService.resendVerification(app, ChannelType.EMAIL, userId);
+        participantService.resendVerification(app, ChannelType.EMAIL, account.getId());
         
         return EMAIL_VERIFY_MSG;
     }
@@ -252,12 +252,12 @@ public class StudyParticipantController extends BaseController {
     @PostMapping("/v5/studies/{studyId}/participants/{userId}/resendPhoneVerification")
     public StatusMessage resendPhoneVerification(@PathVariable String studyId, @PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-
+        Account account = getValidAccountInStudy(session.getAppId(), studyId, userId);
+        
         IS_COORD_OR_RESEARCHER.checkAndThrow(STUDY_ID, studyId);
-        checkAccountInStudy(session.getAppId(), studyId, userId);
         
         App app = appService.getApp(session.getAppId());
-        participantService.resendVerification(app, ChannelType.PHONE, userId);
+        participantService.resendVerification(app, ChannelType.PHONE, account.getId());
         
         return PHONE_VERIFY_MSG;
     }
@@ -266,13 +266,13 @@ public class StudyParticipantController extends BaseController {
     public StatusMessage resendConsentAgreement(@PathVariable String studyId, @PathVariable String userId,
             @PathVariable String guid) {
         UserSession session = getAdministrativeSession();
-
+        Account account = getValidAccountInStudy(session.getAppId(), studyId, userId);
+        
         IS_COORD_OR_RESEARCHER.checkAndThrow(STUDY_ID, studyId);
-        checkAccountInStudy(session.getAppId(), studyId, userId);
         
         App app = appService.getApp(session.getAppId());
         SubpopulationGuid subpopGuid = SubpopulationGuid.create(guid);
-        participantService.resendConsentAgreement(app, subpopGuid, userId);
+        participantService.resendConsentAgreement(app, subpopGuid, account.getId());
         
         return CONSENT_RESENT_MSG;
     }
@@ -283,27 +283,27 @@ public class StudyParticipantController extends BaseController {
             @RequestParam(required = false) String endTime, @RequestParam(required = false) Integer pageSize,
             @RequestParam(required = false) String offsetKey) {
         UserSession session = getAdministrativeSession();
-
+        Account account = getValidAccountInStudy(session.getAppId(), studyId, userId);
+        
         IS_COORD_OR_RESEARCHER.checkAndThrow(STUDY_ID, studyId);
-        checkAccountInStudy(session.getAppId(), studyId, userId);
         
         App app = appService.getApp(session.getAppId());
         DateTime startTimeDate = getDateTimeOrDefault(startTime, null);
         DateTime endTimeDate = getDateTimeOrDefault(endTime, null);
 
-        return participantService.getUploads(app, userId, startTimeDate, endTimeDate, pageSize, offsetKey);
+        return participantService.getUploads(app, account.getId(), startTimeDate, endTimeDate, pageSize, offsetKey);
     }
 
     @GetMapping("/v5/studies/{studyId}/participants/{userId}/notifications")
     public ResourceList<NotificationRegistration> getNotificationRegistrations(@PathVariable String studyId,
             @PathVariable String userId) {
         UserSession session = getAdministrativeSession();
-
+        Account account = getValidAccountInStudy(session.getAppId(), studyId, userId);
+        
         IS_COORD_OR_RESEARCHER.checkAndThrow(STUDY_ID, studyId);
-        checkAccountInStudy(session.getAppId(), studyId, userId);
         
         App app = appService.getApp(session.getAppId());
-        List<NotificationRegistration> registrations = participantService.listRegistrations(app, userId);
+        List<NotificationRegistration> registrations = participantService.listRegistrations(app, account.getId());
         return new ResourceList<>(registrations);
     }
 
@@ -311,13 +311,13 @@ public class StudyParticipantController extends BaseController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public StatusMessage sendNotification(@PathVariable String studyId, @PathVariable String userId) {
         UserSession session = getAdministrativeSession();
+        Account account = getValidAccountInStudy(session.getAppId(), studyId, userId);
 
         IS_COORD_OR_RESEARCHER.checkAndThrow(STUDY_ID, studyId);
-        checkAccountInStudy(session.getAppId(), studyId, userId);
         
         NotificationMessage message = parseJson(NotificationMessage.class);
         App app = appService.getApp(session.getAppId());
-        Set<String> erroredNotifications = participantService.sendNotification(app, userId, message);
+        Set<String> erroredNotifications = participantService.sendNotification(app, account.getId(), message);
         
         if (erroredNotifications.isEmpty()) {
             return NOTIFY_SUCCESS_MSG;                    
@@ -329,76 +329,61 @@ public class StudyParticipantController extends BaseController {
     @DeleteMapping("/v5/studies/{studyId}/participants/{userId}")
     public StatusMessage deleteTestParticipant(@PathVariable String studyId, @PathVariable String userId) {
         UserSession session = getAdministrativeSession();
+        Account account = getValidAccountInStudy(session.getAppId(), studyId, userId);
         
         IS_COORD_OR_RESEARCHER.checkAndThrow(STUDY_ID, studyId);
         
-        AccountId accountId = BridgeUtils.parseAccountId(session.getAppId(), userId);
-        Account account = accountService.getAccount(accountId);
-        if (account == null) {
-            throw new EntityNotFoundException(Account.class);
-        }
-        boolean inStudy = account.getEnrollments().stream()
-                .anyMatch(en -> studyId.equals(en.getStudyId()));
-        if (!inStudy) {
-            throw new EntityNotFoundException(Account.class);
-        }
         if (!account.getDataGroups().contains(TEST_USER_GROUP)) {
             throw new UnauthorizedException("Account is not a test account.");
         }
         App app = appService.getApp(session.getAppId());
-        userAdminService.deleteUser(app, userId);
+        userAdminService.deleteUser(app, account.getId());
         
         return DELETE_MSG;
     }    
     
     @GetMapping(path = {"/v5/studies/{studyId}/participants/{userId}/activityEvents"},
             produces={APPLICATION_JSON_UTF8_VALUE})
-    public String getActivityEvents(@PathVariable String studyId, @PathVariable String userId) throws JsonProcessingException {
+    public ResourceList<ActivityEvent> getActivityEvents(@PathVariable String studyId, @PathVariable String userId) throws JsonProcessingException {
         UserSession session = getAdministrativeSession();
-
+        Account account = getValidAccountInStudy(session.getAppId(), studyId, userId);
+        
         IS_COORD_OR_RESEARCHER.checkAndThrow(STUDY_ID, studyId);
-        checkAccountInStudy(session.getAppId(), studyId, userId);
         
         App app = appService.getApp(session.getAppId());
-        List<ActivityEvent> events = participantService.getActivityEvents(app, studyId, userId);
+        List<ActivityEvent> events = participantService.getActivityEvents(app, studyId, account.getId());
         
-        return ActivityEvent.ACTIVITY_EVENT_WRITER
-                .writeValueAsString(new ResourceList<>(events));
+        return new ResourceList<>(events);
     }
     
     @PostMapping("/v5/studies/{studyId}/participants/{userId}/activityEvents")
     @ResponseStatus(HttpStatus.CREATED)
     public StatusMessage createActivityEvent(@PathVariable String studyId, @PathVariable String userId) {
-        // TODO: Fix permissions with study coordinator stuff before merging
         UserSession session = getAdministrativeSession();
+        Account account = getValidAccountInStudy(session.getAppId(), studyId, userId);
         
         IS_COORD_OR_RESEARCHER.checkAndThrow(STUDY_ID, studyId);
-        checkAccountInStudy(session.getAppId(), studyId, userId);
-        
-        AccountId accountId = AccountId.forId(session.getAppId(), userId);
-        String healthCode = accountService.getHealthCodeForAccount(accountId);
         
         CustomActivityEventRequest event = parseJson(CustomActivityEventRequest.class);
         
         App app = appService.getApp(session.getAppId());
         activityEventService.publishCustomEvent(app, studyId,
-                healthCode, event.getEventKey(), event.getTimestamp());
+                account.getHealthCode(), event.getEventKey(), event.getTimestamp());
         
         return EVENT_RECORDED_MSG;
     }
     
     @GetMapping(path = {"/v5/studies/{studyId}/participants/self/activityEvents"},
             produces={APPLICATION_JSON_UTF8_VALUE})
-    public String getSelfActivityEvents(@PathVariable String studyId) throws JsonProcessingException {
+    public ResourceList<ActivityEvent> getSelfActivityEvents(@PathVariable String studyId) throws JsonProcessingException {
         UserSession session = getAuthenticatedAndConsentedSession();
         
-        checkAccountInStudy(session.getAppId(), studyId, session.getId());
+        getValidAccountInStudy(session.getAppId(), studyId, session.getId());
         
         List<ActivityEvent> events = activityEventService.getActivityEventList(
                 session.getAppId(), studyId, session.getHealthCode());
         
-        return ActivityEvent.ACTIVITY_EVENT_WRITER
-                .writeValueAsString(new ResourceList<>(events));
+        return new ResourceList<>(events);
     }
 
     @PostMapping("/v5/studies/{studyId}/participants/self/activityEvents")
@@ -406,7 +391,7 @@ public class StudyParticipantController extends BaseController {
     public StatusMessage createSelfActivityEvent(@PathVariable String studyId) {
         UserSession session = getAuthenticatedAndConsentedSession();
 
-        checkAccountInStudy(session.getAppId(), studyId, session.getId());
+        getValidAccountInStudy(session.getAppId(), studyId, session.getId());
         
         CustomActivityEventRequest event = parseJson(CustomActivityEventRequest.class);
         
@@ -418,15 +403,20 @@ public class StudyParticipantController extends BaseController {
     }    
     
     /**
-     * Verify that the account referenced is enrolled in the target study.
-     * 
-     * @throws EntityNotFoundException
+     * Get the account no matter what identifier is used (in particular, externalId:<externalId> can be
+     * useful for the client), and throw an exception if the account does not exists, or it is not 
+     * enrolled in the target study.
      */
-    void checkAccountInStudy(String appId, String studyId, String userId) {
-        List<EnrollmentDetail> enrollments = enrollmentService.getEnrollmentsForUser(appId, studyId, userId);
-        boolean matches = enrollments.stream().anyMatch(en -> studyId.equals(en.getStudyId()));
+    private Account getValidAccountInStudy(String appId, String studyId, String idToken) {
+        AccountId accountId = BridgeUtils.parseAccountId(appId, idToken);
+        Account account = accountService.getAccount(accountId);
+        if (account == null) {
+            throw new EntityNotFoundException(Account.class);
+        }
+        boolean matches = account.getEnrollments().stream().anyMatch(en -> studyId.equals(en.getStudyId()));
         if (!matches) {
             throw new EntityNotFoundException(Account.class);
         }
+        return account;
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/validators/ActivityEventValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/ActivityEventValidator.java
@@ -1,14 +1,31 @@
 package org.sagebionetworks.bridge.validators;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.ACTIVITIES_RETRIEVED;
+import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.CREATED_ON;
+import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.ENROLLMENT;
+
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
 
 import org.sagebionetworks.bridge.dynamodb.DynamoActivityEvent;
+
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
 public class ActivityEventValidator implements Validator {
 
     public static final ActivityEventValidator INSTANCE = new ActivityEventValidator();
+    
+    static final String EVENT_ID_ERROR = "cannot be null (may be missing object or event type)";
+    static final String EVENT_ID_IMMUTABLE_ERROR = "is immutable and cannot be changed or deleted";
+    static final String ANSWER_VALUE_ERROR = "cannot be null or blank if the event indicates the answer to a survey";
+    
+    private static final Set<String> IMMUTABLE_EVENTS = ImmutableSet.of(
+            ENROLLMENT.name().toLowerCase() + ":",
+            ACTIVITIES_RETRIEVED.name().toLowerCase() + ":",
+            CREATED_ON.name().toLowerCase() + ":" );
     
     @Override
     public boolean supports(Class<?> clazz) {
@@ -19,18 +36,20 @@ public class ActivityEventValidator implements Validator {
     public void validate(Object object, Errors errors) {
         DynamoActivityEvent event = (DynamoActivityEvent)object;
         
-        String eventId = event.getEventId(); 
-
-        if (isBlank(event.getHealthCode())) {
-            errors.rejectValue("healthCode", "cannot be null or blank");
-        }
+        String eventId = event.getEventId();
+        
         if (eventId == null) {
-            errors.rejectValue("eventId", "cannot be null (may be missing object or event type)");
+            errors.rejectValue("eventId", EVENT_ID_ERROR);
+        } else if ( IMMUTABLE_EVENTS.stream().anyMatch(str -> eventId.startsWith(str))) {
+            errors.rejectValue("eventId", EVENT_ID_IMMUTABLE_ERROR);
         } else if (eventId.endsWith(":answered") && isBlank(event.getAnswerValue())) {
-            errors.rejectValue("answerValue", "cannot be null or blank if the event indicates the answer to a survey");
+            errors.rejectValue("answerValue", ANSWER_VALUE_ERROR);
         }
-        if (eventId != null && !eventId.startsWith("custom:") && event.getTimestamp() == null) {
-            errors.rejectValue("timestamp", "cannot be null");
+        if (event.getTimestamp() == null) {
+            errors.rejectValue("timestamp", Validate.CANNOT_BE_NULL);
+        }
+        if (isBlank(event.getHealthCode())) {
+            errors.rejectValue("healthCode", Validate.CANNOT_BE_BLANK);
         }
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/validators/ActivityEventValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/ActivityEventValidator.java
@@ -18,17 +18,19 @@ public class ActivityEventValidator implements Validator {
     @Override
     public void validate(Object object, Errors errors) {
         DynamoActivityEvent event = (DynamoActivityEvent)object;
+        
+        String eventId = event.getEventId(); 
 
         if (isBlank(event.getHealthCode())) {
             errors.rejectValue("healthCode", "cannot be null or blank");
         }
-        if (event.getTimestamp() == null) {
-            errors.rejectValue("timestamp", "cannot be null");
-        }
-        if (event.getEventId() == null) {
+        if (eventId == null) {
             errors.rejectValue("eventId", "cannot be null (may be missing object or event type)");
-        } else if (event.getEventId().endsWith(":answered") && isBlank(event.getAnswerValue())) {
+        } else if (eventId.endsWith(":answered") && isBlank(event.getAnswerValue())) {
             errors.rejectValue("answerValue", "cannot be null or blank if the event indicates the answer to a survey");
+        }
+        if (eventId != null && !eventId.startsWith("custom:") && event.getTimestamp() == null) {
+            errors.rejectValue("timestamp", "cannot be null");
         }
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/validators/Validate.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/Validate.java
@@ -22,7 +22,7 @@ import com.google.common.collect.Maps;
 
 public class Validate {
     
-    public static final String CANNOT_BE_BLANK = "%s cannot be missing, null, or blank";
+    public static final String CANNOT_BE_BLANK = "%s cannot be null or blank";
     public static final String CANNOT_BE_EMPTY = "%s cannot be empty";
     public static final String CANNOT_BE_EMPTY_STRING = "%s cannot be an empty string";
     public static final String CANNOT_BE_NEGATIVE = "%s cannot be negative";

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoActivityEventDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoActivityEventDaoTest.java
@@ -109,19 +109,6 @@ public class DynamoActivityEventDaoTest extends Mockito {
     }
     
     @Test
-    public void publishEventIsImmutableFails() {
-        when(mockMapper.load(any())).thenReturn(ENROLLMENT_EVENT);
-        
-        DynamoActivityEvent laterEvent = new DynamoActivityEvent.Builder().withHealthCode(HEALTH_CODE)
-                .withObjectType(ENROLLMENT).withTimestamp(TIMESTAMP.plusHours(1)).build();
-        
-        boolean result = dao.publishEvent(laterEvent);
-        assertFalse(result);
-        
-        verify(mockMapper, never()).save(any());
-    }
-    
-    @Test
     public void publishEventWithStudyId() {
         boolean result = dao.publishEvent(ENROLLMENT_EVENT_WITH_STUDY_ID);
         assertTrue(result);
@@ -148,18 +135,31 @@ public class DynamoActivityEventDaoTest extends Mockito {
     }
     
     @Test
-    public void publishEventDeletesCustomEvent() {
+    public void deletesCustomEvent() {
         DynamoActivityEvent event = new DynamoActivityEvent.Builder().withHealthCode(HEALTH_CODE)
                 .withObjectType(CUSTOM).withObjectId("AAA").build();
         
         when(mockMapper.load(any())).thenReturn(event);
         
-        boolean result = dao.publishEvent(event);
+        boolean result = dao.deleteCustomEvent(event);
         assertTrue(result);
         
         verify(mockMapper).delete(event);
     }
 
+    @Test
+    public void deletesCustomEventEventNotFound() {
+        DynamoActivityEvent event = new DynamoActivityEvent.Builder().withHealthCode(HEALTH_CODE)
+                .withObjectType(CUSTOM).withObjectId("AAA").build();
+        
+        when(mockMapper.load(any())).thenReturn(null);
+        
+        boolean result = dao.deleteCustomEvent(event);
+        assertFalse(result);
+        
+        verify(mockMapper, never()).delete(any());
+    }
+    
     @Test
     public void getActivityEventMap() {
         List<DynamoActivityEvent> savedEvents = ImmutableList.of(ENROLLMENT_EVENT, SURVEY_FINISHED_EVENT,

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoActivityEventDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoActivityEventDaoTest.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.dynamodb;
 import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.ACTIVITY;
+import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.CUSTOM;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.ENROLLMENT;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.QUESTION;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.SURVEY;
@@ -144,6 +145,19 @@ public class DynamoActivityEventDaoTest extends Mockito {
         assertFalse(result);
         
         verify(mockMapper, never()).save(any());
+    }
+    
+    @Test
+    public void publishEventDeletesCustomEvent() {
+        DynamoActivityEvent event = new DynamoActivityEvent.Builder().withHealthCode(HEALTH_CODE)
+                .withObjectType(CUSTOM).withObjectId("AAA").build();
+        
+        when(mockMapper.load(any())).thenReturn(event);
+        
+        boolean result = dao.publishEvent(event);
+        assertTrue(result);
+        
+        verify(mockMapper).delete(event);
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/models/activities/CustomActivityEventRequestTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/activities/CustomActivityEventRequestTest.java
@@ -41,5 +41,15 @@ public class CustomActivityEventRequestTest {
         assertEquals(node.size(), 3);
         assertEquals(node.get("eventKey").textValue(), EVENT_KEY);
         TestUtils.assertDatesWithTimeZoneEqual(EVENT_TIMESTAMP, DateTime.parse(node.get("timestamp").textValue()));
+        
+        // test alias of eventKey to eventId
+        jsonText = "{\n" +
+                "   \"eventId\":\"" + EVENT_KEY + "\",\n" +
+                "   \"timestamp\":\"" + EVENT_TIMESTAMP_STRING + "\"\n" +
+                "}";
+
+        // Convert to POJO
+        req = BridgeObjectMapper.get().readValue(jsonText, CustomActivityEventRequest.class);
+        assertEquals(req.getEventKey(), EVENT_KEY);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/ActivityEventServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ActivityEventServiceTest.java
@@ -342,7 +342,7 @@ public class ActivityEventServiceTest {
                 .withConsentCreatedOn(now.minusDays(10).getMillis())
                 .withSignedOn(now.getMillis()).build();
 
-        activityEventService.publishEnrollmentEvent(App.create(),null, "AAA-BBB-CCC", signature);
+        activityEventService.publishEnrollmentEvent(App.create(), null, "AAA-BBB-CCC", signature.getSignedOnAsDateTime());
         
         ArgumentCaptor<ActivityEvent> argument = ArgumentCaptor.forClass(ActivityEvent.class);
         verify(activityEventDao).publishEvent(argument.capture());
@@ -371,7 +371,7 @@ public class ActivityEventServiceTest {
                 .withSignedOn(now.getMillis()).build();
         when(activityEventDao.publishEvent(any())).thenReturn(true);
         
-        activityEventService.publishEnrollmentEvent(app, TEST_STUDY_ID, HEALTH_CODE, signature);
+        activityEventService.publishEnrollmentEvent(app, TEST_STUDY_ID, HEALTH_CODE, signature.getSignedOnAsDateTime());
         
         ArgumentCaptor<ActivityEvent> argument = ArgumentCaptor.forClass(ActivityEvent.class);
         verify(activityEventDao, times(4)).publishEvent(argument.capture());
@@ -419,7 +419,7 @@ public class ActivityEventServiceTest {
                 .withSignedOn(now.getMillis()).build();
         when(activityEventDao.publishEvent(any())).thenReturn(false);
 
-        activityEventService.publishEnrollmentEvent(App.create(), TEST_STUDY_ID, HEALTH_CODE, signature);
+        activityEventService.publishEnrollmentEvent(App.create(), TEST_STUDY_ID, HEALTH_CODE, signature.getSignedOnAsDateTime());
         
         ArgumentCaptor<ActivityEvent> argument = ArgumentCaptor.forClass(ActivityEvent.class);
         verify(activityEventDao, times(2)).publishEvent(argument.capture());
@@ -454,7 +454,7 @@ public class ActivityEventServiceTest {
         when(activityEventDao.publishEvent(any())).thenReturn(true);
         
         // Execute
-        activityEventService.publishEnrollmentEvent(app,null, "AAA-BBB-CCC", signature);
+        activityEventService.publishEnrollmentEvent(app,null, "AAA-BBB-CCC", signature.getSignedOnAsDateTime());
 
         // Verify published events (4)
         ArgumentCaptor<ActivityEvent> publishedEventCaptor = ArgumentCaptor.forClass(ActivityEvent.class);
@@ -497,7 +497,8 @@ public class ActivityEventServiceTest {
         
         when(activityEventDao.publishEvent(any())).thenReturn(false);
         
-        activityEventService.publishEnrollmentEvent(app,null, "AAA-BBB-CCC", new ConsentSignature.Builder().build());
+        // timestamp here does not matter
+        activityEventService.publishEnrollmentEvent(app, null, "AAA-BBB-CCC", CREATED_ON);
         
         // Only happens once, none of the other custom events are published.
         verify(activityEventDao, times(1)).publishEvent(any());
@@ -539,7 +540,8 @@ public class ActivityEventServiceTest {
         
         when(activityEventDao.publishEvent(any())).thenReturn(false);
         
-        activityEventService.publishEnrollmentEvent(app,null, "AAA-BBB-CCC", new ConsentSignature.Builder().build());
+        // timestamp here does not matter
+        activityEventService.publishEnrollmentEvent(app,null, "AAA-BBB-CCC", CREATED_ON);
         
         // Only happens once, none of the other custom events are published.
         verify(activityEventDao, times(1)).publishEvent(any());

--- a/src/test/java/org/sagebionetworks/bridge/services/AssessmentServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AssessmentServiceTest.java
@@ -220,7 +220,7 @@ public class AssessmentServiceTest extends Mockito {
     }
     
     @Test(expectedExceptions = InvalidEntityException.class,
-            expectedExceptionsMessageRegExp = ".*identifier cannot be missing.*")
+            expectedExceptionsMessageRegExp = ".*identifier cannot be null or blank.*")
     public void createAssessmentInvalid() {
         when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
             .thenReturn(mockOrganization);
@@ -310,7 +310,7 @@ public class AssessmentServiceTest extends Mockito {
     }
 
     @Test(expectedExceptions = InvalidEntityException.class,
-            expectedExceptionsMessageRegExp = ".*identifier cannot be missing.*")
+            expectedExceptionsMessageRegExp = ".*identifier cannot be null or blank.*")
     public void createAssessmentRevisionInvalid() {
         when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
             .thenReturn(mockOrganization);

--- a/src/test/java/org/sagebionetworks/bridge/services/ConsentServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ConsentServiceTest.java
@@ -121,8 +121,6 @@ public class ConsentServiceTest extends Mockito {
     @Mock
     private StudyConsentService studyConsentService;
     @Mock
-    private ActivityEventService activityEventService;
-    @Mock
     private SubpopulationService subpopService;
     @Mock
     private NotificationsService notificationsService;
@@ -239,10 +237,6 @@ public class ConsentServiceTest extends Mockito {
         assertEquals(updatedConsentList.get(1).getConsentCreatedOn(), CONSENT_CREATED_ON);
         assertNull(updatedConsentList.get(1).getWithdrewOn());
 
-        // Consent we send to activityEventService is same as the second consent.
-        verify(activityEventService).publishEnrollmentEvent(app, TEST_STUDY_ID,
-                PARTICIPANT.getHealthCode(), updatedConsentList.get(1));
-
         verify(sendMailService).sendEmail(emailCaptor.capture());
 
         // We notify the app administrator and send a copy to the user.
@@ -278,7 +272,6 @@ public class ConsentServiceTest extends Mockito {
                     false);
             fail("Exception expected.");
         } catch (InvalidEntityException e) {
-            verifyNoMoreInteractions(activityEventService);
             verifyNoMoreInteractions(accountService);
         }
     }
@@ -294,7 +287,6 @@ public class ConsentServiceTest extends Mockito {
                     SharingScope.NO_SHARING, false);
             fail("Exception expected.");
         } catch (EntityAlreadyExistsException e) {
-            verifyNoMoreInteractions(activityEventService);
             verify(accountService).getAccount(any());
             verifyNoMoreInteractions(accountService);
         }
@@ -307,7 +299,6 @@ public class ConsentServiceTest extends Mockito {
                     SharingScope.NO_SHARING, false);
             fail("Exception expected.");
         } catch (Throwable e) {
-            verifyNoMoreInteractions(activityEventService);
             verify(accountService).getAccount(any());
             verifyNoMoreInteractions(accountService);
         }
@@ -983,7 +974,7 @@ public class ConsentServiceTest extends Mockito {
 
         assertEquals(account.getDataGroups(), TestConstants.USER_DATA_GROUPS);
         
-        verify(mockEnrollmentService, times(2)).enroll(any(), enrollmentCaptor.capture());
+        verify(mockEnrollmentService, times(2)).addEnrollment(any(), enrollmentCaptor.capture());
         assertEquals(enrollmentCaptor.getAllValues().stream()
             .map(Enrollment::getStudyId)
             .collect(Collectors.toSet()), TestConstants.USER_STUDY_IDS);

--- a/src/test/java/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -319,7 +319,7 @@ public class ParticipantServiceTest extends Mockito {
         // suppress email (true) == sendEmail (false)
         verify(accountService).createAccount(eq(APP), accountCaptor.capture());
         verify(accountWorkflowService).sendEmailVerificationToken(APP, ID, EMAIL);
-        verify(enrollmentService).enroll(eq(accountCaptor.getValue()), enrollmentCaptor.capture());
+        verify(enrollmentService).addEnrollment(eq(accountCaptor.getValue()), enrollmentCaptor.capture());
         
         Account account = accountCaptor.getValue();
         assertEquals(account.getId(), ID);
@@ -646,7 +646,7 @@ public class ParticipantServiceTest extends Mockito {
         mockHealthCodeAndAccountRetrieval(null, null, null);
         when(studyService.getStudy(TEST_APP_ID, STUDY_ID, false)).thenReturn(Study.create());
         
-        when(enrollmentService.enroll(any(), any())).thenAnswer(args -> {
+        when(enrollmentService.addEnrollment(any(), any())).thenAnswer(args -> {
             account.getEnrollments().add(args.getArgument(1));
             return args.getArgument(1);
         });
@@ -1224,7 +1224,7 @@ public class ParticipantServiceTest extends Mockito {
         
         participantService.updateParticipant(APP, PARTICIPANT);
         
-        verify(enrollmentService, never()).enroll(any(), any());
+        verify(enrollmentService, never()).addEnrollment(any(), any());
     }
     
     // The exception here results from the fact that the caller can't see the existance of the 
@@ -2056,7 +2056,7 @@ public class ParticipantServiceTest extends Mockito {
         StudyParticipant participant = withParticipant().build();
         
         participantService.createParticipant(APP, participant, false);
-        verify(enrollmentService, never()).enroll(any(), any());
+        verify(enrollmentService, never()).addEnrollment(any(), any());
     }
     
     @Test
@@ -2068,7 +2068,7 @@ public class ParticipantServiceTest extends Mockito {
                 .withExternalIds(ENROLLMENT_MAP).build();
         
         participantService.updateParticipant(APP, participant);
-        verify(enrollmentService, never()).enroll(any(), any());
+        verify(enrollmentService, never()).addEnrollment(any(), any());
         
         assertEquals(Iterables.getFirst(account.getEnrollments(), null).getExternalId(), EXTERNAL_ID);
     }
@@ -2080,7 +2080,7 @@ public class ParticipantServiceTest extends Mockito {
         // Participant has no external ID, so externalIdService is not called
         StudyParticipant participant = withParticipant().withExternalId(null).build();
         participantService.updateParticipant(APP, participant);
-        verify(enrollmentService, never()).enroll(any(), any());
+        verify(enrollmentService, never()).addEnrollment(any(), any());
         assertEquals(Iterables.getFirst(account.getEnrollments(),  null).getExternalId(), EXTERNAL_ID);
     }
 
@@ -2091,7 +2091,7 @@ public class ParticipantServiceTest extends Mockito {
         StudyParticipant participant = withParticipant().withExternalIds(ENROLLMENT_MAP).build();
         participantService.updateParticipant(APP, participant);
         
-        verify(enrollmentService, never()).enroll(any(), any());
+        verify(enrollmentService, never()).addEnrollment(any(), any());
     }
     
     // Removed because you can no longer simply remove an external ID
@@ -2163,7 +2163,7 @@ public class ParticipantServiceTest extends Mockito {
         participantService.createParticipant(APP, participant, false);
         
         verify(accountService).createAccount(APP, account);
-        verify(enrollmentService, never()).enroll(any(), any());
+        verify(enrollmentService, never()).addEnrollment(any(), any());
     }
     @Test
     public void normalUserCannotCreateParticipantWithExternalId() {
@@ -2176,7 +2176,7 @@ public class ParticipantServiceTest extends Mockito {
         participantService.createParticipant(APP, participant, false);
         
         verify(accountService).createAccount(APP, account);
-        verify(enrollmentService, never()).enroll(any(), any());
+        verify(enrollmentService, never()).addEnrollment(any(), any());
     }
     @Test
     public void updateParticipantNoExternalIdsNoneAddedDoesNothing() {
@@ -2187,7 +2187,7 @@ public class ParticipantServiceTest extends Mockito {
         
         participantService.updateParticipant(APP, participant);
         
-        verify(enrollmentService, never()).enroll(any(), any());
+        verify(enrollmentService, never()).addEnrollment(any(), any());
         verify(accountService).updateAccount(account);
         assertTrue(account.getEnrollments().isEmpty());
     }
@@ -2202,7 +2202,7 @@ public class ParticipantServiceTest extends Mockito {
         participantService.updateParticipant(APP, participant);
         
         verify(accountService).updateAccount(account);
-        verify(enrollmentService, never()).enroll(any(), any());
+        verify(enrollmentService, never()).addEnrollment(any(), any());
     }
 
     @Test
@@ -2288,7 +2288,7 @@ public class ParticipantServiceTest extends Mockito {
         participantService.updateParticipant(APP, participant);
         
         verify(accountService).updateAccount(accountCaptor.capture());
-        verify(enrollmentService, never()).enroll(any(), any());
+        verify(enrollmentService, never()).addEnrollment(any(), any());
     }
     
     @Test
@@ -2336,7 +2336,7 @@ public class ParticipantServiceTest extends Mockito {
         
         verify(accountService).createAccount(eq(APP), any(Account.class));
         
-        verify(enrollmentService).enroll(any(Account.class), enrollmentCaptor.capture());
+        verify(enrollmentService).addEnrollment(any(Account.class), enrollmentCaptor.capture());
         Enrollment enrollment = enrollmentCaptor.getValue();
         assertEquals(enrollment.getAppId(), TEST_APP_ID);
         assertEquals(enrollment.getStudyId(), STUDY_ID);
@@ -2354,7 +2354,7 @@ public class ParticipantServiceTest extends Mockito {
         participantService.createParticipant(APP, participant, false);
         
         verify(accountService).createAccount(eq(APP), accountCaptor.capture());
-        verify(enrollmentService).enroll(any(), enrollmentCaptor.capture());
+        verify(enrollmentService).addEnrollment(any(), enrollmentCaptor.capture());
         
         Enrollment enrollment = enrollmentCaptor.getValue();
         assertEquals(enrollment.getAppId(), TEST_APP_ID);
@@ -2392,7 +2392,7 @@ public class ParticipantServiceTest extends Mockito {
         participantService.createParticipant(APP, participant, false);
         
         verify(accountService).createAccount(eq(APP), accountCaptor.capture());
-        verify(enrollmentService).enroll(any(), enrollmentCaptor.capture());
+        verify(enrollmentService).addEnrollment(any(), enrollmentCaptor.capture());
         
         Enrollment enrollment = enrollmentCaptor.getValue();
         assertEquals(enrollment.getAppId(), TEST_APP_ID);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ActivityEventControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ActivityEventControllerTest.java
@@ -7,14 +7,12 @@ import static org.sagebionetworks.bridge.TestUtils.assertCreate;
 import static org.sagebionetworks.bridge.TestUtils.assertCrossOrigin;
 import static org.sagebionetworks.bridge.TestUtils.assertGet;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
 
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.ImmutableList;
 
 import org.mockito.InjectMocks;
@@ -27,7 +25,6 @@ import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoActivityEvent;
-import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.StatusMessage;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
@@ -112,14 +109,11 @@ public class ActivityEventControllerTest extends Mockito {
         
         List<ActivityEvent> activityEvents = ImmutableList.of(event);
         when(mockActivityEventService.getActivityEventList(TEST_APP_ID, null, HEALTH_CODE)).thenReturn(activityEvents);
-        String response = controller.getSelfActivityEvents();
         
-        ResourceList<ActivityEvent> list = BridgeObjectMapper.get().readValue(response, 
-                new TypeReference<ResourceList<ActivityEvent>>() {});
+        ResourceList<ActivityEvent> list = controller.getSelfActivityEvents();
         ActivityEvent returnedEvent = list.getItems().get(0);
         assertEquals("foo", returnedEvent.getEventId());
         assertEquals(new Long(TIMESTAMP.getMillis()), returnedEvent.getTimestamp());
-        assertNull(returnedEvent.getHealthCode());
         
         verify(mockActivityEventService).getActivityEventList(TEST_APP_ID, null, HEALTH_CODE);
     }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
@@ -1561,9 +1561,7 @@ public class ParticipantControllerTest extends Mockito {
         List<ActivityEvent> events = ImmutableList.of(new DynamoActivityEvent(), new DynamoActivityEvent());
         when(mockParticipantService.getActivityEvents(app, null, TEST_USER_ID)).thenReturn(events);        
         
-        String retValue = controller.getActivityEvents(TEST_USER_ID);
-        
-        ResourceList<ActivityEvent> retList = BridgeObjectMapper.get().readValue(retValue, new TypeReference<ResourceList<ActivityEvent>>() {});
+        ResourceList<ActivityEvent> retList = controller.getActivityEvents(TEST_USER_ID);
         assertEquals(retList.getItems().size(), 2);
         
         verify(mockParticipantService).getActivityEvents(app, null, TEST_USER_ID);

--- a/src/test/java/org/sagebionetworks/bridge/validators/ActivityEventValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/ActivityEventValidatorTest.java
@@ -1,0 +1,77 @@
+package org.sagebionetworks.bridge.validators;
+
+import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
+import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
+import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
+import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.CUSTOM;
+import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.ENROLLMENT;
+import static org.sagebionetworks.bridge.models.activities.ActivityEventType.ANSWERED;
+import static org.sagebionetworks.bridge.validators.ActivityEventValidator.ANSWER_VALUE_ERROR;
+import static org.sagebionetworks.bridge.validators.ActivityEventValidator.EVENT_ID_ERROR;
+import static org.sagebionetworks.bridge.validators.ActivityEventValidator.EVENT_ID_IMMUTABLE_ERROR;
+import static org.sagebionetworks.bridge.validators.ActivityEventValidator.INSTANCE;
+
+import org.joda.time.DateTime;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.dynamodb.DynamoActivityEvent;
+import org.sagebionetworks.bridge.models.activities.ActivityEvent;
+import org.sagebionetworks.bridge.models.activities.ActivityEventType;
+
+public class ActivityEventValidatorTest {
+    
+    // It's easier to start with a fully-constructed object, and alter for a test
+    private DynamoActivityEvent.Builder getEvent() {
+        return new DynamoActivityEvent.Builder()
+                .withHealthCode(HEALTH_CODE)
+                .withStudyId(TEST_STUDY_ID)
+                .withTimestamp(CREATED_ON)
+                .withObjectType(CUSTOM)
+                .withObjectId("fooboo")
+                .withEventType(ANSWERED) // irrelevant here
+                .withAnswerValue("anAnswer");
+    }
+    
+    @Test
+    public void validates() {
+        Validate.entityThrowingException(INSTANCE, getEvent().build());
+    }
+    
+    @Test
+    public void eventIdNull() {
+        ActivityEvent event = getEvent()
+                .withObjectType(null)
+                .withObjectId(null)
+                .withEventType(null)
+                .withAnswerValue(null)
+                .build();
+        assertValidatorMessage(INSTANCE, event, "eventId", EVENT_ID_ERROR);
+    }
+
+    @Test
+    public void immutableEventProhibitied() {
+        ActivityEvent event = getEvent().withObjectType(ENROLLMENT).build();
+        assertValidatorMessage(INSTANCE, event, "eventId", EVENT_ID_IMMUTABLE_ERROR);
+    }
+
+    @Test
+    public void answerValueRequired() {
+        ActivityEvent event = getEvent().withEventType(ActivityEventType.ANSWERED)
+                .withAnswerValue(null).build();
+        assertValidatorMessage(INSTANCE, event, "answerValue", ANSWER_VALUE_ERROR);
+    }
+    
+    @Test
+    public void timestampNull() {
+        ActivityEvent event = getEvent().withTimestamp((DateTime)null).build();
+        assertValidatorMessage(INSTANCE, event, "timestamp", Validate.CANNOT_BE_NULL);
+    }
+
+    @Test
+    public void healthCodeNull() {
+        ActivityEvent event = getEvent().withHealthCode(null).build();
+        assertValidatorMessage(INSTANCE, event, "healthCode", Validate.CANNOT_BE_BLANK);
+    }
+
+}


### PR DESCRIPTION
EDIT: I am going to change the deletion behavior so you call a DELETE endpoint like every other API on Bridge. This will certainly change where the timestamp validation occurs. Hold off on reviewing until this is updated.

An enrollment event is now created no matter how someone is enrolled in a study (and it's study-specific where appropriate).

It's now possible to delete custom events (this will be very helpful for testing schedules).


Fixed a bug: if ActivityEvent was validated and threw an InvalidEntityException, it revealed the healthCode field. Changed how this is serialized so this won't happen and adjusted tests appropriately.

Changed the StudyParticipantController to allow for all forms of ID token. In working with the API I found it very helpful to be able to use externalId:* rather than the ID to retrieve external ID-based accounts (otherwise the client needs to do an ID lookup first).