### PR TITLE
Study additions

### DIFF
--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -3,4 +3,7 @@
         is marked @Nullable -->
     <Bug pattern="NP_NONNULL_PARAM_VIOLATION" />
     <Bug pattern="SE_NO_SERIALVERSIONID" />
+    <!-- This generates a false positive on Oracles java compiler, and they cannot be easily 
+        eliminated. -->
+    <Bug pattern="DLS_DEAD_LOCAL_STORE" />
 </FindBugsFilter>

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudy.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudy.java
@@ -115,9 +115,8 @@ public class HibernateStudy implements Study {
     /**
      * For partial construction of object by Hibernate, excluding expensive fields like clientData.
      */
-    public HibernateStudy(String name, String identifier, String appId, 
-            DateTime createdOn, DateTime modifiedOn, boolean deleted, 
-            StudyPhase phase, List<SignInType> signInTypes, Long version) {
+    public HibernateStudy(String name, String identifier, String appId, DateTime createdOn, 
+            DateTime modifiedOn, boolean deleted, StudyPhase phase, Long version) {
         this.name = name;
         this.identifier = identifier;
         this.appId = appId;
@@ -125,7 +124,6 @@ public class HibernateStudy implements Study {
         this.modifiedOn = modifiedOn;
         this.deleted = deleted;
         this.phase = phase;
-        this.signInTypes = signInTypes;
         this.version = version;
     }
     

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudy.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudy.java
@@ -1,7 +1,9 @@
 package org.sagebionetworks.bridge.hibernate;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
@@ -18,6 +20,8 @@ import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 import javax.persistence.Version;
 
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
@@ -25,6 +29,7 @@ import org.sagebionetworks.bridge.json.BridgeTypeName;
 import org.sagebionetworks.bridge.models.assessments.ColorScheme;
 import org.sagebionetworks.bridge.models.studies.Contact;
 import org.sagebionetworks.bridge.models.studies.IrbDecisionType;
+import org.sagebionetworks.bridge.models.studies.SignInType;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyId;
 import org.sagebionetworks.bridge.models.studies.StudyPhase;
@@ -69,16 +74,38 @@ public class HibernateStudy implements Study {
     private ColorScheme colorScheme;
     private String institutionId;
     private String scheduleGuid;
-    private String disease;
-    private String studyDesignType;
     @Version
     private Long version;
+    
+    // the subselect annotations below reduce the number of SQL queries that
+    // hibernate makes to retrieve the full study object. Tables are being used
+    // for collections that we might use in future queries; JSON for collections
+    // that we'll never reference apart from the study object.
+    
     @ElementCollection(fetch = FetchType.EAGER)
+    @Fetch(value = FetchMode.SUBSELECT)
     @OrderColumn(name="pos") // can’t use 'position' in this case
     @CollectionTable(name="StudyContacts", joinColumns= {
             @JoinColumn(name="appId"), @JoinColumn(name="studyId")
     })
     private List<Contact> contacts;
+    
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Fetch(value = FetchMode.SUBSELECT)
+    @CollectionTable(name="StudyDiseases", 
+        joinColumns = {@JoinColumn(name="appId"), @JoinColumn(name="studyId")})
+    @Column(name="disease")
+    private Set<String> diseases;
+    
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Fetch(value = FetchMode.SUBSELECT)
+    @CollectionTable(name="StudyDesignTypes", 
+        joinColumns = {@JoinColumn(name="appId"), @JoinColumn(name="studyId")})
+    @Column(name = "designType")
+    private Set<String> studyDesignTypes;
+
+    @Convert(converter = SignInTypeListConverter.class)
+    private List<SignInType> signInTypes;
     
     /**
      * For full construction of object by Hibernate.
@@ -90,7 +117,7 @@ public class HibernateStudy implements Study {
      */
     public HibernateStudy(String name, String identifier, String appId, 
             DateTime createdOn, DateTime modifiedOn, boolean deleted, 
-            StudyPhase phase, Long version) {
+            StudyPhase phase, List<SignInType> signInTypes, Long version) {
         this.name = name;
         this.identifier = identifier;
         this.appId = appId;
@@ -98,6 +125,7 @@ public class HibernateStudy implements Study {
         this.modifiedOn = modifiedOn;
         this.deleted = deleted;
         this.phase = phase;
+        this.signInTypes = signInTypes;
         this.version = version;
     }
     
@@ -316,22 +344,41 @@ public class HibernateStudy implements Study {
     }
 
     @Override
-    public String getDisease() {
-        return disease;
+    public Set<String> getDiseases() {
+        if (diseases == null) {
+            diseases = new HashSet<>();
+        }
+        return diseases;
     }
 
     @Override
-    public void setDisease(String disease) {
-        this.disease = disease;
+    public void setDiseases(Set<String> diseases) {
+        this.diseases = diseases;
     }
 
     @Override
-    public String getStudyDesignType() {
-        return studyDesignType;
+    public Set<String> getStudyDesignTypes() {
+        if (studyDesignTypes == null) {
+            studyDesignTypes = new HashSet<>();
+        }
+        return studyDesignTypes;
     }
 
     @Override
-    public void setStudyDesignType(String studyDesignType) {
-        this.studyDesignType = studyDesignType;
+    public void setStudyDesignTypes(Set<String> studyDesignTypes) {
+        this.studyDesignTypes = studyDesignTypes;
+    }
+    
+    @Override
+    public List<SignInType> getSignInTypes() {
+        if (signInTypes == null) {
+            signInTypes = new ArrayList<>();
+        }
+        return signInTypes;
+    }
+    
+    @Override
+    public void setSignInTypes(List<SignInType> signInTypes) {
+        this.signInTypes = signInTypes;
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudy.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudy.java
@@ -74,6 +74,7 @@ public class HibernateStudy implements Study {
     private ColorScheme colorScheme;
     private String institutionId;
     private String scheduleGuid;
+    private String keywords;
     @Version
     private Long version;
     
@@ -341,6 +342,16 @@ public class HibernateStudy implements Study {
         this.scheduleGuid = scheduleGuid;
     }
 
+    @Override
+    public String getKeywords() { 
+        return keywords;
+    }
+    
+    @Override
+    public void setKeywords(String keywords) {
+        this.keywords = keywords;
+    }
+    
     @Override
     public Set<String> getDiseases() {
         if (diseases == null) {

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudyDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudyDao.java
@@ -25,7 +25,7 @@ public class HibernateStudyDao implements StudyDao {
     static final String COUNT_PHRASE = "select count(*) ";
     static final String SELECT_PHRASE = "select new org.sagebionetworks.bridge.hibernate."
             + "HibernateStudy(study.name, study.identifier, study.appId, study.createdOn, "
-            + "study.modifiedOn, study.deleted, study.phase, study.version) ";
+            + "study.modifiedOn, study.deleted, study.phase, study.signInTypes, study.version) ";
     static final String FROM_PHRASE = "from HibernateStudy as study where appId = :appId"; 
     
     private HibernateHelper hibernateHelper;

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudyDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudyDao.java
@@ -25,7 +25,7 @@ public class HibernateStudyDao implements StudyDao {
     static final String COUNT_PHRASE = "select count(*) ";
     static final String SELECT_PHRASE = "select new org.sagebionetworks.bridge.hibernate."
             + "HibernateStudy(study.name, study.identifier, study.appId, study.createdOn, "
-            + "study.modifiedOn, study.deleted, study.phase, study.signInTypes, study.version) ";
+            + "study.modifiedOn, study.deleted, study.phase, study.version) ";
     static final String FROM_PHRASE = "from HibernateStudy as study where appId = :appId"; 
     
     private HibernateHelper hibernateHelper;

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/SignInTypeListConverter.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/SignInTypeListConverter.java
@@ -1,0 +1,21 @@
+package org.sagebionetworks.bridge.hibernate;
+
+import java.util.List;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import org.sagebionetworks.bridge.models.studies.SignInType;
+
+public class SignInTypeListConverter extends BaseJsonAttributeConverter<List<SignInType>> {
+
+    private static final TypeReference<List<SignInType>> TYPE_REF = new TypeReference<List<SignInType>>() {};
+    
+    @Override
+    public String convertToDatabaseColumn(List<SignInType> list) {
+        return serialize(list);
+    }
+    @Override
+    public List<SignInType> convertToEntityAttribute(String string) {
+        return deserialize(string, TYPE_REF);
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/models/studies/SignInType.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/studies/SignInType.java
@@ -1,0 +1,18 @@
+package org.sagebionetworks.bridge.models.studies;
+
+public enum SignInType {
+    /** Study expects participants to sign in with an email address and a password. */
+    EMAIL_PASSWORD,
+    /** Study expects participants to sign in with a phone number and a password. */
+    PHONE_PASSWORD,
+    /** Study expects participants to sign in with an external ID and a password. */
+    EXTERNAL_ID_PASSWORD,
+    /** Study expects participants to sign in by sending an email message to the 
+     * participant’s email account with a sign in code or sign in link. 
+     */
+    EMAIL_MESSAGE,
+    /** Study expects participants to sign in by sending an SMS message to the 
+     * participant’s phone number with a sign in code or sign in link. 
+     */
+    PHONE_MESSAGE
+}

--- a/src/main/java/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/studies/Study.java
@@ -8,6 +8,7 @@ import org.sagebionetworks.bridge.models.BridgeEntity;
 import org.sagebionetworks.bridge.models.assessments.ColorScheme;
 
 import java.util.List;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -76,14 +77,17 @@ public interface Study extends BridgeEntity {
     String getScheduleGuid();
     void setScheduleGuid(String scheduleGuid);
     
-    String getDisease();
-    void setDisease(String disease);
+    Set<String> getDiseases();
+    void setDiseases(Set<String> diseases);
     
-    String getStudyDesignType();
-    void setStudyDesignType(String studyDesignType);
+    Set<String> getStudyDesignTypes();
+    void setStudyDesignTypes(Set<String> studyDesignTypes);
     
     List<Contact> getContacts();
     void setContacts(List<Contact> contacts);
+    
+    List<SignInType> getSignInTypes();
+    void setSignInTypes(List<SignInType> signInTypes);
 
     Long getVersion();
     void setVersion(Long version);

--- a/src/main/java/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/studies/Study.java
@@ -77,6 +77,9 @@ public interface Study extends BridgeEntity {
     String getScheduleGuid();
     void setScheduleGuid(String scheduleGuid);
     
+    String getKeywords();
+    void setKeywords(String keywords);
+    
     Set<String> getDiseases();
     void setDiseases(Set<String> diseases);
     

--- a/src/main/java/org/sagebionetworks/bridge/validators/StudyValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/StudyValidator.java
@@ -4,6 +4,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_EVENT_ID_ERROR;
 import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_EVENT_ID_PATTERN;
 import static org.sagebionetworks.bridge.BridgeConstants.OWASP_REGEXP_VALID_EMAIL;
+import static org.sagebionetworks.bridge.models.studies.IrbDecisionType.APPROVED;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL;
 import static org.sagebionetworks.bridge.validators.Validate.INVALID_EMAIL_ERROR;
@@ -62,12 +63,11 @@ public class StudyValidator implements Validator {
         if (validateIrb) {
             if (study.getIrbDecisionType() == null) {
                 errors.rejectValue(IRB_DECISION_TYPE_FIELD, CANNOT_BE_NULL);
-            }
+            } else if (study.getIrbDecisionType() == APPROVED && study.getIrbExpiresOn() == null) {
+                errors.rejectValue(IRB_EXPIRES_ON_FIELD, CANNOT_BE_NULL);
+            }                
             if (study.getIrbDecisionOn() == null) { 
                 errors.rejectValue(IRB_DECISION_ON_FIELD, CANNOT_BE_NULL);
-            }
-            if (study.getIrbExpiresOn() == null) {
-                errors.rejectValue(IRB_EXPIRES_ON_FIELD, CANNOT_BE_NULL);
             }
         }
         for (int i=0; i < study.getContacts().size(); i++) {

--- a/src/main/resources/db/changelog/changelog.sql
+++ b/src/main/resources/db/changelog/changelog.sql
@@ -722,7 +722,8 @@ ADD COLUMN `timelineAccessedOn` varchar(255);
 ALTER TABLE `Substudies`
 DROP COLUMN `disease`,
 DROP COLUMN `studyDesignType`,
-ADD COLUMN `signInTypes` text;
+ADD COLUMN `signInTypes` text,
+ADD COLUMN `keywords` varchar(255);
 
 CREATE TABLE IF NOT EXISTS `StudyDiseases` (
   `appId` varchar(255) NOT NULL,

--- a/src/main/resources/db/changelog/changelog.sql
+++ b/src/main/resources/db/changelog/changelog.sql
@@ -716,3 +716,26 @@ CREATE TABLE `AdherenceRecords` (
 
 ALTER TABLE `RequestInfos`
 ADD COLUMN `timelineAccessedOn` varchar(255);
+
+-- changeset bridge:39
+
+ALTER TABLE `Substudies`
+DROP COLUMN `disease`,
+DROP COLUMN `studyDesignType`,
+ADD COLUMN `signInTypes` text;
+
+CREATE TABLE IF NOT EXISTS `StudyDiseases` (
+  `appId` varchar(255) NOT NULL,
+  `studyId` varchar(255) NOT NULL,
+  `disease` varchar(255) NOT NULL,
+  PRIMARY KEY (`appId`, `studyId`, `disease`),
+  CONSTRAINT `StudyDiseases-Study-Constraint` FOREIGN KEY (`studyId`, `appId`) REFERENCES `Substudies` (`id`, `studyId`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `StudyDesignTypes` (
+  `appId` varchar(255) NOT NULL,
+  `studyId` varchar(255) NOT NULL,
+  `designType` varchar(255) NOT NULL,
+  PRIMARY KEY (`appId`, `studyId`, `designType`),
+  CONSTRAINT `StudyDesignTypes-Study-Constraint` FOREIGN KEY (`studyId`, `appId`) REFERENCES `Substudies` (`id`, `studyId`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateStudyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateStudyTest.java
@@ -71,6 +71,7 @@ public class HibernateStudyTest {
         study.setCreatedOn(CREATED_ON);
         study.setModifiedOn(MODIFIED_ON);
         study.setClientData(TestUtils.getClientData());
+        study.setKeywords("keywords");
         study.setVersion(3L);
         
         Contact c1 = new Contact();
@@ -95,7 +96,7 @@ public class HibernateStudyTest {
         study.setSignInTypes(TYPES);
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(study);
-        assertEquals(node.size(), 24);
+        assertEquals(node.size(), 25);
         assertEquals(node.get("identifier").textValue(), "oneId");
         assertEquals(node.get("name").textValue(), "name");
         assertTrue(node.get("deleted").booleanValue());
@@ -124,6 +125,7 @@ public class HibernateStudyTest {
         assertEquals(node.get("studyDesignTypes").get(0).textValue(), "observational case control");
         assertEquals(node.get("signInTypes").get(0).textValue(), "email_message");
         assertEquals(node.get("signInTypes").get(1).textValue(), "email_password");
+        assertEquals(node.get("keywords").textValue(), "keywords");
         assertEquals(node.get("type").textValue(), "Study");
         assertNull(node.get("studyId"));
         assertNull(node.get("appId"));
@@ -151,6 +153,7 @@ public class HibernateStudyTest {
         assertEquals(deser.getPhase(), ANALYSIS);
         assertEquals(deser.getDiseases(), ImmutableSet.of("subjective cognitive decline"));
         assertEquals(deser.getStudyDesignTypes(), ImmutableSet.of("observational case control"));
+        assertEquals(deser.getKeywords(), "keywords");
         assertEquals(deser.getSignInTypes(), TYPES);
         assertEquals(deser.getVersion(), new Long(3));
         

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateStudyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateStudyTest.java
@@ -8,11 +8,14 @@ import org.testng.annotations.Test;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.studies.Contact;
+import org.sagebionetworks.bridge.models.studies.SignInType;
 import org.sagebionetworks.bridge.models.studies.Study;
 
 import static org.sagebionetworks.bridge.TestConstants.COLOR_SCHEME;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.models.studies.IrbDecisionType.APPROVED;
+import static org.sagebionetworks.bridge.models.studies.SignInType.EMAIL_MESSAGE;
+import static org.sagebionetworks.bridge.models.studies.SignInType.EMAIL_PASSWORD;
 import static org.sagebionetworks.bridge.models.studies.StudyPhase.ANALYSIS;
 import static org.sagebionetworks.bridge.models.studies.StudyPhase.DESIGN;
 import static org.testng.Assert.assertEquals;
@@ -20,9 +23,12 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
+import java.util.List;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class HibernateStudyTest {
 
@@ -30,11 +36,12 @@ public class HibernateStudyTest {
     private static final DateTime MODIFIED_ON = DateTime.now().minusHours(1).withZone(DateTimeZone.UTC);
     private static final LocalDate APPROVED_ON = DateTime.now().toLocalDate();
     private static final LocalDate EXPIRES_ON = DateTime.now().plusDays(10).toLocalDate();
+    private static final List<SignInType> TYPES = ImmutableList.of(EMAIL_MESSAGE, EMAIL_PASSWORD);
     
     @Test
     public void shortConstructor() {
         HibernateStudy study = new HibernateStudy("name", "identifier", "appId", 
-                CREATED_ON, MODIFIED_ON, true, DESIGN, 10L);
+                CREATED_ON, MODIFIED_ON, true, DESIGN, TYPES, 10L);
         assertEquals(study.getName(), "name");
         assertEquals(study.getIdentifier(), "identifier");
         assertEquals(study.getAppId(), "appId");
@@ -42,6 +49,7 @@ public class HibernateStudyTest {
         assertEquals(study.getModifiedOn(), MODIFIED_ON);
         assertTrue(study.isDeleted());
         assertEquals(study.getPhase(), DESIGN);
+        assertEquals(study.getSignInTypes(), TYPES);
         assertEquals(study.getVersion(), Long.valueOf(10L));
     }
     
@@ -49,6 +57,9 @@ public class HibernateStudyTest {
     public void collectionsNotNull() {
         HibernateStudy study = new HibernateStudy();
         assertNotNull(study.getContacts());
+        assertNotNull(study.getSignInTypes());
+        assertNotNull(study.getDiseases());
+        assertNotNull(study.getStudyDesignTypes());
     }
     
     @Test
@@ -80,11 +91,12 @@ public class HibernateStudyTest {
         study.setIrbProtocolName("anIrbName");
         study.setScheduleGuid("aScheduleGuid");
         study.setPhase(ANALYSIS);
-        study.setDisease("subjective cognitive decline");
-        study.setStudyDesignType("observational case control");
+        study.setDiseases(ImmutableSet.of("subjective cognitive decline"));
+        study.setStudyDesignTypes(ImmutableSet.of("observational case control"));
+        study.setSignInTypes(TYPES);
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(study);
-        assertEquals(node.size(), 23);
+        assertEquals(node.size(), 24);
         assertEquals(node.get("identifier").textValue(), "oneId");
         assertEquals(node.get("name").textValue(), "name");
         assertTrue(node.get("deleted").booleanValue());
@@ -109,8 +121,10 @@ public class HibernateStudyTest {
         assertEquals(node.get("irbProtocolId").textValue(), "anIrbProtocolId");
         assertEquals(node.get("scheduleGuid").textValue(), "aScheduleGuid");
         assertEquals(node.get("phase").textValue(), "analysis");
-        assertEquals(node.get("disease").textValue(), "subjective cognitive decline");
-        assertEquals(node.get("studyDesignType").textValue(), "observational case control");
+        assertEquals(node.get("diseases").get(0).textValue(), "subjective cognitive decline");
+        assertEquals(node.get("studyDesignTypes").get(0).textValue(), "observational case control");
+        assertEquals(node.get("signInTypes").get(0).textValue(), "email_message");
+        assertEquals(node.get("signInTypes").get(1).textValue(), "email_password");
         assertEquals(node.get("type").textValue(), "Study");
         assertNull(node.get("studyId"));
         assertNull(node.get("appId"));
@@ -136,8 +150,9 @@ public class HibernateStudyTest {
         assertEquals(deser.getContacts().get(0).getName(), "Name1");
         assertEquals(deser.getContacts().get(1).getName(), "Name2");
         assertEquals(deser.getPhase(), ANALYSIS);
-        assertEquals(deser.getDisease(), "subjective cognitive decline");
-        assertEquals(deser.getStudyDesignType(), "observational case control");
+        assertEquals(deser.getDiseases(), ImmutableSet.of("subjective cognitive decline"));
+        assertEquals(deser.getStudyDesignTypes(), ImmutableSet.of("observational case control"));
+        assertEquals(deser.getSignInTypes(), TYPES);
         assertEquals(deser.getVersion(), new Long(3));
         
         JsonNode deserClientData = deser.getClientData();

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateStudyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateStudyTest.java
@@ -41,7 +41,7 @@ public class HibernateStudyTest {
     @Test
     public void shortConstructor() {
         HibernateStudy study = new HibernateStudy("name", "identifier", "appId", 
-                CREATED_ON, MODIFIED_ON, true, DESIGN, TYPES, 10L);
+                CREATED_ON, MODIFIED_ON, true, DESIGN, 10L);
         assertEquals(study.getName(), "name");
         assertEquals(study.getIdentifier(), "identifier");
         assertEquals(study.getAppId(), "appId");
@@ -49,7 +49,6 @@ public class HibernateStudyTest {
         assertEquals(study.getModifiedOn(), MODIFIED_ON);
         assertTrue(study.isDeleted());
         assertEquals(study.getPhase(), DESIGN);
-        assertEquals(study.getSignInTypes(), TYPES);
         assertEquals(study.getVersion(), Long.valueOf(10L));
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/SignInTypeListConverterTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/SignInTypeListConverterTest.java
@@ -1,0 +1,54 @@
+package org.sagebionetworks.bridge.hibernate;
+
+import static org.sagebionetworks.bridge.models.studies.SignInType.EMAIL_MESSAGE;
+import static org.sagebionetworks.bridge.models.studies.SignInType.PHONE_PASSWORD;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.models.studies.SignInType;
+
+public class SignInTypeListConverterTest {
+
+    SignInTypeListConverter converter;
+    
+    @BeforeMethod
+    public void beforeMethod() {
+        converter = new SignInTypeListConverter();
+    }
+    
+    @Test
+    public void convertToDatabaseColumn() {
+        List<SignInType> types = ImmutableList.of(EMAIL_MESSAGE, PHONE_PASSWORD);
+        
+        String json = converter.convertToDatabaseColumn(types);
+        
+        assertEquals(json, "[\"email_message\",\"phone_password\"]");
+    }
+    
+    @Test
+    public void convertToEntityAttribute() {
+        String json = "[\"email_message\",\"phone_password\"]";
+        
+        List<SignInType> types = converter.convertToEntityAttribute(json);
+        assertEquals(types.get(0), EMAIL_MESSAGE);
+        assertEquals(types.get(1), PHONE_PASSWORD);
+    }
+    
+    @Test
+    public void convertToDatabaseColumn_handlesNull() {
+        assertNull( converter.convertToDatabaseColumn(null) );
+    }
+    
+    @Test
+    public void convertToEntityAttribute_handlesNull() {
+        assertNull( converter.convertToEntityAttribute(null) );
+    }
+
+}

--- a/src/test/java/org/sagebionetworks/bridge/services/AssessmentResourceServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AssessmentResourceServiceTest.java
@@ -46,7 +46,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.RequestContext;
-import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.dao.AssessmentResourceDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;

--- a/src/test/java/org/sagebionetworks/bridge/services/AssessmentServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AssessmentServiceTest.java
@@ -49,7 +49,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.RequestContext;
-import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.dao.AssessmentDao;
 import org.sagebionetworks.bridge.dao.AssessmentResourceDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/SharedAssessmentControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/SharedAssessmentControllerTest.java
@@ -30,7 +30,6 @@ import org.mockito.Spy;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.UserSession;

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/SharedAssessmentResourceControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/SharedAssessmentResourceControllerTest.java
@@ -37,7 +37,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.RequestContext;
-import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;

--- a/src/test/java/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -7,6 +7,7 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 import static org.sagebionetworks.bridge.models.studies.ContactRole.TECHNICAL_SUPPORT;
 import static org.sagebionetworks.bridge.models.studies.IrbDecisionType.APPROVED;
+import static org.sagebionetworks.bridge.models.studies.IrbDecisionType.EXEMPT;
 import static org.sagebionetworks.bridge.models.studies.StudyPhase.DESIGN;
 import static org.sagebionetworks.bridge.validators.StudyValidator.APP_ID_FIELD;
 import static org.sagebionetworks.bridge.validators.StudyValidator.CONTACTS_FIELD;
@@ -159,6 +160,15 @@ public class StudyValidatorTest {
         study.setIrbDecisionType(APPROVED);
         
         assertValidatorMessage(INSTANCE, study, StudyValidator.IRB_EXPIRES_ON_FIELD, CANNOT_BE_NULL);
+    }
+    
+    @Test
+    public void irbExemptionDoesNotRequireExpiration() {
+        study = createStudy();
+        study.setIrbDecisionType(EXEMPT);
+        study.setIrbDecisionOn(DECISION_ON);
+        study.setIrbExpiresOn(null);
+        entityThrowingException(INSTANCE, study);
     }
     
     @Test


### PR DESCRIPTION
- Adding list of sign in types to indicate to participant clients (if they have a study ID) what kind of authentication should be presented to the user;
- Converted study design types and diseases to lists;
- Annotations to reduce the number of queries to retrieve studies (to one, it appears);
- If the IRB decision type is "exempt," then an expiresOn value for the decision is no longer required.