### PR TITLE
Add mimeType validation

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/validators/ParticipantFileValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/ParticipantFileValidator.java
@@ -27,5 +27,8 @@ public class ParticipantFileValidator implements Validator {
         if (StringUtils.isBlank(file.getAppId())) {
             errors.rejectValue("appId", "is required");
         }
+        if (StringUtils.isBlank(file.getMimeType())) {
+            errors.rejectValue("mimeType", "is required");
+        }
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/validators/ParticipantFileValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/ParticipantFileValidatorTest.java
@@ -23,6 +23,8 @@ public class ParticipantFileValidatorTest {
     public void fileIdRequired() {
         ParticipantFile file = ParticipantFile.create();
         file.setUserId("user");
+        file.setMimeType("dummy");
+        file.setAppId("api");
 
         assertValidatorMessage(INSTANCE, file, "fileId", "is required");
     }
@@ -32,6 +34,7 @@ public class ParticipantFileValidatorTest {
         ParticipantFile file = ParticipantFile.create();
         file.setUserId("user");
         file.setFileId("file");
+        file.setMimeType("dummy");
 
         assertValidatorMessage(INSTANCE, file, "appId", "is required");
     }
@@ -40,8 +43,19 @@ public class ParticipantFileValidatorTest {
     public void userIdRequired() {
         ParticipantFile file = ParticipantFile.create();
         file.setFileId("file");
+        file.setMimeType("dummy");
         file.setAppId("api");
 
         assertValidatorMessage(INSTANCE, file, "userId", "is required");
+    }
+    
+    @Test
+    public void mimeTypeRequired() {
+        ParticipantFile file = ParticipantFile.create();
+        file.setUserId("user");
+        file.setFileId("file");
+        file.setAppId("api");
+
+        assertValidatorMessage(INSTANCE, file, "mimeType", "is required");
     }
 }


### PR DESCRIPTION
Mime type is not required when you create a file, but then later your presigned URL will not be correct and you'll never be able to download the file again. So, require the mime type when creating a file handle for upload.