### PR TITLE
Support the 'externalId' field on sign up where an account doesn't already exist

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -8,6 +8,13 @@ import static org.sagebionetworks.bridge.models.accounts.AccountSecretType.REAUT
 import static org.sagebionetworks.bridge.services.AuthenticationService.ChannelType.EMAIL;
 import static org.sagebionetworks.bridge.services.AuthenticationService.ChannelType.PHONE;
 
+import java.util.Set;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+
 import org.apache.commons.lang3.StringUtils;
 
 import org.sagebionetworks.bridge.BridgeUtils;
@@ -55,7 +62,7 @@ import org.springframework.validation.Validator;
 @Component("authenticationService")
 public class AuthenticationService {
     private static final Logger LOG = LoggerFactory.getLogger(AuthenticationService.class);
-
+    
     static final int SIGNIN_GRACE_PERIOD_SECONDS = 5*60; // 5 min
 
     public enum ChannelType {
@@ -75,6 +82,7 @@ public class AuthenticationService {
     private AccountSecretDao accountSecretDao;
     private OAuthProviderService oauthProviderService;
     private SponsorService sponsorService;
+    private StudyService studyService;
     
     @Autowired
     final void setCacheProvider(CacheProvider cache) {
@@ -124,6 +132,10 @@ public class AuthenticationService {
     @Autowired
     final void setSponsorService(SponsorService sponsorService) {
         this.sponsorService = sponsorService;
+    }
+    @Autowired
+    final void setStudyService(StudyService studyService) {
+        this.studyService = studyService;
     }
     
     /**
@@ -263,6 +275,23 @@ public class AuthenticationService {
         checkNotNull(app);
         checkNotNull(participant);
         
+        // Code to maintain apps in production. External IDs must now be associated to a study 
+        // because they explicitly enroll you in a study. Payloads with an externalId field but
+        // no externalIds map are not declaring a study.
+        if (participant.getExternalId() != null && participant.getExternalIds().isEmpty()) {
+            // For apps that create accounts prior to calling sign up from the app (which happens), check and if 
+            // the account with this external ID already exists, return quietly.
+            AccountId accountId = AccountId.forExternalId(app.getIdentifier(), participant.getExternalId());
+            Account account = accountService.getAccount(accountId); 
+            if (account != null) {
+                return new IdentifierHolder(account.getId());
+            }
+            // Or, they are calling signup with an external ID and a password, but no study. Try to guess
+            // a reasonable default. If we can't the participant is returned as is and will fail validation
+            // (but all production apps we can guess a reasonable default).
+            participant = findDefaultStudyForExternalId(app, participant);
+        }
+        
         try {
             // This call is exposed without authentication, so the request context has no roles, and no roles 
             // can be assigned to this user.
@@ -289,6 +318,42 @@ public class AuthenticationService {
             accountWorkflowService.notifyAccountExists(app, accountId);
             return null;
         }
+    }
+    
+    /**
+     * The StudyParticipant has been submitted to signUp using the externalId field (only). The issue is that 
+     * we must know what study this external ID enrolls them in. Attempt to infer it for several studies that 
+     * are submitting production accounts in this manner.
+     */
+    protected StudyParticipant findDefaultStudyForExternalId(App app, StudyParticipant participant) {
+        Set<String> studyIds = studyService.getStudyIds(app.getIdentifier());
+        String studyId = null;
+        
+        // Psorcast Validation has one study named "test", so use it if it’s all there is 
+        if (studyIds.size() == 1) {
+            studyId = Iterables.getFirst(studyIds, null);
+        } else {
+            // PKU Study and FPHS Lab want to use the *other* of two studies that's not the test study. Remove 
+            // "test" and in these cases, they have one remaining study. That’s all the studies using this 
+            // format, but if someone adds a further study, we will not break...but the study we take is no 
+            // longer determinant. So log it for follow-up.
+            studyIds = Sets.difference(studyIds, ImmutableSet.of("test"));
+            studyId = Iterables.getFirst(studyIds, null);
+            if (studyIds.size() != 1) {
+                // There's a client that is not using the new API, but is adding studies to their app.
+                LOG.info("StudyParticipant created in app '" + app.getIdentifier() + "' with an externalId that "
+                        + "has no study, assigning externalId " + participant.getExternalId() + " to study " + studyId);
+            }
+        }
+        // Fix the participant record so they are property enrolled if we found a studyId. For an app with no 
+        // studies could be null. It’s impossible to add an external ID in that case (I added a study to every
+        // app in an earlier migration).
+        if (studyId != null) {
+            return new StudyParticipant.Builder().copyOf(participant)
+                    .withExternalIds(ImmutableMap.of(studyId, participant.getExternalId()))
+                    .build();
+        }
+        return participant;
     }
 
     public void verifyChannel(ChannelType type, Verification verification) {

--- a/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
@@ -140,7 +140,7 @@ public class EnrollmentService {
         return newEnrollment;
     }
     
-    public void updateEnrollment(Account account, Enrollment newEnrollment, Enrollment existingEnrollment) {
+    private void updateEnrollment(Account account, Enrollment newEnrollment, Enrollment existingEnrollment) {
         existingEnrollment.setWithdrawnOn(null);
         existingEnrollment.setWithdrawnBy(null);
         existingEnrollment.setWithdrawalNote(null);

--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -412,17 +412,6 @@ public class ParticipantService {
             throwExceptionIfLimitMetOrExceeded(app);
         }
         
-        // Fix for callers that include only externalId and not the new externalId map: in these cases, tools are 
-        // creating the participant before the sign up call (through the Bridge Study Manager). Check and if 
-        // the account with this external ID already exists, return quietly. Otherwise proceed as before.
-        if (participant.getExternalId() != null && participant.getExternalIds().isEmpty()) {
-            AccountId accountId = AccountId.forExternalId(app.getIdentifier(), participant.getExternalId());
-            Account account = accountService.getAccount(accountId); 
-            if (account != null) {
-                return new IdentifierHolder(account.getId());
-            }
-        }
-        
         StudyParticipantValidator validator = new StudyParticipantValidator(studyService, organizationService, app,
                 true);
         Validate.entityThrowingException(validator, participant);
@@ -498,7 +487,7 @@ public class ParticipantService {
         }
         return new IdentifierHolder(account.getId());
     }
-    
+
     // Provided to override in tests
     protected Account getAccount() {
         return Account.create();
@@ -559,18 +548,16 @@ public class ParticipantService {
        
         RequestContext requestContext = RequestContext.get();
         
-        // You can no longer enroll users or add them to studies through the enrollments table just
-        // by updating the participant account. There are separate APIs for this. HOWEVER we have one 
-        // important exception: accounts that are identifiable only by an external ID. Since an external
-        // ID enrolls you in a study, administrative callers can supply study:externalId mappings 
-        // to enroll such an account at account creation.
-        if (isNew && requestContext.isAdministrator()) {
+        // New accounts to be simultaneously enroll themselves in a study using an external ID.
+        // This isn’t ideal since this is enrolling them but we must support for legacy apps.
+        if (isNew) {
             for (Map.Entry<String, String> entry : participant.getExternalIds().entrySet()) {
                 String studyId = entry.getKey();
                 String externalId = entry.getValue();
                 
                 Enrollment enrollment = Enrollment.create(account.getAppId(), studyId, account.getId(), externalId);
-                enrollmentService.addEnrollment(account, enrollment);
+                enrollmentService.updateEnrollment(account, enrollment, enrollment);
+                account.getEnrollments().add(enrollment);
             }
         }
         

--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -548,8 +548,8 @@ public class ParticipantService {
        
         RequestContext requestContext = RequestContext.get();
         
-        // New accounts to be simultaneously enroll themselves in a study using an external ID.
-        // This isn’t ideal since this is enrolling them but we must support for legacy apps.
+        // New accounts can simultaneously enroll themselves in a study using an external ID.
+        // Legacy apps do this so we must continue to support it.
         if (isNew) {
             for (Map.Entry<String, String> entry : participant.getExternalIds().entrySet()) {
                 String studyId = entry.getKey();

--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -551,13 +551,14 @@ public class ParticipantService {
         // New accounts can simultaneously enroll themselves in a study using an external ID.
         // Legacy apps do this so we must continue to support it.
         if (isNew) {
+            RequestContext.acquireAccountIdentity(account);
+            
             for (Map.Entry<String, String> entry : participant.getExternalIds().entrySet()) {
                 String studyId = entry.getKey();
                 String externalId = entry.getValue();
                 
                 Enrollment enrollment = Enrollment.create(account.getAppId(), studyId, account.getId(), externalId);
-                enrollmentService.updateEnrollment(account, enrollment, enrollment);
-                account.getEnrollments().add(enrollment);
+                enrollmentService.addEnrollment(account, enrollment);
             }
         }
         

--- a/src/main/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandler.java
@@ -53,7 +53,6 @@ public class BridgeExceptionHandler {
     }
 
     private void logException(HttpServletRequest request, Throwable throwable) {
-        throwable.printStackTrace();
         final String requestId = request.getHeader(X_REQUEST_ID_HEADER);
         final String msg = "request: " + requestId + " " + throwable.getMessage();
         if (throwable.getClass().isAnnotationPresent(NoStackTraceException.class)) {

--- a/src/main/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandler.java
@@ -53,6 +53,7 @@ public class BridgeExceptionHandler {
     }
 
     private void logException(HttpServletRequest request, Throwable throwable) {
+        throwable.printStackTrace();
         final String requestId = request.getHeader(X_REQUEST_ID_HEADER);
         final String msg = "request: " + requestId + " " + throwable.getMessage();
         if (throwable.getClass().isAnnotationPresent(NoStackTraceException.class)) {

--- a/src/main/java/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
@@ -91,7 +91,7 @@ public class StudyParticipantValidator implements Validator {
             // External IDs can be updated during creation or on update. If it's already assigned to another user, 
             // the database constraints will prevent this record's persistence.
             if (isNotBlank(participant.getExternalId()) && participant.getExternalIds().isEmpty()) {
-                errors.rejectValue("externalId", "must now be supplied in the externalIds property that maps a study ID to the new external ID");
+                errors.rejectValue("externalId", "must now be supplied in the externalIds property that maps a study ID to the new external ID");    
             }
             if (participant.getExternalIds() != null) {
                 for (Map.Entry<String, String> entry : participant.getExternalIds().entrySet()) {

--- a/src/test/java/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -1608,5 +1608,6 @@ public class AuthenticationServiceTest {
        Map<String,String> map = participantCaptor.getValue().getExternalIds();
        String extId =  map.containsKey("studyA") ? map.get("studyA") : map.get("studyB");
        assertEquals(extId, EXTERNAL_ID);
+       assertFalse(map.keySet().contains("test"));
    }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -78,6 +78,7 @@ import org.sagebionetworks.bridge.models.oauth.OAuthAuthorizationToken;
 import org.sagebionetworks.bridge.models.studies.Enrollment;
 import org.sagebionetworks.bridge.models.accounts.PasswordReset;
 import org.sagebionetworks.bridge.models.accounts.GeneratedPassword;
+import org.sagebionetworks.bridge.models.accounts.IdentifierHolder;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
@@ -171,6 +172,8 @@ public class AuthenticationServiceTest {
     private SponsorService sponsorService;
     @Mock
     private AccountSecretDao accountSecretDao;
+    @Mock 
+    private StudyService studyService;
     @Captor
     private ArgumentCaptor<UserSession> sessionCaptor;
     @Captor
@@ -1502,5 +1505,108 @@ public class AuthenticationServiceTest {
        when(participantService.getParticipant(any(), eq(account), eq(false))).thenReturn(participant);
        
        service.oauthSignIn(CONTEXT, token);
+   }
+   
+   @Test
+   public void signUp_newExternalIdsFormatIgnoresMigrationCode() {
+       StudyParticipant participant = new StudyParticipant.Builder()
+               .withExternalIds(ImmutableMap.of(TEST_APP_ID, "externalId"))
+               .build();
+       
+       service.signUp(app, participant);
+       
+       verify(accountService, never()).getAccount(any());
+       verify(studyService, never()).getStudyIds(TEST_APP_ID);
+   }
+   
+   @Test
+   public void signUp_bothExternalIdFormatsIgnoresMigrationCode() {
+       StudyParticipant participant = new StudyParticipant.Builder()
+               .withExternalId(EXTERNAL_ID)
+               .withExternalIds(ImmutableMap.of(TEST_APP_ID, EXTERNAL_ID))
+               .build();
+       
+       service.signUp(app, participant);
+       
+       verify(accountService, never()).getAccount(any());
+       verify(studyService, never()).getStudyIds(TEST_APP_ID);
+   }
+   
+   @Test
+   public void signIn_oldExternalIdsFormatForExistingAccountReturnsQuietly() {
+       StudyParticipant participant = new StudyParticipant.Builder()
+               .withExternalId(EXTERNAL_ID)
+               .build();
+       
+       AccountId accountId = AccountId.forExternalId(TEST_APP_ID, EXTERNAL_ID);
+       when(accountService.getAccount(accountId)).thenReturn(account);
+       
+       IdentifierHolder retValue = service.signUp(app, participant);
+       assertEquals(retValue.getIdentifier(), USER_ID);
+       
+       verify(accountService).getAccount(accountId);
+       verify(studyService, never()).getStudyIds(TEST_APP_ID);
+       verify(participantService, never()).createParticipant(app, participant, true);
+   }
+   
+   @Test
+   public void signUp_oldExternalIdsFormatOneStudyRemapsToStudy() {
+       StudyParticipant participant = new StudyParticipant.Builder()
+               .withExternalId(EXTERNAL_ID)
+               .build();
+       
+       when(studyService.getStudyIds(TEST_APP_ID)).thenReturn(ImmutableSet.of("studyA"));
+       
+       service.signUp(app, participant);
+       
+       verify(participantService).createParticipant(eq(app), participantCaptor.capture(), eq(true));
+       Map<String,String> map = participantCaptor.getValue().getExternalIds();
+       assertEquals(map.get("studyA"), EXTERNAL_ID);
+   }
+   
+   @Test
+   public void signUp_oldExternalIdsFormatTwoStudiesOneTestRemapsToOtherStudy() {
+       StudyParticipant participant = new StudyParticipant.Builder()
+               .withExternalId(EXTERNAL_ID)
+               .build();
+       
+       when(studyService.getStudyIds(TEST_APP_ID)).thenReturn(ImmutableSet.of("test", "studyA"));
+       
+       service.signUp(app, participant);
+       
+       verify(participantService).createParticipant(eq(app), participantCaptor.capture(), eq(true));
+       Map<String,String> map = participantCaptor.getValue().getExternalIds();
+       assertEquals(map.get("studyA"), EXTERNAL_ID);       
+   }
+
+   @Test
+   public void signUp_oldExternalIdsFormatNoStudiesDoesNotRemap() {
+       StudyParticipant participant = new StudyParticipant.Builder()
+               .withExternalId(EXTERNAL_ID)
+               .build();
+       
+       when(studyService.getStudyIds(TEST_APP_ID)).thenReturn(ImmutableSet.of());
+       
+       service.signUp(app, participant);
+       
+       verify(participantService).createParticipant(eq(app), participantCaptor.capture(), eq(true));
+       assertTrue(participantCaptor.getValue().getExternalIds().isEmpty());
+       assertEquals(participantCaptor.getValue().getExternalId(), EXTERNAL_ID);
+   }
+
+   @Test
+   public void signUp_oldExternalIdsFormatTwoOrMoreStudiesPicksOne() {
+       StudyParticipant participant = new StudyParticipant.Builder()
+               .withExternalId(EXTERNAL_ID)
+               .build();
+       
+       when(studyService.getStudyIds(TEST_APP_ID)).thenReturn(ImmutableSet.of("test", "studyA", "studyB"));
+       
+       service.signUp(app, participant);
+       
+       verify(participantService).createParticipant(eq(app), participantCaptor.capture(), eq(true));
+       Map<String,String> map = participantCaptor.getValue().getExternalIds();
+       String extId =  map.containsKey("studyA") ? map.get("studyA") : map.get("studyB");
+       assertEquals(extId, EXTERNAL_ID);
    }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -321,7 +321,7 @@ public class ParticipantServiceTest extends Mockito {
         // suppress email (true) == sendEmail (false)
         verify(accountService).createAccount(eq(APP), accountCaptor.capture());
         verify(accountWorkflowService).sendEmailVerificationToken(APP, ID, EMAIL);
-        verify(enrollmentService).updateEnrollment(eq(accountCaptor.getValue()), enrollmentCaptor.capture(), any(Enrollment.class));
+        verify(enrollmentService).addEnrollment(eq(accountCaptor.getValue()), enrollmentCaptor.capture());
         
         Account account = accountCaptor.getValue();
         assertEquals(account.getId(), ID);
@@ -2271,10 +2271,6 @@ public class ParticipantServiceTest extends Mockito {
                 scheduledOnStart, scheduledOnEnd, "offsetKey", 112);
     }
     
-    /* ==================== */
-    /* TESTS */
-    /* ==================== */
-    
     @Test
     public void adminCanAddExternalIdOnCreate() {
         RequestContext.set(new RequestContext.Builder().withCallerRoles(ImmutableSet.of(ADMIN)).build());
@@ -2286,14 +2282,9 @@ public class ParticipantServiceTest extends Mockito {
         participantService.createParticipant(APP, participant, false);
         
         verify(accountService).createAccount(eq(APP), accountCaptor.capture());
-        Enrollment enrollment = accountCaptor.getValue().getEnrollments().iterator().next();
-        assertEquals(enrollment.getAppId(), TEST_APP_ID);
-        assertEquals(enrollment.getStudyId(), STUDY_ID);
-        assertEquals(enrollment.getExternalId(), EXTERNAL_ID);
-        assertEquals(enrollment.getAccountId(), ID);
         
-        verify(enrollmentService).updateEnrollment(any(Account.class), enrollmentCaptor.capture(), any(Enrollment.class));
-        enrollment = enrollmentCaptor.getValue();
+        verify(enrollmentService).addEnrollment(any(Account.class), enrollmentCaptor.capture());
+        Enrollment enrollment = enrollmentCaptor.getValue();
         assertEquals(enrollment.getAppId(), TEST_APP_ID);
         assertEquals(enrollment.getStudyId(), STUDY_ID);
         assertEquals(enrollment.getExternalId(), EXTERNAL_ID);
@@ -2310,7 +2301,7 @@ public class ParticipantServiceTest extends Mockito {
         participantService.createParticipant(APP, participant, false);
         
         verify(accountService).createAccount(eq(APP), accountCaptor.capture());
-        verify(enrollmentService).updateEnrollment(any(), enrollmentCaptor.capture(), any());
+        verify(enrollmentService).addEnrollment(any(), enrollmentCaptor.capture());
         
         Enrollment enrollment = enrollmentCaptor.getValue();
         assertEquals(enrollment.getAppId(), TEST_APP_ID);
@@ -2348,7 +2339,7 @@ public class ParticipantServiceTest extends Mockito {
         participantService.createParticipant(APP, participant, false);
         
         verify(accountService).createAccount(eq(APP), accountCaptor.capture());
-        verify(enrollmentService).updateEnrollment(any(), enrollmentCaptor.capture(), any());
+        verify(enrollmentService).addEnrollment(any(), enrollmentCaptor.capture());
         
         Enrollment enrollment = enrollmentCaptor.getValue();
         assertEquals(enrollment.getAppId(), TEST_APP_ID);


### PR DESCRIPTION
After pushing changes to production, we learned that PKU study was receiving 400s on sign up because it was not passing validation with a sign up payload. The payload only included an external ID, and did not already have an account in the system (which is a rare configuration...I can't confirm there are other apps that do this). So the existing trap for this was insufficient. I've added more aggressive catches to maintain this app and a couple of others where it could conceivably be an issue, and moved this code to AuthenticationService where it makes more sense and is easier to test.