### PR TITLE
Dom4j fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,12 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
             <version>${hibernate.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>dom4j</groupId>
+                    <artifactId>dom4j</artifactId>
+                </exclusion>
+            </exclusions>             
         </dependency>
         <dependency>
            <groupId>org.liquibase</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <apache.http.version>4.5.6</apache.http.version>
         <aws.version>1.11.944</aws.version>
-        <hibernate.version>5.2.9.Final</hibernate.version>
+        <hibernate.version>5.4.27.Final</hibernate.version>
         <jackson.version>2.10.0</jackson.version>
         <java.version>1.8</java.version>
         <logback.version>1.2.3</logback.version>
@@ -154,12 +154,6 @@
             <version>1.7</version>
         </dependency>
         <dependency>
-            <!-- Needed to resolve dependency conflicts for Hibernate -->
-            <groupId>org.dom4j</groupId>
-            <artifactId>dom4j</artifactId>
-            <version>2.1.3</version>
-        </dependency>
-        <dependency>
             <groupId>javax.mail</groupId>
             <artifactId>mail</artifactId>
             <version>1.4.7</version>
@@ -178,12 +172,6 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
             <version>${hibernate.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>dom4j</groupId>
-                    <artifactId>dom4j</artifactId>
-                </exclusion>
-            </exclusions>             
         </dependency>
         <dependency>
            <groupId>org.liquibase</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -155,9 +155,9 @@
         </dependency>
         <dependency>
             <!-- Needed to resolve dependency conflicts for Hibernate -->
-            <groupId>dom4j</groupId>
+            <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
-            <version>1.6.1</version>
+            <version>2.1.3</version>
         </dependency>
         <dependency>
             <groupId>javax.mail</groupId>


### PR DESCRIPTION
Unit tests pass and integration tests pass, and the version of dom4j that Hibernate 5.4.27.Final relies upon is 2.1.3, the version that resolves our security issue.