### PR TITLE
Fix bug: Can bypass phone region validation if you use international format

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/models/accounts/Phone.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/accounts/Phone.java
@@ -23,7 +23,8 @@ public final class Phone {
         checkNotNull(phone);
         try {
             PhoneNumber phoneNumber = PHONE_UTIL.parse(phone.getNumber(), phone.getRegionCode());
-            return PHONE_UTIL.isValidNumber(phoneNumber);
+            return PHONE_UTIL.isValidNumber(phoneNumber) &&
+                    PHONE_UTIL.isValidNumberForRegion(phoneNumber, phone.getRegionCode());
         } catch (NumberParseException e) {
         }
         return false;

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/PhoneTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/PhoneTest.java
@@ -96,7 +96,17 @@ public class PhoneTest {
     public void phoneIsMissingRegionCode() {
         assertFalse(Phone.isValid(new Phone("206.547.2600", null)));
     }
-    
+
+    @Test
+    public void phoneInvalidRegionCode() {
+        assertFalse(Phone.isValid(new Phone("206.547.2600", "gibberish")));
+    }
+
+    @Test
+    public void phoneInvalidRegionCodeInternationalFormat() {
+        assertFalse(Phone.isValid(new Phone("+12065472600", "gibberish")));
+    }
+
     @Test
     public void phoneIsMissingNumber() {
         assertFalse(Phone.isValid(new Phone(null, "US")));

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/PhoneTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/PhoneTest.java
@@ -98,6 +98,11 @@ public class PhoneTest {
     }
 
     @Test
+    public void phoneThreeCharacterRegionNotAllowed() {
+        assertFalse(Phone.isValid(new Phone("206.547.2600", "USA")));
+    }
+
+    @Test
     public void phoneInvalidRegionCode() {
         assertFalse(Phone.isValid(new Phone("206.547.2600", "gibberish")));
     }


### PR DESCRIPTION
I was scrubbing the logs and found something interesting. Apparently, we were getting SQL exceptions because a couple requests were trying to write phone region codes into the database that were longer than the allowed width of 2 characters.

Digging a little deeper, I discovered that while Google's PhoneNumberUtil only allows 2-character region codes, if you supply an international format phone number to PhoneNumberUtil.parse(), it will ignore the specified region code altogether:
https://www.javadoc.io/doc/com.googlecode.libphonenumber/libphonenumber/8.4.1/com/google/i18n/phonenumbers/PhoneNumberUtil.html#parse-java.lang.String-java.lang.String-

I wrote a few unit tests to verify. PhoneTest.phoneInvalidRegionCodeInternationalFormat() fails without changes to Phone.isValid(), but succeeds after the changes are made.