### PR TITLE
Restore the enrollment migration APIs to migrate MoleMapper (they had one implicit study we effectively missed).

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/models/studies/EnrollmentMigration.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/studies/EnrollmentMigration.java
@@ -1,0 +1,107 @@
+package org.sagebionetworks.bridge.models.studies;
+
+import org.joda.time.DateTime;
+
+/**
+ * A (temporary?) model object so supeadmins can migratie user enrollments. 
+ */
+public class EnrollmentMigration {
+    
+    public static final EnrollmentMigration create(Enrollment enrollment) {
+        EnrollmentMigration m = new EnrollmentMigration();
+        m.setAppId(enrollment.getAppId());
+        m.setStudyId(enrollment.getStudyId());
+        m.setUserId(enrollment.getAccountId());
+        m.setExternalId(enrollment.getExternalId());
+        m.setEnrolledOn(enrollment.getEnrolledOn());
+        m.setWithdrawnOn(enrollment.getWithdrawnOn());
+        m.setEnrolledBy(enrollment.getEnrolledBy());
+        m.setWithdrawnBy(enrollment.getWithdrawnBy());
+        m.setWithdrawalNote(enrollment.getWithdrawalNote());
+        m.setConsentRequired(enrollment.isConsentRequired());
+        return m;
+    }
+    
+    private String appId;
+    private String studyId;
+    private String userId;
+    private String externalId;
+    private DateTime enrolledOn;
+    private DateTime withdrawnOn;
+    private String enrolledBy;
+    private String withdrawnBy;
+    private String withdrawalNote;
+    private boolean consentRequired;
+
+    public String getAppId() {
+        return appId;
+    }
+    public void setAppId(String appId) {
+        this.appId = appId;
+    }
+    public String getStudyId() {
+        return studyId;
+    }
+    public void setStudyId(String studyId) {
+        this.studyId = studyId;
+    }
+    public String getUserId() {
+        return userId;
+    }
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+    public String getExternalId() {
+        return externalId;
+    }
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+    public DateTime getEnrolledOn() {
+        return enrolledOn;
+    }
+    public void setEnrolledOn(DateTime enrolledOn) {
+        this.enrolledOn = enrolledOn;
+    }
+    public DateTime getWithdrawnOn() {
+        return withdrawnOn;
+    }
+    public void setWithdrawnOn(DateTime withdrawnOn) {
+        this.withdrawnOn = withdrawnOn;
+    }
+    public String getEnrolledBy() {
+        return enrolledBy;
+    }
+    public void setEnrolledBy(String enrolledBy) {
+        this.enrolledBy = enrolledBy;
+    }
+    public String getWithdrawnBy() {
+        return withdrawnBy;
+    }
+    public void setWithdrawnBy(String withdrawnBy) {
+        this.withdrawnBy = withdrawnBy;
+    }
+    public String getWithdrawalNote() {
+        return withdrawalNote;
+    }
+    public void setWithdrawalNote(String withdrawalNote) {
+        this.withdrawalNote = withdrawalNote;
+    }
+    public boolean isConsentRequired() {
+        return consentRequired;
+    }
+    public void setConsentRequired(boolean consentRequired) {
+        this.consentRequired = consentRequired;
+    }
+    
+    public Enrollment asEnrollment() {
+        Enrollment enrollment = Enrollment.create(appId, studyId, userId, externalId);
+        enrollment.setEnrolledBy(enrolledBy);
+        enrollment.setEnrolledOn(enrolledOn);
+        enrollment.setWithdrawnBy(withdrawnBy);
+        enrollment.setWithdrawnOn(withdrawnOn);
+        enrollment.setWithdrawalNote(withdrawalNote);
+        enrollment.setConsentRequired(consentRequired);
+        return enrollment;
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentController.java
@@ -1,8 +1,15 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 import static org.sagebionetworks.bridge.AuthEvaluatorField.STUDY_ID;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_STUDY_PARTICIPANTS;
 import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
+import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
+
+import java.util.List;
+
+import com.fasterxml.jackson.core.type.TypeReference;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -16,11 +23,16 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.PagedResourceList;
+import org.sagebionetworks.bridge.models.StatusMessage;
+import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.Enrollment;
 import org.sagebionetworks.bridge.models.studies.EnrollmentDetail;
 import org.sagebionetworks.bridge.models.studies.EnrollmentFilter;
+import org.sagebionetworks.bridge.models.studies.EnrollmentMigration;
 import org.sagebionetworks.bridge.services.EnrollmentService;
 
 @CrossOrigin
@@ -79,4 +91,36 @@ public class EnrollmentController extends BaseController {
         
         return service.unenroll(enrollment);
     }
+    
+    @GetMapping("/v3/participants/{userId}/enrollments")
+    public List<EnrollmentMigration> getUserEnrollments(@PathVariable String userId) {
+        UserSession session = getAuthenticatedSession(SUPERADMIN);
+        
+        AccountId accountId = BridgeUtils.parseAccountId(session.getAppId(), userId);
+        
+        Account account = accountService.getAccount(accountId);
+        if (account == null) {
+            throw new EntityNotFoundException(Account.class);
+        }
+        return account.getEnrollments().stream()
+                .map(EnrollmentMigration::create).collect(toList());
+    }
+    
+    @PostMapping("/v3/participants/{userId}/enrollments")
+    public StatusMessage updateUserEnrollments(@PathVariable String userId) {
+        UserSession session = getAuthenticatedSession(SUPERADMIN);
+        
+        List<EnrollmentMigration> migrations = parseJson(new TypeReference<List<EnrollmentMigration>>() {});
+        
+        AccountId accountId = BridgeUtils.parseAccountId(session.getAppId(), userId);
+        Account acct = accountService.getAccount(accountId);
+        if (acct == null) {
+            throw new EntityNotFoundException(Account.class);
+        }
+        accountService.editAccount(session.getAppId(), acct.getHealthCode(), (account) -> {
+            account.getEnrollments().clear();
+            account.getEnrollments().addAll(migrations.stream().map(m -> m.asEnrollment()).collect(toSet()));
+        });
+        return new StatusMessage("Enrollments updated.");
+    }    
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/studies/EnrollmentMigrationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/studies/EnrollmentMigrationTest.java
@@ -1,0 +1,58 @@
+package org.sagebionetworks.bridge.models.studies;
+
+import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
+import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
+import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+public class EnrollmentMigrationTest {
+    
+    @Test
+    public void test() throws Exception {
+        EnrollmentMigration enrollment = new EnrollmentMigration(); 
+        enrollment.setAppId(TEST_APP_ID);
+        enrollment.setStudyId(TEST_STUDY_ID);
+        enrollment.setUserId(TEST_USER_ID);
+        enrollment.setExternalId("externalId");
+        enrollment.setEnrolledOn(CREATED_ON);
+        enrollment.setWithdrawnOn(MODIFIED_ON);
+        enrollment.setEnrolledBy("enrolledBy");
+        enrollment.setWithdrawnBy("withdrawnBy");
+        enrollment.setWithdrawalNote("withdrawalNote");
+        enrollment.setConsentRequired(true);
+        
+        String json = BridgeObjectMapper.get().writeValueAsString(enrollment);
+        EnrollmentMigration em = BridgeObjectMapper.get().readValue(json, EnrollmentMigration.class);
+        
+        assertEquals(em.getAppId(), TEST_APP_ID);
+        assertEquals(em.getStudyId(), TEST_STUDY_ID);
+        assertEquals(em.getUserId(), TEST_USER_ID);
+        assertEquals(em.getExternalId(), "externalId");
+        assertEquals(em.getEnrolledOn(), CREATED_ON);
+        assertEquals(em.getWithdrawnOn(), MODIFIED_ON);
+        assertEquals(em.getEnrolledBy(), "enrolledBy");
+        assertEquals(em.getWithdrawnBy(), "withdrawnBy");
+        assertEquals(em.getWithdrawalNote(), "withdrawalNote");
+        assertTrue(em.isConsentRequired());
+        
+        Enrollment en = em.asEnrollment();
+        assertEquals(en.getAppId(), TEST_APP_ID);
+        assertEquals(en.getStudyId(), TEST_STUDY_ID);
+        assertEquals(en.getAccountId(), TEST_USER_ID);
+        assertEquals(en.getExternalId(), "externalId");
+        assertEquals(en.getEnrolledOn(), CREATED_ON);
+        assertEquals(en.getWithdrawnOn(), MODIFIED_ON);
+        assertEquals(en.getEnrolledBy(), "enrolledBy");
+        assertEquals(en.getWithdrawnBy(), "withdrawnBy");
+        assertEquals(en.getWithdrawalNote(), "withdrawalNote");
+        assertTrue(en.isConsentRequired());
+    }
+
+}

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentControllerTest.java
@@ -1,8 +1,11 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
+import static java.util.stream.Collectors.toSet;
 import static org.sagebionetworks.bridge.RequestContext.NULL_INSTANCE;
 import static org.sagebionetworks.bridge.Roles.STUDY_COORDINATOR;
+import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
 import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
+import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
@@ -10,16 +13,22 @@ import static org.sagebionetworks.bridge.TestUtils.assertCreate;
 import static org.sagebionetworks.bridge.TestUtils.assertCrossOrigin;
 import static org.sagebionetworks.bridge.TestUtils.assertDelete;
 import static org.sagebionetworks.bridge.TestUtils.assertGet;
+import static org.sagebionetworks.bridge.TestUtils.mockEditAccount;
+import static org.sagebionetworks.bridge.TestUtils.mockRequestBody;
 import static org.sagebionetworks.bridge.models.studies.EnrollmentFilter.ENROLLED;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -34,11 +43,17 @@ import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.hibernate.HibernateEnrollment;
 import org.sagebionetworks.bridge.models.PagedResourceList;
+import org.sagebionetworks.bridge.models.StatusMessage;
+import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.Enrollment;
 import org.sagebionetworks.bridge.models.studies.EnrollmentDetail;
+import org.sagebionetworks.bridge.models.studies.EnrollmentMigration;
+import org.sagebionetworks.bridge.services.AccountService;
 import org.sagebionetworks.bridge.services.EnrollmentService;
 
 public class EnrollmentControllerTest extends Mockito {
@@ -158,4 +173,120 @@ public class EnrollmentControllerTest extends Mockito {
         assertEquals(value.getStudyId(), TEST_STUDY_ID);
         assertEquals(value.getAccountId(), TEST_USER_ID);
     }
+    
+    @Test
+    public void getUserEnrollments() throws Exception {
+        UserSession session = new UserSession();
+        session.setAppId(TEST_APP_ID);
+        doReturn(session).when(controller).getAuthenticatedSession(SUPERADMIN);
+        
+        AccountId accountId = AccountId.forId(TEST_APP_ID, TEST_USER_ID);
+        
+        AccountService mockAccountService = mock(AccountService.class);
+        controller.setAccountService(mockAccountService);
+        
+        Account account = Account.create();
+        Enrollment en1 = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID, "externalId");
+        Enrollment en2 = Enrollment.create(TEST_APP_ID, "anotherStudy", TEST_USER_ID);
+        en2.setConsentRequired(true);
+        en2.setEnrolledOn(CREATED_ON);
+        en2.setWithdrawnOn(MODIFIED_ON);
+        en2.setEnrolledBy("enrolledBy");
+        en2.setWithdrawnBy("withdrawnBy");
+        en2.setWithdrawalNote("withdrawal note");
+        account.setEnrollments(ImmutableSet.of(en1, en2));
+        when(mockAccountService.getAccount(accountId)).thenReturn(account);
+        
+        List<EnrollmentMigration> returnValue = controller.getUserEnrollments(TEST_USER_ID);
+        assertEquals(returnValue.size(), 2);
+        assertEquals(returnValue.stream().map(m -> m.getStudyId()).collect(toSet()), 
+                ImmutableSet.of(TEST_STUDY_ID, "anotherStudy"));
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void getUserEnrollmentsAccountNotFound() throws Exception {
+        UserSession session = new UserSession();
+        session.setAppId(TEST_APP_ID);
+        doReturn(session).when(controller).getAuthenticatedSession(SUPERADMIN);
+        
+        AccountService mockAccountService = mock(AccountService.class);
+        controller.setAccountService(mockAccountService);
+        
+        when(mockAccountService.getAccount(any())).thenReturn(null);
+        
+        controller.getUserEnrollments(TEST_USER_ID);
+    }
+    
+    @Test
+    public void updateUserEnrollments() throws Exception {
+        UserSession session = new UserSession();
+        session.setAppId(TEST_APP_ID);
+        doReturn(session).when(controller).getAuthenticatedSession(SUPERADMIN);
+
+        Enrollment newEnrollment = Enrollment.create(TEST_APP_ID, "anotherStudy", TEST_USER_ID);
+        mockRequestBody(mockRequest, ImmutableSet.of(EnrollmentMigration.create(newEnrollment)));
+        
+        AccountId accountId = AccountId.forHealthCode(TEST_APP_ID, TEST_USER_ID);
+        
+        AccountService mockAccountService = mock(AccountService.class);
+        controller.setAccountService(mockAccountService);
+        
+        Account mockAccount = mock(Account.class);
+        Enrollment en1 = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID, "externalId");
+        Set<Enrollment> enrollments = Sets.newHashSet(en1);
+        when(mockAccount.getEnrollments()).thenReturn(enrollments);
+        when(mockAccountService.getAccount(accountId)).thenReturn(mockAccount);
+        
+        mockEditAccount(mockAccountService, mockAccount);
+        
+        StatusMessage message = controller.updateUserEnrollments("healthcode:" + TEST_USER_ID);
+        assertEquals(message.getMessage(), "Enrollments updated.");
+        
+        verify(mockAccount, times(2)).getEnrollments();
+        assertEquals(enrollments.size(), 1);
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void updateUserEnrollmentsAccountNotFound() throws Exception {
+        UserSession session = new UserSession();
+        session.setAppId(TEST_APP_ID);
+        doReturn(session).when(controller).getAuthenticatedSession(SUPERADMIN);
+
+        Enrollment newEnrollment = Enrollment.create(TEST_APP_ID, "anotherStudy", TEST_USER_ID);
+        mockRequestBody(mockRequest, ImmutableSet.of(EnrollmentMigration.create(newEnrollment)));
+        
+        AccountService mockAccountService = mock(AccountService.class);
+        controller.setAccountService(mockAccountService);
+        
+        when(mockAccountService.getAccount(any())).thenReturn(null);
+        
+        controller.updateUserEnrollments(TEST_USER_ID);
+    }
+    
+    @Test
+    public void updateUserEnrollmentsRemovingAll() throws Exception {
+        UserSession session = new UserSession();
+        session.setAppId(TEST_APP_ID);
+        doReturn(session).when(controller).getAuthenticatedSession(SUPERADMIN);
+
+        mockRequestBody(mockRequest, ImmutableSet.of());
+        
+        AccountId accountId = AccountId.forHealthCode(TEST_APP_ID, TEST_USER_ID);
+        
+        AccountService mockAccountService = mock(AccountService.class);
+        controller.setAccountService(mockAccountService);
+        
+        Account mockAccount = mock(Account.class);
+        Enrollment en1 = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID, "externalId");
+        Set<Enrollment> enrollments = Sets.newHashSet(en1);
+        when(mockAccount.getEnrollments()).thenReturn(enrollments);
+        when(mockAccountService.getAccount(accountId)).thenReturn(mockAccount);
+        
+        mockEditAccount(mockAccountService, mockAccount);
+        
+        controller.updateUserEnrollments("healthcode:" + TEST_USER_ID);
+        
+        verify(mockAccount, times(2)).getEnrollments();
+        assertTrue(enrollments.isEmpty());
+    }    
 }


### PR DESCRIPTION
These were previously reviewed and used successfully to migrate most of our production apps...but we missed one case where there was an implicit study that needs to be made explicit and backfilled. So I'm going to merge to fix this today.