### PR TITLE
Move audit-like code somewhere more accessible to other classes

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/dao/AccountDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dao/AccountDao.java
@@ -7,6 +7,7 @@ import org.sagebionetworks.bridge.models.AccountSummarySearch;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
+import org.sagebionetworks.bridge.models.accounts.AccountRef;
 import org.sagebionetworks.bridge.models.accounts.AccountSummary;
 import org.sagebionetworks.bridge.models.apps.App;
 
@@ -58,4 +59,9 @@ public interface AccountDao {
      *      paging parameters.
      */
     PagedResourceList<AccountSummary> getPagedAccountSummaries(String appId, AccountSummarySearch search);
+    
+    /**
+     * Get a light-weight object describing an account for auditing purposes.
+     */
+    AccountRef getAccountRef(String appId, String userId);
 }    

--- a/src/main/java/org/sagebionetworks/bridge/dao/EnrollmentDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dao/EnrollmentDao.java
@@ -3,18 +3,18 @@ package org.sagebionetworks.bridge.dao;
 import java.util.List;
 
 import org.sagebionetworks.bridge.models.PagedResourceList;
-import org.sagebionetworks.bridge.models.studies.EnrollmentDetail;
+import org.sagebionetworks.bridge.models.studies.Enrollment;
 import org.sagebionetworks.bridge.models.studies.EnrollmentFilter;
 
 public interface EnrollmentDao {
     /**
      * Get accounts that have been enrolled in the study (past and present).
      */
-    PagedResourceList<EnrollmentDetail> getEnrollmentsForStudy(String appId, String studyId, 
+    PagedResourceList<Enrollment> getEnrollmentsForStudy(String appId, String studyId, 
             EnrollmentFilter filter, boolean includeTesters, Integer offsetBy, Integer pageSize);
     
     /**
      * Get enrollments for a specific account.
      */
-    public List<EnrollmentDetail> getEnrollmentsForUser(String appId, String userId);
+    public List<Enrollment> getEnrollmentsForUser(String appId, String userId);
 }

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateEnrollmentDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateEnrollmentDao.java
@@ -1,29 +1,23 @@
 package org.sagebionetworks.bridge.hibernate;
 
-import static java.util.stream.Collectors.toList;
 import static org.sagebionetworks.bridge.BridgeConstants.TEST_USER_GROUP;
 
 import java.util.List;
 
 import javax.annotation.Resource;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import org.springframework.stereotype.Component;
 
 import org.sagebionetworks.bridge.dao.EnrollmentDao;
 import org.sagebionetworks.bridge.models.PagedResourceList;
-import org.sagebionetworks.bridge.models.accounts.AccountRef;
-import org.sagebionetworks.bridge.models.studies.EnrollmentDetail;
+import org.sagebionetworks.bridge.models.studies.Enrollment;
 import org.sagebionetworks.bridge.models.studies.EnrollmentFilter;
 
 @Component
 public class HibernateEnrollmentDao implements EnrollmentDao {
-    
-    static final String REF_QUERY = "SELECT new org.sagebionetworks.bridge.hibernate.HibernateAccount("
-            + "a.firstName, a.lastName, a.email, a.phone, a.synapseUserId, a.orgMembership, a.id) FROM "
-            + "org.sagebionetworks.bridge.hibernate.HibernateAccount a WHERE a.appId = :appId AND a.id = :id";
 
     private HibernateHelper hibernateHelper;
     
@@ -33,7 +27,7 @@ public class HibernateEnrollmentDao implements EnrollmentDao {
     }
     
     @Override
-    public PagedResourceList<EnrollmentDetail> getEnrollmentsForStudy(String appId, String studyId, 
+    public PagedResourceList<Enrollment> getEnrollmentsForStudy(String appId, String studyId, 
             EnrollmentFilter filter, boolean includeTesters, Integer offsetBy, Integer pageSize) {
         QueryBuilder builder = new QueryBuilder();
         builder.append("FROM HibernateEnrollment AS h");
@@ -50,40 +44,18 @@ public class HibernateEnrollmentDao implements EnrollmentDao {
         List<HibernateEnrollment> enrollments = hibernateHelper.queryGet("SELECT h " + builder.getQuery(),
                 builder.getParameters(), offsetBy, pageSize, HibernateEnrollment.class);
         
-        List<EnrollmentDetail> dtos = enrollments.stream().map(enrollment -> {
-            AccountRef participantRef = nullSafeAccountRef(appId, enrollment.getAccountId());
-            AccountRef enrolledByRef = nullSafeAccountRef(appId, enrollment.getEnrolledBy());
-            AccountRef withdrawnByRef = nullSafeAccountRef(appId, enrollment.getWithdrawnBy());
-            return new EnrollmentDetail(enrollment, participantRef, enrolledByRef, withdrawnByRef);
-        }).collect(toList());
-        return new PagedResourceList<>(dtos, total, true);
+        return new PagedResourceList<>(ImmutableList.copyOf(enrollments), total, true);
     }
     
     @Override
-    public List<EnrollmentDetail> getEnrollmentsForUser(String appId, String userId) {
+    public List<Enrollment> getEnrollmentsForUser(String appId, String userId) {
         QueryBuilder builder = new QueryBuilder();
         builder.append("FROM HibernateEnrollment WHERE");
         builder.append("appId = :appId AND accountId = :userId", "appId", appId, "userId", userId);
         
         List<HibernateEnrollment> enrollments = hibernateHelper.queryGet(builder.getQuery(),
                 builder.getParameters(), null, null, HibernateEnrollment.class);
-        return enrollments.stream().map(enrollment -> {
-            AccountRef participantRef = nullSafeAccountRef(appId, enrollment.getAccountId());
-            AccountRef enrolledByRef = nullSafeAccountRef(appId, enrollment.getEnrolledBy());
-            AccountRef withdrawnByRef = nullSafeAccountRef(appId, enrollment.getWithdrawnBy());
-            return new EnrollmentDetail(enrollment, participantRef, enrolledByRef, withdrawnByRef);
-        }).collect(toList());
-    }
-    
-    private AccountRef nullSafeAccountRef(String appId, String id) {
-        if (id == null) {
-            return null;
-        }
-        List<HibernateAccount> accounts = hibernateHelper.queryGet(REF_QUERY, 
-                ImmutableMap.of("appId", appId, "id", id), null, 1, HibernateAccount.class);
-        if (accounts.isEmpty()) {
-            return null;
-        }
-        return new AccountRef(accounts.get(0));
+        
+        return ImmutableList.copyOf(enrollments);
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
@@ -41,6 +41,7 @@ import org.sagebionetworks.bridge.models.AccountSummarySearch;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
+import org.sagebionetworks.bridge.models.accounts.AccountRef;
 import org.sagebionetworks.bridge.models.accounts.AccountSummary;
 import org.sagebionetworks.bridge.models.accounts.PasswordAlgorithm;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
@@ -348,6 +349,12 @@ public class AccountService {
         } else {
             return null;
         }
+    }
+    
+    public AccountRef getAccountRef(String appId, String userId) {
+        checkNotNull(appId);
+        
+        return accountDao.getAccountRef(appId, userId);
     }
     
     protected Account authenticateInternal(App app, Account account, SignIn signIn) {

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateEnrollmentDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateEnrollmentDaoTest.java
@@ -4,10 +4,8 @@ import static org.sagebionetworks.bridge.BridgeConstants.TEST_USER_GROUP;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
-import static org.sagebionetworks.bridge.hibernate.HibernateEnrollmentDao.REF_QUERY;
 import static org.sagebionetworks.bridge.models.studies.EnrollmentFilter.ENROLLED;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
 
 import java.util.List;
 import java.util.Map;
@@ -24,7 +22,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.models.PagedResourceList;
-import org.sagebionetworks.bridge.models.studies.EnrollmentDetail;
+import org.sagebionetworks.bridge.models.studies.Enrollment;
 
 public class HibernateEnrollmentDaoTest extends Mockito {
     
@@ -45,7 +43,6 @@ public class HibernateEnrollmentDaoTest extends Mockito {
         MockitoAnnotations.initMocks(this);
     }
     
-    @SuppressWarnings("unchecked")
     @Test
     public void getEnrollmentsForStudy() {
         HibernateEnrollment en1 = new HibernateEnrollment();
@@ -58,30 +55,9 @@ public class HibernateEnrollmentDaoTest extends Mockito {
         when(mockHelper.queryCount(any(), any())).thenReturn(20);
         when(mockHelper.queryGet(any(), any(), any(), any(), eq(HibernateEnrollment.class))).thenReturn(page);
         
-        HibernateAccount account1 = new HibernateAccount();
-        account1.setLastName("account1");
-        HibernateAccount account2 = new HibernateAccount();
-        account2.setLastName("account2");
-        HibernateAccount account3 = new HibernateAccount();
-        account3.setLastName("account3");
-        
-        when(mockHelper.queryGet(eq(REF_QUERY), any(), isNull(), eq(1), eq(HibernateAccount.class)))
-            .thenReturn(ImmutableList.of(account1), ImmutableList.of(account2), ImmutableList.of(account3));
-        
-        PagedResourceList<EnrollmentDetail> retValue = dao.getEnrollmentsForStudy(TEST_APP_ID, TEST_STUDY_ID, null, true, 10, 75);
+        PagedResourceList<Enrollment> retValue = dao.getEnrollmentsForStudy(TEST_APP_ID, TEST_STUDY_ID, null, true, 10, 75);
         assertEquals(retValue.getTotal(), Integer.valueOf(20));
-        assertEquals(retValue.getItems().size(), 2);
-        
-        EnrollmentDetail detail1 = retValue.getItems().get(0);
-        assertEquals(detail1.getParticipant().getLastName(), "account1");
-        assertEquals(detail1.getEnrolledBy().getLastName(), "account2");
-        assertEquals(detail1.getWithdrawnBy().getLastName(), "account3");
-        
-        // This one is empty
-        EnrollmentDetail detail2 = retValue.getItems().get(1);
-        assertNull(detail2.getParticipant());
-        assertNull(detail2.getEnrolledBy());
-        assertNull(detail2.getWithdrawnBy());
+        assertEquals(retValue.getItems(), page);
         
         verify(mockHelper).queryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(10), eq(75),
                 eq(HibernateEnrollment.class));
@@ -90,7 +66,6 @@ public class HibernateEnrollmentDaoTest extends Mockito {
         assertEquals(paramsCaptor.getValue().get("studyId"), TEST_STUDY_ID);
     }
     
-    @SuppressWarnings("unchecked")
     @Test
     public void getEnrollmentsForStudyWithArguments() {
         HibernateEnrollment en1 = new HibernateEnrollment();
@@ -103,31 +78,11 @@ public class HibernateEnrollmentDaoTest extends Mockito {
         when(mockHelper.queryCount(any(), any())).thenReturn(20);
         when(mockHelper.queryGet(any(), any(), any(), any(), eq(HibernateEnrollment.class))).thenReturn(page);
         
-        HibernateAccount account1 = new HibernateAccount();
-        account1.setLastName("account1");
-        HibernateAccount account2 = new HibernateAccount();
-        account2.setLastName("account2");
-        HibernateAccount account3 = new HibernateAccount();
-        account3.setLastName("account3");
         
-        when(mockHelper.queryGet(eq(REF_QUERY), any(), isNull(), eq(1), eq(HibernateAccount.class)))
-            .thenReturn(ImmutableList.of(account1), ImmutableList.of(account2), ImmutableList.of(account3));
-        
-        PagedResourceList<EnrollmentDetail> retValue = dao.getEnrollmentsForStudy(TEST_APP_ID, TEST_STUDY_ID, ENROLLED,
-                true, 10, 75);
+        PagedResourceList<Enrollment> retValue = dao.getEnrollmentsForStudy(
+                TEST_APP_ID, TEST_STUDY_ID, ENROLLED, true, 10, 75);
         assertEquals(retValue.getTotal(), Integer.valueOf(20));
-        assertEquals(retValue.getItems().size(), 2);
-        
-        EnrollmentDetail detail1 = retValue.getItems().get(0);
-        assertEquals(detail1.getParticipant().getLastName(), "account1");
-        assertEquals(detail1.getEnrolledBy().getLastName(), "account2");
-        assertEquals(detail1.getWithdrawnBy().getLastName(), "account3");
-        
-        // This one is empty
-        EnrollmentDetail detail2 = retValue.getItems().get(1);
-        assertNull(detail2.getParticipant());
-        assertNull(detail2.getEnrolledBy());
-        assertNull(detail2.getWithdrawnBy());
+        assertEquals(retValue.getItems(), page);
         
         verify(mockHelper).queryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(10), eq(75),
                 eq(HibernateEnrollment.class));
@@ -137,7 +92,6 @@ public class HibernateEnrollmentDaoTest extends Mockito {
         assertEquals(paramsCaptor.getValue().get("studyId"), TEST_STUDY_ID);
     }
     
-    @SuppressWarnings("unchecked")
     @Test
     public void getEnrollmentsForStudyExcludesTestUsers() {
         HibernateEnrollment en1 = new HibernateEnrollment();
@@ -150,31 +104,10 @@ public class HibernateEnrollmentDaoTest extends Mockito {
         when(mockHelper.queryCount(any(), any())).thenReturn(20);
         when(mockHelper.queryGet(any(), any(), any(), any(), eq(HibernateEnrollment.class))).thenReturn(page);
         
-        HibernateAccount account1 = new HibernateAccount();
-        account1.setLastName("account1");
-        HibernateAccount account2 = new HibernateAccount();
-        account2.setLastName("account2");
-        HibernateAccount account3 = new HibernateAccount();
-        account3.setLastName("account3");
-        
-        when(mockHelper.queryGet(eq(REF_QUERY), any(), isNull(), eq(1), eq(HibernateAccount.class)))
-            .thenReturn(ImmutableList.of(account1), ImmutableList.of(account2), ImmutableList.of(account3));
-        
-        PagedResourceList<EnrollmentDetail> retValue = dao.getEnrollmentsForStudy(TEST_APP_ID, TEST_STUDY_ID, ENROLLED,
-                false, 10, 75);
+        PagedResourceList<Enrollment> retValue = dao.getEnrollmentsForStudy(
+                TEST_APP_ID, TEST_STUDY_ID, ENROLLED, false, 10, 75);
         assertEquals(retValue.getTotal(), Integer.valueOf(20));
-        assertEquals(retValue.getItems().size(), 2);
-        
-        EnrollmentDetail detail1 = retValue.getItems().get(0);
-        assertEquals(detail1.getParticipant().getLastName(), "account1");
-        assertEquals(detail1.getEnrolledBy().getLastName(), "account2");
-        assertEquals(detail1.getWithdrawnBy().getLastName(), "account3");
-        
-        // This one is empty
-        EnrollmentDetail detail2 = retValue.getItems().get(1);
-        assertNull(detail2.getParticipant());
-        assertNull(detail2.getEnrolledBy());
-        assertNull(detail2.getWithdrawnBy());
+        assertEquals(retValue.getItems(), page);
         
         verify(mockHelper).queryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(10), eq(75),
                 eq(HibernateEnrollment.class));
@@ -187,7 +120,6 @@ public class HibernateEnrollmentDaoTest extends Mockito {
         assertEquals(paramsCaptor.getValue().get("NOTIN1"), TEST_USER_GROUP);
     }
     
-    @SuppressWarnings("unchecked")
     @Test
     public void getEnrollmentsForUser() {
         HibernateEnrollment en1 = new HibernateEnrollment();
@@ -199,21 +131,8 @@ public class HibernateEnrollmentDaoTest extends Mockito {
         
         when(mockHelper.queryGet(any(), any(), isNull(), isNull(), eq(HibernateEnrollment.class))).thenReturn(page);
         
-        HibernateAccount account1 = new HibernateAccount();
-        account1.setLastName("account1");
-        HibernateAccount account2 = new HibernateAccount();
-        account2.setLastName("account2");
-        HibernateAccount account3 = new HibernateAccount();
-        account3.setLastName("account3");
-        
-        when(mockHelper.queryGet(eq(REF_QUERY), any(), isNull(), eq(1), eq(HibernateAccount.class)))
-            .thenReturn(ImmutableList.of(account1), ImmutableList.of(account2), ImmutableList.of(account3));
-        
-        List<EnrollmentDetail> retValue = dao.getEnrollmentsForUser(TEST_APP_ID, TEST_USER_ID);
-        EnrollmentDetail detail1 = retValue.get(0);
-        assertEquals(detail1.getParticipant().getLastName(), "account1");
-        assertEquals(detail1.getEnrolledBy().getLastName(), "account2");
-        assertEquals(detail1.getWithdrawnBy().getLastName(), "account3");
+        List<Enrollment> retValue = dao.getEnrollmentsForUser(TEST_APP_ID, TEST_USER_ID);
+        assertEquals(retValue, page);
 
         verify(mockHelper).queryGet(queryCaptor.capture(),
                 paramsCaptor.capture(), isNull(), isNull(), eq(HibernateEnrollment.class));
@@ -222,5 +141,4 @@ public class HibernateEnrollmentDaoTest extends Mockito {
         assertEquals(paramsCaptor.getValue().get("appId"), TEST_APP_ID);
         assertEquals(paramsCaptor.getValue().get("userId"), TEST_USER_ID);
     }
-
 }


### PR DESCRIPTION
which will do something similar under the current design plan. Arguably this simple code could be useful even if we create an audit table, to look up account information for a user ID (which would be what is in the audit table).