### PR TITLE
Study additions

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
@@ -41,7 +41,8 @@ public class AuthUtils {
             .hasAnyRole(ADMIN);
     
     /**
-     * Can the caller and/remove organization members? Must be the organizations's admin.
+     * Can the caller and/remove organization members? Must be the organizations's admin. Note 
+     * that this check is currently also used for sponsors...which are not members.
      */
     public static final AuthEvaluator CAN_EDIT_MEMBERS = new AuthEvaluator()
             .isInOrg().hasAnyRole(ORG_ADMIN).or()
@@ -105,7 +106,7 @@ public class AuthUtils {
      */
     public static final AuthEvaluator CAN_READ_STUDIES = new AuthEvaluator()
             .canAccessStudy().hasAnyRole(STUDY_COORDINATOR, ORG_ADMIN).or()
-            .hasAnyRole(ADMIN);
+            .hasAnyRole(DEVELOPER, ADMIN);
     
     /**
      * Can the caller edit studies? Caller must be a study coordinator, or a developer.

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudy.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudy.java
@@ -47,11 +47,12 @@ public class HibernateStudy implements Study {
     /**
      * For partial construction of object by Hibernate, excluding expensive fields like clientData.
      */
-    public HibernateStudy(String name, String identifier, String appId, boolean deleted) {
+    public HibernateStudy(String name, String identifier, String appId, boolean deleted, Long version) {
         this.name = name;
         this.identifier = identifier;
         this.appId = appId;
         this.deleted = deleted;
+        this.version = version;
     }
     
     @Override

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudyDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudyDao.java
@@ -24,7 +24,7 @@ public class HibernateStudyDao implements StudyDao {
     
     static final String COUNT_PHRASE = "select count(*) ";
     static final String SELECT_PHRASE = "select new org.sagebionetworks.bridge.hibernate."
-            + "HibernateStudy(study.name, study.identifier, study.appId, study.deleted) ";
+            + "HibernateStudy(study.name, study.identifier, study.appId, study.deleted, study.version) ";
     static final String FROM_PHRASE = "from HibernateStudy as study where appId = :appId"; 
     
     private HibernateHelper hibernateHelper;
@@ -41,7 +41,7 @@ public class HibernateStudyDao implements StudyDao {
         
         QueryBuilder builder = new QueryBuilder();
         builder.append(FROM_PHRASE, "appId", appId);
-        if (studyIds != null && !studyIds.isEmpty()) {
+        if (studyIds != null) {
             builder.append("and identifier in (:studies)", "studies", studyIds);
         }
         if (!includeDeleted) {

--- a/src/main/java/org/sagebionetworks/bridge/services/SponsorService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/SponsorService.java
@@ -137,6 +137,19 @@ public class SponsorService {
         cacheProvider.removeObject( CacheKey.orgSponsoredStudies(appId, orgId) );
     }
 
+    /**
+     * Similar to adding a sponsor to a study, but this is done without further security
+     * checks as part of study creation.
+     */
+    public void createStudyWithSponsorship(String appId, String studyId, String orgId) {
+        checkNotNull(appId);
+        checkNotNull(studyId);
+        checkNotNull(orgId);
+        
+        sponsorDao.addStudySponsor(appId, studyId, orgId);
+        cacheProvider.removeObject( CacheKey.orgSponsoredStudies(appId, orgId) );
+    }
+    
     public void removeStudySponsor(String appId, String studyId, String orgId) {
         checkNotNull(appId);
         checkNotNull(studyId);

--- a/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
@@ -118,11 +118,11 @@ public class StudyService {
         VersionHolder version = studyDao.createStudy(study);
         // You cannot do this when creating an app because it will fail: the caller's organization will not 
         // yet exist. After initial app creation when accounts are established in the app, it should be 
-        // possible to create studies that are associated to the caller's organization (so the caller can 
-        // access the study!).
+        // possible to create studies that are associated to the caller's organization (so the study 
+        // creator can access the study!).
         String orgId = RequestContext.get().getCallerOrgMembership();
         if (setStudySponsor && orgId != null) {
-            sponsorService.addStudySponsor(appId, study.getIdentifier(), orgId);    
+            sponsorService.createStudyWithSponsorship(appId, study.getIdentifier(), orgId);    
         }
         return version;
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AccountsController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AccountsController.java
@@ -5,6 +5,7 @@ import static org.sagebionetworks.bridge.AuthEvaluatorField.USER_ID;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_ACCOUNTS;
 import static org.sagebionetworks.bridge.BridgeUtils.parseAccountId;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
+import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.ORG_ADMIN;
 import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
 import static org.sagebionetworks.bridge.models.RequestInfo.REQUEST_INFO_WRITER;
@@ -100,14 +101,14 @@ public class AccountsController extends BaseController  {
     
     @GetMapping("/v1/accounts/{userId}")
     public Account getAccount(@PathVariable String userId) {
-        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
         
         return verifyOrgAdminIsActingOnOrgMember(session, userId);
     }
     
     @PostMapping("/v1/accounts/{userId}")
     public StatusMessage updateAccount(@PathVariable String userId) {
-        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
         
         Account account = verifyOrgAdminIsActingOnOrgMember(session, userId);
         App app = appService.getApp(session.getAppId());
@@ -144,7 +145,7 @@ public class AccountsController extends BaseController  {
             produces = { APPLICATION_JSON_UTF8_VALUE })
     public String getRequestInfo(@PathVariable String userId) 
             throws JsonProcessingException {
-        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
         
         verifyOrgAdminIsActingOnOrgMember(session, userId);
         
@@ -160,7 +161,7 @@ public class AccountsController extends BaseController  {
     @PostMapping("/v1/accounts/{userId}/requestResetPassword")
     @ResponseStatus(code = ACCEPTED)
     public StatusMessage requestResetPassword(@PathVariable String userId) {
-        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
         
         verifyOrgAdminIsActingOnOrgMember(session, userId);
 
@@ -173,7 +174,7 @@ public class AccountsController extends BaseController  {
     @PostMapping("/v1/accounts/{userId}/resendEmailVerification")
     @ResponseStatus(code = ACCEPTED)
     public StatusMessage resendEmailVerification(@PathVariable String userId) {
-        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
         
         verifyOrgAdminIsActingOnOrgMember(session, userId);
 
@@ -186,7 +187,7 @@ public class AccountsController extends BaseController  {
     @PostMapping("/v1/accounts/{userId}/resendPhoneVerification")
     @ResponseStatus(code = ACCEPTED)
     public StatusMessage resendPhoneVerification(@PathVariable String userId) {
-        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
         
         verifyOrgAdminIsActingOnOrgMember(session, userId);
 
@@ -214,7 +215,7 @@ public class AccountsController extends BaseController  {
     @PostMapping("/v1/accounts/{userId}/signOut")
     public StatusMessage signOut(@PathVariable String userId,
             @RequestParam(required = false) boolean deleteReauthToken) {
-        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
         
         verifyOrgAdminIsActingOnOrgMember(session, userId);
 

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AccountsController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AccountsController.java
@@ -101,14 +101,14 @@ public class AccountsController extends BaseController  {
     
     @GetMapping("/v1/accounts/{userId}")
     public Account getAccount(@PathVariable String userId) {
-        UserSession session = getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
         
         return verifyOrgAdminIsActingOnOrgMember(session, userId);
     }
     
     @PostMapping("/v1/accounts/{userId}")
     public StatusMessage updateAccount(@PathVariable String userId) {
-        UserSession session = getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
         
         Account account = verifyOrgAdminIsActingOnOrgMember(session, userId);
         App app = appService.getApp(session.getAppId());
@@ -145,7 +145,7 @@ public class AccountsController extends BaseController  {
             produces = { APPLICATION_JSON_UTF8_VALUE })
     public String getRequestInfo(@PathVariable String userId) 
             throws JsonProcessingException {
-        UserSession session = getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
         
         verifyOrgAdminIsActingOnOrgMember(session, userId);
         
@@ -161,7 +161,7 @@ public class AccountsController extends BaseController  {
     @PostMapping("/v1/accounts/{userId}/requestResetPassword")
     @ResponseStatus(code = ACCEPTED)
     public StatusMessage requestResetPassword(@PathVariable String userId) {
-        UserSession session = getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
         
         verifyOrgAdminIsActingOnOrgMember(session, userId);
 
@@ -174,7 +174,7 @@ public class AccountsController extends BaseController  {
     @PostMapping("/v1/accounts/{userId}/resendEmailVerification")
     @ResponseStatus(code = ACCEPTED)
     public StatusMessage resendEmailVerification(@PathVariable String userId) {
-        UserSession session = getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
         
         verifyOrgAdminIsActingOnOrgMember(session, userId);
 
@@ -187,7 +187,7 @@ public class AccountsController extends BaseController  {
     @PostMapping("/v1/accounts/{userId}/resendPhoneVerification")
     @ResponseStatus(code = ACCEPTED)
     public StatusMessage resendPhoneVerification(@PathVariable String userId) {
-        UserSession session = getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
         
         verifyOrgAdminIsActingOnOrgMember(session, userId);
 
@@ -215,7 +215,7 @@ public class AccountsController extends BaseController  {
     @PostMapping("/v1/accounts/{userId}/signOut")
     public StatusMessage signOut(@PathVariable String userId,
             @RequestParam(required = false) boolean deleteReauthToken) {
-        UserSession session = getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
         
         verifyOrgAdminIsActingOnOrgMember(session, userId);
 

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
@@ -180,7 +180,8 @@ public class ParticipantController extends BaseController {
     
     @GetMapping("/v3/participants/{userId}/enrollments")
     public PagedResourceList<EnrollmentDetail> getEnrollments(@PathVariable String userId) {
-        UserSession session = getAuthenticatedSession(false, RESEARCHER);
+        UserSession session = getAdministrativeSession();
+        CAN_EDIT_PARTICIPANTS.checkAndThrow(USER_ID, userId);
         
         // A limitation of Swagger as we use it is that we don't want different collection
         // containers for the same kind of entity. Since some APIs can page enrollments, 
@@ -334,7 +335,8 @@ public class ParticipantController extends BaseController {
     @GetMapping(path="/v3/participants/{userId}", produces={APPLICATION_JSON_UTF8_VALUE})
     public String getParticipant(@PathVariable String userId, @RequestParam(defaultValue = "true") boolean consents)
             throws Exception {
-        UserSession session = getAuthenticatedSession(RESEARCHER);
+        UserSession session = getAdministrativeSession();
+        CAN_EDIT_PARTICIPANTS.checkAndThrow(USER_ID, userId);
 
         App app = appService.getApp(session.getAppId());
 

--- a/src/test/java/org/sagebionetworks/bridge/services/SponsorServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/SponsorServiceTest.java
@@ -181,6 +181,14 @@ public class SponsorServiceTest extends Mockito {
     }
     
     @Test
+    public void createStudyWithSponsorship() {
+        service.createStudyWithSponsorship(TEST_APP_ID, TEST_STUDY_ID, TEST_ORG_ID);
+        
+        verify(mockSponsorDao).addStudySponsor(TEST_APP_ID, TEST_STUDY_ID, TEST_ORG_ID);
+        verify(mockCacheProvider).removeObject( CacheKey.orgSponsoredStudies(TEST_APP_ID, TEST_ORG_ID) );
+    }
+    
+    @Test
     public void removeStudySponsorAsAdmin() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());

--- a/src/test/java/org/sagebionetworks/bridge/services/StudyServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/StudyServiceTest.java
@@ -226,7 +226,7 @@ public class StudyServiceTest {
         assertNotEquals(persisted.getCreatedOn(), timestamp);
         assertNotEquals(persisted.getModifiedOn(), timestamp);
         
-        verify(sponsorService).addStudySponsor(TEST_APP_ID, "oneId", TEST_ORG_ID);
+        verify(sponsorService).createStudyWithSponsorship(TEST_APP_ID, "oneId", TEST_ORG_ID);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/StudyServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/StudyServiceTest.java
@@ -180,6 +180,22 @@ public class StudyServiceTest {
     }
     
     @Test
+    public void getStudiesScopesSearchForScopedRolesWhenTheyAreNull() {
+        Set<String> studies = ImmutableSet.of();
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
+                .withOrgSponsoredStudies(studies)
+                .build());
+        
+        when(studyDao.getStudies(TEST_APP_ID, studies, null, null, false))
+            .thenReturn(new PagedResourceList<>(ImmutableList.of(), 0));
+
+        service.getStudies(TEST_APP_ID, null, null, false);
+    
+        verify(studyDao).getStudies(TEST_APP_ID, studies, null, null, false);
+    }
+    
+    @Test
     public void getStudiesDoesNotScopeSearchForUnscopedRoles() {
         Set<String> studies = ImmutableSet.of("studyA", "studyB");
         RequestContext.set(new RequestContext.Builder()

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AccountsControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AccountsControllerTest.java
@@ -2,7 +2,6 @@ package org.sagebionetworks.bridge.spring.controllers;
 
 import static org.sagebionetworks.bridge.RequestContext.NULL_INSTANCE;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
-import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.ORG_ADMIN;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
@@ -212,7 +211,7 @@ public class AccountsControllerTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
         
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
@@ -226,7 +225,7 @@ public class AccountsControllerTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
         
         session.setParticipant(new StudyParticipant.Builder().withOrgMembership(TEST_ORG_ID).build());
         
@@ -278,7 +277,7 @@ public class AccountsControllerTest extends Mockito {
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
         
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
@@ -296,7 +295,7 @@ public class AccountsControllerTest extends Mockito {
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
         
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
@@ -314,7 +313,7 @@ public class AccountsControllerTest extends Mockito {
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
         
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
@@ -331,7 +330,7 @@ public class AccountsControllerTest extends Mockito {
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
         
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
@@ -347,7 +346,7 @@ public class AccountsControllerTest extends Mockito {
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
         
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
@@ -363,7 +362,7 @@ public class AccountsControllerTest extends Mockito {
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
         
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AccountsControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AccountsControllerTest.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.spring.controllers;
 
 import static org.sagebionetworks.bridge.RequestContext.NULL_INSTANCE;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
+import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.ORG_ADMIN;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
@@ -211,7 +212,7 @@ public class AccountsControllerTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
-        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
         
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
@@ -225,7 +226,7 @@ public class AccountsControllerTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
-        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
         
         session.setParticipant(new StudyParticipant.Builder().withOrgMembership(TEST_ORG_ID).build());
         
@@ -277,7 +278,7 @@ public class AccountsControllerTest extends Mockito {
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         
-        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
         
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
@@ -295,7 +296,7 @@ public class AccountsControllerTest extends Mockito {
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         
-        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
         
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
@@ -313,7 +314,7 @@ public class AccountsControllerTest extends Mockito {
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         
-        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
         
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
@@ -330,7 +331,7 @@ public class AccountsControllerTest extends Mockito {
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         
-        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
         
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
@@ -346,7 +347,7 @@ public class AccountsControllerTest extends Mockito {
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         
-        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
         
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);
@@ -362,7 +363,7 @@ public class AccountsControllerTest extends Mockito {
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         
-        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ORG_ADMIN, ADMIN);
         
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(account);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
@@ -44,6 +44,7 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.HashMap;
 import java.util.List;
@@ -407,6 +408,14 @@ public class ParticipantControllerTest extends Mockito {
         assertFalse(node.has("encryptedHealthCode"));
 
         verify(mockParticipantService).getParticipant(app, "aUser", true);
+    }
+    
+    @Test(expectedExceptions = UnauthorizedException.class)
+    public void getParticipantDeveloperIsNotSelf() throws Exception {
+        session.setParticipant(new StudyParticipant.Builder().copyOf(session.getParticipant())
+                .withRoles(ImmutableSet.of(DEVELOPER)).build());
+
+        controller.getParticipant("aUser", true);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
@@ -44,7 +44,6 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 import java.util.HashMap;
 import java.util.List;


### PR DESCRIPTION
Some security-related tweaks based on manual testing in the Bridge Study Manager and our evolving discussions about security roles on the Bridge Server as we implement MTB.

- developers can edit studies, so they should be able to read studies (added this permission);
- if you don't include the version attribute in the summary study objects, you can't submit them to logically delete from BSM's summary/list view (so I've added that field);
- if you are a user who unfortunately is not associated to any studies, then you should see _no_ studies, not _all_ studies, so there is a difference in the check between a null set of studies and an empty set of studies (fixed this);
- developers/study developers can create new studies, at least for now. They therefore need these studies to be sponsored by their organizations, but a security check prevented devs from changing sponsorship relationships (now fixed);
- opened a couple of more endpoints for participants to be accessible to developers as long as they are operating on their own account. This is currently our support for testing...we create an account for a developer and then they use it to enroll, and they can see what is going on with the account as a participant. We need more to get people off of the researcher role, but this is at least working for now. 