### PR TITLE
Fixing an NPE in AdherenceController

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AdherenceController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AdherenceController.java
@@ -9,8 +9,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.StatusMessage;
+import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecord;
@@ -72,7 +74,9 @@ public class AdherenceController extends BaseController {
         
         String healthCode = accountService.getHealthCodeForAccount(
                 AccountId.forId(session.getAppId(), userId));
-        
+        if (healthCode == null) {
+            throw new EntityNotFoundException(Account.class);
+        }
         return service.getAdherenceRecords(session.getAppId(), healthCode, search);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AdherenceControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AdherenceControllerTest.java
@@ -30,6 +30,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.StatusMessage;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
@@ -164,5 +165,15 @@ public class AdherenceControllerTest extends Mockito {
         assertEquals(captured.getUserId(), "some-other-id");
         assertEquals(captured.getOffsetBy(), Integer.valueOf(10));
         assertEquals(captured.getPageSize(), Integer.valueOf(50));        
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void searchForAdherenceRecords_noAccount() throws Exception {
+        doReturn(session).when(controller).getAuthenticatedSession(RESEARCHER, STUDY_COORDINATOR);
+        
+        AdherenceRecordsSearch search = new AdherenceRecordsSearch.Builder().build();
+        mockRequestBody(mockRequest, search);
+        
+        controller.searchForAdherenceRecords(TEST_STUDY_ID, "some-other-id");
     }
 }


### PR DESCRIPTION
This is a simple one...the method to lookup a healthCode will return null if the user ID is junk.