### PR TITLE
Accept user ID 'token' in many calls and parse it.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
@@ -245,6 +245,8 @@ public class BridgeUtils {
             return AccountId.forSynapseUserId(appId, userIdToken.substring(14));
         } else if (id.startsWith("syn:")) {
             return AccountId.forSynapseUserId(appId, userIdToken.substring(4));
+        } else if (id.startsWith("email:")) {
+            return AccountId.forEmail(appId, userIdToken.substring(6));
         }
         return AccountId.forId(appId, userIdToken);
     }

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceRecordsSearch.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceRecordsSearch.java
@@ -14,7 +14,6 @@ import com.google.common.collect.ImmutableSet;
 
 import org.joda.time.DateTime;
 
-import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.models.BridgeEntity;
 
 /**

--- a/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import com.google.common.collect.Sets;
 
@@ -358,18 +359,23 @@ public class AccountService {
         return accountDao.getPagedAccountSummaries(appId, search);
     }
     
-    /**
-     * For MailChimp, and other external systems, we need a way to get a healthCode for a given email.
-     */
-    public String getHealthCodeForAccount(AccountId accountId) {
-        checkNotNull(accountId);
-        
-        Account account = getAccount(accountId);
-        if (account != null) {
-            return account.getHealthCode();
-        } else {
-            return null;
+    public Optional<String> getAccountHealthCode(String appId, String userIdToken) {
+        return getAccountField(appId, userIdToken, Account::getHealthCode);
+    }
+    
+    public Optional<String> getAccountId(String appId, String userIdToken) {
+        return getAccountField(appId, userIdToken, Account::getId);
+    }
+    
+    private Optional<String> getAccountField(String appId, String userIdToken, Function<Account,String> func) {
+        if (appId != null && userIdToken != null) {
+            AccountId accountId = BridgeUtils.parseAccountId(appId, userIdToken);
+            Account account = getAccount(accountId);
+            if (account != null) {
+                return Optional.ofNullable(func.apply(account));
+            }
         }
+        return Optional.empty();
     }
     
     protected Account authenticateInternal(App app, Account account, SignIn signIn) {

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/EmailController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/EmailController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
-import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.apps.App;
 
 @CrossOrigin
@@ -60,11 +59,9 @@ public class EmailController extends BaseController {
             }
             
             // This should always return a healthCode under normal circumstances.
-            AccountId accountId = AccountId.forEmail(app.getIdentifier(), email);
-            String healthCode = accountService.getHealthCodeForAccount(accountId);
-            if (healthCode == null) {
-                throw new BadRequestException("Email not found.");
-            }
+            String healthCode = accountService.getAccountHealthCode(app.getIdentifier(), "email:"+email)
+                    .orElseThrow(() -> new BadRequestException("Email not found."));
+
             accountService.editAccount(app.getIdentifier(), healthCode, account -> account.setNotifyByEmail(false));
             
             return "You have been unsubscribed from future email.";

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportController.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.DateRangeResourceList;
@@ -34,7 +35,6 @@ import org.sagebionetworks.bridge.models.StatusMessage;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
-import org.sagebionetworks.bridge.models.apps.App;
 import org.sagebionetworks.bridge.models.reports.ReportData;
 import org.sagebionetworks.bridge.models.reports.ReportDataKey;
 import org.sagebionetworks.bridge.models.reports.ReportIndex;
@@ -124,96 +124,113 @@ public class ParticipantReportController extends BaseController {
     }
 
     /** API to get reports for the given user by date. */
-    @GetMapping("/v3/participants/{userId}/reports/{identifier}")
-    public DateRangeResourceList<? extends ReportData> getParticipantReport(@PathVariable String userId,
+    @GetMapping("/v3/participants/{userIdToken}/reports/{identifier}")
+    public DateRangeResourceList<? extends ReportData> getParticipantReport(@PathVariable String userIdToken,
             @PathVariable String identifier, @RequestParam(required = false) String startDate,
             @RequestParam(required = false) String endDate) {
         UserSession session = getAdministrativeSession();
-        CAN_EDIT_PARTICIPANTS.checkAndThrow(USER_ID, userId);
         
-        return getParticipantReportInternal(session.getAppId(), userId, identifier, startDate, endDate);
+        AccountId accountId = BridgeUtils.parseAccountId(session.getAppId(), userIdToken);
+        Account account = accountService.getAccount(accountId);
+        if (account == null) {
+            throw new EntityNotFoundException(Account.class);
+        }
+        
+        CAN_EDIT_PARTICIPANTS.checkAndThrow(USER_ID, account.getId());
+        
+        return getParticipantReportInternal(session.getAppId(), account, identifier, startDate, endDate);
     }
 
     /** Worker API to get reports for the given user in the given app by date. */
-    @GetMapping(path = { "/v1/apps/{appId}/participants/{userId}/reports/{reportId}",
-            "/v3/studies/{appId}/participants/{userId}/reports/{reportId}" })
+    @GetMapping(path = { "/v1/apps/{appId}/participants/{userIdToken}/reports/{reportId}",
+            "/v3/studies/{appId}/participants/{userIdToken}/reports/{reportId}" })
     public DateRangeResourceList<? extends ReportData> getParticipantReportForWorker(@PathVariable String appId,
-            @PathVariable String userId, @PathVariable String reportId, @RequestParam(required = false) String startDate,
+            @PathVariable String userIdToken, @PathVariable String reportId, @RequestParam(required = false) String startDate,
             @RequestParam(required = false) String endDate) {
         getAuthenticatedSession(WORKER);
-        return getParticipantReportInternal(appId, userId, reportId, startDate, endDate);
+        
+        AccountId accountId = BridgeUtils.parseAccountId(appId, userIdToken);
+        Account account = accountService.getAccount(accountId);
+        if (account == null) {
+            throw new EntityNotFoundException(Account.class);
+        }
+        
+        return getParticipantReportInternal(appId, account, reportId, startDate, endDate);
     }
 
-    private DateRangeResourceList<? extends ReportData> getParticipantReportInternal(String appId, String userId, String reportId,
+    private DateRangeResourceList<? extends ReportData> getParticipantReportInternal(String appId, Account account, String reportId,
             String startDateString, String endDateString) {
         LocalDate startDate = getLocalDateOrDefault(startDateString, null);
         LocalDate endDate = getLocalDateOrDefault(endDateString, null);
 
-        Account account = accountService.getAccount(AccountId.forId(appId, userId));
-        if (account == null) {
-            throw new EntityNotFoundException(Account.class);
-        }
         return reportService.getParticipantReport(appId, reportId, account.getHealthCode(), startDate, endDate);
     }
 
     /** API to get reports for the given user by date-time. */
-    @GetMapping("/v4/participants/{userId}/reports/{identifier}")
-    public ForwardCursorPagedResourceList<ReportData> getParticipantReportV4(@PathVariable String userId,
+    @GetMapping("/v4/participants/{userIdToken}/reports/{identifier}")
+    public ForwardCursorPagedResourceList<ReportData> getParticipantReportV4(@PathVariable String userIdToken,
             @PathVariable String identifier, @RequestParam(required = false) String startTime,
             @RequestParam(required = false) String endTime, @RequestParam(required = false) String offsetKey,
             @RequestParam(required = false) String pageSize) {
         UserSession session = getAdministrativeSession();
-        CAN_EDIT_PARTICIPANTS.checkAndThrow(USER_ID, userId);
+
+        AccountId accountId = BridgeUtils.parseAccountId(session.getAppId(), userIdToken);
+        Account account = accountService.getAccount(accountId);
+        if (account == null) {
+            throw new EntityNotFoundException(Account.class);
+        }
         
-        return getParticipantReportInternalV4(session.getAppId(), userId, identifier, 
+        CAN_EDIT_PARTICIPANTS.checkAndThrow(USER_ID, session.getId());
+        
+        return getParticipantReportInternalV4(session.getAppId(), account, identifier, 
                 startTime, endTime, offsetKey, pageSize);
     }
 
     /** Worker API to get reports for the given user in the given app by date-time. */
-    @GetMapping(path = {"/v2/apps/{appId}/participants/{userId}/reports/{reportId}",
-            "/v4/studies/{appId}/participants/{userId}/reports/{reportId}"})
+    @GetMapping(path = {"/v2/apps/{appId}/participants/{userIdToken}/reports/{reportId}",
+            "/v4/studies/{appId}/participants/{userIdToken}/reports/{reportId}"})
     public ForwardCursorPagedResourceList<ReportData> getParticipantReportForWorkerV4(@PathVariable String appId,
-            @PathVariable String userId, @PathVariable String reportId,
+            @PathVariable String userIdToken, @PathVariable String reportId,
             @RequestParam(required = false) String startTime, @RequestParam(required = false) String endTime,
             @RequestParam(required = false) String offsetKey, @RequestParam(required = false) String pageSize) {
         getAuthenticatedSession(WORKER);
-        return getParticipantReportInternalV4(appId, userId, reportId, startTime, endTime, offsetKey, pageSize);
+        
+        AccountId accountId = BridgeUtils.parseAccountId(appId, userIdToken);
+        Account account = accountService.getAccount(accountId);
+        if (account == null) {
+            throw new EntityNotFoundException(Account.class);
+        }
+        return getParticipantReportInternalV4(appId, account, reportId, startTime, endTime, offsetKey, pageSize);
     }
 
     // Helper method, shared by both getParticipantReportV4() and getParticipantReportForWorkerV4().
-    private ForwardCursorPagedResourceList<ReportData> getParticipantReportInternalV4(String appId, String userId, String reportId,
-            String startTimeString, String endTimeString, String offsetKey, String pageSizeString) {
+    private ForwardCursorPagedResourceList<ReportData> getParticipantReportInternalV4(String appId, Account account,
+            String reportId, String startTimeString, String endTimeString, String offsetKey, String pageSizeString) {
         DateTime startTime = getDateTimeOrDefault(startTimeString, null);
         DateTime endTime = getDateTimeOrDefault(endTimeString, null);
         int pageSize = getIntOrDefault(pageSizeString, API_DEFAULT_PAGE_SIZE);
 
-        Account account = accountService.getAccount(AccountId.forId(appId, userId));
-        if (account == null) {
-            throw new EntityNotFoundException(Account.class);
-        }
-        return reportService.getParticipantReportV4(appId, reportId, account.getHealthCode(), startTime, endTime,
-                offsetKey, pageSize);
+        return reportService.getParticipantReportV4(appId, reportId, account.getHealthCode(), 
+                startTime, endTime, offsetKey, pageSize);
     }
 
     /**
      * Report participant data can be saved by developers or by worker processes. The JSON for these must 
      * include a healthCode field. This is validated when constructing the DataReportKey.
      */
-    @PostMapping({"/v4/participants/{userId}/reports/{identifier}", "/v3/participants/{userId}/reports/{identifier}"})
+    @PostMapping({"/v4/participants/{userIdToken}/reports/{identifier}", "/v3/participants/{userIdToken}/reports/{identifier}"})
     @ResponseStatus(HttpStatus.CREATED)
-    public StatusMessage saveParticipantReport(@PathVariable String userId, @PathVariable String identifier) {
+    public StatusMessage saveParticipantReport(@PathVariable String userIdToken, @PathVariable String identifier) {
         UserSession session = getAuthenticatedSession(DEVELOPER);
-        App app = appService.getApp(session.getAppId());
 
-        Account account = accountService.getAccount(AccountId.forId(app.getIdentifier(), userId));
-        if (account == null) {
-            throw new EntityNotFoundException(Account.class);
-        }
+        String healthCode = accountService.getAccountHealthCode(session.getAppId(), userIdToken)
+                .orElseThrow(() -> new EntityNotFoundException(Account.class));
+
         ReportData reportData = parseJson(ReportData.class);
         reportData.setKey(null); // set in service, but just so no future use depends on it
         
         reportService.saveParticipantReport(session.getAppId(), identifier, 
-                account.getHealthCode(), reportData);
+                healthCode, reportData);
         
         return new StatusMessage("Report data saved.");
     }
@@ -247,17 +264,15 @@ public class ParticipantReportController extends BaseController {
      * to know the user ID for records). This deletes all reports for all users. This is not 
      * performant for large data sets and should only be done during testing. 
      */
-    @DeleteMapping({ "/v4/participants/{userId}/reports/{identifier}",
-            "/v3/participants/{userId}/reports/{identifier}" })
-    public StatusMessage deleteParticipantReport(@PathVariable String userId, @PathVariable String identifier) {
+    @DeleteMapping({ "/v4/participants/{userIdToken}/reports/{identifier}",
+            "/v3/participants/{userIdToken}/reports/{identifier}" })
+    public StatusMessage deleteParticipantReport(@PathVariable String userIdToken, @PathVariable String identifier) {
         UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
-        App app = appService.getApp(session.getAppId());
         
-        Account account = accountService.getAccount(AccountId.forId(app.getIdentifier(), userId));
-        if (account == null) {
-            throw new EntityNotFoundException(Account.class);    
-        }
-        reportService.deleteParticipantReport(session.getAppId(), identifier, account.getHealthCode());
+        String healthCode = accountService.getAccountHealthCode(session.getAppId(), userIdToken)
+                .orElseThrow(() -> new EntityNotFoundException(Account.class));
+
+        reportService.deleteParticipantReport(session.getAppId(), identifier, healthCode);
         
         return new StatusMessage("Report deleted.");
     }
@@ -265,17 +280,15 @@ public class ParticipantReportController extends BaseController {
     /**
      * Delete an individual participant report record
      */
-    @DeleteMapping("/v3/participants/{userId}/reports/{identifier}/{date}")
-    public StatusMessage deleteParticipantReportRecord(@PathVariable String userId, @PathVariable String identifier,
+    @DeleteMapping("/v3/participants/{userIdToken}/reports/{identifier}/{date}")
+    public StatusMessage deleteParticipantReportRecord(@PathVariable String userIdToken, @PathVariable String identifier,
             @PathVariable String date) {
         UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
-        App app = appService.getApp(session.getAppId());
         
-        Account account = accountService.getAccount(AccountId.forId(app.getIdentifier(), userId));
-        if (account == null) {
-            throw new EntityNotFoundException(Account.class);
-        }
-        reportService.deleteParticipantReportRecord(session.getAppId(), identifier, date, account.getHealthCode());
+        String healthCode = accountService.getAccountHealthCode(session.getAppId(), userIdToken)
+                .orElseThrow(() -> new EntityNotFoundException(Account.class));
+
+        reportService.deleteParticipantReportRecord(session.getAppId(), identifier, date, healthCode);
         
         return new StatusMessage("Report record deleted.");
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantController.java
@@ -436,9 +436,9 @@ public class StudyParticipantController extends BaseController {
             @PathVariable String studyId, @PathVariable String userId) {
         UserSession session = getAdministrativeSession();
         
-        getValidAccountInStudy(session.getAppId(), studyId, userId);
+        Account account = getValidAccountInStudy(session.getAppId(), studyId, userId);
         
-        return studyActivityEventService.getRecentStudyActivityEvents(session.getAppId(), userId, studyId);
+        return studyActivityEventService.getRecentStudyActivityEvents(session.getAppId(), account.getId(), studyId);
     }
     
     @GetMapping("/v5/studies/{studyId}/participants/{userId}/activityevents/{eventId}")
@@ -449,12 +449,12 @@ public class StudyParticipantController extends BaseController {
             @RequestParam(required = false) String pageSize) {
         UserSession session = getAdministrativeSession();
         
-        getValidAccountInStudy(session.getAppId(), studyId, userId);
+        Account account = getValidAccountInStudy(session.getAppId(), studyId, userId);
         
         Integer offsetByInt = BridgeUtils.getIntOrDefault(offsetBy, 0);
         Integer pageSizeInt = BridgeUtils.getIntOrDefault(pageSize, API_DEFAULT_PAGE_SIZE);
         
-        AccountId accountId = BridgeUtils.parseAccountId(session.getAppId(), userId);
+        AccountId accountId = AccountId.forId(account.getAppId(),  account.getId());
         
         return studyActivityEventService.getStudyActivityEventHistory(accountId, 
                 studyId, eventId, offsetByInt, pageSizeInt);
@@ -465,12 +465,12 @@ public class StudyParticipantController extends BaseController {
     public StatusMessage publishActivityEvent(@PathVariable String studyId, @PathVariable String userId) {
         UserSession session = getAdministrativeSession();
         
-        getValidAccountInStudy(session.getAppId(), studyId, userId);
+        Account account = getValidAccountInStudy(session.getAppId(), studyId, userId);
         
         StudyActivityEventRequest request = parseJson(StudyActivityEventRequest.class)
                 .appId(session.getAppId())
                 .studyId(studyId)
-                .userId(userId)
+                .userId(account.getId())
                 .objectType(CUSTOM);
         
         studyActivityEventService.publishEvent(request);
@@ -484,12 +484,12 @@ public class StudyParticipantController extends BaseController {
             @PathVariable String eventId) {
         UserSession session = getAdministrativeSession();
         
-        getValidAccountInStudy(session.getAppId(), studyId, userId);
+        Account account = getValidAccountInStudy(session.getAppId(), studyId, userId);
 
         studyActivityEventService.deleteCustomEvent(new StudyActivityEventRequest()
                 .appId(session.getAppId())
                 .studyId(studyId)
-                .userId(userId)
+                .userId(account.getId())
                 .objectId(eventId)
                 .objectType(CUSTOM));
         

--- a/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -482,6 +482,10 @@ public class BridgeUtilsTest {
         accountId = BridgeUtils.parseAccountId("test", "syn:IdentifierA12");
         assertEquals(accountId.getAppId(), "test");
         assertEquals(accountId.getSynapseUserId(), "IdentifierA12");
+
+        accountId = BridgeUtils.parseAccountId("test", "email:bridge-testing@sagebase.org");
+        assertEquals(accountId.getAppId(), "test");
+        assertEquals(accountId.getEmail(), "bridge-testing@sagebase.org");
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoActivityEventTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoActivityEventTest.java
@@ -1,7 +1,5 @@
 package org.sagebionetworks.bridge.dynamodb;
 
-import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
-import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertDatesWithTimeZoneEqual;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.ACTIVITIES_RETRIEVED;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.CUSTOM;

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAdherenceRecordDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAdherenceRecordDaoTest.java
@@ -20,9 +20,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
-import javax.persistence.Column;
-import javax.persistence.Convert;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
@@ -339,24 +339,43 @@ public class AccountServiceTest extends Mockito {
     }
 
     @Test
-    public void getHealthCodeForAccount() throws Exception {
+    public void getAccountHealthCode() throws Exception {
         Account account = mockGetAccountById(ACCOUNT_ID, false);
         account.setHealthCode(HEALTH_CODE);
 
-        String healthCode = service.getHealthCodeForAccount(ACCOUNT_ID);
-        assertEquals(healthCode, HEALTH_CODE);
+        Optional<String> healthCode = service.getAccountHealthCode(TEST_APP_ID, TEST_USER_ID);
+        assertEquals(healthCode.get(), HEALTH_CODE);
         verify(mockAccountDao).getAccount(ACCOUNT_ID);
     }
     
     @Test
-    public void getHealthCodeForAccountNoAccount() {
+    public void getAccountHealthCodeNoAccount() {
         when(mockAccountDao.getAccount(ACCOUNT_ID)).thenReturn(Optional.empty());
         
-        String healthCode = service.getHealthCodeForAccount(ACCOUNT_ID);
-        assertNull(healthCode);
+        Optional<String> healthCode = service.getAccountHealthCode(TEST_APP_ID, TEST_USER_ID);
+        assertFalse(healthCode.isPresent());
         verify(mockAccountDao).getAccount(ACCOUNT_ID);
     }    
 
+    @Test
+    public void getAccountId() throws Exception {
+        Account account = mockGetAccountById(ACCOUNT_ID, false);
+        account.setId(TEST_USER_ID);
+
+        Optional<String> userId = service.getAccountId(TEST_APP_ID, TEST_USER_ID);
+        assertEquals(userId.get(), TEST_USER_ID);
+        verify(mockAccountDao).getAccount(ACCOUNT_ID);
+    }
+    
+    @Test
+    public void getAccountIdNoAccount() {
+        when(mockAccountDao.getAccount(ACCOUNT_ID)).thenReturn(Optional.empty());
+        
+        Optional<String> userId = service.getAccountId(TEST_APP_ID, TEST_USER_ID);
+        assertFalse(userId.isPresent());
+        verify(mockAccountDao).getAccount(ACCOUNT_ID);
+    }
+    
     @Test
     public void verifyEmailUsingToken() {
         Account account = Account.create();

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AdherenceControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AdherenceControllerTest.java
@@ -2,7 +2,6 @@ package org.sagebionetworks.bridge.spring.controllers;
 
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.STUDY_COORDINATOR;
-import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
@@ -13,6 +12,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
 
 import java.util.List;
+import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -91,6 +91,9 @@ public class AdherenceControllerTest extends Mockito {
     public void updateAdherenceRecords() throws Exception {
         doReturn(session).when(controller).getAuthenticatedSession(RESEARCHER, STUDY_COORDINATOR);
         
+        when(mockAccountService.getAccountId(TEST_APP_ID, TEST_USER_ID))
+            .thenReturn(Optional.of(TEST_USER_ID));
+        
         AdherenceRecord rec1 = TestUtils.getAdherenceRecord("AAA");
         AdherenceRecord rec2 = TestUtils.getAdherenceRecord("BBB");
         AdherenceRecordList list = new AdherenceRecordList(ImmutableList.of(rec1, rec2));
@@ -160,7 +163,7 @@ public class AdherenceControllerTest extends Mockito {
     public void searchForAdherenceRecords() throws Exception {
         doReturn(session).when(controller).getAuthenticatedSession(RESEARCHER, STUDY_COORDINATOR);
         
-        when(mockAccountService.getHealthCodeForAccount(any())).thenReturn(HEALTH_CODE);
+        when(mockAccountService.getAccountId(any(), any())).thenReturn(Optional.of("some-other-id"));
 
         AdherenceRecord rec1 = TestUtils.getAdherenceRecord("AAA");
         AdherenceRecord rec2 = TestUtils.getAdherenceRecord("BBB");

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/EmailControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/EmailControllerTest.java
@@ -5,6 +5,7 @@ import static org.sagebionetworks.bridge.TestUtils.mockEditAccount;
 import static org.testng.Assert.assertEquals;
 
 import java.util.Map;
+import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -21,7 +22,6 @@ import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.models.accounts.Account;
-import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.apps.App;
 import org.sagebionetworks.bridge.services.AccountService;
 import org.sagebionetworks.bridge.services.AppService;
@@ -36,7 +36,6 @@ public class EmailControllerTest extends Mockito {
     private static final String STUDY = "study";
     private static final String APP_ID = "appId";
     private static final String EMAIL_ADDRESS = "bridge-testing@sagebase.org";
-    private static final AccountId ACCOUNT_ID = AccountId.forEmail(TEST_APP_ID, EMAIL_ADDRESS);
 
     @Mock
     AppService mockAppService;
@@ -66,7 +65,8 @@ public class EmailControllerTest extends Mockito {
     public void before() {
         MockitoAnnotations.initMocks(this);
         when(mockConfig.getEmailUnsubscribeToken()).thenReturn(UNSUBSCRIBE_TOKEN);
-        when(mockAccountService.getHealthCodeForAccount(ACCOUNT_ID)).thenReturn(HEALTH_CODE);
+        when(mockAccountService.getAccountHealthCode(TEST_APP_ID, "email:"+EMAIL_ADDRESS))
+            .thenReturn(Optional.of(HEALTH_CODE));
         doReturn(mockRequest).when(controller).request();
         doReturn(mockResponse).when(controller).response();
         mockEditAccount(mockAccountService, mockAccount);
@@ -133,7 +133,8 @@ public class EmailControllerTest extends Mockito {
     @Test
     public void noAccountThrowsException() throws Exception {
         mockContext(DATA_BRACKET_EMAIL, EMAIL_ADDRESS, STUDY, TEST_APP_ID, TOKEN, UNSUBSCRIBE_TOKEN);
-        doReturn(null).when(mockAccountService).getHealthCodeForAccount(ACCOUNT_ID);
+        doReturn(Optional.empty()).when(mockAccountService)
+            .getAccountHealthCode(TEST_APP_ID, "email:"+EMAIL_ADDRESS);
 
         String result = controller.unsubscribeFromEmail();
         assertEquals(result, "Email not found.");

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportControllerTest.java
@@ -249,7 +249,8 @@ public class ParticipantReportControllerTest extends Mockito {
     @Test
     public void getParticipantReportForWorkerV4_DefaultParams() throws Exception {
         // Mock dependencies
-        when(mockAccountService.getAccount(OTHER_ACCOUNT_ID)).thenReturn(mockAccount);
+        when(mockAccountService.getAccountHealthCode(TEST_APP_ID, OTHER_PARTICIPANT_ID))
+            .thenReturn(Optional.of(HEALTH_CODE));
 
         ForwardCursorPagedResourceList<ReportData> expectedPage = makePagedResults(START_TIME, END_TIME, null,
                 API_DEFAULT_PAGE_SIZE);
@@ -270,7 +271,8 @@ public class ParticipantReportControllerTest extends Mockito {
     @Test
     public void getParticipantReportForWorkerV4_OptionalParams() throws Exception {
         // Mock dependencies
-        when(mockAccountService.getAccount(OTHER_ACCOUNT_ID)).thenReturn(mockAccount);
+        when(mockAccountService.getAccountHealthCode(TEST_APP_ID, OTHER_PARTICIPANT_ID))
+            .thenReturn(Optional.of(HEALTH_CODE));
 
         ForwardCursorPagedResourceList<ReportData> expectedPage = makePagedResults(START_TIME, END_TIME, OFFSET_KEY,
                 PAGE_SIZE_INT);
@@ -347,7 +349,8 @@ public class ParticipantReportControllerTest extends Mockito {
     @Test
     public void getParticipantReportForWorker_DefaultParams() throws Exception {
         // Mock dependencies
-        when(mockAccountService.getAccount(OTHER_ACCOUNT_ID)).thenReturn(mockAccount);
+        when(mockAccountService.getAccountHealthCode(TEST_APP_ID, OTHER_PARTICIPANT_ID))
+            .thenReturn(Optional.of(HEALTH_CODE));
 
         DateRangeResourceList<ReportData> expectedPage = makeResults(START_DATE, END_DATE);
         doReturn(expectedPage).when(mockReportService).getParticipantReport(TEST_APP_ID, REPORT_ID, HEALTH_CODE,
@@ -365,7 +368,8 @@ public class ParticipantReportControllerTest extends Mockito {
     @Test
     public void getParticipantReportForWorker_OptionalParams() throws Exception {
         // Mock dependencies
-        when(mockAccountService.getAccount(OTHER_ACCOUNT_ID)).thenReturn(mockAccount);
+        when(mockAccountService.getAccountHealthCode(TEST_APP_ID, OTHER_PARTICIPANT_ID))
+            .thenReturn(Optional.of(HEALTH_CODE));
 
         DateRangeResourceList<ReportData> expectedPage = makeResults(START_DATE, END_DATE);
         doReturn(expectedPage).when(mockReportService).getParticipantReport(TEST_APP_ID, REPORT_ID, HEALTH_CODE,

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportControllerTest.java
@@ -20,6 +20,7 @@ import static org.testng.Assert.fail;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -127,9 +128,7 @@ public class ParticipantReportControllerTest extends Mockito {
         
         StudyParticipant participant = new StudyParticipant.Builder().withHealthCode(HEALTH_CODE)
                 .withRoles(Sets.newHashSet(DEVELOPER)).build();
-        
-        doReturn(mockOtherAccount).when(mockAccountService).getAccount(OTHER_ACCOUNT_ID);
-        
+
         ConsentStatus status = new ConsentStatus.Builder().withName("Name").withGuid(SubpopulationGuid.create("GUID"))
                 .withConsented(true).withRequired(true).withSignedMostRecentConsent(true).build();
         Map<SubpopulationGuid,ConsentStatus> statuses = Maps.newHashMap();
@@ -292,11 +291,8 @@ public class ParticipantReportControllerTest extends Mockito {
 
     @Test
     public void getParticipantReportDataAsResearcher() throws Exception {
-        // No consents so user is not consented, but is a researcher and can also see these reports
-        session.setConsentStatuses(Maps.newHashMap());
-        StudyParticipant participant = new StudyParticipant.Builder().withHealthCode(HEALTH_CODE)
-                .withRoles(Sets.newHashSet(RESEARCHER)).build();
-        session.setParticipant(participant);
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
         
         doReturn(mockAccount).when(mockAccountService).getAccount(OTHER_ACCOUNT_ID);
         
@@ -317,7 +313,8 @@ public class ParticipantReportControllerTest extends Mockito {
         StudyParticipant participant = new StudyParticipant.Builder().withHealthCode(HEALTH_CODE)
                 .withId(OTHER_PARTICIPANT_ID).withRoles(Sets.newHashSet(DEVELOPER)).build();
         session.setParticipant(participant);
-        
+
+        when(mockAccount.getId()).thenReturn(OTHER_PARTICIPANT_ID);
         doReturn(mockAccount).when(mockAccountService).getAccount(OTHER_ACCOUNT_ID);
         
         doReturn(makeResults(START_DATE, END_DATE)).when(mockReportService).getParticipantReport(session.getAppId(),
@@ -387,6 +384,8 @@ public class ParticipantReportControllerTest extends Mockito {
     public void saveParticipantReportData() throws Exception {
         String json = TestUtils.createJson("{'date':'2015-02-12','data':{'field1':'Last','field2':'Name'}}");
         mockRequestBody(mockRequest, json);
+        when(mockAccountService.getAccountHealthCode(TEST_APP_ID, OTHER_PARTICIPANT_ID))
+            .thenReturn(Optional.of(OTHER_PARTICIPANT_HEALTH_CODE));
 
         StatusMessage result = controller.saveParticipantReport(OTHER_PARTICIPANT_ID, REPORT_ID);
         assertEquals(result.getMessage(), "Report data saved.");
@@ -404,7 +403,9 @@ public class ParticipantReportControllerTest extends Mockito {
             expectedExceptionsMessageRegExp = ".*Error parsing JSON in request body, fields:.*")
     public void saveParticipantReportForWorkerBadJson() throws Exception {
         mockRequestBody(mockRequest, "\"+1234567890\"");
-        
+        when(mockAccountService.getAccountHealthCode(TEST_APP_ID, OTHER_PARTICIPANT_ID))
+            .thenReturn(Optional.of(OTHER_PARTICIPANT_HEALTH_CODE));
+
         controller.saveParticipantReport(TEST_USER_ID, REPORT_ID);
     }
     
@@ -413,6 +414,8 @@ public class ParticipantReportControllerTest extends Mockito {
     public void saveParticipantEmptyReportData() throws Exception {
         String json = TestUtils.createJson("{'date':'2015-02-12','data':{}}");
         mockRequestBody(mockRequest, json);
+        when(mockAccountService.getAccountHealthCode(TEST_APP_ID, OTHER_PARTICIPANT_ID))
+            .thenReturn(Optional.of(OTHER_PARTICIPANT_HEALTH_CODE));
 
         StatusMessage result = controller.saveParticipantReport(OTHER_PARTICIPANT_ID, REPORT_ID);
         assertEquals(result.getMessage(), "Report data saved.");
@@ -484,6 +487,9 @@ public class ParticipantReportControllerTest extends Mockito {
     
     @Test
     public void deleteParticipantReportData() throws Exception {
+        when(mockAccountService.getAccountHealthCode(TEST_APP_ID, OTHER_PARTICIPANT_ID))
+            .thenReturn(Optional.of(OTHER_PARTICIPANT_HEALTH_CODE));
+        
         StatusMessage result = controller.deleteParticipantReport(OTHER_PARTICIPANT_ID, REPORT_ID);
         assertEquals(result.getMessage(), "Report deleted.");
         
@@ -492,6 +498,9 @@ public class ParticipantReportControllerTest extends Mockito {
     
     @Test
     public void deleteParticipantReportDataRecord() throws Exception {
+        when(mockAccountService.getAccountHealthCode(TEST_APP_ID, OTHER_PARTICIPANT_ID))
+            .thenReturn(Optional.of(OTHER_PARTICIPANT_HEALTH_CODE));
+        
         StatusMessage result = controller.deleteParticipantReportRecord(OTHER_PARTICIPANT_ID, REPORT_ID, "2014-05-10");
         assertEquals(result.getMessage(), "Report record deleted.");
         

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantControllerTest.java
@@ -1407,6 +1407,8 @@ public class StudyParticipantControllerTest extends Mockito {
         doReturn(session).when(controller).getAdministrativeSession();
         
         Account account = Account.create();
+        account.setAppId(TEST_APP_ID);
+        account.setId(TEST_USER_ID);
         Enrollment en = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         account.setEnrollments(ImmutableSet.of(en));
         when(mockAccountService.getAccount(any())).thenReturn(account);


### PR DESCRIPTION
This lead to a clean up of the getHealthCodeForAccount() method while adding a similar method to get the account ID. No other changes to functionality.