### PR TITLE
Adding startEventId and time window GUID to the metadata record

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/ScheduledAssessment.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/ScheduledAssessment.java
@@ -8,6 +8,9 @@ public class ScheduledAssessment {
 
     private final String refKey;
     private final String instanceGuid;
+    // This is carried over in order to make it faster and easer to construct
+    // the TimelineMetadata object during construction of the Timeline. It is
+    // not part of the JSON serialization of the ScheduledAssessment.
     private final AssessmentReference reference;
     
     public ScheduledAssessment(String refKey, String instanceGuid, AssessmentReference reference) {

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Scheduler.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Scheduler.java
@@ -104,7 +104,8 @@ public class Scheduler {
             builder.withSessionInfo(SessionInfo.create(session));
             
             ScheduledSession.Builder scheduledSession = new ScheduledSession.Builder();
-            scheduledSession.withRefGuid(session.getGuid());
+            scheduledSession.withSession(session);
+            scheduledSession.withTimeWindow(window);
             scheduledSession.withStartDay(startDay);
             scheduledSession.withEndDay(endDay);
             scheduledSession.withStartTime(window.getStartTime());

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Timeline.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Timeline.java
@@ -91,6 +91,8 @@ public class Timeline {
             sessionMeta.setSessionInstanceGuid(schSession.getInstanceGuid());
             sessionMeta.setSessionGuid(schSession.getSession().getGuid());
             sessionMeta.setSessionStartEventId(schSession.getSession().getStartEventId());
+            sessionMeta.setSessionInstanceStartDay(schSession.getStartDay());
+            sessionMeta.setSessionInstanceEndDay(schSession.getEndDay());
             sessionMeta.setTimeWindowGuid(schSession.getTimeWindow().getGuid());
             metadata.add(sessionMeta);
             

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Timeline.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Timeline.java
@@ -79,20 +79,22 @@ public class Timeline {
             this.lang = lang;
             return this;
         }
-        public Builder withScheduledSession(ScheduledSession session) {
-            this.scheduledSessions.add(session);
+        public Builder withScheduledSession(ScheduledSession schSession) {
+            this.scheduledSessions.add(schSession);
             
             TimelineMetadata sessionMeta = new TimelineMetadata();
-            sessionMeta.setGuid(session.getInstanceGuid());
+            sessionMeta.setGuid(schSession.getInstanceGuid());
             sessionMeta.setAppId(schedule.getAppId());
             sessionMeta.setScheduleGuid(schedule.getGuid());
             sessionMeta.setScheduleModifiedOn(schedule.getModifiedOn());
             sessionMeta.setSchedulePublished(schedule.isPublished());
-            sessionMeta.setSessionInstanceGuid(session.getInstanceGuid());
-            sessionMeta.setSessionGuid(session.getRefGuid());
+            sessionMeta.setSessionInstanceGuid(schSession.getInstanceGuid());
+            sessionMeta.setSessionGuid(schSession.getSession().getGuid());
+            sessionMeta.setSessionStartEventId(schSession.getSession().getStartEventId());
+            sessionMeta.setTimeWindowGuid(schSession.getTimeWindow().getGuid());
             metadata.add(sessionMeta);
             
-            for (ScheduledAssessment schAsmt : session.getAssessments()) { 
+            for (ScheduledAssessment schAsmt : schSession.getAssessments()) { 
                 TimelineMetadata schMeta = TimelineMetadata.copy(sessionMeta);
                 schMeta.setGuid(schAsmt.getInstanceGuid());
                 schMeta.setAssessmentInstanceGuid(schAsmt.getInstanceGuid());

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineMetadata.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineMetadata.java
@@ -1,13 +1,12 @@
 package org.sagebionetworks.bridge.models.schedules2.timelines;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
-import javax.persistence.Transient;
 
 import org.joda.time.DateTime;
 
@@ -34,15 +33,30 @@ public class TimelineMetadata implements BridgeEntity {
         copy.setSessionInstanceGuid(meta.getSessionInstanceGuid());
         copy.setSessionGuid(meta.getSessionGuid());
         copy.setScheduleGuid(meta.getScheduleGuid());
+        copy.setSessionStartEventId(meta.getSessionStartEventId());
+        copy.setTimeWindowGuid(meta.getTimeWindowGuid());
         copy.setScheduleModifiedOn(meta.getScheduleModifiedOn());
         copy.setSchedulePublished(meta.isSchedulePublished());
         copy.setAppId(meta.getAppId());
-        if (meta.getStudyIds() != null) {
-            Set<String> set = new HashSet<>();
-            set.addAll(meta.getStudyIds());
-            copy.setStudyIds(set);
-        }
         return copy;
+    }
+    
+    public final Map<String,String> asMap() {
+        Map<String,String> map = new HashMap<>();
+        map.put("guid", guid);
+        map.put("assessmentInstanceGuid", assessmentInstanceGuid);
+        map.put("assessmentGuid", assessmentGuid);
+        map.put("assessmentId", assessmentId);
+        map.put("assessmentRevision", Integer.toString(assessmentRevision));
+        map.put("sessionInstanceGuid", sessionInstanceGuid);
+        map.put("sessionGuid", sessionGuid);
+        map.put("sessionStartEventId", sessionStartEventId);
+        map.put("timeWindowGuid", timeWindowGuid);
+        map.put("scheduleGuid", scheduleGuid);
+        map.put("scheduleModifiedOn", scheduleModifiedOn.toString());
+        map.put("schedulePublished", Boolean.toString(schedulePublished));
+        map.put("appId", appId);
+        return map;
     }
     
     @Id
@@ -53,19 +67,13 @@ public class TimelineMetadata implements BridgeEntity {
     private Integer assessmentRevision;
     private String sessionInstanceGuid;
     private String sessionGuid;
+    private String sessionStartEventId;
+    private String timeWindowGuid;
     private String scheduleGuid;
     @Convert(converter = DateTimeToLongAttributeConverter.class)
     private DateTime scheduleModifiedOn;
     private boolean schedulePublished;
     private String appId;
-    /**
-     * A timeline is generated 1:1 from a schedule, but schedule can be used in
-     * more than one study (or study arm). The study IDs for this record will be
-     * the intersection of the participant’s enrolled studies, and the schedules
-     * that apply to the participant through these study relationships.
-     */
-    @Transient
-    private Set<String> studyIds;
     
     public String getGuid() {
         return guid;
@@ -109,6 +117,18 @@ public class TimelineMetadata implements BridgeEntity {
     public void setSessionGuid(String sessionGuid) {
         this.sessionGuid = sessionGuid;
     }
+    public String getSessionStartEventId() {
+        return sessionStartEventId;
+    }
+    public void setSessionStartEventId(String sessionStartEventId) {
+        this.sessionStartEventId = sessionStartEventId;
+    }
+    public String getTimeWindowGuid( ) {
+        return timeWindowGuid;
+    }
+    public void setTimeWindowGuid(String timeWindowGuid) {
+        this.timeWindowGuid = timeWindowGuid;
+    }
     public String getScheduleGuid() {
         return scheduleGuid;
     }
@@ -127,17 +147,10 @@ public class TimelineMetadata implements BridgeEntity {
     public void setSchedulePublished(boolean schedulePublished) {
         this.schedulePublished = schedulePublished;
     }
-    public Set<String> getStudyIds() {
-        return studyIds;
-    }
-    public void setStudyIds(Set<String> studyIds) {
-        this.studyIds = studyIds;
-    }
     public String getAppId() {
         return appId;
     }
     public void setAppId(String appId) {
         this.appId = appId;
     }
-
 }

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineMetadata.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineMetadata.java
@@ -32,6 +32,8 @@ public class TimelineMetadata implements BridgeEntity {
         copy.setAssessmentRevision(meta.getAssessmentRevision());
         copy.setSessionInstanceGuid(meta.getSessionInstanceGuid());
         copy.setSessionGuid(meta.getSessionGuid());
+        copy.setSessionInstanceStartDay(meta.getSessionInstanceStartDay());
+        copy.setSessionInstanceEndDay(meta.getSessionInstanceEndDay());
         copy.setScheduleGuid(meta.getScheduleGuid());
         copy.setSessionStartEventId(meta.getSessionStartEventId());
         copy.setTimeWindowGuid(meta.getTimeWindowGuid());
@@ -50,6 +52,8 @@ public class TimelineMetadata implements BridgeEntity {
         map.put("assessmentRevision", Integer.toString(assessmentRevision));
         map.put("sessionInstanceGuid", sessionInstanceGuid);
         map.put("sessionGuid", sessionGuid);
+        map.put("sessionInstanceStartDay", Integer.toString(sessionInstanceStartDay));
+        map.put("sessionInstanceEndDay", Integer.toString(sessionInstanceEndDay));
         map.put("sessionStartEventId", sessionStartEventId);
         map.put("timeWindowGuid", timeWindowGuid);
         map.put("scheduleGuid", scheduleGuid);
@@ -68,6 +72,8 @@ public class TimelineMetadata implements BridgeEntity {
     private String sessionInstanceGuid;
     private String sessionGuid;
     private String sessionStartEventId;
+    private Integer sessionInstanceStartDay;
+    private Integer sessionInstanceEndDay;
     private String timeWindowGuid;
     private String scheduleGuid;
     @Convert(converter = DateTimeToLongAttributeConverter.class)
@@ -122,6 +128,18 @@ public class TimelineMetadata implements BridgeEntity {
     }
     public void setSessionStartEventId(String sessionStartEventId) {
         this.sessionStartEventId = sessionStartEventId;
+    }
+    public Integer getSessionInstanceStartDay() {
+        return sessionInstanceStartDay;
+    }
+    public void setSessionInstanceStartDay(Integer startDay) {
+        this.sessionInstanceStartDay = startDay;
+    }
+    public Integer getSessionInstanceEndDay() {
+        return sessionInstanceEndDay;
+    }
+    public void setSessionInstanceEndDay(Integer endDay) {
+        this.sessionInstanceEndDay = endDay;
     }
     public String getTimeWindowGuid( ) {
         return timeWindowGuid;

--- a/src/main/resources/db/changelog/changelog.sql
+++ b/src/main/resources/db/changelog/changelog.sql
@@ -585,3 +585,8 @@ CREATE TABLE `StudyContacts` (
   CONSTRAINT `StudyContact-Study-Constraint` FOREIGN KEY (`studyId`,`appId`) REFERENCES `Substudies` (`id`, `studyId`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
+-- changeset bridge:30
+
+ALTER TABLE `TimelineMetadata`
+ADD COLUMN `sessionStartEventId` varchar(255) NOT NULL,
+ADD COLUMN `timeWindowGuid` varchar(60) NOT NULL;

--- a/src/main/resources/db/changelog/changelog.sql
+++ b/src/main/resources/db/changelog/changelog.sql
@@ -589,4 +589,6 @@ CREATE TABLE `StudyContacts` (
 
 ALTER TABLE `TimelineMetadata`
 ADD COLUMN `sessionStartEventId` varchar(255) NOT NULL,
-ADD COLUMN `timeWindowGuid` varchar(60) NOT NULL;
+ADD COLUMN `timeWindowGuid` varchar(60) NOT NULL,
+ADD COLUMN `sessionInstanceStartDay` int(10) NOT NULL,
+ADD COLUMN `sessionInstanceEndDay` int(10) NOT NULL;

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/SessionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/SessionTest.java
@@ -53,6 +53,7 @@ public class SessionTest {
         AssessmentReference asmt1 = new AssessmentReference();
         asmt1.setGuid(ASSESSMENT_1_GUID);
         asmt1.setAppId("local");
+        asmt1.setIdentifier("Local Assessment 1");
         asmt1.setTitle("Assessment 1");
         asmt1.setMinutesToComplete(3);
         asmt1.setRevision(100);
@@ -61,6 +62,7 @@ public class SessionTest {
         AssessmentReference asmt2 = new AssessmentReference();
         asmt2.setGuid(ASSESSMENT_2_GUID);
         asmt2.setAppId("shared");
+        asmt2.setIdentifier("Shared Assessment 2");
         asmt2.setTitle("Assessment 2");
         asmt2.setMinutesToComplete(5);
         asmt2.setRevision(200);
@@ -102,9 +104,10 @@ public class SessionTest {
         
         ArrayNode asmtsArray = (ArrayNode)node.get("assessments");
         assertEquals(asmtsArray.size(), 2);
-        assertEquals(asmtsArray.get(0).size(), 7);
+        assertEquals(asmtsArray.get(0).size(), 8);
         assertEquals(asmtsArray.get(0).get("guid").textValue(), ASSESSMENT_1_GUID);
         assertEquals(asmtsArray.get(0).get("appId").textValue(), "local");
+        assertEquals(asmtsArray.get(0).get("identifier").textValue(), "Local Assessment 1");
         assertEquals(asmtsArray.get(0).get("title").textValue(), "Assessment 1");
         assertEquals(asmtsArray.get(0).get("minutesToComplete").intValue(), 3);
         assertEquals(asmtsArray.get(0).get("revision").intValue(), 100);

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineMetadataTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineMetadataTest.java
@@ -1,9 +1,13 @@
 package org.sagebionetworks.bridge.models.schedules2.timelines;
 
+import static org.sagebionetworks.bridge.TestConstants.ASSESSMENT_1_GUID;
 import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
-import static org.sagebionetworks.bridge.TestConstants.USER_STUDY_IDS;
+import static org.sagebionetworks.bridge.TestConstants.SESSION_GUID_1;
+import static org.sagebionetworks.bridge.TestConstants.SESSION_WINDOW_GUID_1;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+
+import java.util.Map;
 
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
@@ -13,52 +17,75 @@ public class TimelineMetadataTest extends Mockito {
     @Test
     public void test() {
         TimelineMetadata meta = createTimelineMetadata();
-        assertEquals(meta.getGuid(), "guid");
+        assertEquals(meta.getGuid(), SESSION_GUID_1);
         assertEquals(meta.getAssessmentInstanceGuid(), "assessmentInstanceGuid");
-        assertEquals(meta.getAssessmentGuid(), "assessmentGuid");
+        assertEquals(meta.getAssessmentGuid(), ASSESSMENT_1_GUID);
         assertEquals(meta.getAssessmentId(), "assessmentId");
         assertEquals(meta.getAssessmentRevision(), Integer.valueOf(7));
         assertEquals(meta.getSessionInstanceGuid(), "sessionInstanceGuid");
         assertEquals(meta.getSessionGuid(), "sessionGuid");
+        assertEquals(meta.getSessionStartEventId(), "enrollment");
+        assertEquals(meta.getTimeWindowGuid(), SESSION_WINDOW_GUID_1);
         assertEquals(meta.getScheduleGuid(), "scheduleGuid");
         assertEquals(meta.getScheduleModifiedOn(), MODIFIED_ON);
         assertTrue(meta.isSchedulePublished());
         assertEquals(meta.getAppId(), "appId");
-        assertEquals(meta.getStudyIds(), USER_STUDY_IDS);
     }
 
     @Test
     public void copy() {
         TimelineMetadata meta = createTimelineMetadata();
         TimelineMetadata copy = TimelineMetadata.copy(meta);
-        assertEquals(copy.getGuid(), "guid");
+        assertEquals(copy.getGuid(), SESSION_GUID_1);
         assertEquals(copy.getAssessmentInstanceGuid(), "assessmentInstanceGuid");
-        assertEquals(copy.getAssessmentGuid(), "assessmentGuid");
+        assertEquals(copy.getAssessmentGuid(), ASSESSMENT_1_GUID);
         assertEquals(copy.getAssessmentId(), "assessmentId");
         assertEquals(copy.getAssessmentRevision(), Integer.valueOf(7));
         assertEquals(copy.getSessionInstanceGuid(), "sessionInstanceGuid");
         assertEquals(copy.getSessionGuid(), "sessionGuid");
+        assertEquals(copy.getSessionStartEventId(), "enrollment");
+        assertEquals(copy.getTimeWindowGuid(), SESSION_WINDOW_GUID_1);
         assertEquals(copy.getScheduleGuid(), "scheduleGuid");
         assertEquals(copy.getScheduleModifiedOn(), MODIFIED_ON);
         assertTrue(copy.isSchedulePublished());
         assertEquals(copy.getAppId(), "appId");
-        assertEquals(copy.getStudyIds(), USER_STUDY_IDS);
+    }
+    
+    @Test
+    public void asMap() {
+        TimelineMetadata meta = createTimelineMetadata();
+        
+        Map<String,String> map = meta.asMap();
+        assertEquals(map.get("appId"), "appId");
+        assertEquals(map.get("guid"), SESSION_GUID_1);
+        assertEquals(map.get("assessmentInstanceGuid"), "assessmentInstanceGuid");
+        assertEquals(map.get("assessmentGuid"), ASSESSMENT_1_GUID);
+        assertEquals(map.get("assessmentId"), "assessmentId");
+        assertEquals(map.get("assessmentRevision"), "7");
+        assertEquals(map.get("sessionInstanceGuid"), "sessionInstanceGuid");
+        assertEquals(map.get("sessionGuid"), "sessionGuid");
+        assertEquals(map.get("sessionStartEventId"), "enrollment");
+        assertEquals(map.get("timeWindowGuid"), SESSION_WINDOW_GUID_1);
+        assertEquals(map.get("scheduleGuid"), "scheduleGuid");
+        assertEquals(map.get("scheduleModifiedOn"), MODIFIED_ON.toString());
+        assertEquals(map.get("schedulePublished"), "true");
     }
 
     private TimelineMetadata createTimelineMetadata() {
         TimelineMetadata meta = new TimelineMetadata();
-        meta.setGuid("guid");
+        meta.setGuid(SESSION_GUID_1);
         meta.setAssessmentInstanceGuid("assessmentInstanceGuid");
-        meta.setAssessmentGuid("assessmentGuid");
+        meta.setAssessmentGuid(ASSESSMENT_1_GUID);
         meta.setAssessmentId("assessmentId");
         meta.setAssessmentRevision(7);
         meta.setSessionInstanceGuid("sessionInstanceGuid");
         meta.setSessionGuid("sessionGuid");
+        meta.setSessionStartEventId("enrollment");
+        meta.setTimeWindowGuid(SESSION_WINDOW_GUID_1);
         meta.setScheduleGuid("scheduleGuid");
         meta.setScheduleModifiedOn(MODIFIED_ON);
         meta.setSchedulePublished(true);
         meta.setAppId("appId");
-        meta.setStudyIds(USER_STUDY_IDS);
         return meta;
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineMetadataTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineMetadataTest.java
@@ -25,6 +25,8 @@ public class TimelineMetadataTest extends Mockito {
         assertEquals(meta.getSessionInstanceGuid(), "sessionInstanceGuid");
         assertEquals(meta.getSessionGuid(), "sessionGuid");
         assertEquals(meta.getSessionStartEventId(), "enrollment");
+        assertEquals(meta.getSessionInstanceStartDay(), Integer.valueOf(5));
+        assertEquals(meta.getSessionInstanceEndDay(), Integer.valueOf(15));
         assertEquals(meta.getTimeWindowGuid(), SESSION_WINDOW_GUID_1);
         assertEquals(meta.getScheduleGuid(), "scheduleGuid");
         assertEquals(meta.getScheduleModifiedOn(), MODIFIED_ON);
@@ -44,6 +46,8 @@ public class TimelineMetadataTest extends Mockito {
         assertEquals(copy.getSessionInstanceGuid(), "sessionInstanceGuid");
         assertEquals(copy.getSessionGuid(), "sessionGuid");
         assertEquals(copy.getSessionStartEventId(), "enrollment");
+        assertEquals(copy.getSessionInstanceStartDay(), Integer.valueOf(5));
+        assertEquals(copy.getSessionInstanceEndDay(), Integer.valueOf(15));
         assertEquals(copy.getTimeWindowGuid(), SESSION_WINDOW_GUID_1);
         assertEquals(copy.getScheduleGuid(), "scheduleGuid");
         assertEquals(copy.getScheduleModifiedOn(), MODIFIED_ON);
@@ -65,6 +69,8 @@ public class TimelineMetadataTest extends Mockito {
         assertEquals(map.get("sessionInstanceGuid"), "sessionInstanceGuid");
         assertEquals(map.get("sessionGuid"), "sessionGuid");
         assertEquals(map.get("sessionStartEventId"), "enrollment");
+        assertEquals(map.get("sessionInstanceStartDay"), "5");
+        assertEquals(map.get("sessionInstanceEndDay"), "15");
         assertEquals(map.get("timeWindowGuid"), SESSION_WINDOW_GUID_1);
         assertEquals(map.get("scheduleGuid"), "scheduleGuid");
         assertEquals(map.get("scheduleModifiedOn"), MODIFIED_ON.toString());
@@ -81,6 +87,8 @@ public class TimelineMetadataTest extends Mockito {
         meta.setSessionInstanceGuid("sessionInstanceGuid");
         meta.setSessionGuid("sessionGuid");
         meta.setSessionStartEventId("enrollment");
+        meta.setSessionInstanceStartDay(5);
+        meta.setSessionInstanceEndDay(15);
         meta.setTimeWindowGuid(SESSION_WINDOW_GUID_1);
         meta.setScheduleGuid("scheduleGuid");
         meta.setScheduleModifiedOn(MODIFIED_ON);

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineTest.java
@@ -1,10 +1,17 @@
 package org.sagebionetworks.bridge.models.schedules2.timelines;
 
 import static org.sagebionetworks.bridge.TestConstants.ASSESSMENT_1_GUID;
+import static org.sagebionetworks.bridge.TestConstants.ASSESSMENT_2_GUID;
+import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
+import static org.sagebionetworks.bridge.TestConstants.SCHEDULE_GUID;
 import static org.sagebionetworks.bridge.TestConstants.SESSION_GUID_1;
+import static org.sagebionetworks.bridge.TestConstants.SESSION_WINDOW_GUID_1;
+import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+
+import java.util.List;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -42,7 +49,7 @@ public class TimelineTest extends Mockito {
         assertEquals(schNode.get("assessments")
                 .get(0).get("instanceGuid").textValue(), "ZBi2x9clKyYLrPcHNqpjmA");
         assertEquals(schNode.get("assessments")
-                .get(0).get("refKey").textValue(), "8ab3cb798ab3cb79");
+                .get(0).get("refKey").textValue(), "646f8c04646f8c04");
         assertEquals(schNode.get("assessments")
                 .get(0).get("type").textValue(), "ScheduledAssessment");
         
@@ -52,7 +59,7 @@ public class TimelineTest extends Mockito {
         assertEquals(asmtNode.get("appId").textValue(), "local");
         assertEquals(asmtNode.get("label").textValue(), "English");
         assertEquals(asmtNode.get("minutesToComplete").intValue(), 3);
-        assertEquals(asmtNode.get("key").textValue(), "8ab3cb798ab3cb79");
+        assertEquals(asmtNode.get("key").textValue(), "646f8c04646f8c04");
         assertEquals(asmtNode.get("revision").intValue(), 100);
         assertEquals(asmtNode.get("type").textValue(), "AssessmentInfo");
 
@@ -72,6 +79,66 @@ public class TimelineTest extends Mockito {
         assertEquals(sessNode.get("message").get("message").textValue(), "Body");
         assertEquals(sessNode.get("message").get("type").textValue(), "NotificationMessage");
         assertEquals(sessNode.get("type").textValue(), "SessionInfo");
+    }
+    
+    @Test
+    public void generatesTimelineMetadataRecord() {
+        Schedule2 schedule = Schedule2Test.createValidSchedule();
+        schedule.setDuration(Period.parse("P2W"));
+        
+        Timeline timeline = Scheduler.INSTANCE.calculateTimeline(schedule);
+        List<TimelineMetadata> metadata = timeline.getMetadata();
+        
+        // This is the session record
+        TimelineMetadata meta1 = metadata.get(0);
+        String sessionInstanceGuid = "So3SXnQm0sIt9vVIqj814Q";
+        assertEquals(meta1.getGuid(), sessionInstanceGuid);
+        assertNull(meta1.getAssessmentInstanceGuid());
+        assertNull(meta1.getAssessmentGuid());
+        assertNull(meta1.getAssessmentId());
+        assertNull(meta1.getAssessmentRevision());
+        assertEquals(meta1.getSessionInstanceGuid(), sessionInstanceGuid);
+        assertEquals(meta1.getSessionGuid(), SESSION_GUID_1);
+        assertEquals(meta1.getSessionStartEventId(), "activities_retrieved");
+        assertEquals(meta1.getTimeWindowGuid(), SESSION_WINDOW_GUID_1);
+        assertEquals(meta1.getScheduleGuid(), SCHEDULE_GUID);
+        assertEquals(meta1.getScheduleModifiedOn(), MODIFIED_ON);
+        assertTrue(meta1.isSchedulePublished());
+        assertEquals(meta1.getAppId(), TEST_APP_ID);
+
+        // This is the assessment #1 record
+        TimelineMetadata meta2 = metadata.get(1);
+        String asmtInstanceGuid = "ZBi2x9clKyYLrPcHNqpjmA";
+        assertEquals(meta2.getGuid(), asmtInstanceGuid);
+        assertEquals(meta2.getAssessmentInstanceGuid(), asmtInstanceGuid);
+        assertEquals(meta2.getAssessmentGuid(), ASSESSMENT_1_GUID);
+        assertEquals(meta2.getAssessmentId(), "Local Assessment 1");
+        assertEquals(meta2.getAssessmentRevision(), Integer.valueOf(100));
+        assertEquals(meta2.getSessionInstanceGuid(), sessionInstanceGuid);
+        assertEquals(meta2.getSessionGuid(), SESSION_GUID_1);
+        assertEquals(meta2.getSessionStartEventId(), "activities_retrieved");
+        assertEquals(meta2.getTimeWindowGuid(), SESSION_WINDOW_GUID_1);
+        assertEquals(meta2.getScheduleGuid(), SCHEDULE_GUID);
+        assertEquals(meta2.getScheduleModifiedOn(), MODIFIED_ON);
+        assertTrue(meta2.isSchedulePublished());
+        assertEquals(meta2.getAppId(), TEST_APP_ID);
+        
+        // This is the assessment #2 record
+        TimelineMetadata meta3 = metadata.get(2);
+        asmtInstanceGuid = "b20vr-Bb2Om655sLmp5MjQ";
+        assertEquals(meta3.getGuid(), asmtInstanceGuid);
+        assertEquals(meta3.getAssessmentInstanceGuid(), asmtInstanceGuid);
+        assertEquals(meta3.getAssessmentGuid(), ASSESSMENT_2_GUID);
+        assertEquals(meta3.getAssessmentId(), "Shared Assessment 2");
+        assertEquals(meta3.getAssessmentRevision(), Integer.valueOf(200));
+        assertEquals(meta3.getSessionInstanceGuid(), sessionInstanceGuid);
+        assertEquals(meta3.getSessionGuid(), SESSION_GUID_1);
+        assertEquals(meta3.getSessionStartEventId(), "activities_retrieved");
+        assertEquals(meta3.getTimeWindowGuid(), SESSION_WINDOW_GUID_1);
+        assertEquals(meta3.getScheduleGuid(), SCHEDULE_GUID);
+        assertEquals(meta3.getScheduleModifiedOn(), MODIFIED_ON);
+        assertTrue(meta3.isSchedulePublished());
+        assertEquals(meta3.getAppId(), TEST_APP_ID);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineTest.java
@@ -100,6 +100,8 @@ public class TimelineTest extends Mockito {
         assertEquals(meta1.getSessionInstanceGuid(), sessionInstanceGuid);
         assertEquals(meta1.getSessionGuid(), SESSION_GUID_1);
         assertEquals(meta1.getSessionStartEventId(), "activities_retrieved");
+        assertEquals(meta1.getSessionInstanceStartDay(), Integer.valueOf(7));
+        assertEquals(meta1.getSessionInstanceEndDay(), Integer.valueOf(13));
         assertEquals(meta1.getTimeWindowGuid(), SESSION_WINDOW_GUID_1);
         assertEquals(meta1.getScheduleGuid(), SCHEDULE_GUID);
         assertEquals(meta1.getScheduleModifiedOn(), MODIFIED_ON);
@@ -117,6 +119,8 @@ public class TimelineTest extends Mockito {
         assertEquals(meta2.getSessionInstanceGuid(), sessionInstanceGuid);
         assertEquals(meta2.getSessionGuid(), SESSION_GUID_1);
         assertEquals(meta2.getSessionStartEventId(), "activities_retrieved");
+        assertEquals(meta2.getSessionInstanceStartDay(), Integer.valueOf(7));
+        assertEquals(meta2.getSessionInstanceEndDay(), Integer.valueOf(13));
         assertEquals(meta2.getTimeWindowGuid(), SESSION_WINDOW_GUID_1);
         assertEquals(meta2.getScheduleGuid(), SCHEDULE_GUID);
         assertEquals(meta2.getScheduleModifiedOn(), MODIFIED_ON);
@@ -134,6 +138,8 @@ public class TimelineTest extends Mockito {
         assertEquals(meta3.getSessionInstanceGuid(), sessionInstanceGuid);
         assertEquals(meta3.getSessionGuid(), SESSION_GUID_1);
         assertEquals(meta3.getSessionStartEventId(), "activities_retrieved");
+        assertEquals(meta3.getSessionInstanceStartDay(), Integer.valueOf(7));
+        assertEquals(meta3.getSessionInstanceEndDay(), Integer.valueOf(13));
         assertEquals(meta3.getTimeWindowGuid(), SESSION_WINDOW_GUID_1);
         assertEquals(meta3.getScheduleGuid(), SCHEDULE_GUID);
         assertEquals(meta3.getScheduleModifiedOn(), MODIFIED_ON);


### PR DESCRIPTION
In addition, fixed a bug where a couple of session fields were not being copied over to the timeline metadata record, and added a method to return the record as a map. Added a test for these fields and the map. 

We're going to take the map, add some user-specific metadata, and attach it to the health data record in the v3 version of the exporter. Along with metadata submitted by the client, that's the tagging of the exported file that researchers will have available to search for/filter/analyze their data.