### PR TITLE
S3 bootstrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Jacoco report will be in target/site/jacoco/index.html
 To run this locally, run
 mvn spring-boot:run
 
+To run this locally without executing boostrapping framework (which improves start-up time):
+mvn spring-boot:run -Dspring.profiles.active=noinit
+
 To debug remotely, run:
 mvn spring-boot:run -Dspring-boot.run.jvmArguments="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005"
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>bridge-base</artifactId>
-            <version>2.7.27</version>
+            <version>2.7.28</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -155,9 +155,9 @@
         </dependency>
         <dependency>
             <!-- Needed to resolve dependency conflicts for Hibernate -->
-            <groupId>org.dom4j</groupId>
+            <groupId>dom4j</groupId>
             <artifactId>dom4j</artifactId>
-            <version>2.1.3</version>
+            <version>1.6.1</version>
         </dependency>
         <dependency>
             <groupId>javax.mail</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -155,9 +155,9 @@
         </dependency>
         <dependency>
             <!-- Needed to resolve dependency conflicts for Hibernate -->
-            <groupId>dom4j</groupId>
+            <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
-            <version>1.6.1</version>
+            <version>2.1.3</version>
         </dependency>
         <dependency>
             <groupId>javax.mail</groupId>

--- a/src/main/java/org/sagebionetworks/bridge/DefaultAppBootstrapper.java
+++ b/src/main/java/org/sagebionetworks/bridge/DefaultAppBootstrapper.java
@@ -8,8 +8,10 @@ import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
 
+import java.util.List;
 import java.util.Set;
 
