### PR TITLE
Many changes based on conversations with client developers.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
@@ -58,7 +58,6 @@ import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.activities.ActivityEventObjectType;
-import org.sagebionetworks.bridge.models.activities.StudyActivityEvent;
 import org.sagebionetworks.bridge.models.apps.App;
 import org.sagebionetworks.bridge.models.apps.PasswordPolicy;
 import org.sagebionetworks.bridge.models.schedules.Activity;
@@ -735,12 +734,13 @@ public class BridgeUtils {
                 return "custom:" + id;
             }
             try {
-                ActivityEventObjectType.valueOf(id.toUpperCase());
+                String[] parts = id.split(":");
+                ActivityEventObjectType.valueOf(parts[0].toUpperCase());
             } catch(IllegalArgumentException e) {
                 return null;
             }
         }
-        return (id == null) ? null : id.toLowerCase();
+        return (id == null) ? null : id;
     }
     
     /**
@@ -766,15 +766,5 @@ public class BridgeUtils {
             }
         }
         return defaultValue;
-    }
-    
-    public static StudyActivityEvent findByEventId(List<StudyActivityEvent> events, ActivityEventObjectType type) {
-        String eventId = type.name().toLowerCase();
-        for (StudyActivityEvent oneEvent : events) {
-            if (oneEvent.getEventId().equals(eventId)) {
-                return oneEvent;
-            }
-        }
-        return null;
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/dao/AdherenceRecordDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dao/AdherenceRecordDao.java
@@ -2,13 +2,12 @@ package org.sagebionetworks.bridge.dao;
 
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecord;
-import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecordList;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecordsSearch;
 
 public interface AdherenceRecordDao {
     
-    void updateAdherenceRecords(AdherenceRecordList recordList);
-
+    void updateAdherenceRecord(AdherenceRecord record);
+    
     PagedResourceList<AdherenceRecord> getAdherenceRecords(AdherenceRecordsSearch search);
 
 }

--- a/src/main/java/org/sagebionetworks/bridge/dao/Schedule2Dao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dao/Schedule2Dao.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.dao;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.sagebionetworks.bridge.models.PagedResourceList;
@@ -25,4 +26,6 @@ public interface Schedule2Dao {
     void deleteSchedulePermanently(Schedule2 schedule);
     
     Optional<TimelineMetadata> getTimelineMetadata(String instanceGuid);
+    
+    List<TimelineMetadata> getAssessmentsForSessionInstance(String instanceGuid);
 }

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAdherenceRecordDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAdherenceRecordDao.java
@@ -38,7 +38,7 @@ public class HibernateAdherenceRecordDao implements AdherenceRecordDao {
         
         if (record.getStartedOn() == null && !record.isDeclined()) {
             AdherenceRecordId id = new AdherenceRecordId(record.getUserId(), record.getStudyId(),
-                    record.getInstanceGuid(), record.getEventTimestamp());
+                    record.getInstanceGuid(), record.getEventTimestamp(), record.getInstanceTimestamp());
             // Cannot delete if the record is already not there, so check for this.
             AdherenceRecord obj = hibernateHelper.getById(AdherenceRecord.class, id);
             if (obj != null) {

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAdherenceRecordDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAdherenceRecordDao.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 import org.sagebionetworks.bridge.dao.AdherenceRecordDao;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecord;
-import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecordList;
+import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecordId;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecordsSearch;
 
 @Component
@@ -33,15 +33,20 @@ public class HibernateAdherenceRecordDao implements AdherenceRecordDao {
     }
     
     @Override
-    public void updateAdherenceRecords(AdherenceRecordList recordList) {
-        checkNotNull(recordList);
+    public void updateAdherenceRecord(AdherenceRecord record) {
+        checkNotNull(record);
         
-        hibernateHelper.executeWithExceptionHandling(recordList, (session) -> {
-            for (AdherenceRecord record: recordList.getRecords()) {
-                session.saveOrUpdate(record);        
+        if (record.getStartedOn() == null && !record.isDeclined()) {
+            AdherenceRecordId id = new AdherenceRecordId(record.getUserId(), record.getStudyId(),
+                    record.getInstanceGuid(), record.getEventTimestamp());
+            // Cannot delete if the record is already not there, so check for this.
+            AdherenceRecord obj = hibernateHelper.getById(AdherenceRecord.class, id);
+            if (obj != null) {
+                hibernateHelper.deleteById(AdherenceRecord.class, id);    
             }
-            return recordList;
-        });
+        } else {
+            hibernateHelper.saveOrUpdate(record);    
+        }
     }
 
     @Override

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2Dao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2Dao.java
@@ -236,4 +236,15 @@ public class HibernateSchedule2Dao implements Schedule2Dao {
         TimelineMetadata tm = hibernateHelper.getById(TimelineMetadata.class, instanceGuid);
         return Optional.ofNullable(tm);
     }
+    
+    @Override
+    public List<TimelineMetadata> getAssessmentsForSessionInstance(String instanceGuid) {
+        checkNotNull(instanceGuid);
+        
+        QueryBuilder builder = new QueryBuilder();
+        builder.append("SELECT * FROM TimelineMetadata WHERE sessionInstanceGuid = :instanceGuid", "instanceGuid", instanceGuid);
+        builder.append("AND assessmentInstanceGuid IS NOT NULL");
+        
+        return hibernateHelper.nativeQueryGet(builder.getQuery(), builder.getParameters(), null, null, TimelineMetadata.class);
+    }
 }

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudy.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudy.java
@@ -24,6 +24,7 @@ import org.joda.time.LocalDate;
 import org.sagebionetworks.bridge.json.BridgeTypeName;
 import org.sagebionetworks.bridge.models.assessments.ColorScheme;
 import org.sagebionetworks.bridge.models.studies.Contact;
+import org.sagebionetworks.bridge.models.studies.IrbDecisionType;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyId;
 import org.sagebionetworks.bridge.models.studies.StudyPhase;
@@ -54,15 +55,19 @@ public class HibernateStudy implements Study {
     @Enumerated(EnumType.STRING)
     private StudyPhase phase;
     private String details;
+    private String irbName;
     @Convert(converter = LocalDateToStringConverter.class)
-    private LocalDate irbApprovedOn;
+    private LocalDate irbDecisionOn;
     @Convert(converter = LocalDateToStringConverter.class)
-    private LocalDate irbApprovedUntil;
+    private LocalDate irbExpiresOn;
+    @Enumerated(EnumType.STRING)
+    private IrbDecisionType irbDecisionType;
+    private String irbProtocolId;
+    private String irbProtocolName;
     private String studyLogoUrl;
     @Convert(converter = ColorSchemeConverter.class)
     private ColorScheme colorScheme;
     private String institutionId;
-    private String irbProtocolId;
     private String scheduleGuid;
     private String disease;
     private String studyDesignType;
@@ -211,25 +216,45 @@ public class HibernateStudy implements Study {
     }
     
     @Override
-    public LocalDate getIrbApprovedOn() {
-        return irbApprovedOn;
+    public String getIrbName() {
+        return irbName;
     }
-
+    
     @Override
-    public void setIrbApprovedOn(LocalDate irbApprovedOn) {
-        this.irbApprovedOn = irbApprovedOn;
+    public void setIrbName(String irbName) {
+        this.irbName = irbName;
     }
-
+    
     @Override
-    public LocalDate getIrbApprovedUntil() {
-        return irbApprovedUntil;
+    public LocalDate getIrbDecisionOn() {
+        return irbDecisionOn;
     }
-
+    
     @Override
-    public void setIrbApprovedUntil(LocalDate irbApprovedUntil) {
-        this.irbApprovedUntil = irbApprovedUntil;
+    public void setIrbDecisionOn(LocalDate irbDecisionOn) {
+        this.irbDecisionOn = irbDecisionOn;
     }
-
+    
+    @Override
+    public LocalDate getIrbExpiresOn() {
+        return irbExpiresOn;
+    }
+    
+    @Override
+    public void setIrbExpiresOn(LocalDate irbExpiresOn) {
+        this.irbExpiresOn = irbExpiresOn;
+    }
+    
+    @Override
+    public IrbDecisionType getIrbDecisionType() {
+        return irbDecisionType;
+    }
+    
+    @Override
+    public void setIrbDecisionType(IrbDecisionType irbDecisionType) {
+        this.irbDecisionType = irbDecisionType;
+    }
+    
     @Override
     public String getStudyLogoUrl() {
         return studyLogoUrl;
@@ -268,6 +293,16 @@ public class HibernateStudy implements Study {
     @Override
     public void setIrbProtocolId(String irbProtocolId) {
         this.irbProtocolId = irbProtocolId;
+    }
+    
+    @Override
+    public String getIrbProtocolName() {
+        return irbProtocolName;
+    }
+    
+    @Override
+    public void setIrbProtocolName(String irbProtocolName) { 
+        this.irbProtocolName = irbProtocolName;
     }
 
     @Override

--- a/src/main/java/org/sagebionetworks/bridge/models/activities/StudyActivityEventRequest.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/activities/StudyActivityEventRequest.java
@@ -184,4 +184,13 @@ public class StudyActivityEventRequest {
         copy.updateType = updateType;
         return copy;
     }
+
+    @Override
+    public String toString() {
+        return "StudyActivityEventRequest [appId=" + appId + ", userId=" + userId + ", studyId=" + studyId
+                + ", timestamp=" + timestamp + ", answerValue=" + answerValue + ", clientTimeZone=" + clientTimeZone
+                + ", createdOn=" + createdOn + ", objectType=" + objectType + ", objectId=" + objectId + ", eventType="
+                + eventType + ", updateType=" + updateType + ", customEvents=" + customEvents + ", eventKeys="
+                + eventKeys + "]";
+    }
 }

--- a/src/main/java/org/sagebionetworks/bridge/models/activities/StudyActivityEventRequest.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/activities/StudyActivityEventRequest.java
@@ -184,13 +184,4 @@ public class StudyActivityEventRequest {
         copy.updateType = updateType;
         return copy;
     }
-
-    @Override
-    public String toString() {
-        return "StudyActivityEventRequest [appId=" + appId + ", userId=" + userId + ", studyId=" + studyId
-                + ", timestamp=" + timestamp + ", answerValue=" + answerValue + ", clientTimeZone=" + clientTimeZone
-                + ", createdOn=" + createdOn + ", objectType=" + objectType + ", objectId=" + objectId + ", eventType="
-                + eventType + ", updateType=" + updateType + ", customEvents=" + customEvents + ", eventKeys="
-                + eventKeys + "]";
-    }
 }

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceRecord.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceRecord.java
@@ -32,16 +32,18 @@ public class AdherenceRecord implements BridgeEntity {
     private String instanceGuid;
     @Id
     @Convert(converter = DateTimeToLongAttributeConverter.class)
+    private DateTime eventTimestamp;
+    
+    @Convert(converter = DateTimeToLongAttributeConverter.class)
     private DateTime startedOn;
     @Convert(converter = DateTimeToLongAttributeConverter.class)
     private DateTime finishedOn;
     @Convert(converter = DateTimeToLongAttributeConverter.class)
-    private DateTime eventTimestamp;
-    @Convert(converter = DateTimeToLongAttributeConverter.class)
     private DateTime uploadedOn;
     @Convert(converter = JsonNodeAttributeConverter.class)
     private JsonNode clientData;
-    private String clientTimeZone; 
+    private String clientTimeZone;
+    private boolean declined;
     
     public String getAppId() {
         return appId;
@@ -105,5 +107,11 @@ public class AdherenceRecord implements BridgeEntity {
     }
     public void setClientTimeZone(String clientTimeZone) {
         this.clientTimeZone = clientTimeZone;
+    }
+    public boolean isDeclined() {
+        return declined;
+    }
+    public void setDeclined(boolean declined) {
+        this.declined = declined;
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceRecord.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceRecord.java
@@ -33,6 +33,10 @@ public class AdherenceRecord implements BridgeEntity {
     @Id
     @Convert(converter = DateTimeToLongAttributeConverter.class)
     private DateTime eventTimestamp;
+    @Id
+    @JsonIgnore
+    @Convert(converter = DateTimeToLongAttributeConverter.class)
+    private DateTime instanceTimestamp;
     
     @Convert(converter = DateTimeToLongAttributeConverter.class)
     private DateTime startedOn;
@@ -86,6 +90,12 @@ public class AdherenceRecord implements BridgeEntity {
     }
     public void setUploadedOn(DateTime uploadedOn) {
         this.uploadedOn = uploadedOn;
+    }
+    public DateTime getInstanceTimestamp() {
+        return instanceTimestamp;
+    }
+    public void setInstanceTimestamp(DateTime instanceTimestamp) {
+        this.instanceTimestamp = instanceTimestamp;
     }
     public DateTime getEventTimestamp() {
         return eventTimestamp;

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceRecordId.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceRecordId.java
@@ -18,18 +18,18 @@ public final class AdherenceRecordId implements Serializable {
     private String userId;
     private String studyId;
     private String instanceGuid;
-    @Column(name = "startedOn")
+    @Column(name = "eventTimestamp")
     @Convert(converter = DateTimeToLongAttributeConverter.class)
-    private DateTime startedOn;
+    private DateTime eventTimestamp;
 
     public AdherenceRecordId() {
     }
  
-    public AdherenceRecordId(String userId, String studyId, String instanceGuid, DateTime startedOn) {
+    public AdherenceRecordId(String userId, String studyId, String instanceGuid, DateTime eventTimestamp) {
         this.userId = userId;
         this.studyId = studyId;
         this.instanceGuid = instanceGuid;
-        this.startedOn = startedOn;
+        this.eventTimestamp = eventTimestamp;
     }
     
     public String getUserId() {
@@ -41,13 +41,13 @@ public final class AdherenceRecordId implements Serializable {
     public String getInstanceGuid() {
         return instanceGuid;
     }
-    public DateTime getStartedOn() {
-        return startedOn;
+    public DateTime getEventTimestamp() {
+        return eventTimestamp;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId, studyId, instanceGuid, startedOn);
+        return Objects.hash(userId, studyId, instanceGuid, eventTimestamp);
     }
 
     @Override
@@ -59,6 +59,12 @@ public final class AdherenceRecordId implements Serializable {
         return Objects.equals(userId, other.userId) &&
                 Objects.equals(studyId, other.studyId) &&
                 Objects.equals(instanceGuid, other.instanceGuid) &&
-                Objects.equals(startedOn, other.startedOn);
+                Objects.equals(eventTimestamp, other.eventTimestamp);
+    }
+
+    @Override
+    public String toString() {
+        return "AdherenceRecordId [userId=" + userId + ", studyId=" + studyId + ", instanceGuid=" + instanceGuid
+                + ", eventTimestamp=" + eventTimestamp + "]";
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceRecordId.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceRecordId.java
@@ -21,15 +21,19 @@ public final class AdherenceRecordId implements Serializable {
     @Column(name = "eventTimestamp")
     @Convert(converter = DateTimeToLongAttributeConverter.class)
     private DateTime eventTimestamp;
+    @Convert(converter = DateTimeToLongAttributeConverter.class)
+    private DateTime instanceTimestamp;
 
     public AdherenceRecordId() {
     }
  
-    public AdherenceRecordId(String userId, String studyId, String instanceGuid, DateTime eventTimestamp) {
+    public AdherenceRecordId(String userId, String studyId, String instanceGuid, DateTime eventTimestamp,
+            DateTime instanceTimestamp) {
         this.userId = userId;
         this.studyId = studyId;
         this.instanceGuid = instanceGuid;
         this.eventTimestamp = eventTimestamp;
+        this.instanceTimestamp = instanceTimestamp;
     }
     
     public String getUserId() {
@@ -44,10 +48,13 @@ public final class AdherenceRecordId implements Serializable {
     public DateTime getEventTimestamp() {
         return eventTimestamp;
     }
+    public DateTime getInstanceTimestamp() {
+        return instanceTimestamp;
+    }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId, studyId, instanceGuid, eventTimestamp);
+        return Objects.hash(userId, studyId, instanceGuid, eventTimestamp, instanceTimestamp);
     }
 
     @Override
@@ -59,6 +66,7 @@ public final class AdherenceRecordId implements Serializable {
         return Objects.equals(userId, other.userId) &&
                 Objects.equals(studyId, other.studyId) &&
                 Objects.equals(instanceGuid, other.instanceGuid) &&
-                Objects.equals(eventTimestamp, other.eventTimestamp);
+                Objects.equals(eventTimestamp, other.eventTimestamp) &&
+                Objects.equals(instanceTimestamp, other.instanceTimestamp);
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceRecordId.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceRecordId.java
@@ -61,10 +61,4 @@ public final class AdherenceRecordId implements Serializable {
                 Objects.equals(instanceGuid, other.instanceGuid) &&
                 Objects.equals(eventTimestamp, other.eventTimestamp);
     }
-
-    @Override
-    public String toString() {
-        return "AdherenceRecordId [userId=" + userId + ", studyId=" + studyId + ", instanceGuid=" + instanceGuid
-                + ", eventTimestamp=" + eventTimestamp + "]";
-    }
 }

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/MetadataContainer.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/MetadataContainer.java
@@ -9,6 +9,11 @@ import java.util.Map;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecord;
 import org.sagebionetworks.bridge.services.Schedule2Service;
 
+/**
+ * When working with adherence records, you frequently need the TimelineMetadata
+ * record, and carrying this between methods on the callstack is tedious. So this
+ * class provides access to metadata as well as being a parameter object.
+ */
 public class MetadataContainer {
     Schedule2Service scheduleService;
     Map<String, TimelineMetadata> metadata = new HashMap<>();
@@ -18,33 +23,38 @@ public class MetadataContainer {
     
     public MetadataContainer(Schedule2Service scheduleService, List<AdherenceRecord> records) {
         this.scheduleService = scheduleService;
-        addRecords(records);
-    }
-    
-    private void addRecords(List<AdherenceRecord> records) {
         for (AdherenceRecord record : records) {
-            this.records.put(record.getInstanceGuid(), record);
-            TimelineMetadata meta = scheduleService.getTimelineMetadata(record.getInstanceGuid()).orElse(null);
-            if (meta != null) {
-                metadata.put(meta.getGuid(), meta);
-                if (meta.getAssessmentInstanceGuid() == null) {
-                    sessionUpdates.put(meta.getSessionInstanceGuid(), record);
-                } else {
-                    assessmentUpdates.add(record);
-                }
-            }
+            addRecord(record);
         }
     }
     
-    public void addSession(AdherenceRecord session) {
-        sessionUpdates.put(session.getInstanceGuid(), session);
+    public void addRecord(AdherenceRecord record) {
+        this.records.put(record.getInstanceGuid(), record);
+        TimelineMetadata meta = scheduleService.getTimelineMetadata(record.getInstanceGuid()).orElse(null);
+        if (meta != null) {
+            metadata.put(meta.getGuid(), meta);
+            // Persistent activities can be done more than once, and are only differentiated by their
+            // start times, while other activities can only be done once in a time stream, so we use
+            // the startedOn timestamp for persistent records and the eventTimestamp for other records. 
+            // This is set on all updates and is not exposed through the API.
+            if (meta.isTimeWindowPersistent()) {
+                record.setInstanceTimestamp(record.getStartedOn());
+            } else {
+                record.setInstanceTimestamp(record.getEventTimestamp());    
+            }
+            if (meta.getAssessmentInstanceGuid() == null) {
+                sessionUpdates.put(meta.getSessionInstanceGuid(), record);
+            } else {
+                assessmentUpdates.add(record);
+            }
+        }
     }
     
     public Collection<AdherenceRecord> getAssessments() {
         return assessmentUpdates;
     }
     
-    public Collection<AdherenceRecord> getSessions() {
+    public Collection<AdherenceRecord> getSessionUpdates() {
         return sessionUpdates.values();
     }
     

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/MetadataContainer.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/MetadataContainer.java
@@ -1,0 +1,64 @@
+package org.sagebionetworks.bridge.models.schedules2.timelines;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecord;
+import org.sagebionetworks.bridge.services.Schedule2Service;
+
+public class MetadataContainer {
+    Schedule2Service scheduleService;
+    Map<String, TimelineMetadata> metadata = new HashMap<>();
+    Map<String, AdherenceRecord> records = new HashMap<>();
+    Map<String, AdherenceRecord> sessionUpdates = new HashMap<>();
+    List<AdherenceRecord> assessmentUpdates = new ArrayList<>();
+    
+    public MetadataContainer(Schedule2Service scheduleService, List<AdherenceRecord> records) {
+        this.scheduleService = scheduleService;
+        addRecords(records);
+    }
+    
+    private void addRecords(List<AdherenceRecord> records) {
+        for (AdherenceRecord record : records) {
+            this.records.put(record.getInstanceGuid(), record);
+            TimelineMetadata meta = scheduleService.getTimelineMetadata(record.getInstanceGuid()).orElse(null);
+            if (meta != null) {
+                metadata.put(meta.getGuid(), meta);
+                if (meta.getAssessmentInstanceGuid() == null) {
+                    sessionUpdates.put(meta.getSessionInstanceGuid(), record);
+                } else {
+                    assessmentUpdates.add(record);
+                }
+            }
+        }
+    }
+    
+    public void addSession(AdherenceRecord session) {
+        sessionUpdates.put(session.getInstanceGuid(), session);
+    }
+    
+    public Collection<AdherenceRecord> getAssessments() {
+        return assessmentUpdates;
+    }
+    
+    public Collection<AdherenceRecord> getSessions() {
+        return sessionUpdates.values();
+    }
+    
+    public AdherenceRecord getRecord(String instanceGuid) {
+        return records.get(instanceGuid);
+    }
+    
+    public TimelineMetadata getMetadata(String instanceGuid) {
+        TimelineMetadata tm = metadata.get(instanceGuid);
+        if (tm == null) {
+            tm = scheduleService.getTimelineMetadata(instanceGuid).orElse(null);
+        }
+        return tm;
+    }
+}
+
+

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionState.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionState.java
@@ -12,6 +12,9 @@ public class SessionState {
     int finished;
     int declined;
     
+    public SessionState(int total) {
+        this.total = total;
+    }
     boolean isUnstarted() {
         return started == 0;
     }
@@ -22,7 +25,6 @@ public class SessionState {
         return declined == total;
     }
     public void add(AdherenceRecord record) {
-        total++;
         if (record.getStartedOn() != null) {
             started++;
         }

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionState.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionState.java
@@ -1,0 +1,76 @@
+package org.sagebionetworks.bridge.models.schedules2.timelines;
+
+import org.joda.time.DateTime;
+
+import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecord;
+
+public class SessionState {
+    DateTime earliest;
+    DateTime latest;
+    int total;
+    int started;
+    int finished;
+    
+    public SessionState(int total) {
+        this.total = total;
+    }
+    boolean isUnstarted() {
+        return started == 0;
+    }
+    boolean isFinished() {
+        return finished == total;
+    }
+    public void add(AdherenceRecord record) {
+        if (record.getStartedOn() != null) {
+            started++;
+        }
+        if (record.getFinishedOn() != null) {
+            finished++;
+        }
+        replaceEarliest(record.getStartedOn());
+        replaceLatest(record.getFinishedOn());
+    }
+    private void replaceEarliest(DateTime current) {
+        if (current != null && (earliest == null || current.isBefore(earliest))) {
+            earliest = current;
+        }
+    }
+    private void replaceLatest(DateTime current) {
+        if (current != null && (latest == null || current.isAfter(latest))) {
+            latest = current;
+        }
+    }
+    public boolean updateSessionRecord(AdherenceRecord sessionRecord) {
+        boolean updated = false;
+        if (isUnstarted()) {
+            if (sessionRecord.getStartedOn() != null) {
+                sessionRecord.setStartedOn(null);
+                updated = true;
+            }
+            if (sessionRecord.getFinishedOn() != null) {
+                sessionRecord.setFinishedOn(null);
+                updated = true;
+            }
+        } else if (isFinished()) {
+            if (sessionRecord.getStartedOn() == null) {
+                sessionRecord.setStartedOn(earliest);
+                updated = true;
+            }
+            if (sessionRecord.getFinishedOn() == null) { 
+                sessionRecord.setFinishedOn(latest);
+                updated = true;
+            }
+        } else {
+            if (sessionRecord.getStartedOn() == null) {
+                sessionRecord.setStartedOn(earliest);
+                updated = true;
+            }
+            // “unfinish” this record, if need be
+            if (sessionRecord.getFinishedOn() != null) {
+                sessionRecord.setFinishedOn(null);
+                updated = true;
+            }
+        }
+        return updated;
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionState.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionState.java
@@ -10,6 +10,7 @@ public class SessionState {
     int total;
     int started;
     int finished;
+    int declined;
     
     public SessionState(int total) {
         this.total = total;
@@ -20,12 +21,18 @@ public class SessionState {
     boolean isFinished() {
         return finished == total;
     }
+    boolean isDeclined() { 
+        return declined == total;
+    }
     public void add(AdherenceRecord record) {
         if (record.getStartedOn() != null) {
             started++;
         }
         if (record.getFinishedOn() != null) {
             finished++;
+        }
+        if (record.isDeclined()) {
+            declined++;
         }
         replaceEarliest(record.getStartedOn());
         replaceLatest(record.getFinishedOn());
@@ -56,7 +63,7 @@ public class SessionState {
                 sessionRecord.setStartedOn(earliest);
                 updated = true;
             }
-            if (sessionRecord.getFinishedOn() == null) { 
+            if (sessionRecord.getFinishedOn() == null) {
                 sessionRecord.setFinishedOn(latest);
                 updated = true;
             }
@@ -70,6 +77,10 @@ public class SessionState {
                 sessionRecord.setFinishedOn(null);
                 updated = true;
             }
+        }
+        if (isDeclined()) {
+            sessionRecord.setDeclined(true);
+            updated = true;
         }
         return updated;
     }

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionState.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionState.java
@@ -12,9 +12,6 @@ public class SessionState {
     int finished;
     int declined;
     
-    public SessionState(int total) {
-        this.total = total;
-    }
     boolean isUnstarted() {
         return started == 0;
     }
@@ -25,6 +22,7 @@ public class SessionState {
         return declined == total;
     }
     public void add(AdherenceRecord record) {
+        total++;
         if (record.getStartedOn() != null) {
             started++;
         }

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Timeline.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Timeline.java
@@ -113,6 +113,7 @@ public class Timeline {
             sessionMeta.setSessionInstanceStartDay(schSession.getStartDay());
             sessionMeta.setSessionInstanceEndDay(schSession.getEndDay());
             sessionMeta.setTimeWindowGuid(schSession.getTimeWindow().getGuid());
+            sessionMeta.setTimeWindowPersistent(schSession.getTimeWindow().isPersistent());
             metadata.add(sessionMeta);
             
             for (ScheduledAssessment schAsmt : schSession.getAssessments()) {

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Timeline.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Timeline.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge.models.schedules2.timelines;
 
+import static org.sagebionetworks.bridge.validators.ValidatorUtils.periodInMinutes;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -12,6 +14,7 @@ import com.google.common.collect.ImmutableList;
 
 import org.joda.time.Period;
 
+import org.sagebionetworks.bridge.models.schedules2.Notification;
 import org.sagebionetworks.bridge.models.schedules2.Schedule2;
 
 /**
@@ -27,20 +30,31 @@ public class Timeline {
     private final List<AssessmentInfo> assessments;
     private final List<SessionInfo> sessions;
     private final List<TimelineMetadata> metadata;
+    private final int totalMinutes;
+    private final int totalNotifications;
     
     private Timeline(Period duration, String lang, List<ScheduledSession> scheduledSessions,
-            List<AssessmentInfo> assessments, List<SessionInfo> sessions, List<TimelineMetadata> metadata) {
+            List<AssessmentInfo> assessments, List<SessionInfo> sessions, List<TimelineMetadata> metadata,
+            int totalMinutes, int totalNotifications) {
         this.duration = duration;
         this.lang = lang;
         this.scheduledSessions = scheduledSessions;
         this.assessments = assessments;
         this.sessions = sessions;
         this.metadata = metadata;
+        this.totalMinutes = totalMinutes;
+        this.totalNotifications = totalNotifications;
     }
     
     @JsonIgnore
     public String getLang() {
         return lang;
+    }
+    public int getTotalMinutes() {
+        return totalMinutes;
+    }
+    public int getTotalNotifications() {
+        return totalNotifications;
     }
     public Period getDuration() {
         return duration;
@@ -69,6 +83,8 @@ public class Timeline {
         // the session.
         private Map<String, SessionInfo> sessions = new LinkedHashMap<>();
         private List<TimelineMetadata> metadata = new ArrayList<>();
+        private int totalMinutes;
+        private int totalNotifications;
         
         public Builder withSchedule(Schedule2 schedule) {
             this.schedule = schedule;
@@ -99,7 +115,7 @@ public class Timeline {
             sessionMeta.setTimeWindowGuid(schSession.getTimeWindow().getGuid());
             metadata.add(sessionMeta);
             
-            for (ScheduledAssessment schAsmt : schSession.getAssessments()) { 
+            for (ScheduledAssessment schAsmt : schSession.getAssessments()) {
                 TimelineMetadata schMeta = TimelineMetadata.copy(sessionMeta);
                 schMeta.setGuid(schAsmt.getInstanceGuid());
                 schMeta.setAssessmentInstanceGuid(schAsmt.getInstanceGuid());
@@ -108,6 +124,24 @@ public class Timeline {
                 schMeta.setAssessmentRevision(schAsmt.getReference().getRevision());
                 metadata.add(schMeta);    
             }
+            
+            for (Notification notification : schSession.getSession().getNotifications()) {
+                this.totalNotifications += 1;
+                // Repeating notifications will produce more notifications. TimeWindow is never
+                // null but try telling that to FindBugs.
+                if (notification.getInterval() != null && schSession.getTimeWindow() != null) {
+                    long windowMinutes = periodInMinutes(schSession.getTimeWindow().getExpiration());
+                    long intervalMinutes = periodInMinutes(notification.getInterval());
+                    this.totalNotifications += Math.floorDiv(windowMinutes, intervalMinutes);
+                }
+            }
+            // Get the sum of all minutes for all sessions. Each time a scheduled session 
+            // is added, we're adding to this running total.
+            Integer min = this.sessions.get(schSession.getRefGuid()).getMinutesToComplete();
+            if (min != null) {
+                this.totalMinutes += min.intValue();
+            }
+            
             return this;
         }
         public Builder withAssessmentInfo(AssessmentInfo asmtInfo) {
@@ -127,7 +161,7 @@ public class Timeline {
                 return res;
             });
             return new Timeline(duration, lang, scheduledSessions, ImmutableList.copyOf(assessments.values()),
-                    ImmutableList.copyOf(sessions.values()), metadata);
+                    ImmutableList.copyOf(sessions.values()), metadata, totalMinutes, totalNotifications);
         }
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineMetadata.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineMetadata.java
@@ -37,6 +37,7 @@ public class TimelineMetadata implements BridgeEntity {
         copy.setScheduleGuid(meta.getScheduleGuid());
         copy.setSessionStartEventId(meta.getSessionStartEventId());
         copy.setTimeWindowGuid(meta.getTimeWindowGuid());
+        copy.setTimeWindowPersistent(meta.isTimeWindowPersistent());
         copy.setScheduleModifiedOn(meta.getScheduleModifiedOn());
         copy.setSchedulePublished(meta.isSchedulePublished());
         copy.setAppId(meta.getAppId());
@@ -56,6 +57,7 @@ public class TimelineMetadata implements BridgeEntity {
         map.put("sessionInstanceEndDay", Integer.toString(sessionInstanceEndDay));
         map.put("sessionStartEventId", sessionStartEventId);
         map.put("timeWindowGuid", timeWindowGuid);
+        map.put("timeWindowPersistent", Boolean.toString(timeWindowPersistent));
         map.put("scheduleGuid", scheduleGuid);
         map.put("scheduleModifiedOn", scheduleModifiedOn.toString());
         map.put("schedulePublished", Boolean.toString(schedulePublished));
@@ -75,6 +77,7 @@ public class TimelineMetadata implements BridgeEntity {
     private Integer sessionInstanceStartDay;
     private Integer sessionInstanceEndDay;
     private String timeWindowGuid;
+    private boolean timeWindowPersistent;
     private String scheduleGuid;
     @Convert(converter = DateTimeToLongAttributeConverter.class)
     private DateTime scheduleModifiedOn;
@@ -146,6 +149,12 @@ public class TimelineMetadata implements BridgeEntity {
     }
     public void setTimeWindowGuid(String timeWindowGuid) {
         this.timeWindowGuid = timeWindowGuid;
+    }
+    public boolean isTimeWindowPersistent( ) {
+        return timeWindowPersistent;
+    }
+    public void setTimeWindowPersistent(boolean timeWindowPersistent) {
+        this.timeWindowPersistent = timeWindowPersistent;
     }
     public String getScheduleGuid() {
         return scheduleGuid;

--- a/src/main/java/org/sagebionetworks/bridge/models/studies/IrbDecisionType.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/studies/IrbDecisionType.java
@@ -1,0 +1,6 @@
+package org.sagebionetworks.bridge.models.studies;
+
+public enum IrbDecisionType {
+    EXEMPT,
+    APPROVED;
+}

--- a/src/main/java/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/studies/Study.java
@@ -46,11 +46,20 @@ public interface Study extends BridgeEntity {
     JsonNode getClientData();
     void setClientData(JsonNode clientData);
     
-    LocalDate getIrbApprovedOn();
-    void setIrbApprovedOn(LocalDate irbApprovedOn);
+    void setIrbName(String irbName);
+    String getIrbName();
     
-    LocalDate getIrbApprovedUntil();
-    void setIrbApprovedUntil(LocalDate irbApprovedUntil);
+    void setIrbDecisionOn(LocalDate irbDecisionOn);
+    LocalDate getIrbDecisionOn();
+    
+    void setIrbExpiresOn(LocalDate irbExpiresOn);
+    LocalDate getIrbExpiresOn();
+    
+    void setIrbDecisionType(IrbDecisionType irbDecisionType);
+    IrbDecisionType  getIrbDecisionType();
+    
+    String getIrbProtocolName();
+    void setIrbProtocolName(String irbProtocolName); 
     
     String getStudyLogoUrl();
     void setStudyLogoUrl(String studyLogoUrl);

--- a/src/main/java/org/sagebionetworks/bridge/services/AdherenceService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AdherenceService.java
@@ -136,7 +136,7 @@ public class AdherenceService {
                 .withEventTimestamps(ImmutableMap.of(asmtMeta.getSessionStartEventId(), asmt.getEventTimestamp()))
                 .withInstanceGuids(instanceGuids).build());
         
-        SessionState state = new SessionState();
+        SessionState state = new SessionState(asmtMetas.size());
         
         // The session record may have been submitted, it may be persisted, or
         // it may not yet exist, and we take the records in that order.

--- a/src/main/java/org/sagebionetworks/bridge/services/AdherenceService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AdherenceService.java
@@ -47,6 +47,7 @@ import org.sagebionetworks.bridge.models.activities.StudyActivityEventRequest;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecord;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecordList;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecordsSearch;
+import org.sagebionetworks.bridge.models.schedules2.timelines.MetadataContainer;
 import org.sagebionetworks.bridge.models.schedules2.timelines.SessionState;
 import org.sagebionetworks.bridge.models.schedules2.timelines.TimelineMetadata;
 import org.sagebionetworks.bridge.validators.AdherenceRecordsSearchValidator;
@@ -97,70 +98,75 @@ public class AdherenceService {
         CAN_ACCESS_ADHERENCE_DATA.checkAndThrow(
                 AuthEvaluatorField.STUDY_ID, recordList.getRecords().get(0).getStudyId(), 
                 AuthEvaluatorField.USER_ID, recordList.getRecords().get(0).getUserId());
-
-        for (AdherenceRecord record : recordList.getRecords()) {
+        
+        MetadataContainer container = new MetadataContainer(scheduleService, recordList.getRecords());
+        
+        // Update assessments
+        for (AdherenceRecord record : container.getAssessments()) {
+            TimelineMetadata meta = container.getMetadata(record.getInstanceGuid());
             dao.updateAdherenceRecord(record);
+            publishEvent(appId, meta, record);
         }
-        for (AdherenceRecord record : recordList.getRecords()) {
-            updateSessionState(appId, record);
+        // Update sessions implied by assessments
+        for (AdherenceRecord record : container.getAssessments()) {
+            updateSessionState(appId, container, record);
+        }
+        // Update sessions
+        for (AdherenceRecord record : container.getSessions()) {
+            TimelineMetadata sessionMeta = container.getMetadata(record.getInstanceGuid());
+            dao.updateAdherenceRecord(record);
+            publishEvent(appId, sessionMeta, record);
         }
     }
     
-    protected void updateSessionState(String appId, AdherenceRecord record) {
-        checkNotNull(appId);
-        checkNotNull(record);
+    protected void updateSessionState(String appId, MetadataContainer container, AdherenceRecord asmt) {
+        TimelineMetadata asmtMeta = container.getMetadata(asmt.getInstanceGuid());
+        String sessionInstanceGuid = asmtMeta.getSessionInstanceGuid();
+
+        List<TimelineMetadata> asmtMetas = scheduleService.getSessionAssessmentMetadata(sessionInstanceGuid);
+
+        Set<String> instanceGuids = asmtMetas.stream()
+                .map(TimelineMetadata::getAssessmentInstanceGuid)
+                .collect(toSet());
+        instanceGuids.add(sessionInstanceGuid);
         
-        TimelineMetadata meta = scheduleService.getTimelineMetadata(record.getInstanceGuid()).orElse(null);
-        if (meta == null) {
-            return;
-        }
-        publishEvent(appId, meta, record);
-
-        // If this is an assessment update, retrieve all session-related records
-        // and ensure the session’s started/finished state is correct
-        if (meta.getAssessmentInstanceGuid() != null) {
-            
-            String sessionInstanceGuid = meta.getSessionInstanceGuid();
-            
-            List<TimelineMetadata> asmtMetas = scheduleService.getSessionAssessmentMetadata(sessionInstanceGuid);
-
-            Set<String> instanceGuids = asmtMetas.stream()
-                    .map(TimelineMetadata::getAssessmentInstanceGuid)
-                    .collect(toSet());
-            instanceGuids.add(sessionInstanceGuid);
-            
-            AdherenceRecordsSearch search = new AdherenceRecordsSearch.Builder()
-                .withUserId(record.getUserId())
-                .withStudyId(record.getStudyId())
-                .withEventTimestamps(ImmutableMap.of(meta.getSessionStartEventId(), record.getEventTimestamp()))
-                .withInstanceGuids(instanceGuids).build();
-            
-            PagedResourceList<AdherenceRecord> allRecords = dao.getAdherenceRecords(search);
-            
-            AdherenceRecord sessionRecord = null;
-            SessionState state = new SessionState(asmtMetas.size());
-            
-            for (AdherenceRecord oneRecord : allRecords.getItems()) {
-                if (sessionInstanceGuid.equals(oneRecord.getInstanceGuid())) {
+        PagedResourceList<AdherenceRecord> allRecords = dao.getAdherenceRecords(new AdherenceRecordsSearch.Builder()
+                .withUserId(asmt.getUserId())
+                .withStudyId(asmt.getStudyId())
+                .withEventTimestamps(ImmutableMap.of(asmtMeta.getSessionStartEventId(), asmt.getEventTimestamp()))
+                .withInstanceGuids(instanceGuids).build());
+        
+        // The session record may have been submitted, it may be persisted, or
+        // it may not yet exist, and we take the records in that order.
+        AdherenceRecord sessionRecord = container.getRecord(sessionInstanceGuid);
+        // The record may already exist
+        SessionState state = new SessionState(asmtMetas.size());
+        
+        for (AdherenceRecord oneRecord : allRecords.getItems()) {
+            if (sessionInstanceGuid.equals(oneRecord.getInstanceGuid())) {
+                // The record was persisted
+                if (sessionRecord == null) {
                     sessionRecord = oneRecord;
-                } else {
-                    state.add(oneRecord);
                 }
+//                sessionRecord.setClientData(oneRecord.getClientData());
+//                sessionRecord.setStartedOn(oneRecord.getStartedOn());
+//                sessionRecord.setFinishedOn(oneRecord.getFinishedOn());
+//                sessionRecord.setDeclined(oneRecord.isDeclined());
+            } else {
+                state.add(oneRecord);
             }
-            if (sessionRecord == null) {
-                sessionRecord = new AdherenceRecord();
-            }
-            sessionRecord.setAppId(record.getAppId());
-            sessionRecord.setUserId(record.getUserId());
-            sessionRecord.setStudyId(record.getStudyId());
+        }
+        // The record is new and needs to be created
+        if (sessionRecord == null) {
+            sessionRecord = new AdherenceRecord();
+            sessionRecord.setAppId(asmt.getAppId());
+            sessionRecord.setUserId(asmt.getUserId());
+            sessionRecord.setStudyId(asmt.getStudyId());
             sessionRecord.setInstanceGuid(sessionInstanceGuid);
-            sessionRecord.setEventTimestamp(record.getEventTimestamp());
-            
-            if (state.updateSessionRecord(sessionRecord)) {
-                dao.updateAdherenceRecord(sessionRecord);
-                TimelineMetadata sessionMeta = scheduleService.getTimelineMetadata(sessionInstanceGuid).orElse(null);
-                publishEvent(appId, sessionMeta, sessionRecord);
-            }
+            sessionRecord.setEventTimestamp(asmt.getEventTimestamp());
+        }
+        if (state.updateSessionRecord(sessionRecord)) {
+            container.addSession(sessionRecord);
         }
     }
 
@@ -182,6 +188,7 @@ public class AdherenceService {
                 request.objectType(ASSESSMENT);
                 request.objectId(meta.getAssessmentId());
             }
+            System.out.println(request);
             studyActivityEventService.publishEvent(request);
         }
     }

--- a/src/main/java/org/sagebionetworks/bridge/services/AdherenceService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AdherenceService.java
@@ -112,7 +112,7 @@ public class AdherenceService {
             updateSessionState(appId, container, record);
         }
         // Update sessions
-        for (AdherenceRecord record : container.getSessions()) {
+        for (AdherenceRecord record : container.getSessionUpdates()) {
             TimelineMetadata sessionMeta = container.getMetadata(record.getInstanceGuid());
             dao.updateAdherenceRecord(record);
             publishEvent(appId, sessionMeta, record);
@@ -136,22 +136,17 @@ public class AdherenceService {
                 .withEventTimestamps(ImmutableMap.of(asmtMeta.getSessionStartEventId(), asmt.getEventTimestamp()))
                 .withInstanceGuids(instanceGuids).build());
         
+        SessionState state = new SessionState();
+        
         // The session record may have been submitted, it may be persisted, or
         // it may not yet exist, and we take the records in that order.
         AdherenceRecord sessionRecord = container.getRecord(sessionInstanceGuid);
-        // The record may already exist
-        SessionState state = new SessionState(asmtMetas.size());
-        
         for (AdherenceRecord oneRecord : allRecords.getItems()) {
             if (sessionInstanceGuid.equals(oneRecord.getInstanceGuid())) {
                 // The record was persisted
                 if (sessionRecord == null) {
                     sessionRecord = oneRecord;
                 }
-//                sessionRecord.setClientData(oneRecord.getClientData());
-//                sessionRecord.setStartedOn(oneRecord.getStartedOn());
-//                sessionRecord.setFinishedOn(oneRecord.getFinishedOn());
-//                sessionRecord.setDeclined(oneRecord.isDeclined());
             } else {
                 state.add(oneRecord);
             }
@@ -166,7 +161,7 @@ public class AdherenceService {
             sessionRecord.setEventTimestamp(asmt.getEventTimestamp());
         }
         if (state.updateSessionRecord(sessionRecord)) {
-            container.addSession(sessionRecord);
+            container.addRecord(sessionRecord);
         }
     }
 
@@ -188,7 +183,6 @@ public class AdherenceService {
                 request.objectType(ASSESSMENT);
                 request.objectId(meta.getAssessmentId());
             }
-            System.out.println(request);
             studyActivityEventService.publishEvent(request);
         }
     }

--- a/src/main/java/org/sagebionetworks/bridge/services/Schedule2Service.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/Schedule2Service.java
@@ -18,6 +18,7 @@ import static org.sagebionetworks.bridge.models.ResourceList.OFFSET_BY;
 import static org.sagebionetworks.bridge.models.ResourceList.PAGE_SIZE;
 import static org.sagebionetworks.bridge.validators.Schedule2Validator.INSTANCE;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -308,6 +309,11 @@ public class Schedule2Service {
     public Optional<TimelineMetadata> getTimelineMetadata(String instanceGuid) {
         checkNotNull(instanceGuid);
         return dao.getTimelineMetadata(instanceGuid);
+    }
+    
+    public List<TimelineMetadata> getSessionAssessmentMetadata(String instanceGuid) {
+        checkNotNull(instanceGuid);
+        return dao.getAssessmentsForSessionInstance(instanceGuid);
     }
     
     /**

--- a/src/main/java/org/sagebionetworks/bridge/services/StudyActivityEventService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyActivityEventService.java
@@ -10,6 +10,7 @@ import static org.sagebionetworks.bridge.BridgeUtils.formatActivityEventId;
 import static org.sagebionetworks.bridge.BridgeUtils.parseAutoEventValue;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.CREATED_ON;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.CUSTOM;
+import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.ENROLLMENT;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventUpdateType.MUTABLE;
 import static org.sagebionetworks.bridge.validators.StudyActivityEventValidator.DELETE_INSTANCE;
 import static org.sagebionetworks.bridge.validators.Validate.INVALID_EVENT_ID;
@@ -37,6 +38,7 @@ import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.activities.StudyActivityEvent;
 import org.sagebionetworks.bridge.models.activities.StudyActivityEventRequest;
 import org.sagebionetworks.bridge.models.apps.App;
+import org.sagebionetworks.bridge.models.studies.Enrollment;
 import org.sagebionetworks.bridge.validators.Validate;
 
 /**
@@ -46,11 +48,18 @@ import org.sagebionetworks.bridge.validators.Validate;
  * system could not maintain, including a client time zone. This API will replace 
  * the v1 API, so some events that span all studies (like the creation of an 
  * account) are also in the events returned by this system. 
+ * 
+ * The code in this class to insert an enrollment event, when there is no enrollment
+ * event in the tables, is backfill code for accounts that were created and enrolled 
+ * in a study before the deployment of study-specific events. There is no apparent 
+ * reason to actually save them in the table at this point since the records should
+ * only be accessed through this service.
  */
 @Component
 public class StudyActivityEventService {
     
-    private static final String CREATED_ON_FIELD = CREATED_ON.name().toLowerCase();
+    static final String CREATED_ON_FIELD = CREATED_ON.name().toLowerCase();
+    static final String ENROLLMENT_FIELD = ENROLLMENT.name().toLowerCase();
 
     private StudyActivityEventDao dao;
     private AppService appService;
@@ -125,6 +134,7 @@ public class StudyActivityEventService {
 
         List<StudyActivityEvent> events = dao.getRecentStudyActivityEvents(userId, studyId);
         events.add(new StudyActivityEvent(CREATED_ON_FIELD, account.getCreatedOn()));
+        addEnrollmentIfMissing(account, events, studyId);
         
         return new ResourceList<>(events); 
     }
@@ -152,7 +162,6 @@ public class StudyActivityEventService {
         
         // createdOn needs to be emulated in the history view, so it doesn't confuse consumers
         if (eventId.equals(CREATED_ON_FIELD)) {
-            
             List<StudyActivityEvent> events = new ArrayList<>();
             events.add(new StudyActivityEvent(CREATED_ON_FIELD, account.getCreatedOn()));
             
@@ -160,8 +169,19 @@ public class StudyActivityEventService {
                     .withRequestParam(ResourceList.OFFSET_BY, offsetBy)
                     .withRequestParam(ResourceList.PAGE_SIZE, pageSize);    
         }
-        return dao.getStudyActivityEventHistory(account.getId(), studyId, eventId, offsetBy, pageSize)
-            .withRequestParam(ResourceList.OFFSET_BY, offsetBy)
+        
+        PagedResourceList<StudyActivityEvent> results = dao.getStudyActivityEventHistory(
+                account.getId(), studyId, eventId, offsetBy, pageSize);
+        
+        if (eventId.equals(ENROLLMENT_FIELD) && results.getItems().size() == 0) {
+            Enrollment en = findEnrollmentByStudyId(account, studyId);
+            if (en != null) {
+                List<StudyActivityEvent> events = new ArrayList<>();
+                events.add(new StudyActivityEvent(ENROLLMENT_FIELD, en.getEnrolledOn()));
+                results = new PagedResourceList<>(events, 1, true);
+            }
+        }
+        return results.withRequestParam(ResourceList.OFFSET_BY, offsetBy)
             .withRequestParam(ResourceList.PAGE_SIZE, pageSize);
     }
     
@@ -189,5 +209,28 @@ public class StudyActivityEventService {
                 dao.publishEvent(automaticEvent);
             }
         }        
+    }
+    
+    private void addEnrollmentIfMissing(Account account, List<StudyActivityEvent> events, String studyId) {
+        // if events do not include enrollment, you can include it. This provides some
+        // migration support.
+        for (StudyActivityEvent oneEvent : events) {
+            if (oneEvent.getEventId().equals(ENROLLMENT_FIELD)) {
+                return;
+            }
+        }
+        Enrollment en = findEnrollmentByStudyId(account, studyId);
+        if (en != null) {
+            events.add(new StudyActivityEvent(ENROLLMENT_FIELD, en.getEnrolledOn()));
+        }
+    }
+    
+    private Enrollment findEnrollmentByStudyId(Account account, String studyId) {
+        for (Enrollment oneEnrollment : account.getEnrollments()) {
+            if (oneEnrollment.getStudyId().equals(studyId)) {
+                return oneEnrollment;
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ActivityEventController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ActivityEventController.java
@@ -25,6 +25,7 @@ import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.StatusMessage;
 import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.activities.ActivityEvent;
 import org.sagebionetworks.bridge.models.activities.CustomActivityEventRequest;
@@ -126,14 +127,10 @@ public class ActivityEventController extends BaseController {
         int offsetByInt = BridgeUtils.getIntOrDefault(offsetBy, 0);
         int pageSizeInt = BridgeUtils.getIntOrDefault(pageSize, API_DEFAULT_PAGE_SIZE);
         
-        StudyActivityEventRequest request = new StudyActivityEventRequest()
-                .appId(session.getAppId())
-                .studyId(studyId)
-                .userId(session.getId())
-                .objectId(eventId)
-                .objectType(CUSTOM);
+        AccountId accountId = AccountId.forId(session.getAppId(), session.getId());
         
-        return studyActivityEventService.getStudyActivityEventHistory(request, offsetByInt, pageSizeInt);
+        return studyActivityEventService.getStudyActivityEventHistory(
+                accountId, studyId, eventId, offsetByInt, pageSizeInt);
     }
     
     @PostMapping("/v5/studies/{studyId}/participants/self/activityevents")

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AdherenceController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AdherenceController.java
@@ -31,13 +31,27 @@ public class AdherenceController extends BaseController {
     }
     
     @PostMapping("/v5/studies/{studyId}/participants/self/adherence")
-    public StatusMessage updateAdherenceRecords(@PathVariable String studyId) {
+    public StatusMessage updateAdherenceRecordsForSelf(@PathVariable String studyId) {
         UserSession session = getAuthenticatedAndConsentedSession();
         
         AdherenceRecordList recordsList = parseJson(AdherenceRecordList.class);
         for (AdherenceRecord oneRecord : recordsList.getRecords()) {
             oneRecord.setAppId(session.getAppId());
             oneRecord.setUserId(session.getId());
+            oneRecord.setStudyId(studyId);
+        }
+        service.updateAdherenceRecords(session.getAppId(), recordsList);
+        return SAVED_MSG;
+    }
+    
+    @PostMapping("/v5/studies/{studyId}/participants/{userId}/adherence")
+    public StatusMessage updateAdherenceRecords(@PathVariable String studyId, @PathVariable String userId) {
+        UserSession session = getAuthenticatedSession(RESEARCHER, STUDY_COORDINATOR);
+        
+        AdherenceRecordList recordsList = parseJson(AdherenceRecordList.class);
+        for (AdherenceRecord oneRecord : recordsList.getRecords()) {
+            oneRecord.setAppId(session.getAppId());
+            oneRecord.setUserId(userId);
             oneRecord.setStudyId(studyId);
         }
         service.updateAdherenceRecords(session.getAppId(), recordsList);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantController.java
@@ -454,14 +454,10 @@ public class StudyParticipantController extends BaseController {
         Integer offsetByInt = BridgeUtils.getIntOrDefault(offsetBy, 0);
         Integer pageSizeInt = BridgeUtils.getIntOrDefault(pageSize, API_DEFAULT_PAGE_SIZE);
         
-        StudyActivityEventRequest request = new StudyActivityEventRequest()
-                .appId(session.getAppId())
-                .studyId(studyId)
-                .userId(userId)
-                .objectId(eventId)
-                .objectType(CUSTOM);
+        AccountId accountId = BridgeUtils.parseAccountId(session.getAppId(), userId);
         
-        return studyActivityEventService.getStudyActivityEventHistory(request, offsetByInt, pageSizeInt);
+        return studyActivityEventService.getStudyActivityEventHistory(accountId, 
+                studyId, eventId, offsetByInt, pageSizeInt);
     }
     
     @PostMapping("/v5/studies/{studyId}/participants/{userId}/activityevents")

--- a/src/main/java/org/sagebionetworks/bridge/validators/AccountIdValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/AccountIdValidator.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge.validators;
 
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_PHONE_ERROR;
+
 import org.apache.commons.lang3.StringUtils;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.Phone;
@@ -51,7 +53,7 @@ public class AccountIdValidator implements Validator {
             if (identifier.getPhone() == null) {
                 errors.rejectValue("phone", "is required");
             } else if (!Phone.isValid(identifier.getPhone())) {
-                errors.rejectValue("phone", "does not appear to be a phone number");
+                errors.rejectValue("phone", INVALID_PHONE_ERROR);
             }
         } else {
             throw new UnsupportedOperationException("Channel type not implemented");

--- a/src/main/java/org/sagebionetworks/bridge/validators/AdherenceRecordListValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/AdherenceRecordListValidator.java
@@ -41,8 +41,9 @@ public class AdherenceRecordListValidator extends AbstractValidator {
             if (isBlank(record.getInstanceGuid())) {
                 errors.rejectValue(INSTANCE_GUID_FIELD, CANNOT_BE_BLANK);
             }
-            if (record.getStartedOn() == null) {
-                errors.rejectValue(STARTED_ON_FIELD, CANNOT_BE_NULL);
+            if (record.getStartedOn() != null && record.getFinishedOn()  != null && 
+                    record.getStartedOn().isAfter(record.getFinishedOn())) {
+                errors.rejectValue(STARTED_ON_FIELD, "cannot be later than finishedOn");
             }
             if (record.getEventTimestamp() == null) {
                 errors.rejectValue(EVENT_TIMESTAMP_FIELD, CANNOT_BE_NULL);

--- a/src/main/java/org/sagebionetworks/bridge/validators/IdentifierUpdateValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/IdentifierUpdateValidator.java
@@ -1,6 +1,9 @@
 package org.sagebionetworks.bridge.validators;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_EMAIL_ERROR;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_PHONE_ERROR;
 
 import org.apache.commons.validator.routines.EmailValidator;
 
@@ -41,19 +44,19 @@ public class IdentifierUpdateValidator implements Validator {
         if (update.getPhoneUpdate() != null) {
             updateFields++;
             if (!Phone.isValid(update.getPhoneUpdate())) {
-                errors.rejectValue("phoneUpdate", "does not appear to be a phone number");
+                errors.rejectValue("phoneUpdate", INVALID_PHONE_ERROR);
             }            
         }
         if (update.getEmailUpdate() != null) {
             updateFields++;
             if (!EMAIL_VALIDATOR.isValid(update.getEmailUpdate())) {
-                errors.rejectValue("emailUpdate", "does not appear to be an email address");
+                errors.rejectValue("emailUpdate", INVALID_EMAIL_ERROR);
             }
         }
         if (update.getSynapseUserIdUpdate() != null) {
             updateFields++;
             if (isBlank(update.getSynapseUserIdUpdate())) {
-                errors.rejectValue("synapseUserIdUpdate", "cannot be blank");
+                errors.rejectValue("synapseUserIdUpdate", CANNOT_BE_BLANK);
             } else if (!update.getSynapseUserIdUpdate().matches("^[0-9]+$")) {
                 errors.rejectValue("synapseUserIdUpdate", "should be a string containing a positive integer");
             }

--- a/src/main/java/org/sagebionetworks/bridge/validators/IntentToParticipateValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/IntentToParticipateValidator.java
@@ -1,6 +1,8 @@
 package org.sagebionetworks.bridge.validators;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_EMAIL_ERROR;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_PHONE_ERROR;
 
 import org.apache.commons.validator.routines.EmailValidator;
 
@@ -41,10 +43,10 @@ public class IntentToParticipateValidator implements Validator {
             errors.reject("either phone or email is required");
         } else {
             if (intent.getPhone() != null && !Phone.isValid(intent.getPhone())) {
-                errors.rejectValue("phone", "does not appear to be a phone number");
+                errors.rejectValue("phone", INVALID_PHONE_ERROR);
             }
             if (intent.getEmail() != null && !EMAIL_VALIDATOR.isValid(intent.getEmail())) {
-                errors.rejectValue("email", "does not appear to be an email address");
+                errors.rejectValue("email", INVALID_EMAIL_ERROR);
             }
         }
         if (intent.getConsentSignature() == null) {

--- a/src/main/java/org/sagebionetworks/bridge/validators/SessionValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/SessionValidator.java
@@ -48,7 +48,7 @@ public class SessionValidator implements Validator {
     static final String START_TIME_FIELD = "startTime";
     static final String TIME_WINDOWS_FIELD = "timeWindows";
     
-    static final String EXPIRATION_LONGER_THAN_INTERVAL_ERROR = "cannot be longer than the sessioal";
+    static final String EXPIRATION_LONGER_THAN_INTERVAL_ERROR = "cannot be longer than the session interval";
     static final String EXPIRATION_REQUIRED_ERROR = "is required when a session has an interval";
     static final String LONGER_THAN_WINDOW_EXPIRATION_ERROR = "cannot be longer than the shortest window expiration";
     static final String START_TIME_MILLIS_INVALID_ERROR = "cannot specify milliseconds";

--- a/src/main/java/org/sagebionetworks/bridge/validators/SignInValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/SignInValidator.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.sagebionetworks.bridge.validators.SignInValidator.RequiredFields.APP;
 import static org.sagebionetworks.bridge.validators.SignInValidator.RequiredFields.EMAIL;
 import static org.sagebionetworks.bridge.validators.SignInValidator.RequiredFields.EMAIL_PHONE_OR_EXTID;
 import static org.sagebionetworks.bridge.validators.SignInValidator.RequiredFields.PASSWORD;
 import static org.sagebionetworks.bridge.validators.SignInValidator.RequiredFields.PHONE;
 import static org.sagebionetworks.bridge.validators.SignInValidator.RequiredFields.TOKEN;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_PHONE_ERROR;
 import static org.sagebionetworks.bridge.validators.SignInValidator.RequiredFields.REAUTH;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -22,28 +22,27 @@ import org.springframework.validation.Validator;
 public class SignInValidator implements Validator {
     
     /** Request to sign in via email. */
-    public static final SignInValidator EMAIL_SIGNIN_REQUEST = new SignInValidator(EnumSet.of(APP, EMAIL));
+    public static final SignInValidator EMAIL_SIGNIN_REQUEST = new SignInValidator(EnumSet.of(EMAIL));
     /** Sign in using token sent through email. */    
-    public static final SignInValidator EMAIL_SIGNIN = new SignInValidator(EnumSet.of(APP, EMAIL, TOKEN));
+    public static final SignInValidator EMAIL_SIGNIN = new SignInValidator(EnumSet.of(EMAIL, TOKEN));
 
     /** Request to sign in via phone. */
-    public static final SignInValidator PHONE_SIGNIN_REQUEST = new SignInValidator(EnumSet.of(APP, PHONE));
+    public static final SignInValidator PHONE_SIGNIN_REQUEST = new SignInValidator(EnumSet.of(PHONE));
     /** Sign in using token sent through SMS. */
-    public static final SignInValidator PHONE_SIGNIN = new SignInValidator(EnumSet.of(APP, PHONE, TOKEN));
+    public static final SignInValidator PHONE_SIGNIN = new SignInValidator(EnumSet.of(PHONE, TOKEN));
 
     /** Request a reset password link via email or SMS. */
-    public static final SignInValidator REQUEST_RESET_PASSWORD = new SignInValidator(EnumSet.of(APP, EMAIL_PHONE_OR_EXTID));
+    public static final SignInValidator REQUEST_RESET_PASSWORD = new SignInValidator(EnumSet.of(EMAIL_PHONE_OR_EXTID));
     
     /** The basics of a sign in that must be present for the admin create user API. */
-    public static final SignInValidator MINIMAL = new SignInValidator(EnumSet.of(APP, EMAIL_PHONE_OR_EXTID));
+    public static final SignInValidator MINIMAL = new SignInValidator(EnumSet.of(EMAIL_PHONE_OR_EXTID));
     
     /** Sign in using an email and password. */
-    public static final SignInValidator PASSWORD_SIGNIN = new SignInValidator(EnumSet.of(APP, EMAIL_PHONE_OR_EXTID, PASSWORD));
+    public static final SignInValidator PASSWORD_SIGNIN = new SignInValidator(EnumSet.of(EMAIL_PHONE_OR_EXTID, PASSWORD));
     /** Reauthentication. */
-    public static final SignInValidator REAUTH_SIGNIN = new SignInValidator(EnumSet.of(APP, EMAIL_PHONE_OR_EXTID, REAUTH));
+    public static final SignInValidator REAUTH_SIGNIN = new SignInValidator(EnumSet.of(EMAIL_PHONE_OR_EXTID, REAUTH));
     
     static enum RequiredFields {
-        APP,
         EMAIL,
         EMAIL_PHONE_OR_EXTID,
         PASSWORD,
@@ -67,7 +66,7 @@ public class SignInValidator implements Validator {
     public void validate(Object object, Errors errors) {
         SignIn signIn = (SignIn)object;
         
-        if (requiredFields.contains(APP) && isBlank(signIn.getAppId())) {
+        if (isBlank(signIn.getAppId())) {
             errors.rejectValue("appId", "is required");
         }
         if (requiredFields.contains(EMAIL) && isBlank(signIn.getEmail())) {
@@ -93,7 +92,7 @@ public class SignInValidator implements Validator {
                 errors.reject("only provide one of email, phone, or external ID");
             }
             if (signIn.getPhone() != null && !Phone.isValid(signIn.getPhone())) {
-                errors.rejectValue("phone", "does not appear to be a phone number");
+                errors.rejectValue("phone", INVALID_PHONE_ERROR);
             }
         }
         if (requiredFields.contains(TOKEN) && isBlank(signIn.getToken())) {
@@ -106,7 +105,7 @@ public class SignInValidator implements Validator {
             if (signIn.getPhone() == null) {
                 errors.rejectValue("phone", "is required");
             } else if (!Phone.isValid(signIn.getPhone())) {
-                errors.rejectValue("phone", "does not appear to be a phone number");
+                errors.rejectValue("phone", INVALID_PHONE_ERROR);
             }
         }
     }

--- a/src/main/java/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
@@ -5,6 +5,9 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.sagebionetworks.bridge.AuthEvaluatorField.ORG_ID;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_ASSESSMENTS;
 import static org.sagebionetworks.bridge.BridgeConstants.OWASP_REGEXP_VALID_EMAIL;
+import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_EMAIL_ERROR;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_PHONE_ERROR;
 
 import java.util.Map;
 import java.util.Optional;
@@ -54,7 +57,7 @@ public class StudyParticipantValidator implements Validator {
             // If provided, phone must be valid
             Phone phone = participant.getPhone();
             if (phone != null && !Phone.isValid(phone)) {
-                errors.rejectValue("phone", "does not appear to be a phone number");
+                errors.rejectValue("phone", INVALID_PHONE_ERROR);
             }
             // If provided, email must be valid. Commons email validator v1.7 causes our test to 
             // fail because the word "test" appears in the user name, for reasons I could not 
@@ -62,7 +65,7 @@ public class StudyParticipantValidator implements Validator {
             // match valid email addresses.
             String email = participant.getEmail();
             if (email != null && !email.matches(OWASP_REGEXP_VALID_EMAIL)) {
-                errors.rejectValue("email", "does not appear to be an email address");
+                errors.rejectValue("email", INVALID_EMAIL_ERROR);
             }
             // External ID is required for non-administrative accounts when it is required on sign-up.
             if (participant.getRoles().isEmpty() && app.isExternalIdRequiredOnSignup() && participant.getExternalIds().isEmpty()) {
@@ -101,7 +104,7 @@ public class StudyParticipantValidator implements Validator {
                         errors.rejectValue("externalIds["+studyId+"]", "is not a study");
                     }
                     if (isBlank(externalId)) {
-                        errors.rejectValue("externalIds["+studyId+"].externalId", "cannot be blank");
+                        errors.rejectValue("externalIds["+studyId+"].externalId", CANNOT_BE_BLANK);
                     }
                 }
             }
@@ -112,7 +115,7 @@ public class StudyParticipantValidator implements Validator {
         }
 
         if (participant.getSynapseUserId() != null && isBlank(participant.getSynapseUserId())) {
-            errors.rejectValue("synapseUserId", "cannot be blank");
+            errors.rejectValue("synapseUserId", CANNOT_BE_BLANK);
         }
                 
         for (String dataGroup : participant.getDataGroups()) {

--- a/src/main/java/org/sagebionetworks/bridge/validators/StudyValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/StudyValidator.java
@@ -6,6 +6,8 @@ import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_EVENT_ID_PATTERN
 import static org.sagebionetworks.bridge.BridgeConstants.OWASP_REGEXP_VALID_EMAIL;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_EMAIL_ERROR;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_PHONE_ERROR;
 
 import org.sagebionetworks.bridge.models.accounts.Phone;
 import org.sagebionetworks.bridge.models.studies.Contact;
@@ -15,7 +17,20 @@ import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
 public class StudyValidator implements Validator {
+    
     public static final StudyValidator INSTANCE = new StudyValidator();
+    
+    static final String APP_ID_FIELD = "appId";
+    static final String CONTACTS_FIELD = "contacts";
+    static final String EMAIL_FIELD = "email";
+    static final String IDENTIFIER_FIELD = "identifier";
+    static final String IRB_DECISION_ON_FIELD = "irbDecisionOn";
+    static final String IRB_DECISION_TYPE_FIELD = "irbDecisionType";
+    static final String IRB_EXPIRES_ON_FIELD = "irbExpiresOn";
+    static final String NAME_FIELD = "name";
+    static final String PHASE_FIELD = "phase";
+    static final String PHONE_FIELD = "phone";
+    static final String ROLE_FIELD = "role";
 
     @Override
     public boolean supports(Class<?> clazz) {
@@ -27,35 +42,50 @@ public class StudyValidator implements Validator {
         Study study = (Study)object;
         
         if (isBlank(study.getIdentifier())) {
-            errors.rejectValue("identifier", "is required");
+            errors.rejectValue(IDENTIFIER_FIELD, CANNOT_BE_BLANK);
         } else if (!study.getIdentifier().matches(BRIDGE_EVENT_ID_PATTERN)) {
-            errors.rejectValue("identifier", BRIDGE_EVENT_ID_ERROR);
+            errors.rejectValue(IDENTIFIER_FIELD, BRIDGE_EVENT_ID_ERROR);
         }
         if (isBlank(study.getAppId())) {
-            errors.rejectValue("appId", "is required");
+            errors.rejectValue(APP_ID_FIELD, CANNOT_BE_BLANK);
         }
         if (isBlank(study.getName())) {
-            errors.rejectValue("name", "is required");
+            errors.rejectValue(NAME_FIELD, CANNOT_BE_BLANK);
         }
         if (study.getPhase() == null) {
-            errors.rejectValue("phase", "is required");
+            errors.rejectValue(PHASE_FIELD, CANNOT_BE_NULL);
+        }
+        // If one of these is supplied, all three need to be supplied
+        boolean validateIrb = study.getIrbDecisionType() != null ||
+                study.getIrbDecisionOn() != null ||
+                study.getIrbExpiresOn() != null;
+        if (validateIrb) {
+            if (study.getIrbDecisionType() == null) {
+                errors.rejectValue(IRB_DECISION_TYPE_FIELD, CANNOT_BE_NULL);
+            }
+            if (study.getIrbDecisionOn() == null) { 
+                errors.rejectValue(IRB_DECISION_ON_FIELD, CANNOT_BE_NULL);
+            }
+            if (study.getIrbExpiresOn() == null) {
+                errors.rejectValue(IRB_EXPIRES_ON_FIELD, CANNOT_BE_NULL);
+            }
         }
         for (int i=0; i < study.getContacts().size(); i++) {
             Contact contact = study.getContacts().get(i);
-            errors.pushNestedPath("contacts[" + i + "]");
+            errors.pushNestedPath(CONTACTS_FIELD + "[" + i + "]");
             if (contact.getRole() == null) {
-                errors.rejectValue("role", CANNOT_BE_NULL);
+                errors.rejectValue(ROLE_FIELD, CANNOT_BE_NULL);
             }
             if (isBlank(contact.getName())) {
-                errors.rejectValue("name", CANNOT_BE_BLANK);
+                errors.rejectValue(NAME_FIELD, CANNOT_BE_BLANK);
             }
             String email = contact.getEmail();
             if (email != null && !email.matches(OWASP_REGEXP_VALID_EMAIL)) {
-                errors.rejectValue("email", "does not appear to be an email address");
+                errors.rejectValue(EMAIL_FIELD, INVALID_EMAIL_ERROR);
             }
             Phone phone = contact.getPhone();
             if (phone != null && !Phone.isValid(phone)) {
-                errors.rejectValue("phone", "does not appear to be a phone number");
+                errors.rejectValue(PHONE_FIELD, INVALID_PHONE_ERROR);
             }
             errors.popNestedPath();
         }

--- a/src/main/java/org/sagebionetworks/bridge/validators/Validate.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/Validate.java
@@ -39,6 +39,8 @@ public class Validate {
     public static final String WRONG_TYPE = "%s is the wrong type";
     public static final String TIME_ZONE_ERROR = "is not a recognized IANA time zone name";
     public static final String INVALID_EVENT_ID = "is not a valid custom event ID";
+    public static final String INVALID_EMAIL_ERROR = "does not appear to be an email address";
+    public static final String INVALID_PHONE_ERROR = "does not appear to be a phone number";
     
     public static Errors getErrorsFor(Object object) {
         String entityName = BridgeUtils.getTypeName(object.getClass());

--- a/src/main/resources/db/changelog/changelog.sql
+++ b/src/main/resources/db/changelog/changelog.sql
@@ -677,3 +677,34 @@ CREATE TABLE `SessionNotifications` (
 
 ALTER TABLE `Accounts`
 ADD COLUMN `note` text;
+
+-- changeset bridge:37
+
+ALTER TABLE `Substudies`
+DROP COLUMN `irbApprovedOn`,
+DROP COLUMN `irbApprovedUntil`,
+ADD COLUMN `irbName` varchar(60) DEFAULT NULL,
+ADD COLUMN `irbProtocolName` varchar(512) DEFAULT NULL,
+ADD COLUMN `irbDecisionOn` varchar(12) DEFAULT NULL,
+ADD COLUMN `irbExpiresOn` varchar(12) DEFAULT NULL,
+ADD COLUMN `irbDecisionType` enum('EXEMPT','APPROVED') DEFAULT NULL;
+
+DROP TABLE `AdherenceRecords`;
+
+CREATE TABLE `AdherenceRecords` (
+  `appId` varchar(255) NOT NULL,
+  `userId` varchar(255) NOT NULL,
+  `studyId` varchar(60) NOT NULL,
+  `instanceGuid` varchar(128) NOT NULL,
+  `startedOn` bigint(20) unsigned,
+  `eventTimestamp` bigint(20) unsigned,
+  `finishedOn` bigint(20) unsigned,
+  `uploadedOn` bigint(20) unsigned,
+  `clientData` text COLLATE utf8_unicode_ci,
+  `clientTimeZone` varchar(255),
+  `declined` tinyint(1) DEFAULT 0,
+  PRIMARY KEY (`userId`, `studyId`, `instanceGuid`, `eventTimestamp`),
+  CONSTRAINT `AdherenceRecord-Account-Constraint` FOREIGN KEY (`userId`) REFERENCES `Accounts` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `AdherenceRecord-Study-Constraint` FOREIGN KEY (`studyId`) REFERENCES `Substudies` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+

--- a/src/main/resources/db/changelog/changelog.sql
+++ b/src/main/resources/db/changelog/changelog.sql
@@ -689,6 +689,9 @@ ADD COLUMN `irbDecisionOn` varchar(12) DEFAULT NULL,
 ADD COLUMN `irbExpiresOn` varchar(12) DEFAULT NULL,
 ADD COLUMN `irbDecisionType` enum('EXEMPT','APPROVED') DEFAULT NULL;
 
+ALTER TABLE `TimelineMetadata`
+ADD COLUMN `timeWindowPersistent` tinyint(1) DEFAULT 0;
+
 DROP TABLE `AdherenceRecords`;
 
 CREATE TABLE `AdherenceRecords` (
@@ -700,11 +703,11 @@ CREATE TABLE `AdherenceRecords` (
   `eventTimestamp` bigint(20) unsigned,
   `finishedOn` bigint(20) unsigned,
   `uploadedOn` bigint(20) unsigned,
+  `instanceTimestamp` bigint(20) unsigned,
   `clientData` text COLLATE utf8_unicode_ci,
   `clientTimeZone` varchar(255),
   `declined` tinyint(1) DEFAULT 0,
-  PRIMARY KEY (`userId`, `studyId`, `instanceGuid`, `eventTimestamp`),
+  PRIMARY KEY (`userId`, `studyId`, `instanceGuid`, `eventTimestamp`, `instanceTimestamp`),
   CONSTRAINT `AdherenceRecord-Account-Constraint` FOREIGN KEY (`userId`) REFERENCES `Accounts` (`id`) ON DELETE CASCADE,
   CONSTRAINT `AdherenceRecord-Study-Constraint` FOREIGN KEY (`studyId`) REFERENCES `Substudies` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
-

--- a/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -6,7 +6,6 @@ import static org.sagebionetworks.bridge.Roles.STUDY_COORDINATOR;
 import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
-import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.TIMELINE_RETRIEVED;
 import static org.sagebionetworks.bridge.models.assessments.ResourceCategory.LICENSE;
 import static org.sagebionetworks.bridge.models.assessments.ResourceCategory.PUBLICATION;
 import static org.sagebionetworks.bridge.models.templates.TemplateType.EMAIL_SIGNED_CONSENT;
@@ -52,7 +51,6 @@ import org.sagebionetworks.bridge.models.Label;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
-import org.sagebionetworks.bridge.models.activities.StudyActivityEvent;
 import org.sagebionetworks.bridge.models.apps.App;
 import org.sagebionetworks.bridge.models.apps.PasswordPolicy;
 import org.sagebionetworks.bridge.models.assessments.ResourceCategory;
@@ -1008,6 +1006,12 @@ public class BridgeUtilsTest {
     }
 
     @Test
+    public void formatActivityEventIdIsValidCompoundSystemId() {
+        String retValue = BridgeUtils.formatActivityEventId(ImmutableSet.of("foo"), "session:_yfDuP0ZgHx8Kx6_oYRlv3-z:finished");
+        assertEquals(retValue, "session:_yfDuP0ZgHx8Kx6_oYRlv3-z:finished");
+    }
+    
+    @Test
     public void formatActivityEventIdBlank() {
         String retValue = BridgeUtils.formatActivityEventId(ImmutableSet.of("foo"), "");
         assertNull(retValue);
@@ -1024,12 +1028,6 @@ public class BridgeUtilsTest {
     public void formatActivityEventIdWithCasing() {
         String retValue = BridgeUtils.formatActivityEventId(ImmutableSet.of("Event1"), "custom:Event1");
         assertEquals(retValue, "custom:Event1");
-    }
-    
-    @Test
-    public void formatActivityEventIdSystemEventWrongCase() {
-        String retValue = BridgeUtils.formatActivityEventId(ImmutableSet.of(), "ENROLLMENT");
-        assertEquals(retValue, "enrollment");
     }
     
     @Test
@@ -1096,25 +1094,6 @@ public class BridgeUtilsTest {
         
         Label sel = BridgeUtils.selectByLang(items, null, LABEL_HI);
         assertEquals(sel, LABEL_HI);
-    }
-    
-    @Test
-    public void findByEventType_emptyEvents() {
-        List<StudyActivityEvent> events = ImmutableList.of();
-        assertNull( BridgeUtils.findByEventId(events, TIMELINE_RETRIEVED) );
-    }
-
-    @Test
-    public void findByEventType_eventMatches() {
-        StudyActivityEvent event1 = new StudyActivityEvent();
-        event1.setEventId("enrollment");
-        
-        StudyActivityEvent event2 = new StudyActivityEvent();
-        event2.setEventId("timeline_retrieved");
-        
-        List<StudyActivityEvent> events = ImmutableList.of(event1, event2);
-        
-        assertEquals( BridgeUtils.findByEventId(events, TIMELINE_RETRIEVED), event2 );
     }
     
     // assertEquals with two sets doesn't verify the order is the same... hence this test method.

--- a/src/test/java/org/sagebionetworks/bridge/TestUtils.java
+++ b/src/test/java/org/sagebionetworks/bridge/TestUtils.java
@@ -68,6 +68,8 @@ import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.SharingScope;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
+import org.sagebionetworks.bridge.models.activities.ActivityEventObjectType;
+import org.sagebionetworks.bridge.models.activities.StudyActivityEvent;
 import org.sagebionetworks.bridge.models.appconfig.AppConfigElement;
 import org.sagebionetworks.bridge.models.appconfig.ConfigResolver;
 import org.sagebionetworks.bridge.models.apps.PasswordPolicy;
@@ -729,5 +731,13 @@ public class TestUtils {
         return new ConfigResolver(mockConfig);
     }
     
-
+    public static StudyActivityEvent findByEventId(List<StudyActivityEvent> events, ActivityEventObjectType type) {
+        String eventId = type.name().toLowerCase();
+        for (StudyActivityEvent oneEvent : events) {
+            if (oneEvent.getEventId().equals(eventId)) {
+                return oneEvent;
+            }
+        }
+        return null;
+    }
 }

--- a/src/test/java/org/sagebionetworks/bridge/TestUtils.java
+++ b/src/test/java/org/sagebionetworks/bridge/TestUtils.java
@@ -655,6 +655,19 @@ public class TestUtils {
         }
     }
     
+    public static AdherenceRecord mockAdherenceRecord(String instanceGuid) {
+        AdherenceRecord record = new AdherenceRecord();
+        record.setStudyId(TEST_STUDY_ID);
+        record.setUserId(TEST_USER_ID);
+        record.setEventTimestamp(CREATED_ON);
+        record.setClientTimeZone("America/Los_Angeles");
+        record.setStartedOn(MODIFIED_ON);
+        record.setInstanceGuid(instanceGuid);
+        record.setClientTimeZone("America/Los_Angeles");
+        return record;
+    }
+
+    
     public static AdherenceRecord getAdherenceRecord(String instanceGuid) { 
         AdherenceRecord record = new AdherenceRecord();
         record.setStudyId(TEST_STUDY_ID);

--- a/src/test/java/org/sagebionetworks/bridge/TestUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/TestUtilsTest.java
@@ -2,13 +2,17 @@ package org.sagebionetworks.bridge;
 
 import static org.sagebionetworks.bridge.models.OperatingSystem.ANDROID;
 import static org.sagebionetworks.bridge.models.OperatingSystem.IOS;
+import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.TIMELINE_RETRIEVED;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.fail;
 
 import java.util.HashSet;
+import java.util.List;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 
 import org.testng.annotations.Test;
@@ -18,6 +22,7 @@ import org.sagebionetworks.bridge.exceptions.ConstraintViolationException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.Criteria;
 import org.sagebionetworks.bridge.models.accounts.Account;
+import org.sagebionetworks.bridge.models.activities.StudyActivityEvent;
 import org.sagebionetworks.bridge.models.appconfig.AppConfig;
 
 public class TestUtilsTest {
@@ -81,6 +86,26 @@ public class TestUtilsTest {
         assertEquals(newCriteria.getNoneOfGroups(), NONE_OF_GROUPS);
         assertEquals(newCriteria.getAppVersionOperatingSystems(), Sets.newHashSet(IOS, ANDROID));
         assertFalse(criteria == newCriteria);
+    }
+    
+    
+    @Test
+    public void findByEventType_emptyEvents() {
+        List<StudyActivityEvent> events = ImmutableList.of();
+        assertNull( TestUtils.findByEventId(events, TIMELINE_RETRIEVED) );
+    }
+
+    @Test
+    public void findByEventType_eventMatches() {
+        StudyActivityEvent event1 = new StudyActivityEvent();
+        event1.setEventId("enrollment");
+        
+        StudyActivityEvent event2 = new StudyActivityEvent();
+        event2.setEventId("timeline_retrieved");
+        
+        List<StudyActivityEvent> events = ImmutableList.of(event1, event2);
+        
+        assertEquals( TestUtils.findByEventId(events, TIMELINE_RETRIEVED), event2 );
     }
     
     private Criteria newCriteria() {

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAdherenceRecordDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAdherenceRecordDaoTest.java
@@ -39,7 +39,6 @@ import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.schedules2.Schedule2;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecord;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecordId;
-import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecordList;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecordsSearch;
 
 public class HibernateAdherenceRecordDaoTest extends Mockito {
@@ -75,18 +74,6 @@ public class HibernateAdherenceRecordDaoTest extends Mockito {
             func.apply(mockSession);
             return args.getArgument(0);
         });
-    }
-    
-    @Test
-    public void updateAdherenceRecords() {
-        AdherenceRecord rec1 = getAdherenceRecord(GUID);
-        AdherenceRecord rec2 = getAdherenceRecord(GUID + "2");
-        AdherenceRecordList list = new AdherenceRecordList(ImmutableList.of(rec1, rec2));
-        
-        dao.updateAdherenceRecords(list);
-        
-        verify(mockSession).saveOrUpdate(rec1);
-        verify(mockSession).saveOrUpdate(rec2);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAdherenceRecordDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAdherenceRecordDaoTest.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.hibernate;
 import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
 import static org.sagebionetworks.bridge.TestConstants.GUID;
 import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
+import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestUtils.getAdherenceRecord;
@@ -18,6 +19,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+
+import javax.persistence.Column;
+import javax.persistence.Convert;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -60,6 +64,9 @@ public class HibernateAdherenceRecordDaoTest extends Mockito {
     
     @Captor
     ArgumentCaptor<AdherenceRecordId> recordIdCaptor;
+    
+    @Captor
+    ArgumentCaptor<AdherenceRecordId> idCaptor;
     
     @InjectMocks
     HibernateAdherenceRecordDao dao;
@@ -285,6 +292,66 @@ public class HibernateAdherenceRecordDaoTest extends Mockito {
                 " ORDER BY ar.startedOn DESC");
         assertEquals(builder.getParameters().get("studyId"), TEST_STUDY_ID);
         assertEquals(builder.getParameters().get("userId"), TEST_USER_ID);
+    }
+    
+    @Test
+    public void updateAdherenceRecord_saveStarted() { 
+        AdherenceRecord record = new AdherenceRecord();
+        record.setStartedOn(CREATED_ON);
+        
+        dao.updateAdherenceRecord(record);
+        
+        verify(mockHelper).saveOrUpdate(record);
+    }
+    
+    @Test
+    public void updateAdherenceRecord_saveDeclined() { 
+        AdherenceRecord record = new AdherenceRecord();
+        record.setDeclined(true);
+        
+        dao.updateAdherenceRecord(record);
+        
+        verify(mockHelper).saveOrUpdate(record);
+    }
+    
+    @Test
+    public void updateAdherenceRecord_deleteOnUpdate() { 
+        AdherenceRecord record = new AdherenceRecord();
+        record.setAppId(TEST_APP_ID);
+        record.setStudyId(TEST_STUDY_ID);
+        record.setUserId(TEST_USER_ID);
+        record.setInstanceGuid(GUID);
+        record.setEventTimestamp(MODIFIED_ON);
+        record.setInstanceTimestamp(MODIFIED_ON.plusHours(1));
+
+        AdherenceRecord persisted = new AdherenceRecord();
+        when(mockHelper.getById(eq(AdherenceRecord.class), any())).thenReturn(persisted);
+        
+        dao.updateAdherenceRecord(record);
+        
+        verify(mockHelper).deleteById(eq(AdherenceRecord.class), idCaptor.capture());
+        assertEquals(idCaptor.getValue().getUserId(), TEST_USER_ID);
+        assertEquals(idCaptor.getValue().getStudyId(), TEST_STUDY_ID);
+        assertEquals(idCaptor.getValue().getInstanceGuid(), GUID);
+        assertEquals(idCaptor.getValue().getEventTimestamp(), MODIFIED_ON);
+        assertEquals(idCaptor.getValue().getInstanceTimestamp(), MODIFIED_ON.plusHours(1));
+    }
+    
+    @Test
+    public void updateAdherenceRecord_deleteRecordThatDoesNotExist() { 
+        AdherenceRecord record = new AdherenceRecord();
+        record.setAppId(TEST_APP_ID);
+        record.setStudyId(TEST_STUDY_ID);
+        record.setUserId(TEST_USER_ID);
+        record.setInstanceGuid(GUID);
+        record.setEventTimestamp(MODIFIED_ON);
+        record.setInstanceTimestamp(MODIFIED_ON.plusHours(1));
+        when(mockHelper.getById(eq(AdherenceRecord.class), any())).thenReturn(null);
+        
+        dao.updateAdherenceRecord(record);
+        
+        verify(mockHelper).getById(eq(AdherenceRecord.class), any());
+        verifyNoMoreInteractions(mockHelper);
     }
     
     private AdherenceRecordsSearch.Builder search() {

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateStudyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateStudyTest.java
@@ -12,6 +12,7 @@ import org.sagebionetworks.bridge.models.studies.Study;
 
 import static org.sagebionetworks.bridge.TestConstants.COLOR_SCHEME;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
+import static org.sagebionetworks.bridge.models.studies.IrbDecisionType.APPROVED;
 import static org.sagebionetworks.bridge.models.studies.StudyPhase.ANALYSIS;
 import static org.sagebionetworks.bridge.models.studies.StudyPhase.DESIGN;
 import static org.testng.Assert.assertEquals;
@@ -28,7 +29,7 @@ public class HibernateStudyTest {
     private static final DateTime CREATED_ON = DateTime.now().withZone(DateTimeZone.UTC);
     private static final DateTime MODIFIED_ON = DateTime.now().minusHours(1).withZone(DateTimeZone.UTC);
     private static final LocalDate APPROVED_ON = DateTime.now().toLocalDate();
-    private static final LocalDate APPROVED_UNTIL = DateTime.now().plusDays(10).toLocalDate();
+    private static final LocalDate EXPIRES_ON = DateTime.now().plusDays(10).toLocalDate();
     
     @Test
     public void shortConstructor() {
@@ -68,19 +69,22 @@ public class HibernateStudyTest {
         c2.setName("Name2");
         study.setContacts(ImmutableList.of(c1, c2));
         study.setDetails("someDetails");
-        study.setIrbApprovedOn(APPROVED_ON);
-        study.setIrbApprovedUntil(APPROVED_UNTIL);
+        study.setIrbName("WIRB");
+        study.setIrbDecisionOn(APPROVED_ON);
+        study.setIrbExpiresOn(EXPIRES_ON);
+        study.setIrbDecisionType(APPROVED);
         study.setStudyLogoUrl("aStudyLogoUrl");
         study.setColorScheme(COLOR_SCHEME);
         study.setInstitutionId("anInstitutionId");
         study.setIrbProtocolId("anIrbProtocolId");
+        study.setIrbProtocolName("anIrbName");
         study.setScheduleGuid("aScheduleGuid");
         study.setPhase(ANALYSIS);
         study.setDisease("subjective cognitive decline");
         study.setStudyDesignType("observational case control");
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(study);
-        assertEquals(node.size(), 20);
+        assertEquals(node.size(), 23);
         assertEquals(node.get("identifier").textValue(), "oneId");
         assertEquals(node.get("name").textValue(), "name");
         assertTrue(node.get("deleted").booleanValue());
@@ -94,8 +98,11 @@ public class HibernateStudyTest {
         assertEquals(node.get("contacts").get(0).get("name").textValue(), "Name1");
         assertEquals(node.get("contacts").get(1).get("name").textValue(), "Name2");
         assertEquals(node.get("details").textValue(), "someDetails");
-        assertEquals(node.get("irbApprovedOn").textValue(), APPROVED_ON.toString());
-        assertEquals(node.get("irbApprovedUntil").textValue(), APPROVED_UNTIL.toString());
+        assertEquals(node.get("irbName").textValue(), "WIRB");
+        assertEquals(node.get("irbProtocolName").textValue(), "anIrbName");
+        assertEquals(node.get("irbDecisionOn").textValue(), APPROVED_ON.toString());
+        assertEquals(node.get("irbExpiresOn").textValue(), EXPIRES_ON.toString());
+        assertEquals(node.get("irbDecisionType").textValue(), "approved");
         assertEquals(node.get("studyLogoUrl").textValue(), "aStudyLogoUrl");
         assertEquals(node.get("colorScheme").get("type").textValue(), "ColorScheme");
         assertEquals(node.get("institutionId").textValue(), "anInstitutionId");
@@ -115,12 +122,15 @@ public class HibernateStudyTest {
         assertEquals(deser.getCreatedOn(), CREATED_ON);
         assertEquals(deser.getModifiedOn(), MODIFIED_ON);
         assertEquals(deser.getDetails(), "someDetails");
-        assertEquals(deser.getIrbApprovedOn(), APPROVED_ON);
-        assertEquals(deser.getIrbApprovedUntil(), APPROVED_UNTIL);
+        assertEquals(deser.getIrbName(), "WIRB");
+        assertEquals(deser.getIrbDecisionOn(), APPROVED_ON);
+        assertEquals(deser.getIrbExpiresOn(), EXPIRES_ON);
+        assertEquals(deser.getIrbDecisionType(), APPROVED);
         assertEquals(deser.getStudyLogoUrl(), "aStudyLogoUrl");
         assertEquals(deser.getColorScheme(), COLOR_SCHEME);
         assertEquals(deser.getInstitutionId(), "anInstitutionId");
         assertEquals(deser.getIrbProtocolId(), "anIrbProtocolId");
+        assertEquals(deser.getIrbProtocolName(), "anIrbName");
         assertEquals(deser.getScheduleGuid(), "aScheduleGuid");
         assertEquals(deser.getContacts().size(), 2);
         assertEquals(deser.getContacts().get(0).getName(), "Name1");

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceRecordIdTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceRecordIdTest.java
@@ -28,7 +28,7 @@ public class AdherenceRecordIdTest {
         assertEquals(id.getUserId(), TEST_USER_ID);
         assertEquals(id.getStudyId(), TEST_STUDY_ID);
         assertEquals(id.getInstanceGuid(), GUID);
-        assertEquals(id.getStartedOn(), CREATED_ON);
+        assertEquals(id.getEventTimestamp(), CREATED_ON);
     }
 
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceRecordIdTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceRecordIdTest.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.models.schedules2.adherence;
 
 import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
 import static org.sagebionetworks.bridge.TestConstants.GUID;
+import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.testng.Assert.assertEquals;
@@ -23,12 +24,13 @@ public class AdherenceRecordIdTest {
     @Test
     public void test() {
         AdherenceRecordId id = new AdherenceRecordId(
-                TEST_USER_ID, TEST_STUDY_ID, GUID, CREATED_ON);
+                TEST_USER_ID, TEST_STUDY_ID, GUID, CREATED_ON, MODIFIED_ON);
      
         assertEquals(id.getUserId(), TEST_USER_ID);
         assertEquals(id.getStudyId(), TEST_STUDY_ID);
         assertEquals(id.getInstanceGuid(), GUID);
         assertEquals(id.getEventTimestamp(), CREATED_ON);
+        assertEquals(id.getInstanceTimestamp(), MODIFIED_ON);
     }
 
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceRecordTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceRecordTest.java
@@ -1,3 +1,4 @@
+
 package org.sagebionetworks.bridge.models.schedules2.adherence;
 
 import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
@@ -8,6 +9,7 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -33,10 +35,11 @@ public class AdherenceRecordTest extends Mockito {
         record.setEventTimestamp(CREATED_ON.plusHours(1));
         record.setClientData(TestUtils.getClientData());
         record.setClientTimeZone("America/Los_Angeles");
+        record.setDeclined(true);
         record.setInstanceGuid(GUID);
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(record);
-        assertEquals(node.size(), 8);
+        assertEquals(node.size(), 9);
         assertEquals(node.get("startedOn").textValue(), CREATED_ON.toString());
         assertEquals(node.get("finishedOn").textValue(), MODIFIED_ON.toString());
         assertEquals(node.get("uploadedOn").textValue(), MODIFIED_ON.plusHours(1).toString());
@@ -44,6 +47,7 @@ public class AdherenceRecordTest extends Mockito {
         assertEquals(node.get("clientData").get("intValue").intValue(), 4);
         assertEquals(node.get("instanceGuid").textValue(), GUID);
         assertEquals(node.get("clientTimeZone").textValue(), "America/Los_Angeles");
+        assertTrue(node.get("declined").booleanValue());
         assertEquals(node.get("type").textValue(), "AdherenceRecord");
         
         AdherenceRecord deser = BridgeObjectMapper.get()
@@ -55,5 +59,6 @@ public class AdherenceRecordTest extends Mockito {
         assertNotNull(deser.getClientData());
         assertEquals(deser.getClientTimeZone(), "America/Los_Angeles");
         assertEquals(deser.getInstanceGuid(), GUID);
+        assertTrue(deser.isDeclined());
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/MetadataContainerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/MetadataContainerTest.java
@@ -1,0 +1,165 @@
+package org.sagebionetworks.bridge.models.schedules2.timelines;
+
+import static java.util.stream.Collectors.toSet;
+import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
+import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
+import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TIMESTAMP;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import org.joda.time.DateTime;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecord;
+import org.sagebionetworks.bridge.services.Schedule2Service;
+
+public class MetadataContainerTest extends Mockito {
+    
+    @Mock
+    Schedule2Service mockScheduleService;
+    
+    MetadataContainer container;
+    
+    @BeforeMethod
+    public void beforeMethod() { 
+        MockitoAnnotations.initMocks(this);
+    }
+    
+    private MetadataContainer createContainer(List<AdherenceRecord> records) {
+        return new MetadataContainer(mockScheduleService, records);
+    }
+    
+    @Test
+    public void constructorLoadsMetadataAndCategorizesRecords() {
+        List<AdherenceRecord> records = ImmutableList.of(
+            ar("AAA", "session1", CREATED_ON, MODIFIED_ON),
+            ar(null, "session1", CREATED_ON, MODIFIED_ON),
+            ar("BBB", "session2", CREATED_ON, MODIFIED_ON),
+            ar("CCC", "session2", CREATED_ON, MODIFIED_ON),
+            ar(null, "session2", CREATED_ON, MODIFIED_ON)
+        );
+        MetadataContainer container = createContainer(records);
+        
+        assertEquals(container.getSessions().size(), 2);
+        assertEquals(container.getSessions().stream()
+                .map(AdherenceRecord::getInstanceGuid)
+                .collect(toSet()), ImmutableSet.of("session1", "session2"));
+        assertEquals(container.getAssessments().size(), 3);
+        assertEquals(container.getAssessments().stream()
+                .map(AdherenceRecord::getInstanceGuid)
+                .collect(toSet()), ImmutableSet.of("AAA", "BBB", "CCC"));
+        
+        verify(mockScheduleService).getTimelineMetadata("AAA");
+        verify(mockScheduleService).getTimelineMetadata("BBB");
+        verify(mockScheduleService).getTimelineMetadata("CCC");
+        verify(mockScheduleService).getTimelineMetadata("session1");
+        verify(mockScheduleService).getTimelineMetadata("session2");
+
+        assertNotNull(container.getMetadata("AAA"));
+        assertNotNull(container.getMetadata("BBB"));
+        assertNotNull(container.getMetadata("CCC"));
+        assertNotNull(container.getMetadata("session1"));
+        assertNotNull(container.getMetadata("session2"));
+    }
+    
+    @Test
+    public void constructorSkipsRecordsWithoutMetadata() { 
+        List<AdherenceRecord> records = ImmutableList.of(
+            ar("AAA", "session1", CREATED_ON, MODIFIED_ON)
+        );
+        // Nothing found however, when we go to look for it
+        reset(mockScheduleService);
+        
+        MetadataContainer container = createContainer(records);
+        assertTrue(container.getAssessments().isEmpty());
+    }
+    
+    @Test
+    public void addSessionWorks() {
+        MetadataContainer container = createContainer(ImmutableList.of());
+        container.addSession(ar(null, "session3", CREATED_ON, MODIFIED_ON));
+        
+        assertEquals(container.getSessions().size(), 1);
+        assertEquals(container.getSessions().stream()
+                .map(AdherenceRecord::getInstanceGuid)
+                .collect(toSet()), ImmutableSet.of("session3"));
+    }
+    
+    @Test
+    public void getRecordWorks() {
+        MetadataContainer container = createContainer(
+            ImmutableList.of(ar("AAA", "session1", CREATED_ON, MODIFIED_ON)));
+    
+        assertNotNull(container.getRecord("AAA"));
+        assertNull(container.getRecord("DDD"));
+    }
+
+    @Test
+    public void getMetadataWorks() {
+        MetadataContainer container = createContainer(
+                ImmutableList.of(ar(null, "session1", CREATED_ON, MODIFIED_ON)));
+        
+        TimelineMetadata meta = container.getMetadata("session1");
+        assertEquals(meta.getSessionInstanceGuid(), "session1");
+        
+        verify(mockScheduleService).getTimelineMetadata("session1");
+    }
+
+    @Test
+    public void getMetadataLoadsMetadata() {
+        MetadataContainer container = createContainer(ImmutableList.of());
+        
+        container.addSession(ar(null, "session1", CREATED_ON, MODIFIED_ON));
+        
+        TimelineMetadata meta = container.getMetadata("session1");
+        assertEquals(meta.getSessionInstanceGuid(), "session1");
+        
+        verify(mockScheduleService).getTimelineMetadata("session1");
+    }
+    
+    private AdherenceRecord ar(String asmtInstanceGuid, String sessionInstanceGuid, DateTime startedOn, DateTime finishedOn) {
+        AdherenceRecord record = new AdherenceRecord();
+        record.setAppId(TEST_APP_ID);
+        record.setUserId(TEST_USER_ID);
+        record.setStudyId(TEST_STUDY_ID);
+        record.setStartedOn(startedOn);
+        record.setFinishedOn(finishedOn);
+        record.setEventTimestamp(TIMESTAMP);
+        
+        TimelineMetadata meta = new TimelineMetadata();
+        meta.setAppId(TEST_APP_ID);
+        meta.setSessionStartEventId("enrollment");
+        if (asmtInstanceGuid == null) {
+            // Session
+            record.setInstanceGuid(sessionInstanceGuid);
+            meta.setGuid(sessionInstanceGuid);
+            meta.setSessionInstanceGuid(sessionInstanceGuid);
+            when(mockScheduleService.getTimelineMetadata(sessionInstanceGuid))
+                .thenReturn(Optional.of(meta));
+        } else {
+            // Assessment
+            record.setInstanceGuid(asmtInstanceGuid);
+            meta.setGuid(asmtInstanceGuid);
+            meta.setSessionInstanceGuid(sessionInstanceGuid);
+            meta.setAssessmentInstanceGuid(asmtInstanceGuid);
+            when(mockScheduleService.getTimelineMetadata(asmtInstanceGuid))
+                .thenReturn(Optional.of(meta));
+        }
+        return record;
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionStateTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionStateTest.java
@@ -1,0 +1,260 @@
+package org.sagebionetworks.bridge.models.schedules2.timelines;
+
+import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
+import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+import org.joda.time.DateTime;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecord;
+
+public class SessionStateTest extends Mockito {
+    private DateTime TS1 = DateTime.now();
+    private DateTime TS2 = DateTime.now().plusHours(1);
+    private DateTime TS3 = DateTime.now().plusHours(2);
+    private DateTime TS4 = DateTime.now().plusHours(3);
+    private DateTime TS5 = DateTime.now().plusHours(4);
+    private DateTime TS6 = DateTime.now().plusHours(5);
+    private DateTime TS7 = DateTime.now().plusHours(6);
+    private DateTime TS8 = DateTime.now().plusHours(7);
+    
+    @Test
+    public void testUnstarted() { 
+        SessionState state = new SessionState(4);
+        assertTrue(state.isUnstarted());
+        
+        state = new SessionState(4);
+        state.add(unstartedRec());
+        state.add(unstartedRec());
+        assertTrue(state.isUnstarted());
+        state.add(unstartedRec());
+        state.add(unstartedRec());
+        assertTrue(state.isUnstarted());
+    }
+
+    @Test
+    public void testFinished() { 
+        SessionState state = new SessionState(4);
+        state.add(finishedRec());
+        state.add(finishedRec());
+        state.add(finishedRec());
+        state.add(finishedRec());
+        assertTrue(state.isFinished());
+        
+        state = new SessionState(4);
+        state.add(finishedRec());
+        state.add(finishedRec());
+        state.add(unstartedRec());
+        state.add(unstartedRec());
+        assertFalse(state.isFinished());
+    }
+    
+    @Test
+    public void testStarted() { 
+        SessionState state = new SessionState(4);
+        state.add(finishedRec());
+        state.add(finishedRec());
+        state.add(unstartedRec());
+        state.add(unstartedRec());
+        assertFalse(state.isUnstarted());
+        assertFalse(state.isFinished());
+        
+        state = new SessionState(4);
+        state.add(finishedRec());
+        state.add(finishedRec());
+        assertFalse(state.isUnstarted());
+        assertFalse(state.isFinished());
+    }
+    
+    @Test
+    public void selectsTimestamps() {
+        List<AdherenceRecord> recs = getRecords();
+        
+        SessionState state = new SessionState(4);
+        state.add(recs.get(0));
+        state.add(recs.get(1));
+        state.add(recs.get(2));
+        state.add(recs.get(3));
+        
+        assertEquals(state.earliest, TS1);
+        assertEquals(state.latest, TS8);
+        
+        AdherenceRecord sessionRecord = new AdherenceRecord();
+        
+        boolean retValue = state.updateSessionRecord(sessionRecord);
+        assertTrue(retValue);
+        assertEquals(sessionRecord.getStartedOn(), TS1);
+        assertEquals(sessionRecord.getFinishedOn(), TS8);
+    }
+    
+    @Test
+    public void unstartsSessionRecord() { 
+        SessionState state = new SessionState(4);
+        
+        AdherenceRecord sessionRecord = new AdherenceRecord();
+        sessionRecord.setStartedOn(CREATED_ON);
+        sessionRecord.setFinishedOn(MODIFIED_ON);
+        
+        boolean retValue = state.updateSessionRecord(sessionRecord);
+        assertTrue(retValue);
+        assertNull(sessionRecord.getStartedOn());
+        assertNull(sessionRecord.getFinishedOn());
+    }
+    
+    @Test
+    public void finishSessionRecord() {
+        List<AdherenceRecord> recs = getRecords();
+        
+        SessionState state = new SessionState(4);
+        state.add(recs.get(0));
+        state.add(recs.get(1));
+        state.add(recs.get(2));
+        state.add(recs.get(3));
+        
+        AdherenceRecord sessionRecord = new AdherenceRecord();
+        
+        boolean retValue = state.updateSessionRecord(sessionRecord);
+        assertTrue(retValue);
+        assertEquals(sessionRecord.getStartedOn(), TS1);
+        assertEquals(sessionRecord.getFinishedOn(), TS8);
+    }
+    
+    @Test
+    public void inProcessSessionRecord() {
+        List<AdherenceRecord> recs = getRecords();
+        
+        SessionState state = new SessionState(4);
+        state.add(recs.get(0));
+        state.add(recs.get(1));
+        state.add(recs.get(2));
+        
+        AdherenceRecord sessionRecord = new AdherenceRecord();
+        sessionRecord.setFinishedOn(MODIFIED_ON);
+        
+        boolean retValue = state.updateSessionRecord(sessionRecord);
+        assertTrue(retValue);
+        assertEquals(sessionRecord.getStartedOn(), TS2); // TS1 was in record #4
+        assertNull(sessionRecord.getFinishedOn());
+    }
+    
+    @Test
+    public void unstartsSessionRecordNotChanged() { 
+        SessionState state = new SessionState(4);
+        
+        AdherenceRecord sessionRecord = new AdherenceRecord();
+        
+        boolean retValue = state.updateSessionRecord(sessionRecord);
+        assertFalse(retValue);
+        assertNull(sessionRecord.getStartedOn());
+        assertNull(sessionRecord.getFinishedOn());
+    }
+
+    @Test
+    public void finishSessionRecordNotChanged() {
+        List<AdherenceRecord> recs = getRecords();
+        
+        SessionState state = new SessionState(4);
+        state.add(recs.get(0));
+        state.add(recs.get(1));
+        state.add(recs.get(2));
+        state.add(recs.get(3));
+        
+        AdherenceRecord sessionRecord = new AdherenceRecord();
+        sessionRecord.setStartedOn(CREATED_ON);
+        sessionRecord.setFinishedOn(MODIFIED_ON);
+        
+        boolean retValue = state.updateSessionRecord(sessionRecord);
+        assertFalse(retValue);
+        assertEquals(sessionRecord.getStartedOn(), CREATED_ON);
+        assertEquals(sessionRecord.getFinishedOn(), MODIFIED_ON);
+    }
+    
+    @Test
+    public void inProcessSessionRecordNotChanged() {
+        List<AdherenceRecord> recs = getRecords();
+        
+        SessionState state = new SessionState(4);
+        state.add(recs.get(0));
+        state.add(recs.get(1));
+        state.add(recs.get(2));
+        
+        AdherenceRecord sessionRecord = new AdherenceRecord();
+        sessionRecord.setStartedOn(CREATED_ON);
+        
+        boolean retValue = state.updateSessionRecord(sessionRecord);
+        assertFalse(retValue);
+        assertEquals(sessionRecord.getStartedOn(), CREATED_ON);
+        assertNull(sessionRecord.getFinishedOn());
+    }
+    /*
+        boolean updated = false;
+        if (isUnstarted()) {
+            if (sessionRecord.getStartedOn() != null) {
+                sessionRecord.setStartedOn(null);
+                updated = true;
+            }
+            if (sessionRecord.getFinishedOn() != null) {
+                sessionRecord.setFinishedOn(null);
+                updated = true;
+            }
+        } else if (isFinished()) {
+            if (sessionRecord.getStartedOn() == null) {
+                sessionRecord.setStartedOn(earliest);
+                updated = true;
+            }
+            if (sessionRecord.getFinishedOn() == null) { 
+                sessionRecord.setFinishedOn(latest);
+                updated = true;
+            }
+        } else {
+            if (sessionRecord.getStartedOn() == null) {
+                sessionRecord.setStartedOn(earliest);
+                updated = true;
+            }
+            // “unfinish” this record, if need be
+            if (sessionRecord.getFinishedOn() != null) {
+                sessionRecord.setFinishedOn(null);
+                updated = true;
+            }
+        }
+        return updated;
+     */
+    
+    private List<AdherenceRecord> getRecords() { 
+        AdherenceRecord rec1 = unstartedRec();
+        rec1.setStartedOn(TS2);
+        rec1.setFinishedOn(TS3);
+        AdherenceRecord rec2 = unstartedRec();
+        rec2.setStartedOn(TS7);
+        rec2.setFinishedOn(TS8);
+        AdherenceRecord rec3 = unstartedRec();
+        rec3.setStartedOn(TS4);
+        rec3.setFinishedOn(TS6);
+        AdherenceRecord rec4 = unstartedRec();
+        rec4.setStartedOn(TS1);
+        rec4.setFinishedOn(TS5);
+        return ImmutableList.of(rec1, rec2, rec3, rec4);
+    }
+
+    private AdherenceRecord unstartedRec() {
+        AdherenceRecord ar = new AdherenceRecord();
+        ar.setDeclined(true); // doesn't matter
+        return ar;
+    }
+
+    private AdherenceRecord finishedRec() {
+        AdherenceRecord ar = new AdherenceRecord();
+        ar.setStartedOn(CREATED_ON);
+        ar.setFinishedOn(MODIFIED_ON);
+        return ar;
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionStateTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionStateTest.java
@@ -29,10 +29,10 @@ public class SessionStateTest extends Mockito {
     
     @Test
     public void testUnstarted() { 
-        SessionState state = new SessionState();
+        SessionState state = new SessionState(4);
         assertTrue(state.isUnstarted());
         
-        state = new SessionState();
+        state = new SessionState(4);
         state.add(unstartedRec());
         state.add(unstartedRec());
         assertTrue(state.isUnstarted());
@@ -43,11 +43,11 @@ public class SessionStateTest extends Mockito {
 
     @Test
     public void testDeclined() { 
-        SessionState state = new SessionState();
+        SessionState state = new SessionState(2);
         state.add(finishedRec());
         assertFalse(state.isDeclined());
         
-        state = new SessionState();
+        state = new SessionState(2);
         state.add(unstartedDeclinedRec());
         state.add(unstartedDeclinedRec());
         assertTrue(state.isDeclined());
@@ -55,14 +55,14 @@ public class SessionStateTest extends Mockito {
     
     @Test
     public void testFinished() { 
-        SessionState state = new SessionState();
+        SessionState state = new SessionState(4);
         state.add(finishedRec());
         state.add(finishedRec());
         state.add(finishedRec());
         state.add(finishedRec());
         assertTrue(state.isFinished());
         
-        state = new SessionState();
+        state = new SessionState(4);
         state.add(finishedRec());
         state.add(finishedRec());
         state.add(unstartedRec());
@@ -72,14 +72,14 @@ public class SessionStateTest extends Mockito {
     
     @Test
     public void testStarted() { 
-        SessionState state = new SessionState();
+        SessionState state = new SessionState(4);
         state.add(finishedRec());
         state.add(finishedRec());
         state.add(unstartedRec());
         state.add(unstartedRec());
         assertFalse(state.isUnstarted());
         
-        state = new SessionState();
+        state = new SessionState(4);
         state.add(unstartedRec());
         state.add(unstartedRec());
         assertTrue(state.isUnstarted());
@@ -89,7 +89,7 @@ public class SessionStateTest extends Mockito {
     public void selectsTimestamps() {
         List<AdherenceRecord> recs = getRecords();
         
-        SessionState state = new SessionState();
+        SessionState state = new SessionState(4);
         state.add(recs.get(0));
         state.add(recs.get(1));
         state.add(recs.get(2));
@@ -108,7 +108,7 @@ public class SessionStateTest extends Mockito {
     
     @Test
     public void unstartsSessionRecord() { 
-        SessionState state = new SessionState();
+        SessionState state = new SessionState(4);
         
         AdherenceRecord sessionRecord = new AdherenceRecord();
         sessionRecord.setStartedOn(CREATED_ON);
@@ -124,7 +124,7 @@ public class SessionStateTest extends Mockito {
     public void finishSessionRecord() {
         List<AdherenceRecord> recs = getRecords();
         
-        SessionState state = new SessionState();
+        SessionState state = new SessionState(4);
         state.add(recs.get(0));
         state.add(recs.get(1));
         state.add(recs.get(2));
@@ -144,7 +144,7 @@ public class SessionStateTest extends Mockito {
         
         recs.get(2).setFinishedOn(null);
         
-        SessionState state = new SessionState();
+        SessionState state = new SessionState(4);
         state.add(recs.get(0));
         state.add(recs.get(1));
         state.add(recs.get(2));
@@ -161,7 +161,7 @@ public class SessionStateTest extends Mockito {
     
     @Test
     public void unstartsSessionRecordNotChanged() { 
-        SessionState state = new SessionState();
+        SessionState state = new SessionState(4);
         state.add(unstartedRec());
         
         AdherenceRecord sessionRecord = new AdherenceRecord();
@@ -176,7 +176,7 @@ public class SessionStateTest extends Mockito {
     public void finishSessionRecordNotChanged() {
         List<AdherenceRecord> recs = getRecords();
         
-        SessionState state = new SessionState();
+        SessionState state = new SessionState(4);
         for (AdherenceRecord rec : recs) {
             state.add(rec);    
         }
@@ -196,7 +196,7 @@ public class SessionStateTest extends Mockito {
     public void inProcessSessionRecordNotChanged() {
         List<AdherenceRecord> recs = getRecords();
         
-        SessionState state = new SessionState();
+        SessionState state = new SessionState(4);
         for (AdherenceRecord oneRec : recs) {
             oneRec.setFinishedOn(null);
             state.add(oneRec);

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionStateTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionStateTest.java
@@ -42,6 +42,20 @@ public class SessionStateTest extends Mockito {
     }
 
     @Test
+    public void testDeclined() { 
+        SessionState state = new SessionState(4);
+        assertFalse(state.isDeclined());
+        
+        state = new SessionState(4);
+        state.add(unstartedDeclinedRec());
+        state.add(unstartedDeclinedRec());
+        assertFalse(state.isDeclined());
+        state.add(unstartedDeclinedRec());
+        state.add(unstartedDeclinedRec());
+        assertTrue(state.isDeclined());
+    }
+    
+    @Test
     public void testFinished() { 
         SessionState state = new SessionState(4);
         state.add(finishedRec());
@@ -162,11 +176,10 @@ public class SessionStateTest extends Mockito {
     public void finishSessionRecordNotChanged() {
         List<AdherenceRecord> recs = getRecords();
         
-        SessionState state = new SessionState(4);
-        state.add(recs.get(0));
-        state.add(recs.get(1));
-        state.add(recs.get(2));
-        state.add(recs.get(3));
+        SessionState state = new SessionState(recs.size());
+        for (AdherenceRecord rec : recs) {
+            state.add(rec);    
+        }
         
         AdherenceRecord sessionRecord = new AdherenceRecord();
         sessionRecord.setStartedOn(CREATED_ON);
@@ -176,6 +189,7 @@ public class SessionStateTest extends Mockito {
         assertFalse(retValue);
         assertEquals(sessionRecord.getStartedOn(), CREATED_ON);
         assertEquals(sessionRecord.getFinishedOn(), MODIFIED_ON);
+        assertFalse(sessionRecord.isDeclined());
     }
     
     @Test
@@ -195,39 +209,6 @@ public class SessionStateTest extends Mockito {
         assertEquals(sessionRecord.getStartedOn(), CREATED_ON);
         assertNull(sessionRecord.getFinishedOn());
     }
-    /*
-        boolean updated = false;
-        if (isUnstarted()) {
-            if (sessionRecord.getStartedOn() != null) {
-                sessionRecord.setStartedOn(null);
-                updated = true;
-            }
-            if (sessionRecord.getFinishedOn() != null) {
-                sessionRecord.setFinishedOn(null);
-                updated = true;
-            }
-        } else if (isFinished()) {
-            if (sessionRecord.getStartedOn() == null) {
-                sessionRecord.setStartedOn(earliest);
-                updated = true;
-            }
-            if (sessionRecord.getFinishedOn() == null) { 
-                sessionRecord.setFinishedOn(latest);
-                updated = true;
-            }
-        } else {
-            if (sessionRecord.getStartedOn() == null) {
-                sessionRecord.setStartedOn(earliest);
-                updated = true;
-            }
-            // “unfinish” this record, if need be
-            if (sessionRecord.getFinishedOn() != null) {
-                sessionRecord.setFinishedOn(null);
-                updated = true;
-            }
-        }
-        return updated;
-     */
     
     private List<AdherenceRecord> getRecords() { 
         AdherenceRecord rec1 = unstartedRec();
@@ -247,10 +228,15 @@ public class SessionStateTest extends Mockito {
 
     private AdherenceRecord unstartedRec() {
         AdherenceRecord ar = new AdherenceRecord();
-        ar.setDeclined(true); // doesn't matter
         return ar;
     }
 
+    private AdherenceRecord unstartedDeclinedRec() {
+        AdherenceRecord ar = new AdherenceRecord();
+        ar.setDeclined(true);
+        return ar;
+    }
+    
     private AdherenceRecord finishedRec() {
         AdherenceRecord ar = new AdherenceRecord();
         ar.setStartedOn(CREATED_ON);

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionStateTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionStateTest.java
@@ -29,10 +29,10 @@ public class SessionStateTest extends Mockito {
     
     @Test
     public void testUnstarted() { 
-        SessionState state = new SessionState(4);
+        SessionState state = new SessionState();
         assertTrue(state.isUnstarted());
         
-        state = new SessionState(4);
+        state = new SessionState();
         state.add(unstartedRec());
         state.add(unstartedRec());
         assertTrue(state.isUnstarted());
@@ -43,13 +43,11 @@ public class SessionStateTest extends Mockito {
 
     @Test
     public void testDeclined() { 
-        SessionState state = new SessionState(4);
+        SessionState state = new SessionState();
+        state.add(finishedRec());
         assertFalse(state.isDeclined());
         
-        state = new SessionState(4);
-        state.add(unstartedDeclinedRec());
-        state.add(unstartedDeclinedRec());
-        assertFalse(state.isDeclined());
+        state = new SessionState();
         state.add(unstartedDeclinedRec());
         state.add(unstartedDeclinedRec());
         assertTrue(state.isDeclined());
@@ -57,14 +55,14 @@ public class SessionStateTest extends Mockito {
     
     @Test
     public void testFinished() { 
-        SessionState state = new SessionState(4);
+        SessionState state = new SessionState();
         state.add(finishedRec());
         state.add(finishedRec());
         state.add(finishedRec());
         state.add(finishedRec());
         assertTrue(state.isFinished());
         
-        state = new SessionState(4);
+        state = new SessionState();
         state.add(finishedRec());
         state.add(finishedRec());
         state.add(unstartedRec());
@@ -74,26 +72,24 @@ public class SessionStateTest extends Mockito {
     
     @Test
     public void testStarted() { 
-        SessionState state = new SessionState(4);
+        SessionState state = new SessionState();
         state.add(finishedRec());
         state.add(finishedRec());
         state.add(unstartedRec());
         state.add(unstartedRec());
         assertFalse(state.isUnstarted());
-        assertFalse(state.isFinished());
         
-        state = new SessionState(4);
-        state.add(finishedRec());
-        state.add(finishedRec());
-        assertFalse(state.isUnstarted());
-        assertFalse(state.isFinished());
+        state = new SessionState();
+        state.add(unstartedRec());
+        state.add(unstartedRec());
+        assertTrue(state.isUnstarted());
     }
     
     @Test
     public void selectsTimestamps() {
         List<AdherenceRecord> recs = getRecords();
         
-        SessionState state = new SessionState(4);
+        SessionState state = new SessionState();
         state.add(recs.get(0));
         state.add(recs.get(1));
         state.add(recs.get(2));
@@ -112,7 +108,7 @@ public class SessionStateTest extends Mockito {
     
     @Test
     public void unstartsSessionRecord() { 
-        SessionState state = new SessionState(4);
+        SessionState state = new SessionState();
         
         AdherenceRecord sessionRecord = new AdherenceRecord();
         sessionRecord.setStartedOn(CREATED_ON);
@@ -128,7 +124,7 @@ public class SessionStateTest extends Mockito {
     public void finishSessionRecord() {
         List<AdherenceRecord> recs = getRecords();
         
-        SessionState state = new SessionState(4);
+        SessionState state = new SessionState();
         state.add(recs.get(0));
         state.add(recs.get(1));
         state.add(recs.get(2));
@@ -146,10 +142,13 @@ public class SessionStateTest extends Mockito {
     public void inProcessSessionRecord() {
         List<AdherenceRecord> recs = getRecords();
         
-        SessionState state = new SessionState(4);
+        recs.get(2).setFinishedOn(null);
+        
+        SessionState state = new SessionState();
         state.add(recs.get(0));
         state.add(recs.get(1));
         state.add(recs.get(2));
+        // not the 4th record
         
         AdherenceRecord sessionRecord = new AdherenceRecord();
         sessionRecord.setFinishedOn(MODIFIED_ON);
@@ -162,7 +161,8 @@ public class SessionStateTest extends Mockito {
     
     @Test
     public void unstartsSessionRecordNotChanged() { 
-        SessionState state = new SessionState(4);
+        SessionState state = new SessionState();
+        state.add(unstartedRec());
         
         AdherenceRecord sessionRecord = new AdherenceRecord();
         
@@ -176,7 +176,7 @@ public class SessionStateTest extends Mockito {
     public void finishSessionRecordNotChanged() {
         List<AdherenceRecord> recs = getRecords();
         
-        SessionState state = new SessionState(recs.size());
+        SessionState state = new SessionState();
         for (AdherenceRecord rec : recs) {
             state.add(rec);    
         }
@@ -196,10 +196,11 @@ public class SessionStateTest extends Mockito {
     public void inProcessSessionRecordNotChanged() {
         List<AdherenceRecord> recs = getRecords();
         
-        SessionState state = new SessionState(4);
-        state.add(recs.get(0));
-        state.add(recs.get(1));
-        state.add(recs.get(2));
+        SessionState state = new SessionState();
+        for (AdherenceRecord oneRec : recs) {
+            oneRec.setFinishedOn(null);
+            state.add(oneRec);
+        }
         
         AdherenceRecord sessionRecord = new AdherenceRecord();
         sessionRecord.setStartedOn(CREATED_ON);

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineMetadataTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineMetadataTest.java
@@ -31,6 +31,7 @@ public class TimelineMetadataTest extends Mockito {
         assertEquals(meta.getScheduleGuid(), "scheduleGuid");
         assertEquals(meta.getScheduleModifiedOn(), MODIFIED_ON);
         assertTrue(meta.isSchedulePublished());
+        assertTrue(meta.isTimeWindowPersistent());
         assertEquals(meta.getAppId(), "appId");
     }
 
@@ -52,6 +53,7 @@ public class TimelineMetadataTest extends Mockito {
         assertEquals(copy.getScheduleGuid(), "scheduleGuid");
         assertEquals(copy.getScheduleModifiedOn(), MODIFIED_ON);
         assertTrue(copy.isSchedulePublished());
+        assertTrue(copy.isTimeWindowPersistent());
         assertEquals(copy.getAppId(), "appId");
     }
     
@@ -72,6 +74,7 @@ public class TimelineMetadataTest extends Mockito {
         assertEquals(map.get("sessionInstanceStartDay"), "5");
         assertEquals(map.get("sessionInstanceEndDay"), "15");
         assertEquals(map.get("timeWindowGuid"), SESSION_WINDOW_GUID_1);
+        assertEquals(map.get("timeWindowPersistent"), "true");
         assertEquals(map.get("scheduleGuid"), "scheduleGuid");
         assertEquals(map.get("scheduleModifiedOn"), MODIFIED_ON.toString());
         assertEquals(map.get("schedulePublished"), "true");
@@ -90,6 +93,7 @@ public class TimelineMetadataTest extends Mockito {
         meta.setSessionInstanceStartDay(5);
         meta.setSessionInstanceEndDay(15);
         meta.setTimeWindowGuid(SESSION_WINDOW_GUID_1);
+        meta.setTimeWindowPersistent(true);
         meta.setScheduleGuid("scheduleGuid");
         meta.setScheduleModifiedOn(MODIFIED_ON);
         meta.setSchedulePublished(true);

--- a/src/test/java/org/sagebionetworks/bridge/services/AdherenceServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AdherenceServiceTest.java
@@ -546,6 +546,8 @@ public class AdherenceServiceTest extends Mockito {
         asmtMeta.setSessionStartEventId("enrollment");
         when(mockScheduleService.getTimelineMetadata("asmtInstanceGuid"))
             .thenReturn(Optional.of(asmtMeta));
+        when(mockScheduleService.getSessionAssessmentMetadata("sessionInstanceGuid"))
+            .thenReturn(ImmutableList.of(asmtMeta));
 
         AdherenceRecord session = new AdherenceRecord();
         session.setInstanceGuid("sessionInstanceGuid");

--- a/src/test/java/org/sagebionetworks/bridge/services/AdherenceServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AdherenceServiceTest.java
@@ -6,7 +6,6 @@ import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
-import static org.sagebionetworks.bridge.TestUtils.getAdherenceRecord;
 import static org.sagebionetworks.bridge.models.ResourceList.ADHERENCE_RECORD_TYPE;
 import static org.sagebionetworks.bridge.models.ResourceList.ASSESSMENT_IDS;
 import static org.sagebionetworks.bridge.models.ResourceList.CURRENT_TIMESTAMPS_ONLY;
@@ -21,7 +20,6 @@ import static org.sagebionetworks.bridge.models.ResourceList.SORT_ORDER;
 import static org.sagebionetworks.bridge.models.ResourceList.START_TIME;
 import static org.sagebionetworks.bridge.models.ResourceList.STUDY_ID;
 import static org.sagebionetworks.bridge.models.ResourceList.TIME_WINDOW_GUIDS;
-import static org.sagebionetworks.bridge.models.activities.ActivityEventType.FINISHED;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventUpdateType.IMMUTABLE;
 import static org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecordType.ASSESSMENT;
 import static org.sagebionetworks.bridge.models.schedules2.adherence.SortOrder.ASC;
@@ -39,6 +37,7 @@ import java.util.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 
 import org.joda.time.DateTime;
 import org.mockito.ArgumentCaptor;
@@ -66,6 +65,7 @@ import org.sagebionetworks.bridge.models.apps.App;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecord;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecordList;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecordsSearch;
+import org.sagebionetworks.bridge.models.schedules2.timelines.MetadataContainer;
 import org.sagebionetworks.bridge.models.schedules2.timelines.TimelineMetadata;
 
 public class AdherenceServiceTest extends Mockito {
@@ -114,14 +114,18 @@ public class AdherenceServiceTest extends Mockito {
                 .withCallerUserId(TEST_USER_ID)
                 .withCallerEnrolledStudies(ImmutableSet.of(TEST_STUDY_ID)).build());
         
-        AdherenceRecord rec1 = getAdherenceRecord("AAA");
-        AdherenceRecord rec2 = getAdherenceRecord("BBB");
-        AdherenceRecordList records = new AdherenceRecordList(ImmutableList.of(rec1, rec2));
+        AdherenceRecordList records = mockRecordUpdate(ar(STARTED_ON, null), 
+                ar(null, null), null);
+        
         service.updateAdherenceRecords(TEST_APP_ID, records);
         
-        verify(mockDao).updateAdherenceRecord(rec1);
-        verify(mockDao).updateAdherenceRecord(rec2);
-        verifyNoMoreInteractions(mockStudyActivityEventService);
+        verify(mockDao, times(3)).updateAdherenceRecord(recordCaptor.capture());
+        assertEquals(recordCaptor.getAllValues().get(0).getInstanceGuid(), "AAA");
+        assertEquals(recordCaptor.getAllValues().get(1).getInstanceGuid(), "BBB");
+        assertEquals(recordCaptor.getAllValues().get(2).getInstanceGuid(), "sessionInstanceGuid");
+        
+        // Nothing is finished, nothing is published.
+        verify(mockStudyActivityEventService, never()).publishEvent(any());
     }
     
     @Test(expectedExceptions = BadRequestException.class)
@@ -131,15 +135,15 @@ public class AdherenceServiceTest extends Mockito {
 
     @Test(expectedExceptions = UnauthorizedException.class)
     public void updateAdherenceRecords_notAuthorized() {
-        AdherenceRecord rec1 = getAdherenceRecord("AAA");
+        AdherenceRecord rec1 = mockAssessmentRecord("AAA");
         service.updateAdherenceRecords(TEST_APP_ID, new AdherenceRecordList(ImmutableList.of(rec1)));
     }
     
     @Test(expectedExceptions = InvalidEntityException.class)
     public void updateAdherenceRecords_invalidRecord() {
-        AdherenceRecord rec1 = getAdherenceRecord("AAA");
+        AdherenceRecord rec1 = mockAssessmentRecord("AAA");
         rec1.setStartedOn(null);
-        AdherenceRecord rec2 = getAdherenceRecord("BBB");
+        AdherenceRecord rec2 = mockAssessmentRecord("BBB");
         rec2.setUserId(null);
         AdherenceRecordList records = new AdherenceRecordList(ImmutableList.of(rec1, rec2));
 
@@ -152,22 +156,16 @@ public class AdherenceServiceTest extends Mockito {
                 .withCallerUserId(TEST_USER_ID)
                 .withCallerEnrolledStudies(ImmutableSet.of(TEST_STUDY_ID)).build());
         
-        TimelineMetadata meta = new TimelineMetadata();
-        meta.setSessionGuid("sessionGuid");
-        when(mockScheduleService.getTimelineMetadata("BBB")).thenReturn(Optional.of(meta));
+        AdherenceRecordList list = mockRecordUpdate(ar(null, FINISHED_ON), 
+                ar(CREATED_ON, FINISHED_ON), null);
         
-        AdherenceRecord rec1 = getAdherenceRecord("AAA");
-        AdherenceRecord rec2 = getAdherenceRecord("BBB");
-        rec2.setFinishedOn(FINISHED_ON);
-        AdherenceRecordList records = new AdherenceRecordList(ImmutableList.of(rec1, rec2));
+        service.updateAdherenceRecords(TEST_APP_ID, list);
         
-        service.updateAdherenceRecords(TEST_APP_ID, records);
+        verify(mockDao).updateAdherenceRecord(list.getRecords().get(0));
+        verify(mockDao).updateAdherenceRecord(list.getRecords().get(1));
+        verify(mockStudyActivityEventService, times(3)).publishEvent(requestCaptor.capture());
         
-        verify(mockDao).updateAdherenceRecord(rec1);
-        verify(mockDao).updateAdherenceRecord(rec2);
-        verify(mockStudyActivityEventService).publishEvent(requestCaptor.capture());
-        
-        StudyActivityEventRequest request = requestCaptor.getValue();
+        StudyActivityEventRequest request = requestCaptor.getAllValues().get(2);
         assertEquals(request.getAppId(), TEST_APP_ID);
         assertEquals(request.getStudyId(), TEST_STUDY_ID);
         assertEquals(request.getUserId(), TEST_USER_ID);
@@ -183,25 +181,13 @@ public class AdherenceServiceTest extends Mockito {
                 .withCallerUserId(TEST_USER_ID)
                 .withCallerEnrolledStudies(ImmutableSet.of(TEST_STUDY_ID)).build());
         
-        TimelineMetadata meta = new TimelineMetadata();
-        meta.setSessionGuid("sessionGuid");
-        meta.setAssessmentInstanceGuid("assessmentInstanceGuid");
-        meta.setAssessmentId("assessmentId");
-        meta.setSessionStartEventId("enrollment");
-        when(mockScheduleService.getTimelineMetadata("BBB")).thenReturn(Optional.of(meta));
-        when(mockDao.getAdherenceRecords(any())).thenReturn(new PagedResourceList<>(ImmutableList.of(), 0));
+        AdherenceRecordList list = mockRecordUpdate(ar(null, null), 
+                ar(STARTED_ON, FINISHED_ON), null);
         
-        AdherenceRecord rec1 = getAdherenceRecord("AAA");
-        rec1.setEventTimestamp(DateTime.now());
-        AdherenceRecord rec2 = getAdherenceRecord("BBB");
-        rec2.setFinishedOn(FINISHED_ON);
-        rec2.setEventTimestamp(DateTime.now());
-        AdherenceRecordList records = new AdherenceRecordList(ImmutableList.of(rec1, rec2));
+        service.updateAdherenceRecords(TEST_APP_ID, list);
         
-        service.updateAdherenceRecords(TEST_APP_ID, records);
-        
-        verify(mockDao).updateAdherenceRecord(rec1);
-        verify(mockDao).updateAdherenceRecord(rec2);
+        verify(mockDao).updateAdherenceRecord(list.getRecords().get(0));
+        verify(mockDao).updateAdherenceRecord(list.getRecords().get(1));
         verify(mockStudyActivityEventService).publishEvent(requestCaptor.capture());
         
         StudyActivityEventRequest request = requestCaptor.getValue();
@@ -209,7 +195,6 @@ public class AdherenceServiceTest extends Mockito {
         assertEquals(request.getStudyId(), TEST_STUDY_ID);
         assertEquals(request.getUserId(), TEST_USER_ID);
         assertEquals(request.getObjectType(), ActivityEventObjectType.ASSESSMENT);
-        assertEquals(request.getObjectId(), "assessmentId");
         assertEquals(request.getEventType(), ActivityEventType.FINISHED);
         assertEquals(request.getTimestamp(), FINISHED_ON); 
     }
@@ -220,95 +205,50 @@ public class AdherenceServiceTest extends Mockito {
                 .withCallerUserId(TEST_USER_ID)
                 .withCallerEnrolledStudies(ImmutableSet.of(TEST_STUDY_ID)).build());
         
-        when(mockScheduleService.getTimelineMetadata("BBB")).thenReturn(Optional.empty());
+        AdherenceRecordList list = mockRecordUpdate(ar(STARTED_ON, null), null, null);
         
-        AdherenceRecord rec1 = getAdherenceRecord("BBB");
-        rec1.setFinishedOn(FINISHED_ON);
-        AdherenceRecordList records = new AdherenceRecordList(ImmutableList.of(rec1));
-        
-        service.updateAdherenceRecords(TEST_APP_ID, records);
+        service.updateAdherenceRecords(TEST_APP_ID, list);
         
         verify(mockStudyActivityEventService, never()).publishEvent(any());
     }
     
-    private AdherenceRecord mockAssessmentRecord() { 
+    private AdherenceRecord mockAssessmentRecord(String id) {
         // This is started, but not finished
         AdherenceRecord asmtRecord = new AdherenceRecord();
         asmtRecord.setAppId(TEST_APP_ID);
         asmtRecord.setUserId(TEST_USER_ID);
         asmtRecord.setStudyId(TEST_STUDY_ID);
-        asmtRecord.setInstanceGuid("assessmentInstanceGuid");
+        asmtRecord.setInstanceGuid(id);
         asmtRecord.setEventTimestamp(EVENT_TS);
         
         TimelineMetadata asmtMeta = new TimelineMetadata();
         asmtMeta.setSessionInstanceGuid("sessionInstanceGuid");
-        asmtMeta.setAssessmentInstanceGuid("assessmentInstanceGuid");
+        asmtMeta.setAssessmentInstanceGuid(id);
         asmtMeta.setSessionStartEventId("enrollment");
-        when(mockScheduleService.getTimelineMetadata("assessmentInstanceGuid"))
-            .thenReturn(Optional.of(asmtMeta));
+        when(mockScheduleService.getTimelineMetadata(id)).thenReturn(Optional.of(asmtMeta));
         
         return asmtRecord;
     }
     
-    private void mockAssessmentRecordSet(DateTime started1, DateTime finished1, DateTime started2, DateTime finished2,
-            boolean withSessionRecord, DateTime sessionStarted, DateTime sessionFinished) {
-        
-        List<AdherenceRecord> asmtList = new ArrayList<>();
-        
-        AdherenceRecord asmtAr1 = new AdherenceRecord();
-        asmtAr1.setInstanceGuid("assessmentInstanceGuid");
-        asmtAr1.setStartedOn(started1);
-        asmtAr1.setFinishedOn(finished1);
-        asmtList.add(asmtAr1);
-        
-        AdherenceRecord asmtAr2 = new AdherenceRecord();
-        asmtAr2.setInstanceGuid("differentAssessmentInstanceGuid");
-        asmtAr2.setStartedOn(started2);
-        asmtAr2.setFinishedOn(finished2);
-        asmtList.add(asmtAr2);
-        
-        if (withSessionRecord) {
-            AdherenceRecord session = new AdherenceRecord();
-            session.setInstanceGuid("sessionInstanceGuid");
-            session.setStartedOn(sessionStarted);
-            session.setFinishedOn(sessionFinished);
-            session.setDeclined(true); // so we can verify this record was used, not a new one 
-            asmtList.add(session);
-        }
-        
-        when(mockDao.getAdherenceRecords(any())).thenReturn(new PagedResourceList<>(asmtList, asmtList.size()));
-        
-        List<TimelineMetadata> metadataList = ImmutableList.of(new TimelineMetadata(), new TimelineMetadata());
-        when(mockScheduleService.getSessionAssessmentMetadata("sessionInstanceGuid")).thenReturn(metadataList);
-    }
-
     @Test
     public void updateAdherenceRecords_doNothingWithStartedSession() {
-        // This is started, but not finished. We don't really care because we're 
-        // going to look at the entire set of assessment records
-        AdherenceRecord asmtRecord = mockAssessmentRecord();
+        AdherenceRecordList list = mockRecordUpdate(null, 
+                ar(STARTED_ON, null), ar(null, STARTED_ON, false));
         
-        // Now mock the set of assessment records (we do want to change these across
-        // a number of tests):
-        mockAssessmentRecordSet(null, null, STARTED_ON, null, true, STARTED_ON, null);
+        MetadataContainer container = new MetadataContainer(mockScheduleService, list.getRecords());
+        service.updateSessionState(TEST_APP_ID, container, list.getRecords().get(0));
         
-        service.updateSessionState(TEST_APP_ID, asmtRecord);
-        
-        verify(mockDao, never()).updateAdherenceRecord(any());
-        verify(mockStudyActivityEventService, never()).publishEvent(any());
+        AdherenceRecord captured = Iterables.getFirst(container.getSessions(), null);
+        assertEquals(captured.getStartedOn(), STARTED_ON);
     }
 
     @Test
     public void updateAdherenceRecords_doNothingWithFinishedSession() {
-        // This is started, but not finished. We don't really care because we're 
-        // going to look at the entire set of assessment records
-        AdherenceRecord asmtRecord = mockAssessmentRecord();
+        AdherenceRecordList list = mockRecordUpdate(ar(STARTED_ON, FINISHED_ON), 
+                ar(STARTED_ON, FINISHED_ON), ar(STARTED_ON, FINISHED_ON, true));
         
-        // Now mock the set of assessment records (we do want to change these across
-        // a number of tests):
-        mockAssessmentRecordSet(STARTED_ON, FINISHED_ON, STARTED_ON, FINISHED_ON, true, STARTED_ON, FINISHED_ON);
-        
-        service.updateSessionState(TEST_APP_ID, asmtRecord);
+        MetadataContainer container = new MetadataContainer(mockScheduleService, list.getRecords());
+        service.updateSessionState(TEST_APP_ID, container, list.getRecords().get(0));
         
         verify(mockDao, never()).updateAdherenceRecord(any());
         verify(mockStudyActivityEventService, never()).publishEvent(any());
@@ -316,18 +256,12 @@ public class AdherenceServiceTest extends Mockito {
     
     @Test
     public void updateAdherenceRecords_createAndStartSessionRecord() {
-        // This is started, but not finished. We don't really care because we're 
-        // going to look at the entire set of assessment records
-        AdherenceRecord asmtRecord = mockAssessmentRecord();
+        AdherenceRecordList list = mockRecordUpdate(null, ar(STARTED_ON, null), null);
         
-        // Now mock the set of assessment records (we do want to change these across
-        // a number of tests):
-        mockAssessmentRecordSet(null, null, STARTED_ON, null, false, null, null);
+        MetadataContainer container = new MetadataContainer(mockScheduleService, list.getRecords());
+        service.updateSessionState(TEST_APP_ID, container, list.getRecords().get(0));
         
-        service.updateSessionState(TEST_APP_ID, asmtRecord);
-        
-        verify(mockDao).updateAdherenceRecord(recordCaptor.capture());
-        AdherenceRecord captured = recordCaptor.getValue();
+        AdherenceRecord captured = Iterables.getFirst(container.getSessions(), null);
         assertEquals(captured.getAppId(), TEST_APP_ID);
         assertEquals(captured.getUserId(), TEST_USER_ID);
         assertEquals(captured.getStudyId(), TEST_STUDY_ID);
@@ -339,37 +273,29 @@ public class AdherenceServiceTest extends Mockito {
     
     @Test
     public void updateAdherenceRecords_createAndFinishSessionRecord() {
-        // This is started, but not finished. We don't really care because we're 
-        // going to look at the entire set of assessment records
-        AdherenceRecord asmtRecord = mockAssessmentRecord();
+        AdherenceRecordList list = mockRecordUpdate(ar(STARTED_ON, FINISHED_ON), 
+                ar(STARTED_ON, null), null);
         
-        // Now mock the set of assessment records (we do want to change these across
-        // a number of tests):
-        mockAssessmentRecordSet(STARTED_ON, FINISHED_ON, STARTED_ON, FINISHED_ON, false, null, null);
+        MetadataContainer container = new MetadataContainer(mockScheduleService, list.getRecords());
         
-        service.updateSessionState(TEST_APP_ID, asmtRecord);
+        service.updateSessionState(TEST_APP_ID, container, list.getRecords().get(0));
         
-        verify(mockDao).updateAdherenceRecord(recordCaptor.capture());
-        AdherenceRecord captured = recordCaptor.getValue();
+        AdherenceRecord captured = Iterables.getFirst(container.getSessions(), null);
+        assertEquals(container.getSessions().size(), 1);
         assertEquals(captured.getInstanceGuid(), "sessionInstanceGuid");
         assertEquals(captured.getStartedOn(), STARTED_ON);
-        assertEquals(captured.getFinishedOn(), FINISHED_ON);
+        assertNull(captured.getFinishedOn());
     }
 
     @Test
     public void updateAdherenceRecords_startExistingSessionRecord() {
-        // This is started, but not finished. We don't really care because we're 
-        // going to look at the entire set of assessment records
-        AdherenceRecord asmtRecord = mockAssessmentRecord();
+        AdherenceRecordList list = mockRecordUpdate(ar(STARTED_ON, null), 
+                null, ar(null, null, true));
         
-        // Now mock the set of assessment records (we do want to change these across
-        // a number of tests). 
-        mockAssessmentRecordSet(null, null, STARTED_ON, null, true, null, null);
+        MetadataContainer container = new MetadataContainer(mockScheduleService, list.getRecords());
+        service.updateSessionState(TEST_APP_ID, container, list.getRecords().get(0));
         
-        service.updateSessionState(TEST_APP_ID, asmtRecord);
-        
-        verify(mockDao).updateAdherenceRecord(recordCaptor.capture());
-        AdherenceRecord captured = recordCaptor.getValue();
+        AdherenceRecord captured = Iterables.getFirst(container.getSessions(), null);
         assertEquals(captured.getAppId(), TEST_APP_ID);
         assertEquals(captured.getUserId(), TEST_USER_ID);
         assertEquals(captured.getStudyId(), TEST_STUDY_ID);
@@ -382,23 +308,14 @@ public class AdherenceServiceTest extends Mockito {
 
     @Test
     public void updateAdherenceRecords_finishExistingSessionRecord() {
-        // This is started, but not finished. We don't really care because we're 
-        // going to look at the entire set of assessment records
-        AdherenceRecord asmtRecord = mockAssessmentRecord();
+        AdherenceRecordList list = mockRecordUpdate(ar(STARTED_ON, FINISHED_ON), 
+                ar(STARTED_ON, FINISHED_ON), ar(null, null, true));
         
-        // Now mock the set of assessment records (we do want to change these across
-        // a number of tests). 
-        mockAssessmentRecordSet(STARTED_ON, FINISHED_ON, STARTED_ON, FINISHED_ON, true, null, null);
+        MetadataContainer container = new MetadataContainer(mockScheduleService, list.getRecords());
+        service.updateSessionState(TEST_APP_ID, container, list.getRecords().get(0));
+        service.updateSessionState(TEST_APP_ID, container, list.getRecords().get(1));
         
-        TimelineMetadata sessionMeta = new TimelineMetadata();
-        sessionMeta.setSessionGuid("sessionGuid");
-        when(mockScheduleService.getTimelineMetadata("sessionInstanceGuid"))
-            .thenReturn(Optional.of(sessionMeta));
-        
-        service.updateSessionState(TEST_APP_ID, asmtRecord);
-        
-        verify(mockDao).updateAdherenceRecord(recordCaptor.capture());
-        AdherenceRecord captured = recordCaptor.getValue();
+        AdherenceRecord captured = Iterables.getFirst(container.getSessions(), null);
         assertEquals(captured.getAppId(), TEST_APP_ID);
         assertEquals(captured.getUserId(), TEST_USER_ID);
         assertEquals(captured.getStudyId(), TEST_STUDY_ID);
@@ -407,29 +324,17 @@ public class AdherenceServiceTest extends Mockito {
         assertEquals(captured.getFinishedOn(), FINISHED_ON);
         assertTrue(captured.isDeclined()); // used the persisted record 
         assertEquals(captured.getEventTimestamp(), EVENT_TS);
-        
-        verify(mockStudyActivityEventService).publishEvent(requestCaptor.capture());
-        StudyActivityEventRequest request = requestCaptor.getValue();
-        assertEquals(request.getEventType(), FINISHED);
-        assertEquals(request.getObjectType(), ActivityEventObjectType.SESSION);
-        assertEquals(request.getTimestamp(), FINISHED_ON);
-        assertEquals(request.getObjectId(), "sessionGuid");
     }
     
     @Test
     public void updateAdherenceRecords_unfinishExistingSessionRecord() {
-        // This is started, but not finished. We don't really care because we're 
-        // going to look at the entire set of assessment records
-        AdherenceRecord asmtRecord = mockAssessmentRecord();
+        AdherenceRecordList list = mockRecordUpdate(ar(STARTED_ON, null), 
+                ar(STARTED_ON, FINISHED_ON), ar(STARTED_ON, FINISHED_ON, true));
         
-        // Now mock the set of assessment records (we do want to change these across
-        // a number of tests). 
-        mockAssessmentRecordSet(STARTED_ON, null, STARTED_ON, FINISHED_ON, true, STARTED_ON, FINISHED_ON);
+        MetadataContainer container = new MetadataContainer(mockScheduleService, list.getRecords());
+        service.updateSessionState(TEST_APP_ID, container, list.getRecords().get(0));
         
-        service.updateSessionState(TEST_APP_ID, asmtRecord);
-        
-        verify(mockDao).updateAdherenceRecord(recordCaptor.capture());
-        AdherenceRecord captured = recordCaptor.getValue();
+        AdherenceRecord captured = Iterables.getFirst(container.getSessions(), null);
         assertNull(captured.getFinishedOn());
         assertTrue(captured.isDeclined()); // used the persisted record
         
@@ -438,21 +343,56 @@ public class AdherenceServiceTest extends Mockito {
     
     @Test
     public void updateAdherenceRecords_unstartExistingSessionRecord() {
-        // This is started, but not finished. We don't really care because we're 
-        // going to look at the entire set of assessment records
-        AdherenceRecord asmtRecord = mockAssessmentRecord();
+        AdherenceRecordList list = mockRecordUpdate(ar(null, null), 
+                null, ar(STARTED_ON, FINISHED_ON, true));
         
-        // Now mock the set of assessment records (we do want to change these across
-        // a number of tests). 
-        mockAssessmentRecordSet(null, null, null, null, true, STARTED_ON, FINISHED_ON);
+        MetadataContainer container = new MetadataContainer(mockScheduleService, list.getRecords());
+        service.updateSessionState(TEST_APP_ID, container, list.getRecords().get(0));
+        service.updateSessionState(TEST_APP_ID, container, list.getRecords().get(1));
         
-        service.updateSessionState(TEST_APP_ID, asmtRecord);
-        
-        verify(mockDao).updateAdherenceRecord(recordCaptor.capture());
-        AdherenceRecord captured = recordCaptor.getValue();
+        AdherenceRecord captured = Iterables.getFirst(container.getSessions(), null);
         assertNull(captured.getStartedOn());
         assertNull(captured.getFinishedOn());
         assertTrue(captured.isDeclined()); // used the persisted record 
+    }
+    
+    @Test
+    public void updateAdherenceRecords_doesNotUpdateSessionRecordMultipleTimes() {
+        AdherenceRecordList list = mockRecordUpdate(ar(STARTED_ON, FINISHED_ON), 
+                ar(STARTED_ON, FINISHED_ON), ar(STARTED_ON, FINISHED_ON, true));
+        
+        MetadataContainer container = new MetadataContainer(mockScheduleService, list.getRecords());
+        service.updateSessionState(TEST_APP_ID, container, list.getRecords().get(0));
+        service.updateSessionState(TEST_APP_ID, container, list.getRecords().get(1));
+        
+        assertEquals(container.getSessions().size(), 1);
+    }
+    
+    @Test
+    public void updateAdherenceRecords_sessionUpdatesMergedCorrectlyWithExistingRecord() {
+        AdherenceRecordList list = mockRecordUpdate(ar(STARTED_ON, FINISHED_ON), 
+                ar(STARTED_ON, FINISHED_ON), ar(STARTED_ON, null, false));
+        
+        AdherenceRecord sess = new AdherenceRecord();
+        sess.setAppId(TEST_APP_ID);
+        sess.setUserId(TEST_USER_ID);
+        sess.setStudyId(TEST_STUDY_ID);
+        sess.setInstanceGuid("sessionInstanceGuid");
+        sess.setFinishedOn(FINISHED_ON.plusHours(1)); // note, this is different
+        sess.setDeclined(true);
+        sess.setEventTimestamp(EVENT_TS);
+        list.getRecords().add(sess);
+        
+        MetadataContainer container = new MetadataContainer(mockScheduleService, list.getRecords());
+        service.updateSessionState(TEST_APP_ID, container, list.getRecords().get(0));
+        service.updateSessionState(TEST_APP_ID, container, list.getRecords().get(1));
+        service.updateSessionState(TEST_APP_ID, container, list.getRecords().get(2));
+        
+        assertEquals(container.getSessions().size(), 1);
+        AdherenceRecord captured = Iterables.getFirst(container.getSessions(), null);
+        assertEquals(captured.getStartedOn(), STARTED_ON);
+        assertEquals(captured.getFinishedOn(), FINISHED_ON.plusHours(1));
+        assertTrue(captured.isDeclined());
     }
     
     @Test
@@ -477,7 +417,7 @@ public class AdherenceServiceTest extends Mockito {
                 .withEndTime(MODIFIED_ON)
                 .withStudyId(TEST_STUDY_ID).build();
         
-        List<AdherenceRecord> list = ImmutableList.of(getAdherenceRecord("AAA"), getAdherenceRecord("BBB"));
+        List<AdherenceRecord> list = ImmutableList.of(mockAssessmentRecord("AAA"), mockAssessmentRecord("BBB"));
         PagedResourceList<AdherenceRecord> page = new PagedResourceList<AdherenceRecord>(list, 100);
         when(mockDao.getAdherenceRecords(any())).thenReturn(page);
         
@@ -588,5 +528,81 @@ public class AdherenceServiceTest extends Mockito {
         assertEquals(retValue.getEventTimestamps().get("custom:event1"), CREATED_ON);
         // the second one is added
         assertEquals(retValue.getEventTimestamps().get("custom:event2"), MODIFIED_ON);
+    }
+    
+    private AdherenceRecord ar(DateTime startedOn, DateTime finishedOn) {
+        AdherenceRecord asmt1 = new AdherenceRecord();
+        asmt1.setAppId(TEST_APP_ID);
+        asmt1.setUserId(TEST_USER_ID);
+        asmt1.setStudyId(TEST_STUDY_ID);
+        asmt1.setStartedOn(startedOn);
+        asmt1.setFinishedOn(finishedOn);
+        asmt1.setEventTimestamp(EVENT_TS);
+        return asmt1;
+    }
+    
+    private AdherenceRecord ar(DateTime startedOn, DateTime finishedOn, boolean declined) {
+        AdherenceRecord sess = new AdherenceRecord();
+        sess.setAppId(TEST_APP_ID);
+        sess.setUserId(TEST_USER_ID);
+        sess.setStudyId(TEST_STUDY_ID);
+        sess.setInstanceGuid("sessionInstanceGuid");
+        sess.setStartedOn(startedOn);
+        sess.setFinishedOn(finishedOn);
+        sess.setDeclined(TRUE.equals(declined));
+        sess.setEventTimestamp(EVENT_TS);
+        return sess;
+    }
+    
+    private AdherenceRecordList mockRecordUpdate(AdherenceRecord rec1, AdherenceRecord rec2, 
+            AdherenceRecord sessionRecord) {
+        List<AdherenceRecord> records = new ArrayList<>();
+        List<TimelineMetadata> metas = new ArrayList<>();
+        
+        if (rec1 != null) {
+            rec1.setInstanceGuid("AAA");
+            records.add(rec1);
+                
+            TimelineMetadata meta1 = new TimelineMetadata();
+            meta1.setGuid("AAA");
+            meta1.setSessionInstanceGuid("sessionInstanceGuid");
+            meta1.setAssessmentInstanceGuid("AAA");
+            meta1.setSessionStartEventId("enrollment");
+            metas.add(meta1);
+            when(mockScheduleService.getTimelineMetadata("AAA")).thenReturn(Optional.of(meta1));
+        }
+        if (rec2 != null) {
+            rec2.setInstanceGuid("BBB");
+            records.add(rec2);
+                
+            TimelineMetadata meta2 = new TimelineMetadata();
+            meta2.setGuid("BBB");
+            meta2.setSessionInstanceGuid("sessionInstanceGuid");
+            meta2.setAssessmentInstanceGuid("BBB");
+            meta2.setSessionStartEventId("enrollment");
+            metas.add(meta2);
+            when(mockScheduleService.getTimelineMetadata("BBB")).thenReturn(Optional.of(meta2));
+        }
+        
+        when(mockScheduleService.getSessionAssessmentMetadata("sessionInstanceGuid"))
+            .thenReturn(ImmutableList.copyOf(metas));
+        
+        if (sessionRecord != null) {
+            records.add(sessionRecord);
+        }
+        TimelineMetadata sessMeta = new TimelineMetadata();
+        sessMeta.setGuid("sessionInstanceGuid");
+        sessMeta.setSessionInstanceGuid("sessionInstanceGuid");
+        sessMeta.setSessionGuid("sessionGuid");
+        sessMeta.setSessionStartEventId("enrollment");
+        metas.add(sessMeta);
+        
+        when(mockScheduleService.getTimelineMetadata("sessionInstanceGuid"))
+            .thenReturn(Optional.of(sessMeta));
+        
+        PagedResourceList<AdherenceRecord> page = new PagedResourceList<>(records, records.size(), true);
+        when(mockDao.getAdherenceRecords(any())).thenReturn(page);
+        
+        return new AdherenceRecordList(records);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -2114,7 +2114,7 @@ public class ParticipantServiceTest extends Mockito {
             fail("Should have thrown exception");
         } catch(InvalidEntityException e) {
             assertEquals(e.getErrors().get("externalIds[studyId].externalId").get(0),
-                    "externalIds[studyId].externalId cannot be blank");
+                    "externalIds[studyId].externalId cannot be null or blank");
         }
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/services/Schedule2ServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/Schedule2ServiceTest.java
@@ -870,4 +870,15 @@ public class Schedule2ServiceTest extends Mockito {
         Optional<TimelineMetadata> retValue = service.getTimelineMetadata(GUID);
         assertSame(retValue.get(), meta);
     }
+    
+    @Test
+    public void getSessionAssessmentMetadata() {
+        List<TimelineMetadata> results = ImmutableList.of();
+        when(mockDao.getAssessmentsForSessionInstance(GUID)).thenReturn(results);
+        
+        List<TimelineMetadata> retValue = service.getSessionAssessmentMetadata(GUID);
+        assertSame(retValue, results);
+        
+        verify(mockDao).getAssessmentsForSessionInstance(GUID);
+    }
 }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ActivityEventControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ActivityEventControllerTest.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
+import static org.sagebionetworks.bridge.TestConstants.ACCOUNT_ID;
 import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
 import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
@@ -12,7 +13,6 @@ import static org.sagebionetworks.bridge.TestUtils.assertDelete;
 import static org.sagebionetworks.bridge.TestUtils.assertGet;
 import static org.sagebionetworks.bridge.TestUtils.assertPost;
 import static org.sagebionetworks.bridge.TestUtils.createJson;
-import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.CUSTOM;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.TIMELINE_RETRIEVED;
 import static org.sagebionetworks.bridge.spring.controllers.ActivityEventController.EVENT_DELETED_MSG;
 import static org.sagebionetworks.bridge.spring.controllers.ActivityEventController.EVENT_RECORDED_MSG;
@@ -228,21 +228,15 @@ public class ActivityEventControllerTest extends Mockito {
         
         List<StudyActivityEvent> list = ImmutableList.of(new StudyActivityEvent(), new StudyActivityEvent());
         PagedResourceList<StudyActivityEvent> page = new PagedResourceList<StudyActivityEvent>(list, 100, true);
-        when(mockStudyActivityEventService.getStudyActivityEventHistory(any(), any(), any()))
+        when(mockStudyActivityEventService.getStudyActivityEventHistory(any(), any(), any(), any(), any()))
             .thenReturn(page);
 
         ResourceList<StudyActivityEvent> retValue = controller.getActivityEventHistoryForSelf(
                 TEST_STUDY_ID, "eventKey", "100", "200");
         assertSame(retValue, page);
         
-        verify(mockStudyActivityEventService).getStudyActivityEventHistory(requestCaptor.capture(), 
-                eq(Integer.valueOf(100)), eq(Integer.valueOf(200)));
-        StudyActivityEventRequest request = requestCaptor.getValue();
-        assertEquals(request.getAppId(), TEST_APP_ID);
-        assertEquals(request.getStudyId(), TEST_STUDY_ID);
-        assertEquals(request.getUserId(), TEST_USER_ID);
-        assertEquals(request.getObjectId(), "eventKey");
-        assertEquals(request.getObjectType(), CUSTOM);
+        verify(mockStudyActivityEventService).getStudyActivityEventHistory(
+                ACCOUNT_ID, TEST_STUDY_ID, "eventKey", Integer.valueOf(100), Integer.valueOf(200));
     }
     
     @Test(expectedExceptions = EntityNotFoundException.class,
@@ -270,15 +264,15 @@ public class ActivityEventControllerTest extends Mockito {
         
         List<StudyActivityEvent> list = ImmutableList.of(new StudyActivityEvent(), new StudyActivityEvent());
         PagedResourceList<StudyActivityEvent> page = new PagedResourceList<StudyActivityEvent>(list, 100, true);
-        when(mockStudyActivityEventService.getStudyActivityEventHistory(any(), any(), any()))
+        when(mockStudyActivityEventService.getStudyActivityEventHistory(any(), any(), any(), any(), any()))
             .thenReturn(page);
 
         ResourceList<StudyActivityEvent> retValue = controller.getActivityEventHistoryForSelf(
                 TEST_STUDY_ID, "eventKey", null, null);
         assertSame(retValue, page);
         
-        verify(mockStudyActivityEventService).getStudyActivityEventHistory(any(), 
-                eq(Integer.valueOf(0)), eq(Integer.valueOf(50)));
+        verify(mockStudyActivityEventService).getStudyActivityEventHistory( 
+                ACCOUNT_ID, TEST_STUDY_ID, "eventKey", Integer.valueOf(0), Integer.valueOf(50));
     }
     
     @Test(expectedExceptions = EntityNotFoundException.class,

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AdherenceControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AdherenceControllerTest.java
@@ -89,6 +89,27 @@ public class AdherenceControllerTest extends Mockito {
     
     @Test
     public void updateAdherenceRecords() throws Exception {
+        doReturn(session).when(controller).getAuthenticatedSession(RESEARCHER, STUDY_COORDINATOR);
+        
+        AdherenceRecord rec1 = TestUtils.getAdherenceRecord("AAA");
+        AdherenceRecord rec2 = TestUtils.getAdherenceRecord("BBB");
+        AdherenceRecordList list = new AdherenceRecordList(ImmutableList.of(rec1, rec2));
+        
+        mockRequestBody(mockRequest, list);
+        
+        StatusMessage retValue = controller.updateAdherenceRecords(TEST_STUDY_ID, TEST_USER_ID);
+        assertEquals(retValue, AdherenceController.SAVED_MSG);
+        
+        verify(mockService).updateAdherenceRecords(eq(TEST_APP_ID), listCaptor.capture());
+        AdherenceRecordList recordsList = listCaptor.getValue();
+        for (AdherenceRecord record : recordsList.getRecords()) {
+            assertEquals(record.getStudyId(), TEST_STUDY_ID);
+            assertEquals(record.getUserId(), TEST_USER_ID);
+        }
+    }    
+    
+    @Test
+    public void updateAdherenceRecordsForSelf() throws Exception {
         doReturn(session).when(controller).getAuthenticatedAndConsentedSession();
         
         AdherenceRecord rec1 = TestUtils.getAdherenceRecord("AAA");
@@ -97,7 +118,7 @@ public class AdherenceControllerTest extends Mockito {
         
         mockRequestBody(mockRequest, list);
         
-        StatusMessage retValue = controller.updateAdherenceRecords(TEST_STUDY_ID);
+        StatusMessage retValue = controller.updateAdherenceRecordsForSelf(TEST_STUDY_ID);
         assertEquals(retValue, AdherenceController.SAVED_MSG);
         
         verify(mockService).updateAdherenceRecords(eq(TEST_APP_ID), listCaptor.capture());

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantControllerTest.java
@@ -5,6 +5,7 @@ import static org.sagebionetworks.bridge.RequestContext.NULL_INSTANCE;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.STUDY_COORDINATOR;
 import static org.sagebionetworks.bridge.Roles.STUDY_DESIGNER;
+import static org.sagebionetworks.bridge.TestConstants.ACCOUNT_ID;
 import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
 import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
 import static org.sagebionetworks.bridge.TestConstants.LANGUAGES;
@@ -21,7 +22,6 @@ import static org.sagebionetworks.bridge.TestUtils.assertPost;
 import static org.sagebionetworks.bridge.TestUtils.createJson;
 import static org.sagebionetworks.bridge.TestUtils.mockRequestBody;
 import static org.sagebionetworks.bridge.cache.CacheKey.scheduleModificationTimestamp;
-import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.CUSTOM;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.TIMELINE_RETRIEVED;
 import static org.sagebionetworks.bridge.spring.controllers.StudyParticipantController.EVENT_DELETED_MSG;
 import static org.sagebionetworks.bridge.spring.controllers.StudyParticipantController.NOTIFY_SUCCESS_MSG;
@@ -1413,14 +1413,8 @@ public class StudyParticipantControllerTest extends Mockito {
         
         controller.getActivityEventHistory(TEST_STUDY_ID, TEST_USER_ID, "eventKey", "100", "250");
         
-        verify(mockStudyActivityEventService).getStudyActivityEventHistory(
-                requestCaptor.capture(), eq(Integer.valueOf(100)), eq(Integer.valueOf(250)));
-        StudyActivityEventRequest request = requestCaptor.getValue();
-        assertEquals(request.getAppId(), TEST_APP_ID);
-        assertEquals(request.getStudyId(), TEST_STUDY_ID);
-        assertEquals(request.getUserId(), TEST_USER_ID);
-        assertEquals(request.getObjectId(), "eventKey");
-        assertEquals(request.getObjectType(), CUSTOM);
+        verify(mockStudyActivityEventService).getStudyActivityEventHistory(ACCOUNT_ID, TEST_STUDY_ID, "eventKey",
+                Integer.valueOf(100), Integer.valueOf(250));
     }
     
     private void mockAccountInStudy() {

--- a/src/test/java/org/sagebionetworks/bridge/validators/AccountIdValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/AccountIdValidatorTest.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.validators;
 
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_PHONE_ERROR;
 
 import org.testng.annotations.Test;
 
@@ -64,7 +65,7 @@ public class AccountIdValidatorTest {
     public void phoneValid() throws Exception {
         AccountId accountId = createId("{'appId':'" + TEST_APP_ID + "','phone':"+
                 "{'number':'4082588569','regionCode':'MX'}}");
-        assertValidatorMessage(AccountIdValidator.getInstance(ChannelType.PHONE), accountId, "phone", "does not appear to be a phone number");
+        assertValidatorMessage(AccountIdValidator.getInstance(ChannelType.PHONE), accountId, "phone", INVALID_PHONE_ERROR);
     }
     
     private AccountId createId(String json) throws Exception {

--- a/src/test/java/org/sagebionetworks/bridge/validators/AdherenceRecordListValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/AdherenceRecordListValidatorTest.java
@@ -15,6 +15,7 @@ import static org.sagebionetworks.bridge.validators.Validate.USER_ID_FIELD;
 
 import com.google.common.collect.ImmutableList;
 
+import org.joda.time.DateTime;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -80,10 +81,11 @@ public class AdherenceRecordListValidatorTest extends Mockito {
     }
     
     @Test
-    public void startedOnNull() {
+    public void startedAfterFinishedOn() {
         AdherenceRecord record = new AdherenceRecord();
-        record.setStartedOn(null);
-        assertValidatorMessage(INSTANCE, asList(record), asField(STARTED_ON_FIELD), CANNOT_BE_NULL);
+        record.setStartedOn(DateTime.now());
+        record.setFinishedOn(DateTime.now().minusHours(1));
+        assertValidatorMessage(INSTANCE, asList(record), asField(STARTED_ON_FIELD), "cannot be later than finishedOn");
     }
     
     @Test
@@ -103,13 +105,13 @@ public class AdherenceRecordListValidatorTest extends Mockito {
     @Test
     public void validatesMultiple() {
         AdherenceRecord rec1 = TestUtils.getAdherenceRecord(GUID);
-        rec1.setStartedOn(null);
+        rec1.setEventTimestamp(null);
         AdherenceRecord rec2 = TestUtils.getAdherenceRecord(GUID);
         rec2.setStudyId(null);
         AdherenceRecordList list = asList(rec1, rec2);
         
         assertValidatorMessage(INSTANCE, list, 
-                asField(STARTED_ON_FIELD), CANNOT_BE_NULL);
+                asField(EVENT_TIMESTAMP_FIELD), CANNOT_BE_NULL);
         assertValidatorMessage(INSTANCE, list, 
                 "records[1]."+STUDY_ID_FIELD, CANNOT_BE_BLANK);
     }

--- a/src/test/java/org/sagebionetworks/bridge/validators/IdentifierUpdateValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/IdentifierUpdateValidatorTest.java
@@ -7,6 +7,9 @@ import static org.sagebionetworks.bridge.TestConstants.SYNAPSE_USER_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 import static org.sagebionetworks.bridge.validators.IdentifierUpdateValidator.INSTANCE;
+import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_EMAIL_ERROR;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_PHONE_ERROR;
 
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
@@ -113,7 +116,7 @@ public class IdentifierUpdateValidatorTest {
                 .withEmail(EMAIL).withReauthToken("asdf").build();
         
         IdentifierUpdate update = new IdentifierUpdate(signIn, null, new Phone("12334578990", "US"), null);
-        assertValidatorMessage(INSTANCE, update, "phoneUpdate", "does not appear to be a phone number");
+        assertValidatorMessage(INSTANCE, update, "phoneUpdate", INVALID_PHONE_ERROR);
     }
     
     @Test
@@ -122,7 +125,7 @@ public class IdentifierUpdateValidatorTest {
                 .withEmail(EMAIL).withReauthToken("asdf").build();
         
         IdentifierUpdate update = new IdentifierUpdate(signIn, "junk", null, null);
-        assertValidatorMessage(INSTANCE, update, "emailUpdate", "does not appear to be an email address");
+        assertValidatorMessage(INSTANCE, update, "emailUpdate", INVALID_EMAIL_ERROR);
     }
     
     @Test
@@ -131,7 +134,7 @@ public class IdentifierUpdateValidatorTest {
                 .build();
         
         IdentifierUpdate update = new IdentifierUpdate(signIn, null, null, "  ");
-        assertValidatorMessage(INSTANCE, update, "synapseUserIdUpdate", "cannot be blank");
+        assertValidatorMessage(INSTANCE, update, "synapseUserIdUpdate", CANNOT_BE_BLANK);
     }
     
     @Test
@@ -149,6 +152,6 @@ public class IdentifierUpdateValidatorTest {
                 .withEmail(EMAIL).withReauthToken("asdf").build();
         
         IdentifierUpdate update = new IdentifierUpdate(signIn, "", null, null);
-        assertValidatorMessage(INSTANCE, update, "emailUpdate", "does not appear to be an email address");
+        assertValidatorMessage(INSTANCE, update, "emailUpdate", INVALID_EMAIL_ERROR);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/validators/IntentToParticipateValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/IntentToParticipateValidatorTest.java
@@ -3,6 +3,8 @@ package org.sagebionetworks.bridge.validators;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 import static org.sagebionetworks.bridge.validators.IntentToParticipateValidator.INSTANCE;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_EMAIL_ERROR;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_PHONE_ERROR;
 
 import org.testng.annotations.Test;
 
@@ -83,12 +85,12 @@ public class IntentToParticipateValidatorTest {
     @Test
     public void phoneIsInvalid() {
         IntentToParticipate intent = builder().withPhone(new Phone("333333333", "US")).build();
-        assertValidatorMessage(INSTANCE, intent, "phone", "does not appear to be a phone number");
+        assertValidatorMessage(INSTANCE, intent, "phone", INVALID_PHONE_ERROR);
     }
     
     @Test
     public void emailInvalid() {
         IntentToParticipate intent = builder().withPhone(null).withEmail("bad-email").build();
-        assertValidatorMessage(INSTANCE, intent, "email", "does not appear to be an email address");
+        assertValidatorMessage(INSTANCE, intent, "email", INVALID_EMAIL_ERROR);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
@@ -5,6 +5,9 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
+import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_EMAIL_ERROR;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_PHONE_ERROR;
 import static org.testng.Assert.assertNull;
 import static org.mockito.Mockito.when;
 
@@ -148,19 +151,19 @@ public class StudyParticipantValidatorTest {
     @Test
     public void emailCannotBeEmptyString() {
         validator = makeValidator(true);
-        assertValidatorMessage(validator, withEmail(""), "email", "does not appear to be an email address");
+        assertValidatorMessage(validator, withEmail(""), "email", INVALID_EMAIL_ERROR);
     }
     
     @Test
     public void emailCannotBeBlankString() {
         validator = makeValidator(true);
-        assertValidatorMessage(validator, withEmail("    \n    \t "), "email", "does not appear to be an email address");
+        assertValidatorMessage(validator, withEmail("    \n    \t "), "email", INVALID_EMAIL_ERROR);
     }
     
     @Test
     public void emailCannotBeInvalid() {
         validator = makeValidator(true);
-        assertValidatorMessage(validator, withEmail("a"), "email", "does not appear to be an email address");
+        assertValidatorMessage(validator, withEmail("a"), "email", INVALID_EMAIL_ERROR);
     }
 
     @Test
@@ -208,7 +211,7 @@ public class StudyParticipantValidatorTest {
     @Test
     public void emptyStringUserSynapseIdRequired() {
         validator = makeValidator(true);
-        assertValidatorMessage(validator, withSynapseUserId(""), "synapseUserId", "cannot be blank");
+        assertValidatorMessage(validator, withSynapseUserId(""), "synapseUserId", CANNOT_BE_BLANK);
     }
     
     @Test
@@ -220,7 +223,7 @@ public class StudyParticipantValidatorTest {
     @Test
     public void validEmail() {
         validator = makeValidator(true);
-        assertValidatorMessage(validator, withEmail("belgium"), "email", "does not appear to be an email address");
+        assertValidatorMessage(validator, withEmail("belgium"), "email", INVALID_EMAIL_ERROR);
     }
     
     @Test
@@ -262,25 +265,25 @@ public class StudyParticipantValidatorTest {
     @Test
     public void validatePhoneRegionRequired() {
         validator = makeValidator(true);
-        assertValidatorMessage(validator, withPhone("1234567890", null), "phone", "does not appear to be a phone number");
+        assertValidatorMessage(validator, withPhone("1234567890", null), "phone", INVALID_PHONE_ERROR);
     }
     
     @Test
     public void validatePhoneRegionIsCode() {
         validator = makeValidator(true);
-        assertValidatorMessage(validator, withPhone("1234567890", "esg"), "phone", "does not appear to be a phone number");
+        assertValidatorMessage(validator, withPhone("1234567890", "esg"), "phone", INVALID_PHONE_ERROR);
     }
     
     @Test
     public void validatePhoneRequired() {
         validator = makeValidator(true);
-        assertValidatorMessage(validator, withPhone(null, "US"), "phone", "does not appear to be a phone number");
+        assertValidatorMessage(validator, withPhone(null, "US"), "phone", INVALID_PHONE_ERROR);
     }
     
     @Test
     public void validatePhonePattern() {
         validator = makeValidator(true);
-        assertValidatorMessage(validator, withPhone("234567890", "US"), "phone", "does not appear to be a phone number");
+        assertValidatorMessage(validator, withPhone("234567890", "US"), "phone", INVALID_PHONE_ERROR);
     }
     
     @Test
@@ -294,7 +297,7 @@ public class StudyParticipantValidatorTest {
     @Test
     public void validateTotallyWrongPhone() {
         validator = makeValidator(true);
-        assertValidatorMessage(validator, withPhone("this isn't a phone number", "US"), "phone", "does not appear to be a phone number");
+        assertValidatorMessage(validator, withPhone("this isn't a phone number", "US"), "phone", INVALID_PHONE_ERROR);
     }
     
     @Test
@@ -341,21 +344,21 @@ public class StudyParticipantValidatorTest {
         StudyParticipant participant = withExternalId(" ");
         
         validator = makeValidator(true);
-        assertValidatorMessage(validator, participant, "externalIds[test-study].externalId", "cannot be blank");
+        assertValidatorMessage(validator, participant, "externalIds[test-study].externalId", CANNOT_BE_BLANK);
     }
     @Test
     public void emptySynapseUserIdOnCreate() {
         StudyParticipant participant = withSynapseUserId(" ");
         
         validator = makeValidator(true);
-        assertValidatorMessage(validator, participant, "synapseUserId", "cannot be blank");
+        assertValidatorMessage(validator, participant, "synapseUserId", CANNOT_BE_BLANK);
     }
     @Test
     public void emptySynapseUserIdOnUpdate() {
         StudyParticipant participant = withSynapseUserId(" ");
         
         validator = makeValidator(false);
-        assertValidatorMessage(validator, participant, "synapseUserId", "cannot be blank");
+        assertValidatorMessage(validator, participant, "synapseUserId", CANNOT_BE_BLANK);
     }
     @Test
     public void validateStudyIdInvalid() {

--- a/src/test/java/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -1,17 +1,34 @@
 package org.sagebionetworks.bridge.validators;
 
+import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_EVENT_ID_ERROR;
 import static org.sagebionetworks.bridge.TestConstants.EMAIL;
 import static org.sagebionetworks.bridge.TestConstants.PHONE;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 import static org.sagebionetworks.bridge.models.studies.ContactRole.TECHNICAL_SUPPORT;
+import static org.sagebionetworks.bridge.models.studies.IrbDecisionType.APPROVED;
 import static org.sagebionetworks.bridge.models.studies.StudyPhase.DESIGN;
+import static org.sagebionetworks.bridge.validators.StudyValidator.APP_ID_FIELD;
+import static org.sagebionetworks.bridge.validators.StudyValidator.CONTACTS_FIELD;
+import static org.sagebionetworks.bridge.validators.StudyValidator.EMAIL_FIELD;
+import static org.sagebionetworks.bridge.validators.StudyValidator.IDENTIFIER_FIELD;
+import static org.sagebionetworks.bridge.validators.StudyValidator.INSTANCE;
+import static org.sagebionetworks.bridge.validators.StudyValidator.IRB_DECISION_ON_FIELD;
+import static org.sagebionetworks.bridge.validators.StudyValidator.IRB_DECISION_TYPE_FIELD;
+import static org.sagebionetworks.bridge.validators.StudyValidator.NAME_FIELD;
+import static org.sagebionetworks.bridge.validators.StudyValidator.PHASE_FIELD;
+import static org.sagebionetworks.bridge.validators.StudyValidator.PHONE_FIELD;
+import static org.sagebionetworks.bridge.validators.StudyValidator.ROLE_FIELD;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_EMAIL_ERROR;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_PHONE_ERROR;
 import static org.sagebionetworks.bridge.validators.Validate.entityThrowingException;
 
 import com.google.common.collect.ImmutableList;
 
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.models.accounts.Phone;
@@ -19,21 +36,23 @@ import org.sagebionetworks.bridge.models.studies.Contact;
 import org.sagebionetworks.bridge.models.studies.Study;
 
 public class StudyValidatorTest {
-    private static final StudyValidator VALIDATOR = StudyValidator.INSTANCE;
+    
+    private static final LocalDate DECISION_ON = DateTime.now().toLocalDate();
+    private static final LocalDate EXPIRES_ON = DateTime.now().plusDays(10).toLocalDate();
     
     private Study study;
     
     @Test
     public void valid() {
         study = createStudy();
-        entityThrowingException(VALIDATOR, study);
+        entityThrowingException(INSTANCE, study);
     }
     
     @Test
     public void idIsRequired() {
         study = createStudy();
         study.setIdentifier(null);
-        assertValidatorMessage(VALIDATOR, study, "identifier", "is required");
+        assertValidatorMessage(INSTANCE, study, IDENTIFIER_FIELD, CANNOT_BE_BLANK);
     }
     
     @Test
@@ -41,28 +60,28 @@ public class StudyValidatorTest {
         study = createStudy();
         study.setIdentifier("id not valid");
         
-        assertValidatorMessage(VALIDATOR, study, "identifier", "must contain only lower- or upper-case letters, numbers, dashes, and/or underscores");
+        assertValidatorMessage(INSTANCE, study, IDENTIFIER_FIELD, BRIDGE_EVENT_ID_ERROR);
     }
 
     @Test
     public void nameIsRequired() {
         study = createStudy();
         study.setName(null);
-        assertValidatorMessage(VALIDATOR, study, "name", "is required");
+        assertValidatorMessage(INSTANCE, study, NAME_FIELD, CANNOT_BE_BLANK);
     }
     
     @Test
     public void phaseRequired() {
         study = createStudy();
         study.setPhase(null);
-        assertValidatorMessage(VALIDATOR, study, "phase", "is required");
+        assertValidatorMessage(INSTANCE, study, PHASE_FIELD, CANNOT_BE_NULL);
     }
 
     @Test
     public void appIdIsRequired() {
         study = createStudy();
         study.setAppId(null);
-        assertValidatorMessage(VALIDATOR, study, "appId", "is required");
+        assertValidatorMessage(INSTANCE, study, APP_ID_FIELD, CANNOT_BE_BLANK);
     }
     
     @Test
@@ -72,7 +91,7 @@ public class StudyValidatorTest {
         c1.setName(null);
         study.setContacts(ImmutableList.of(c1));
         
-        assertValidatorMessage(VALIDATOR, study, "contacts[0].name", CANNOT_BE_BLANK);
+        assertValidatorMessage(INSTANCE, study, CONTACTS_FIELD + "[0]." + NAME_FIELD, CANNOT_BE_BLANK);
     }
     
     @Test
@@ -82,7 +101,7 @@ public class StudyValidatorTest {
         c1.setName("");
         study.setContacts(ImmutableList.of(c1));
         
-        assertValidatorMessage(VALIDATOR, study, "contacts[0].name", CANNOT_BE_BLANK);
+        assertValidatorMessage(INSTANCE, study, CONTACTS_FIELD + "[0]." + NAME_FIELD, CANNOT_BE_BLANK);
     }
     
     @Test
@@ -92,7 +111,7 @@ public class StudyValidatorTest {
         c1.setRole(null);
         study.setContacts(ImmutableList.of(c1));
         
-        assertValidatorMessage(VALIDATOR, study, "contacts[0].role", CANNOT_BE_NULL);
+        assertValidatorMessage(INSTANCE, study, CONTACTS_FIELD + "[0]." + ROLE_FIELD, CANNOT_BE_NULL);
     }
     
     @Test
@@ -102,7 +121,7 @@ public class StudyValidatorTest {
         c1.setEmail("junk");
         study.setContacts(ImmutableList.of(c1));
         
-        assertValidatorMessage(VALIDATOR, study, "contacts[0].email", "does not appear to be an email address");
+        assertValidatorMessage(INSTANCE, study, CONTACTS_FIELD + "[0]." + EMAIL_FIELD, INVALID_EMAIL_ERROR);
     }
     
     @Test
@@ -112,7 +131,34 @@ public class StudyValidatorTest {
         c1.setPhone(new Phone("333333", "Portual"));
         study.setContacts(ImmutableList.of(c1));
         
-        assertValidatorMessage(VALIDATOR, study, "contacts[0].phone", "does not appear to be a phone number");
+        assertValidatorMessage(INSTANCE, study, CONTACTS_FIELD + "[0]." + PHONE_FIELD, INVALID_PHONE_ERROR);
+    }
+    
+    @Test
+    public void irbDecisionOnRequired() {
+        study = createStudy();
+        study.setIrbDecisionType(APPROVED);
+        study.setIrbExpiresOn(EXPIRES_ON);
+        
+        assertValidatorMessage(INSTANCE, study, IRB_DECISION_ON_FIELD, CANNOT_BE_NULL);
+    }
+    
+    @Test
+    public void irbDecisionTypeRequired() {
+        study = createStudy();
+        study.setIrbDecisionOn(DECISION_ON);
+        study.setIrbExpiresOn(EXPIRES_ON);
+        
+        assertValidatorMessage(INSTANCE, study, IRB_DECISION_TYPE_FIELD, CANNOT_BE_NULL);
+    }
+    
+    @Test
+    public void irbExpiresOnRequired() {
+        study = createStudy();
+        study.setIrbDecisionOn(DECISION_ON);
+        study.setIrbDecisionType(APPROVED);
+        
+        assertValidatorMessage(INSTANCE, study, StudyValidator.IRB_EXPIRES_ON_FIELD, CANNOT_BE_NULL);
     }
     
     @Test
@@ -120,7 +166,7 @@ public class StudyValidatorTest {
         study = createStudy();
         study.setContacts(null);
         
-        entityThrowingException(VALIDATOR, study);
+        entityThrowingException(INSTANCE, study);
     }
     
     @Test
@@ -130,7 +176,7 @@ public class StudyValidatorTest {
         c1.setEmail(null);
         study.setContacts(ImmutableList.of(c1));
         
-        entityThrowingException(VALIDATOR, study);
+        entityThrowingException(INSTANCE, study);
     }
 
     @Test
@@ -140,7 +186,7 @@ public class StudyValidatorTest {
         c1.setPhone(null);
         study.setContacts(ImmutableList.of(c1));
         
-        entityThrowingException(VALIDATOR, study);
+        entityThrowingException(INSTANCE, study);
     }
     
     private Study createStudy() {


### PR DESCRIPTION
BRIDGE-2989, BRIDGE-3001, BRIDGE-3002, BRIDGE-3004

- More robust formatActivityEventId event which will accept session/assessment finished events;
- change PK for adherence records to use event timestamp as part of PK (not createdOn), so that:
- you can change createdOn without creating a new record, and you can delete adherence records, which seems useful for testing;
- updates to assessment adherence records will not start and finish session adherence records, since the former are what the clients are working with and the latter are more useful for adherence & compliance reporting;
- added API so a study coordinator/researcher can edit a user's adherence records (again, useful for testing);
- changes to IRB-related fields in study;
- you can mark an AR as “declined”;
- totalMinutes and totalNotifications added to the Timeline;
- test cleanup, such as moving a test method out of the main utilities class;
- if enrollment is missing in the "recent study events" or "study event history" APIs, add it.