### PR TITLE
Small changes to scheduling

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/models/ParticipantRosterRequest.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/ParticipantRosterRequest.java
@@ -1,8 +1,6 @@
 package org.sagebionetworks.bridge.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.sagebionetworks.bridge.json.DateTimeDeserializer;
 
 /**
  * Request for participant roster download.

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/AssessmentInfo.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/AssessmentInfo.java
@@ -1,6 +1,8 @@
 package org.sagebionetworks.bridge.models.schedules2.timelines;
 
 import static com.google.common.base.Charsets.UTF_8;
+import static org.sagebionetworks.bridge.BridgeConstants.SHARED_APP_ID;
+import static org.sagebionetworks.bridge.models.appconfig.ConfigResolver.INSTANCE;
 
 import java.util.List;
 import java.util.Objects;
@@ -12,6 +14,7 @@ import com.google.common.hash.Hashing;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.models.Label;
+import org.sagebionetworks.bridge.models.appconfig.ConfigResolver;
 import org.sagebionetworks.bridge.models.assessments.ColorScheme;
 import org.sagebionetworks.bridge.models.schedules2.AssessmentReference;
 
@@ -28,7 +31,7 @@ public final class AssessmentInfo {
     private final String label;
     private final Integer minutesToComplete;
     private final ColorScheme colorScheme;
-
+    
     public static AssessmentInfo create(AssessmentReference ref) {
         List<String> languages = RequestContext.get().getCallerLanguages();
         
@@ -66,8 +69,8 @@ public final class AssessmentInfo {
         }
     }
     
-    private AssessmentInfo(String key, String guid, String appId, String identifier, Integer revision, String label,
-            Integer minutesToComplete, ColorScheme colorScheme) {
+    private AssessmentInfo(String key, String guid, String appId, String identifier,
+            Integer revision, String label, Integer minutesToComplete, ColorScheme colorScheme) {
         this.key = key;
         this.guid = guid;
         this.appId = appId;
@@ -108,6 +111,19 @@ public final class AssessmentInfo {
 
     public ColorScheme getColorScheme() {
         return colorScheme;
+    }
+    
+    public String getConfigUrl() {
+        if (guid == null) {
+            return null;
+        }
+        String path = SHARED_APP_ID.equals(appId) ? "/v1/sharedassessments/" : "/v1/assessments/";
+        return getConfigResolver().url("ws", path + guid + "/config");
+    }
+    
+    // converted to an accessor allow for testing.
+    ConfigResolver getConfigResolver() {
+        return INSTANCE;
     }
     
     @Override

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/AssessmentInfo.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/AssessmentInfo.java
@@ -14,7 +14,6 @@ import com.google.common.hash.Hashing;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.models.Label;
-import org.sagebionetworks.bridge.models.appconfig.ConfigResolver;
 import org.sagebionetworks.bridge.models.assessments.ColorScheme;
 import org.sagebionetworks.bridge.models.schedules2.AssessmentReference;
 
@@ -118,12 +117,7 @@ public final class AssessmentInfo {
             return null;
         }
         String path = SHARED_APP_ID.equals(appId) ? "/v1/sharedassessments/" : "/v1/assessments/";
-        return getConfigResolver().url("ws", path + guid + "/config");
-    }
-    
-    // converted to an accessor allow for testing.
-    ConfigResolver getConfigResolver() {
-        return INSTANCE;
+        return INSTANCE.url("ws", path + guid + "/config");
     }
     
     @Override

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/ScheduledSession.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/ScheduledSession.java
@@ -84,6 +84,9 @@ public class ScheduledSession {
     public TimeWindow getTimeWindow() {
         return window;
     }
+    public String getTimeWindowGuid() {
+        return window.getGuid();
+    }
     
     public static class Builder {
         private String instanceGuid;

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Scheduler.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Scheduler.java
@@ -55,8 +55,9 @@ public class Scheduler {
     }
     
     int calculateEndDay(int studyLengthInDays, LocalTime startTime, int startDay, Period expiration) {
+        // endDay is zero indexed, so we subtract one from studyLengthInDays.
         if (expiration == null) {
-            return studyLengthInDays;
+            return studyLengthInDays - 1;
         }
         int expInMinutes = expiration.toStandardMinutes().getMinutes();
         int minutesInDay = (startTime.getHourOfDay() * 60) + startTime.getMinuteOfHour();
@@ -95,9 +96,13 @@ public class Scheduler {
             Period expiration = window.getExpiration();
             
             endDay = calculateEndDay(studyLengthInDays, startTime, startDay, expiration);
-            // If it extends beyond the end of the study, it is not included in timeline
-            if (endDay > studyLengthInDays) {
+            // If it extends beyond the end of the study, it is not included in timeline.
+            // days are zero indexed so we subtract 1 from studyLengthInDays.
+            if (endDay > (studyLengthInDays-1)) {
                 break;
+            }
+            if (expiration == null) {
+                expiration = Period.parse("P" + (endDay - startDay) + "D");
             }
             
             // This session will be used, so we can add it
@@ -109,7 +114,7 @@ public class Scheduler {
             scheduledSession.withStartDay(startDay);
             scheduledSession.withEndDay(endDay);
             scheduledSession.withStartTime(window.getStartTime());
-            scheduledSession.withExpiration(window.getExpiration());
+            scheduledSession.withExpiration(expiration);
             scheduledSession.withPersistent(window.isPersistent());
             // If it is the first day, and there is a delay set that is less than a day,
             // it’s not entirely defined what should happen in this situation. We include

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionInfo.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionInfo.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.models.schedules2.timelines;
 
+import static java.util.stream.Collectors.toList;
 import static org.sagebionetworks.bridge.BridgeUtils.selectByLang;
 
 import java.util.List;
@@ -14,6 +15,7 @@ import org.sagebionetworks.bridge.models.schedules2.NotificationType;
 import org.sagebionetworks.bridge.models.schedules2.PerformanceOrder;
 import org.sagebionetworks.bridge.models.schedules2.ReminderType;
 import org.sagebionetworks.bridge.models.schedules2.Session;
+import org.sagebionetworks.bridge.models.schedules2.TimeWindow;
 
 public class SessionInfo {
 
@@ -27,6 +29,7 @@ public class SessionInfo {
     private Boolean allowSnooze;
     private Integer minutesToComplete;
     private NotificationMessage message;
+    private List<String> timeWindowGuids;
     
     public static final SessionInfo create(Session session) {
         List<String> languages = RequestContext.get().getCallerLanguages();
@@ -51,6 +54,8 @@ public class SessionInfo {
         if (session.isAllowSnooze()) {
             info.allowSnooze = Boolean.TRUE;    
         }
+        info.timeWindowGuids = session.getTimeWindows().stream()
+                .map(TimeWindow::getGuid).collect(toList());
         if (min > 0) {
             info.minutesToComplete = min;    
         }
@@ -88,4 +93,7 @@ public class SessionInfo {
     public NotificationMessage getMessage() {
         return message;
     }
+    public List<String> getTimeWindowGuids() {
+        return timeWindowGuids;
+    }    
 }

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Timeline.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Timeline.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.models.schedules2.timelines;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -64,7 +65,9 @@ public class Timeline {
         private String lang;
         private List<ScheduledSession> scheduledSessions = new ArrayList<>();
         private Map<String, AssessmentInfo> assessments = new HashMap<>();
-        private Map<String, SessionInfo> sessions = new HashMap<>();
+        // maintain the order the sessions are inserted, which is the order they exist in 
+        // the session.
+        private Map<String, SessionInfo> sessions = new LinkedHashMap<>();
         private List<TimelineMetadata> metadata = new ArrayList<>();
         
         public Builder withSchedule(Schedule2 schedule) {

--- a/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
@@ -45,7 +45,6 @@ import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.AccountSummary;
 import org.sagebionetworks.bridge.models.accounts.PasswordAlgorithm;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
-import org.sagebionetworks.bridge.models.activities.StudyActivityEvent;
 import org.sagebionetworks.bridge.models.activities.StudyActivityEventRequest;
 import org.sagebionetworks.bridge.models.apps.App;
 import org.sagebionetworks.bridge.models.studies.Enrollment;

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/ScheduledSessionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/ScheduledSessionTest.java
@@ -50,6 +50,7 @@ public class ScheduledSessionTest extends Mockito {
         assertEquals(node.get("startTime").textValue(), "17:00");
         assertEquals(node.get("delayTime").textValue(), "PT3H");
         assertEquals(node.get("expiration").textValue(), "PT30M");
+        assertEquals(node.get("timeWindowGuid").textValue(), SESSION_WINDOW_GUID_1);
         assertTrue(node.get("persistent").booleanValue());
         assertEquals(node.get("type").textValue(), "ScheduledSession");
         assertEquals(node.get("assessments").size(), 1);

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/SchedulerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/SchedulerTest.java
@@ -978,6 +978,27 @@ public class SchedulerTest extends Mockito {
         assertEquals(endDay, 23);
     }
     
+    // This verifies that we set an expiration for scheduled sessions based on windows without
+    // an expiration, and (since these had an off-by-one error) verifies that we are calculating
+    // the endDay for these sessions correctly.
+    @Test
+    public void expirationDefaultsToLastDayOfStudy() {
+        int endDay = INSTANCE.calculateEndDay(21, LocalTime.parse("10:00"), 7, null);
+        assertEquals(endDay, 20);
+        
+        Schedule2 schedule = createSchedule("P21D");
+        Session session = createOneTimeSession("P2D");
+        session.getTimeWindows().get(0).setExpiration(null); // no expiration
+        schedule.setSessions(ImmutableList.of(session));
+        
+        Timeline timeline = INSTANCE.calculateTimeline(schedule);
+        assertEquals(timeline.getSchedule().size(), 1);
+        
+        ScheduledSession schSession = timeline.getSchedule().get(0);
+        assertEquals(schSession.getEndDay(), 20);
+        assertEquals(schSession.getExpiration(), Period.parse("P18D"));
+    }
+    
     // This behavior was not what I expected 
     @Test
     public void weeklyAppearsAt28Days() {

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionInfoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionInfoTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.models.schedules2.timelines;
 
 import static org.sagebionetworks.bridge.TestConstants.SESSION_GUID_1;
+import static org.sagebionetworks.bridge.TestConstants.SESSION_WINDOW_GUID_1;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -29,6 +30,7 @@ public class SessionInfoTest extends Mockito {
         assertEquals(node.get("performanceOrder").textValue(), "randomized");
         assertEquals(node.get("notifyAt").textValue(), "start_of_window");
         assertEquals(node.get("remindAt").textValue(), "before_window_end");
+        assertEquals(node.get("timeWindowGuids").get(0).textValue(), SESSION_WINDOW_GUID_1);
         assertTrue(node.get("allowSnooze").booleanValue());
         // this combines the minutes from two assessments, correctly
         assertEquals(node.get("minutesToComplete").intValue(), 8);
@@ -79,7 +81,8 @@ public class SessionInfoTest extends Mockito {
         SessionInfo info = SessionInfo.create(new Session());
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(info);
-        assertEquals(node.size(), 1);
+        assertEquals(node.get("timeWindowGuids").size(), 0);
+        assertEquals(node.size(), 2);
         assertEquals(node.get("type").textValue(), "SessionInfo");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -40,7 +40,6 @@ import java.util.Set;
 import com.amazonaws.services.sqs.AmazonSQSClient;
 import com.amazonaws.services.sqs.model.SendMessageResult;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
 
 import org.joda.time.DateTime;
@@ -50,9 +49,7 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.sagebionetworks.bridge.config.BridgeConfig;
-import org.sagebionetworks.bridge.models.BridgeEntity;
 import org.sagebionetworks.bridge.models.ParticipantRosterRequest;
-import org.sagebionetworks.bridge.models.upload.UploadRequest;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
@@ -133,7 +133,6 @@ import org.sagebionetworks.bridge.services.SponsorService;
 import org.sagebionetworks.bridge.services.AppService;
 import org.sagebionetworks.bridge.services.UserAdminService;
 import org.sagebionetworks.bridge.services.AuthenticationService.ChannelType;
-import org.testng.internal.annotations.ExpectedExceptionsAnnotation;
 
 public class ParticipantControllerTest extends Mockito {
 


### PR DESCRIPTION
1) Time window GUIDs are added to the timeline. Knowing these is very helpful when visualizing the timeline in certain ways, since it allows you to regroup timeline elements into separate streams;

2) Added configURL to assessment info: instead of documenting how this should be calculated, it's now just available and adjusts for whether or not the assessment is a shared assessment, or study specific;

3) Sessions in the timeline now appear in the same order they appear in the schedule. Again for certain UI visualizations, this is helpful.