+import com.amazonaws.services.dynamodbv2.model.TableDescription;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
@@ -76,8 +78,8 @@ public class DefaultAppBootstrapper implements ApplicationListener<ContextRefres
 
     @Override
     public void onApplicationEvent(ContextRefreshedEvent event) {
-//        List<TableDescription> tables = annotationBasedTableCreator.getTables("org.sagebionetworks.bridge.dynamodb");
-//        dynamoInitializer.init(tables);
+        List<TableDescription> tables = annotationBasedTableCreator.getTables("org.sagebionetworks.bridge.dynamodb");
+        dynamoInitializer.init(tables);
         
         s3Initializer.initBuckets();
         

--- a/src/main/java/org/sagebionetworks/bridge/DefaultAppBootstrapper.java
+++ b/src/main/java/org/sagebionetworks/bridge/DefaultAppBootstrapper.java
@@ -16,7 +16,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
 import org.sagebionetworks.bridge.config.BridgeConfig;
-import org.sagebionetworks.bridge.config.BridgeConfigFactory;
 import org.sagebionetworks.bridge.dynamodb.AnnotationBasedTableCreator;
 import org.sagebionetworks.bridge.dynamodb.DynamoInitializer;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
@@ -29,11 +28,19 @@ import org.sagebionetworks.bridge.services.UserAdminService;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.stereotype.Component;
 
+/**
+ * Bootstrapping only occurs if you run Spring Boot with the "init" profile. You should run
+ * Spring Boot with the "init" profile the first time you run it, or any time you want the 
+ * system to re-check and updated the resources we manage dynamically at start-up. This 
+ * includes database migrations; DynamoDB table/index creation; and S3 bucket creation. 
+ */
 @Component
-public class DefaultAppBootstrapper  implements ApplicationListener<ContextRefreshedEvent> {
+@Profile("default")
+public class DefaultAppBootstrapper implements ApplicationListener<ContextRefreshedEvent> {
 
     static final SubpopulationGuid SHARED_SUBPOP = SubpopulationGuid.create(SHARED_APP_ID);
     static final SubpopulationGuid API_SUBPOP = SubpopulationGuid.create(API_APP_ID);
@@ -49,26 +56,31 @@ public class DefaultAppBootstrapper  implements ApplicationListener<ContextRefre
      */
     public static final Set<String> TEST_TASK_IDENTIFIERS = ImmutableSet.of("task:AAA", "task:BBB", "task:CCC", "CCC", "task1");
 
+    private final BridgeConfig bridgeConfig;
     private final UserAdminService userAdminService;
     private final AppService appService;
     private final DynamoInitializer dynamoInitializer;
     private final AnnotationBasedTableCreator annotationBasedTableCreator;
+    private final S3Initializer s3Initializer;
 
     @Autowired
-    public DefaultAppBootstrapper(UserAdminService userAdminService, AppService appService,
-            AnnotationBasedTableCreator annotationBasedTableCreator, DynamoInitializer dynamoInitializer) {
+    public DefaultAppBootstrapper(BridgeConfig bridgeConfig, UserAdminService userAdminService, 
+            AppService appService, AnnotationBasedTableCreator annotationBasedTableCreator, 
+            DynamoInitializer dynamoInitializer, S3Initializer s3Initializer) {
+        this.bridgeConfig = bridgeConfig;
         this.userAdminService = userAdminService;
         this.appService = appService;
         this.dynamoInitializer = dynamoInitializer;
         this.annotationBasedTableCreator = annotationBasedTableCreator;
+        this.s3Initializer = s3Initializer;
     }
 
     @Override
     public void onApplicationEvent(ContextRefreshedEvent event) {
-        List<TableDescription> tables = annotationBasedTableCreator.getTables("org.sagebionetworks.bridge.dynamodb");
-        dynamoInitializer.init(tables);
-
-        BridgeConfig config = BridgeConfigFactory.getConfig();
+//        List<TableDescription> tables = annotationBasedTableCreator.getTables("org.sagebionetworks.bridge.dynamodb");
+//        dynamoInitializer.init(tables);
+        
+        s3Initializer.initBuckets();
         
         RequestContext.set(new RequestContext.Builder().withCallerAppId(API_APP_ID)
                 .withCallerRoles(ImmutableSet.of(ADMIN, SUPERADMIN, DEVELOPER, RESEARCHER))
@@ -97,14 +109,14 @@ public class DefaultAppBootstrapper  implements ApplicationListener<ContextRefre
             app = appService.createApp(app);
             
             StudyParticipant admin = new StudyParticipant.Builder()
-                    .withEmail(config.get("admin.email"))
-                    .withPassword(config.get("admin.password"))
+                    .withEmail(bridgeConfig.get("admin.email"))
+                    .withPassword(bridgeConfig.get("admin.password"))
                     .withRoles(ImmutableSet.of(SUPERADMIN)).build();
             userAdminService.createUser(app, admin, API_SUBPOP, false, false);
 
             StudyParticipant dev = new StudyParticipant.Builder()
-                    .withEmail(config.get("api.developer.email"))
-                    .withPassword(config.get("api.developer.password"))
+                    .withEmail(bridgeConfig.get("api.developer.email"))
+                    .withPassword(bridgeConfig.get("api.developer.password"))
                     .withRoles(ImmutableSet.of(DEVELOPER)).build();
             userAdminService.createUser(app, dev, API_SUBPOP, false, false);
         }
@@ -119,16 +131,16 @@ public class DefaultAppBootstrapper  implements ApplicationListener<ContextRefre
             app.setShortName("SharedLib");
             app.setSponsorName("Sage Bionetworks");
             app.setIdentifier(SHARED_APP_ID);
-            app.setSupportEmail(config.get("admin.email"));
-            app.setTechnicalEmail(config.get("admin.email"));
-            app.setConsentNotificationEmail(config.get("admin.email"));
+            app.setSupportEmail(bridgeConfig.get("admin.email"));
+            app.setTechnicalEmail(bridgeConfig.get("admin.email"));
+            app.setConsentNotificationEmail(bridgeConfig.get("admin.email"));
             app.setEmailVerificationEnabled(true);
             app.setVerifyChannelOnSignInEnabled(true);
             app = appService.createApp(app);
             
             StudyParticipant dev = new StudyParticipant.Builder()
-                    .withEmail(config.get("shared.developer.email"))
-                    .withPassword(config.get("shared.developer.password"))
+                    .withEmail(bridgeConfig.get("shared.developer.email"))
+                    .withPassword(bridgeConfig.get("shared.developer.password"))
                     .withRoles(ImmutableSet.of(DEVELOPER)).build();
             userAdminService.createUser(app, dev, SHARED_SUBPOP, false, false);
         }

--- a/src/main/java/org/sagebionetworks/bridge/DefaultAppBootstrapper.java
+++ b/src/main/java/org/sagebionetworks/bridge/DefaultAppBootstrapper.java
@@ -31,11 +31,11 @@ import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.stereotype.Component;
 
 /**
- * Bootstrapping occurs on startup by default unless you start the Spring Boot application 
- * with the "nonit" profile enabled (mvn spring-boot:run -Dspring.profiles.active=noinit).
  * This bootstrapper creates DynamoDB and S3 buckets that are needed by Bridge, as well as
- * two initial apps and administrative accounts. The "noinit" profile will also disable the 
- * database migrations that we run through Liquibase. 
+ * two initial apps and administrative accounts. Bootstrapping occurs on startup by default 
+ * unless you start the Spring Boot application with the "nonit" profile enabled 
+ * (mvn spring-boot:run -Dspring.profiles.active=noinit). The "noinit" profile will also 
+ * disable the database migrations that we run through Liquibase. 
  */
 @Component
 @Profile("default")

--- a/src/main/java/org/sagebionetworks/bridge/DefaultAppBootstrapper.java
+++ b/src/main/java/org/sagebionetworks/bridge/DefaultAppBootstrapper.java
@@ -8,10 +8,8 @@ import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
 
-import java.util.List;
 import java.util.Set;
 
-import com.amazonaws.services.dynamodbv2.model.TableDescription;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
@@ -33,10 +31,11 @@ import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.stereotype.Component;
 
 /**
- * Bootstrapping only occurs if you run Spring Boot with the "init" profile. You should run
- * Spring Boot with the "init" profile the first time you run it, or any time you want the 
- * system to re-check and updated the resources we manage dynamically at start-up. This 
- * includes database migrations; DynamoDB table/index creation; and S3 bucket creation. 
+ * Bootstrapping occurs on startup by default unless you start the Spring Boot application 
+ * with the "nonit" profile enabled (mvn spring-boot:run -Dspring.profiles.active=noinit).
+ * This bootstrapper creates DynamoDB and S3 buckets that are needed by Bridge, as well as
+ * two initial apps and administrative accounts. The "noinit" profile will also disable the 
+ * database migrations that we run through Liquibase. 
  */
 @Component
 @Profile("default")

--- a/src/main/java/org/sagebionetworks/bridge/S3Initializer.java
+++ b/src/main/java/org/sagebionetworks/bridge/S3Initializer.java
@@ -72,7 +72,7 @@ public class S3Initializer {
             .withAllowedHeaders(ImmutableList.of("*"))
             .withAllowedMethods(ImmutableList.of(AllowedMethods.PUT))
             .withAllowedOrigins(ImmutableList.of("*"))
-            .withMaxAgeSeconds(30000);
+            .withMaxAgeSeconds(3000);
     
     public static enum BucketType {
         INTERNAL(null, null),

--- a/src/main/java/org/sagebionetworks/bridge/S3Initializer.java
+++ b/src/main/java/org/sagebionetworks/bridge/S3Initializer.java
@@ -1,0 +1,131 @@
+package org.sagebionetworks.bridge;
+
+import static org.sagebionetworks.bridge.BridgeUtils.resolveTemplate;
+
+import java.util.Map;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CreateBucketRequest;
+import com.amazonaws.services.s3.model.Region;
+import com.google.common.collect.ImmutableMap;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.sagebionetworks.bridge.config.BridgeConfig;
+import org.sagebionetworks.bridge.services.AccountService;
+
+@Component
+public class S3Initializer {
+    private static final Logger LOG = LoggerFactory.getLogger(AccountService.class);
+
+    private static final String SYNAPSE_ACCESS_POLICY = "{"
+            + "    \"Version\": \"2008-10-17\","
+            + "    \"Statement\": ["
+            + "        {"
+            + "            \"Effect\": \"Allow\","
+            + "            \"Principal\": {"
+            + "                \"AWS\": \"arn:aws:iam::325565585839:root\""
+            + "            },"
+            + "            \"Action\": ["
+            + "                \"s3:ListBucket*\","
+            + "                \"s3:GetBucketLocation\""
+            + "            ],"
+            + "            \"Resource\": \"arn:aws:s3:::${bucketName}\""
+            + "        },"
+            + "        {"
+            + "            \"Effect\": \"Allow\","
+            + "            \"Principal\": {"
+            + "                \"AWS\": \"arn:aws:iam::325565585839:root\""
+            + "            },"
+            + "            \"Action\": ["
+            + "                \"s3:GetObject*\","
+            + "                \"s3:*MultipartUpload*\""
+            + "            ],"
+            + "            \"Resource\": \"arn:aws:s3:::${bucketName}/*\""
+            + "        }"
+            + "    ]"
+            + "}";
+    
+    private static final String PUBLIC_ACCESS_POLICY = "{"
+            + "    \"Version\": \"2012-10-17\","
+            + "    \"Id\": \"Policy20160803001\","
+            + "    \"Statement\": ["
+            + "        {"
+            + "            \"Sid\": \"Stmt20160803001\","
+            + "            \"Effect\": \"Allow\","
+            + "            \"Principal\": \"*\","
+            + "            \"Action\": \"s3:GetObject\","
+            + "            \"Resource\": \"arn:aws:s3:::${bucketName}/*\""
+            + "        }"
+            + "    ]"
+            + "}";
+
+    public static enum BucketType {
+        INTERNAL(null),
+        SYNAPSE_ACCESSIBLE(SYNAPSE_ACCESS_POLICY),
+        PUBLIC_ACCESSIBLE(PUBLIC_ACCESS_POLICY);
+        
+        String policy;
+        private BucketType(String policy) {
+            this.policy = policy;
+        }
+    }
+    
+    BridgeConfig bridgeConfig;
+    
+    AmazonS3Client s3Client;
+    
+    @Autowired
+    public final void setBridgeConfig(BridgeConfig bridgeConfig) {
+        this.bridgeConfig = bridgeConfig;
+    }
+    
+    @Autowired
+    public final void setS3Client(AmazonS3Client s3Client) {
+        this.s3Client = s3Client;
+    }
+    
+    private static Map<String, BucketType> S3_BUCKET_PROP_NAMES = new ImmutableMap.Builder<String, BucketType>()
+            .put("attachment.bucket", BucketType.SYNAPSE_ACCESSIBLE)
+            .put("health.data.bucket.raw", BucketType.SYNAPSE_ACCESSIBLE)
+            .put("health.data.bucket.processed", BucketType.SYNAPSE_ACCESSIBLE)
+            .put("upload.bucket", BucketType.INTERNAL)
+            .put("upload.cms.cert.bucket", BucketType.INTERNAL)
+            .put("upload.cms.priv.bucket", BucketType.INTERNAL)
+            .put("consents.bucket", BucketType.INTERNAL)
+            .put("usersigned.consents.bucket", BucketType.INTERNAL)
+            .put("participant-file.bucket", BucketType.INTERNAL)
+            .put("docs.bucket", BucketType.PUBLIC_ACCESSIBLE)
+            .build();
+    
+    // Accessor so we can mock this list of buckets
+    Map<String, BucketType> getBucketNames() {
+        return S3_BUCKET_PROP_NAMES;
+    }
+    
+    public void initBuckets() {
+        for (Map.Entry<String, BucketType> entry : getBucketNames().entrySet()) {
+            String propName = entry.getKey();
+            BucketType type = entry.getValue();
+            String bucketName = bridgeConfig.get(propName);
+            
+            if (StringUtils.isBlank(bucketName)) {
+                throw new RuntimeException("Value is missing for bucket property: " + propName);
+            }
+            if (!s3Client.doesBucketExistV2(bucketName)) {
+                LOG.info("Creating bucket " + bucketName + " with policy to be " + type);
+                
+                s3Client.createBucket(new CreateBucketRequest(bucketName, Region.US_Standard));
+                
+                if (type.policy != null) {
+                    String policy = resolveTemplate(type.policy, ImmutableMap.of("bucketName", bucketName));
+                    s3Client.setBucketPolicy(bucketName, policy);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/S3Initializer.java
+++ b/src/main/java/org/sagebionetworks/bridge/S3Initializer.java
@@ -105,8 +105,6 @@ public class S3Initializer {
     
     private static Map<String, BucketType> S3_BUCKET_PROP_NAMES = new ImmutableMap.Builder<String, BucketType>()
             .put("attachment.bucket", BucketType.SYNAPSE_ACCESSIBLE)
-            .put("health.data.bucket.raw", BucketType.SYNAPSE_ACCESSIBLE)
-            .put("health.data.bucket.processed", BucketType.SYNAPSE_ACCESSIBLE)
             .put("upload.bucket", BucketType.INTERNAL_UPLOAD_ACCESSIBLE)
             .put("upload.cms.cert.bucket", BucketType.INTERNAL)
             .put("upload.cms.priv.bucket", BucketType.INTERNAL)

--- a/src/main/java/org/sagebionetworks/bridge/config/SpringConfig.java
+++ b/src/main/java/org/sagebionetworks/bridge/config/SpringConfig.java
@@ -210,13 +210,6 @@ public class SpringConfig {
                 bridgeConfig.getProperty("aws.secret.key"));
     }
 
-    @Bean(name = "snsCredentials")
-    public BasicAWSCredentials snsCredentials() {
-        BridgeConfig bridgeConfig = bridgeConfig();
-        return new BasicAWSCredentials(bridgeConfig.getProperty("sns.key"),
-                bridgeConfig.getProperty("sns.secret.key"));
-    }
-    
     @Bean(name = "dynamoDbClient")
     @Resource(name = "awsCredentials")
     public AmazonDynamoDBClient dynamoDbClient() {
@@ -227,9 +220,9 @@ public class SpringConfig {
     }
     
     @Bean(name = "snsClient")
-    @Resource(name = "snsCredentials")
+    @Resource(name = "awsCredentials")
     public AmazonSNSClient snsClient() {
-        return new AmazonSNSClient(snsCredentials());
+        return new AmazonSNSClient(awsCredentials());
     }
 
     @Bean(name = "dataPipelineClient")

--- a/src/main/java/org/sagebionetworks/bridge/crypto/CmsEncryptorCacheLoader.java
+++ b/src/main/java/org/sagebionetworks/bridge/crypto/CmsEncryptorCacheLoader.java
@@ -31,7 +31,7 @@ public class CmsEncryptorCacheLoader extends CacheLoader<String, CmsEncryptor> {
     private S3Helper s3CmsHelper;
 
     /** S3 helper, configured by Spring. */
-    @Resource(name = "s3CmsHelper")
+    @Resource(name = "s3Helper")
     public void setS3CmsHelper(S3Helper s3CmsHelper) {
         this.s3CmsHelper = s3CmsHelper;
     }

--- a/src/main/java/org/sagebionetworks/bridge/services/AppService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AppService.java
@@ -109,6 +109,7 @@ public class AppService {
     private static final String APP_EMAIL_VERIFICATION_EXPIRATION_PERIOD = "appEmailVerificationExpirationPeriod";
     private static final String IDENTIFIER_PROPERTY = "identifier";
     public static final Set<ACCESS_TYPE> READ_DOWNLOAD_ACCESS = ImmutableSet.of(ACCESS_TYPE.READ, ACCESS_TYPE.DOWNLOAD);
+    private static final Set<String> BOOTSTRAP_STUDY_IDS = ImmutableSet.of("shared", "api");
 
     private Set<String> appWhitelist;
     private String bridgeSupportEmailPlain;
@@ -339,7 +340,12 @@ public class AppService {
         
         Study study = Study.create();
         study.setAppId(app.getIdentifier());
-        study.setIdentifier(app.getIdentifier() + "-study");
+        // For legacy reasons, these two default apps use non-standard initial study IDs. 
+        if (BOOTSTRAP_STUDY_IDS.contains(app.getIdentifier())) {
+            study.setIdentifier(app.getIdentifier());
+        } else {
+            study.setIdentifier(app.getIdentifier() + "-study");    
+        }
         study.setName(app.getName() + " Study");
         studyService.createStudy(app.getIdentifier(), study, false);
         subpopService.createDefaultSubpopulation(app, study);

--- a/src/main/java/org/sagebionetworks/bridge/services/AppService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AppService.java
@@ -109,7 +109,6 @@ public class AppService {
     private static final String APP_EMAIL_VERIFICATION_EXPIRATION_PERIOD = "appEmailVerificationExpirationPeriod";
     private static final String IDENTIFIER_PROPERTY = "identifier";
     public static final Set<ACCESS_TYPE> READ_DOWNLOAD_ACCESS = ImmutableSet.of(ACCESS_TYPE.READ, ACCESS_TYPE.DOWNLOAD);
-    private static final Set<String> BOOTSTRAP_STUDY_IDS = ImmutableSet.of("shared", "api");
 
     private Set<String> appWhitelist;
     private String bridgeSupportEmailPlain;
@@ -340,12 +339,7 @@ public class AppService {
         
         Study study = Study.create();
         study.setAppId(app.getIdentifier());
-        // For legacy reasons, these two default apps use non-standard initial study IDs. 
-        if (BOOTSTRAP_STUDY_IDS.contains(app.getIdentifier())) {
-            study.setIdentifier(app.getIdentifier());
-        } else {
-            study.setIdentifier(app.getIdentifier() + "-study");    
-        }
+        study.setIdentifier(app.getIdentifier() + "-study");    
         study.setName(app.getName() + " Study");
         studyService.createStudy(app.getIdentifier(), study, false);
         subpopService.createDefaultSubpopulation(app, study);

--- a/src/main/java/org/sagebionetworks/bridge/services/StudyConsentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyConsentService.java
@@ -126,12 +126,12 @@ public class StudyConsentService {
      * S3 client. We need to use the S3 client to call writeBytesToPublicS3(), which wasn't migrated to bridge-base
      * because it references BridgePF-specific classes.
      */
-    @Resource(name = "s3ConsentsClient")
+    @Resource(name = "s3Client")
     final void setS3Client(AmazonS3Client s3Client) {
         this.s3Client = s3Client;
     }
 
-    @Resource(name = "s3ConsentsHelper")
+    @Resource(name = "s3Helper")
     final void setS3Helper(S3Helper helper) {
         this.s3Helper = helper;
     }

--- a/src/main/java/org/sagebionetworks/bridge/services/UploadCertificateService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/UploadCertificateService.java
@@ -42,12 +42,12 @@ public class UploadCertificateService {
         certificateFactory = new BcCertificateFactory();
     }
 
-    @Resource(name = "s3CmsClient")
+    @Resource(name = "s3Client")
     public final void setS3CmsClient(AmazonS3 s3CmsClient) {
         this.s3CmsClient = s3CmsClient;
     }
 
-    @Resource(name = "s3CmsHelper")
+    @Resource(name = "s3Helper")
     public final void setS3CmsHelper(S3Helper s3CmsHelper) {
         this.s3CmsHelper = s3CmsHelper;
     }

--- a/src/main/java/org/sagebionetworks/bridge/services/UploadService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/UploadService.java
@@ -96,7 +96,7 @@ public class UploadService {
         this.healthDataService = healthDataService;
     }
 
-    @Resource(name = "s3UploadClient")
+    @Resource(name = "s3Client")
     public void setS3UploadClient(AmazonS3 s3UploadClient) {
         this.s3UploadClient = s3UploadClient;
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/CRCController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/CRCController.java
@@ -73,7 +73,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;

--- a/src/main/resources/BridgeServer2.conf
+++ b/src/main/resources/BridgeServer2.conf
@@ -125,12 +125,12 @@ udd.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-Work
 local.udd.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-WorkerPlatform-Request-local
 
 # List of apps that should never be deleted
-local.app.whitelist = api
-dev.app.whitelist = api
-uat.app.whitelist = api,ios-sdk-int-tests,asthma,cardiovascular
-prod.app.whitelist = api,asthma,breastcancer,cardiovascular,diabetes,fphs,fphs-lab,ohsu-molemapper,parkinson,parkinson-lux,lilly
+local.app.whitelist = api,shared
+dev.app.whitelist = api,shared
+uat.app.whitelist = api,shared,ios-sdk-int-tests,asthma,cardiovascular
+prod.app.whitelist = api,shared,asthma,breastcancer,cardiovascular,diabetes,fphs,fphs-lab,ohsu-molemapper,parkinson,parkinson-lux,lilly
 
-local.usersigned.consents.bucket = local.usersigned.consents.bucket
+local.usersigned.consents.bucket = org-sagebridge-usersigned-consents-${bucket.suffix}
 dev.usersigned.consents.bucket = bridgepf-develop-awss3usersignedconsentsdownloadb-apwbxc8ldmj2
 uat.usersigned.consents.bucket = bridgepf-uat-awss3usersignedconsentsdownloadbucke-hcuoz4eztd8g
 prod.usersigned.consents.bucket = bridgepf-prod-awss3usersignedconsentsdownloadbuck-1slz1bcz0mls7

--- a/src/main/resources/BridgeServer2.conf
+++ b/src/main/resources/BridgeServer2.conf
@@ -11,10 +11,6 @@ prod.bucket.suffix = prod
 aws.key = dummy-value
 aws.secret.key = dummy-value
 
-# AWS credentials for sending push notifications
-sns.key = dummy-value
-sns.secret.key = dummy-value
-
 heartbeat.interval.minutes=30
 
 channel.throttle.max.requests = 1
@@ -86,10 +82,10 @@ uat.synapse.tracking.view = syn20683693
 prod.synapse.tracking.view = syn11956745
 
 # Upload buckets
-local.upload.bucket = org-sagebridge-upload-${bucket.suffix}
+upload.bucket = org-sagebridge-upload-${bucket.suffix}
 
 # Health Data Attachment buckets
-local.attachment.bucket = org-sagebridge-attachment-${bucket.suffix}
+attachment.bucket = org-sagebridge-attachment-${bucket.suffix}
 
 # Upload CMS certificate information
 upload.cms.certificate.country = US
@@ -112,12 +108,12 @@ max.zip.entry.size = 100000000
 max.num.zip.entries = 100
 
 # Buckets for the content of each consent revision
-local.consents.bucket = org-sagebridge-consents-${bucket.suffix}
+consents.bucket = org-sagebridge-consents-${bucket.suffix}
 
 # Bridge Exporter SQS queues
 
 exporter.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-EX-Request-${bucket.suffix}
-# Until we have a SQS intializer, we must break the suffix pattern
+# Until we have a SQS initializer, we must break the suffix pattern
 local.exporter.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-EX-Request-local
 
 # Bridge User Data Download Service SQS queues
@@ -130,9 +126,8 @@ dev.app.whitelist = api,shared
 uat.app.whitelist = api,shared,ios-sdk-int-tests,asthma,cardiovascular
 prod.app.whitelist = api,shared,asthma,breastcancer,cardiovascular,diabetes,fphs,fphs-lab,ohsu-molemapper,parkinson,parkinson-lux,lilly
 
-local.usersigned.consents.bucket = org-sagebridge-usersigned-consents-${bucket.suffix}
-dev.usersigned.consents.bucket = bridgepf-develop-awss3usersignedconsentsdownloadb-apwbxc8ldmj2
-uat.usersigned.consents.bucket = bridgepf-uat-awss3usersignedconsentsdownloadbucke-hcuoz4eztd8g
+usersigned.consents.bucket = org-sagebridge-usersigned-consents-${bucket.suffix}
+# Must maintain this bucket in production (doesn't follow the naming pattern)
 prod.usersigned.consents.bucket = bridgepf-prod-awss3usersignedconsentsdownloadbuck-1slz1bcz0mls7
 
 # Bootstrap credentials for integration tests (will only be used when first initializing your database). 
@@ -181,9 +176,3 @@ participant-file.bucket = org-sagebridge-participantfile-${bucket.suffix}
 
 # Public documents folder
 docs.bucket = docs${host.postfix}
-
-# Note however that the CloudFormation-created buckets are not this straight-forward, and
-# will have to be special-cased when added. 
-health.data.bucket.raw = bridgeserver2-${bucket.suffix}-rawhealthdatabucket
-health.data.bucket.processed = bridgeserver2-${bucket.suffix}-processedhealthdatabucket
-

--- a/src/main/resources/BridgeServer2.conf
+++ b/src/main/resources/BridgeServer2.conf
@@ -1,6 +1,21 @@
 bridge.env=local
 bridge.user=your-username-here
 
+# CloudFormation did not match our original environment tokens, so we must map between them
+# in some cases
+local.bucket.suffix = local-${bridge.user}
+dev.bucket.suffix = develop
+uat.bucket.suffix = uat
+prod.bucket.suffix = prod
+
+# AWS server account
+aws.key = dummy-value
+aws.secret.key = dummy-value
+
+# AWS credentials for sending push notifications
+sns.key = dummy-value
+sns.secret.key = dummy-value
+
 heartbeat.interval.minutes=30
 
 channel.throttle.max.requests = 1
@@ -14,8 +29,6 @@ synapse.api.key = yours-synapse-api-key
 exporter.synapse.id = 3325672
 test.synapse.user.id = 3348228
 
-aws.key = dummy-value
-aws.secret.key = dummy-value
 
 # Excludes the original try. For example, if this is set to 1, DDB will try a total of twice (one try, one retry)
 ddb.max.retries = 1
@@ -36,33 +49,29 @@ elasticache.url = redis://localhost:6379
 
 async.worker.thread.count = 20
 
-support.email = Bridge (Sage Bionetworks) <support@sagebridge.org>
 support.email.plain = support@sagebridge.org
+support.email = Bridge (Sage Bionetworks) <${support.email.plain}>
 sysops.email = Bridge IT <bridge-testing+sysops@sagebase.org>
 
 email.unsubscribe.token = dummy-value
 
 bridge.healthcode.redis.key = zEjhUL/FVsN8vti6HO27XgrM32i1a3huEuXWD4Hq06I=
 
-local.fphs.id.add.limit = 10
-dev.fphs.id.add.limit = 10
+fphs.id.add.limit = 10
 uat.fphs.id.add.limit = 100
 prod.fphs.id.add.limit = 100
 
-local.external.id.add.limit = 10
-dev.external.id.add.limit = 10
+external.id.add.limit = 10
 uat.external.id.add.limit = 100
 prod.external.id.add.limit = 100
 
-local.host.postfix = -local.sagebridge.org
+local.host.postfix = -local-${bridge.user}.sagebridge.org
 dev.host.postfix = -develop.sagebridge.org
 uat.host.postfix = -staging.sagebridge.org
 prod.host.postfix = .sagebridge.org
 
+webservices.url = https://ws-${host.postfix}
 local.webservices.url = http://localhost:9000
-dev.webservices.url = https://ws-develop.sagebridge.org
-uat.webservices.url = https://ws-staging.sagebridge.org
-prod.webservices.url = https://ws.sagebridge.org
 
 route53.zone = ZP0HNVK1V670D
 
@@ -78,16 +87,10 @@ uat.synapse.tracking.view = syn20683693
 prod.synapse.tracking.view = syn11956745
 
 # Upload buckets
-local.upload.bucket = org-sagebridge-upload-local
-dev.upload.bucket = org-sagebridge-upload-develop
-uat.upload.bucket = org-sagebridge-upload-uat
-prod.upload.bucket = org-sagebridge-upload-prod
+local.upload.bucket = org-sagebridge-upload-${bucket.suffix}
 
 # Health Data Attachment buckets
-local.attachment.bucket = org-sagebridge-attachment-local
-dev.attachment.bucket = org-sagebridge-attachment-develop
-uat.attachment.bucket = org-sagebridge-attachment-uat
-prod.attachment.bucket = org-sagebridge-attachment-prod
+local.attachment.bucket = org-sagebridge-attachment-${bucket.suffix}
 
 # Upload CMS certificate information
 upload.cms.certificate.country = US
@@ -98,41 +101,29 @@ upload.cms.certificate.team = Bridge
 upload.cms.certificate.email = bridgeIT@sagebase.org
 
 # Buckets for CMS key pairs
+# System needs the CMS keys in the shared local buckets, or integration tests fail
+upload.cms.cert.bucket = org-sagebridge-upload-cms-cert-${bucket.suffix}
 local.upload.cms.cert.bucket = org-sagebridge-upload-cms-cert-local
+upload.cms.priv.bucket = org-sagebridge-upload-cms-priv-${bucket.suffix}
 local.upload.cms.priv.bucket = org-sagebridge-upload-cms-priv-local
-dev.upload.cms.cert.bucket = org-sagebridge-upload-cms-cert-develop
-dev.upload.cms.priv.bucket = org-sagebridge-upload-cms-priv-develop
-uat.upload.cms.cert.bucket = org-sagebridge-upload-cms-cert-uat
-uat.upload.cms.priv.bucket = org-sagebridge-upload-cms-priv-uat
-prod.upload.cms.cert.bucket = org-sagebridge-upload-cms-cert-prod
-prod.upload.cms.priv.bucket = org-sagebridge-upload-cms-priv-prod
 
-// Maximum 100 MB per zip entry
+# Maximum 100 MB per zip entry
 max.zip.entry.size = 100000000
-// Maximum 100 zip entries per archive
+# Maximum 100 zip entries per archive
 max.num.zip.entries = 100
 
-# AWS credentials for sending push notifications
-sns.key = dummy-value
-sns.secret.key = dummy-value
-
 # Buckets for the content of each consent revision
-local.consents.bucket = org-sagebridge-consents-local
-dev.consents.bucket = org-sagebridge-consents-dev
-uat.consents.bucket = org-sagebridge-consents-uat
-prod.consents.bucket = org-sagebridge-consents-prod
+local.consents.bucket = org-sagebridge-consents-${bucket.suffix}
 
 # Bridge Exporter SQS queues
+
+exporter.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-EX-Request-${bucket.suffix}
+# Until we have a SQS intializer, we must break the suffix pattern
 local.exporter.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-EX-Request-local
-dev.exporter.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-EX-Request-dev
-uat.exporter.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-EX-Request-uat
-prod.exporter.request.sqs.queue.url=https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-EX-Request-prod
 
 # Bridge User Data Download Service SQS queues
+udd.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-WorkerPlatform-Request-${bucket.suffix}
 local.udd.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-WorkerPlatform-Request-local
-dev.udd.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-WorkerPlatform-Request-dev
-uat.udd.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-WorkerPlatform-Request-uat
-prod.udd.sqs.queue.url = https://sqs.us-east-1.amazonaws.com/649232250620/Bridge-WorkerPlatform-Request-prod
 
 # List of apps that should never be deleted
 local.app.whitelist = api
@@ -187,15 +178,12 @@ gbf.api.key = dummy-value
 query.param.allowlist = type,appId,studyId,IdFilter,assignmentFilter,externalId,identifier,ownerId,newIdentifier,name,notes,tags,includeDeleted,physical,format,summary,startTime,endTime,pageSize,offsetKey,offsetBy,tag,category,minRevision,maxRevision,queryParam,createAccount,createdOnStart,createdOnEnd,consents,scheduledOnStart,scheduledOnEnd,startDate,endDate,deleteReauthToken,until,daysAhead,minimumPerSchedule,mostRecent,mostrecent,published,newSchemaRev,synchronous,redrive
 
 # Participant File S3 bucket name
-dev.participant-file.bucket = org-sagebridge-participantfile-dev
-uat.participant-file.bucket = org-sagebridge-participantfile-uat
-prod.participant-file.bucket = org-sagebridge-participantfile-prod
-# Set in your ~/BridgeServe2.conf file
-# local.participant-file.bucket = org-sagebridge-participantfile-prod-local-[bridge-user]
+participant-file.bucket = org-sagebridge-participantfile-${bucket.suffix}
 
 # Public documents folder
-dev.docs.bucket = docs-develop.sagebridge.org
-uat.docs.bucket = docs-staging.sagebridge.org
-prod.docs.bucket = docs.sagebridge.org
-# Set in your ~/BridgeServe2.conf file
-# local.docs.bucket = docs-[bridge-user].sagebridge.org
+docs.bucket = docs${host.postfix}
+
+# Note however that the CloudFormation-created buckets are not this straight-forward
+health.data.bucket.raw = bridgeserver2-${bucket.suffix}-rawhealthdatabucket
+health.data.bucket.processed = bridgeserver2-${bucket.suffix}-processedhealthdatabucket
+

--- a/src/main/resources/BridgeServer2.conf
+++ b/src/main/resources/BridgeServer2.conf
@@ -77,10 +77,6 @@ dev.synapse.tracking.view = syn20683692
 uat.synapse.tracking.view = syn20683693
 prod.synapse.tracking.view = syn11956745
 
-# AWS credentials for doing pre-signed upload
-aws.key.upload = dummy-value
-aws.secret.key.upload = dummy-value
-
 # Upload buckets
 local.upload.bucket = org-sagebridge-upload-local
 dev.upload.bucket = org-sagebridge-upload-develop
@@ -101,10 +97,6 @@ upload.cms.certificate.organization = Sage Bionetworks
 upload.cms.certificate.team = Bridge
 upload.cms.certificate.email = bridgeIT@sagebase.org
 
-# AWS credentials for writing and reading CMS key pairs
-aws.key.upload.cms = dummy-value
-aws.secret.key.upload.cms = dummy-value
-
 # Buckets for CMS key pairs
 local.upload.cms.cert.bucket = org-sagebridge-upload-cms-cert-local
 local.upload.cms.priv.bucket = org-sagebridge-upload-cms-priv-local
@@ -119,10 +111,6 @@ prod.upload.cms.priv.bucket = org-sagebridge-upload-cms-priv-prod
 max.zip.entry.size = 100000000
 // Maximum 100 zip entries per archive
 max.num.zip.entries = 100
-
-# AWS credentials for reading/writing consent documents to S3
-aws.key.consents = dummy-value
-aws.secret.key.consents = dummy-value
 
 # AWS credentials for sending push notifications
 sns.key = dummy-value
@@ -204,3 +192,10 @@ uat.participant-file.bucket = org-sagebridge-participantfile-uat
 prod.participant-file.bucket = org-sagebridge-participantfile-prod
 # Set in your ~/BridgeServe2.conf file
 # local.participant-file.bucket = org-sagebridge-participantfile-prod-local-[bridge-user]
+
+# Public documents folder
+dev.docs.bucket = docs-develop.sagebridge.org
+uat.docs.bucket = docs-staging.sagebridge.org
+prod.docs.bucket = docs.sagebridge.org
+# Set in your ~/BridgeServe2.conf file
+# local.docs.bucket = docs-[bridge-user].sagebridge.org

--- a/src/main/resources/BridgeServer2.conf
+++ b/src/main/resources/BridgeServer2.conf
@@ -1,8 +1,7 @@
 bridge.env=local
 bridge.user=your-username-here
 
-# CloudFormation did not match our original environment tokens, so we must map between them
-# in some cases
+# CloudFormation did not match our original environment tokens, so we must map between them in some cases
 local.bucket.suffix = local-${bridge.user}
 dev.bucket.suffix = develop
 uat.bucket.suffix = uat
@@ -183,7 +182,8 @@ participant-file.bucket = org-sagebridge-participantfile-${bucket.suffix}
 # Public documents folder
 docs.bucket = docs${host.postfix}
 
-# Note however that the CloudFormation-created buckets are not this straight-forward
+# Note however that the CloudFormation-created buckets are not this straight-forward, and
+# will have to be special-cased when added. 
 health.data.bucket.raw = bridgeserver2-${bucket.suffix}-rawhealthdatabucket
 health.data.bucket.processed = bridgeserver2-${bucket.suffix}-processedhealthdatabucket
 

--- a/src/test/java/org/sagebionetworks/bridge/S3InitializerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/S3InitializerTest.java
@@ -1,0 +1,135 @@
+package org.sagebionetworks.bridge;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.Map;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CreateBucketRequest;
+import com.google.common.collect.ImmutableMap;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.config.BridgeConfig;
+
+public class S3InitializerTest extends Mockito {
+    private static final String BUCKET_NAME = "oneBucketName";
+
+    @Mock
+    BridgeConfig mockBridgeConfig;
+    
+    @Mock
+    AmazonS3Client mockS3Client;
+    
+    @InjectMocks
+    @Spy
+    S3Initializer initializer;
+    
+    @Captor
+    ArgumentCaptor<CreateBucketRequest> requestCaptor;
+    
+    @Captor
+    ArgumentCaptor<String> stringCaptor;
+    
+    @BeforeMethod
+    public void beforeMethod() {
+        MockitoAnnotations.initMocks(this);
+    }
+    
+    @Test
+    public void bucketExists() {
+        Map<String,S3Initializer.BucketType> props = ImmutableMap.of("bucket.prop", 
+                S3Initializer.BucketType.SYNAPSE_ACCESSIBLE);
+        
+        when(initializer.getBucketNames()).thenReturn(props);
+        when(mockBridgeConfig.get("bucket.prop")).thenReturn(BUCKET_NAME);
+        when(mockS3Client.doesBucketExistV2(BUCKET_NAME)).thenReturn(true);
+        
+        initializer.initBuckets();
+        
+        verify(mockS3Client, never()).createBucket(any(CreateBucketRequest.class));
+        verify(mockS3Client, never()).setBucketPolicy(any(), any());
+    }
+    
+    @Test
+    public void bucketCreatedForSynapseBucket() {
+        Map<String,S3Initializer.BucketType> props = ImmutableMap.of(
+                "bucket.prop", S3Initializer.BucketType.SYNAPSE_ACCESSIBLE);
+        
+        when(initializer.getBucketNames()).thenReturn(props);
+        when(mockBridgeConfig.get("bucket.prop")).thenReturn(BUCKET_NAME);
+        when(mockS3Client.doesBucketExistV2(BUCKET_NAME)).thenReturn(false);
+        
+        initializer.initBuckets();
+        
+        String resolvedPolicy = BridgeUtils.resolveTemplate(
+                S3Initializer.BucketType.SYNAPSE_ACCESSIBLE.policy, 
+                ImmutableMap.of("bucketName", BUCKET_NAME));
+        
+        verify(mockS3Client).createBucket(requestCaptor.capture());
+        verify(mockS3Client).setBucketPolicy(eq(BUCKET_NAME), stringCaptor.capture());
+        
+        assertEquals(requestCaptor.getValue().getBucketName(), BUCKET_NAME);
+        assertEquals(resolvedPolicy, stringCaptor.getValue());
+    }
+    
+    @Test
+    public void bucketCreatedForPublicBucket() {
+        Map<String,S3Initializer.BucketType> props = ImmutableMap.of(
+                "bucket.prop", S3Initializer.BucketType.PUBLIC_ACCESSIBLE);
+        
+        when(initializer.getBucketNames()).thenReturn(props);
+        when(mockBridgeConfig.get("bucket.prop")).thenReturn(BUCKET_NAME);
+        when(mockS3Client.doesBucketExistV2(BUCKET_NAME)).thenReturn(false);
+        
+        initializer.initBuckets();
+        
+        String resolvedPolicy = BridgeUtils.resolveTemplate(
+                S3Initializer.BucketType.PUBLIC_ACCESSIBLE.policy, 
+                ImmutableMap.of("bucketName", BUCKET_NAME));
+        
+        verify(mockS3Client).createBucket(requestCaptor.capture());
+        verify(mockS3Client).setBucketPolicy(eq(BUCKET_NAME), stringCaptor.capture());
+        
+        assertEquals(requestCaptor.getValue().getBucketName(), BUCKET_NAME);
+        assertEquals(resolvedPolicy, stringCaptor.getValue());
+    }
+    
+    @Test
+    public void bucketCreatedForInternalBucket() {
+        Map<String,S3Initializer.BucketType> props = ImmutableMap.of(
+                "bucket.prop", S3Initializer.BucketType.INTERNAL);
+        
+        when(initializer.getBucketNames()).thenReturn(props);
+        when(mockBridgeConfig.get("bucket.prop")).thenReturn(BUCKET_NAME);
+        when(mockS3Client.doesBucketExistV2(BUCKET_NAME)).thenReturn(false);
+        
+        initializer.initBuckets();
+        
+        verify(mockS3Client).createBucket(requestCaptor.capture());
+        verify(mockS3Client, never()).setBucketPolicy(any(), any());
+        
+        assertEquals(requestCaptor.getValue().getBucketName(), BUCKET_NAME);
+    }
+    
+    @Test(expectedExceptions = RuntimeException.class,
+            expectedExceptionsMessageRegExp = "Value is missing for bucket property: bucket.prop")
+    public void missingBucketConfigThrowsException() {
+        Map<String,S3Initializer.BucketType> props = ImmutableMap.of("bucket.prop", 
+                S3Initializer.BucketType.SYNAPSE_ACCESSIBLE);
+        
+        when(initializer.getBucketNames()).thenReturn(props);
+        when(mockBridgeConfig.get("bucket.prop")).thenReturn(null);
+        when(mockS3Client.doesBucketExistV2(BUCKET_NAME)).thenReturn(true);
+        
+        initializer.initBuckets();
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/S3InitializerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/S3InitializerTest.java
@@ -41,9 +41,6 @@ public class S3InitializerTest extends Mockito {
     ArgumentCaptor<CreateBucketRequest> requestCaptor;
     
     @Captor
-    ArgumentCaptor<String> stringCaptor;
-    
-    @Captor
     ArgumentCaptor<BucketCrossOriginConfiguration> corsConfigCaptor;
     
     @BeforeMethod
@@ -82,10 +79,9 @@ public class S3InitializerTest extends Mockito {
                 ImmutableMap.of("bucketName", BUCKET_NAME));
         
         verify(mockS3Client).createBucket(requestCaptor.capture());
-        verify(mockS3Client).setBucketPolicy(eq(BUCKET_NAME), stringCaptor.capture());
+        verify(mockS3Client).setBucketPolicy(BUCKET_NAME, resolvedPolicy);
         
         assertEquals(requestCaptor.getValue().getBucketName(), BUCKET_NAME);
-        assertEquals(resolvedPolicy, stringCaptor.getValue());
     }
     
     @Test
@@ -104,10 +100,9 @@ public class S3InitializerTest extends Mockito {
                 ImmutableMap.of("bucketName", BUCKET_NAME));
         
         verify(mockS3Client).createBucket(requestCaptor.capture());
-        verify(mockS3Client).setBucketPolicy(eq(BUCKET_NAME), stringCaptor.capture());
+        verify(mockS3Client).setBucketPolicy(BUCKET_NAME, resolvedPolicy);
         
         assertEquals(requestCaptor.getValue().getBucketName(), BUCKET_NAME);
-        assertEquals(resolvedPolicy, stringCaptor.getValue());
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/S3InitializerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/S3InitializerTest.java
@@ -141,7 +141,7 @@ public class S3InitializerTest extends Mockito {
     }
     
     @Test
-    public void createBucketWithCrsSupport() {
+    public void createBucketWithCORSSupport() {
         Map<String,S3Initializer.BucketType> props = ImmutableMap.of(
                 "bucket.prop", S3Initializer.BucketType.INTERNAL_UPLOAD_ACCESSIBLE);
         


### PR DESCRIPTION
- added a "noinit" Spring profile. When you start BridgeServer2 with this profile, it takes off ~30 seconds from your start time by skipping db migrations and our boostrapping code for DynamoDB and S3;
- removed redundant S3 clients and S3 helpers;
- created an S3 initializer during bootstrapping to create missing S3 buckets.