### PR TITLE
Deleting previous S3 file during create request

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoParticipantFileDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoParticipantFileDao.java
@@ -53,7 +53,7 @@ public class DynamoParticipantFileDao implements ParticipantFileDao {
             nextPageOffsetKey = fileResults.get(fileResults.size() - 1).getFileId();
         }
 
-        return new ForwardCursorPagedResourceList<>(fileResults, nextPageOffsetKey)
+        return new ForwardCursorPagedResourceList<>(fileResults, nextPageOffsetKey, true)
                 .withRequestParam(ResourceList.OFFSET_KEY, offsetKey)
                 .withRequestParam(ResourceList.PAGE_SIZE, pageSize);
     }

--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantFileService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantFileService.java
@@ -118,6 +118,10 @@ public class ParticipantFileService {
 
         participantFileDao.uploadParticipantFile(file);
 
+        // Deleting any previous object prevents a user from updating the ParticipantFile
+        // but leaving the previous object on S3.
+        s3Client.deleteObject(bucketName, getFilePath(file));
+
         file.setUploadUrl(generatePresignedRequest(file, PUT).toExternalForm());
         return file;
     }

--- a/src/test/java/org/sagebionetworks/bridge/services/ParticipantFileServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ParticipantFileServiceTest.java
@@ -154,6 +154,8 @@ public class ParticipantFileServiceTest {
         assertEquals(result.getCreatedOn().getMillis(), TestConstants.TIMESTAMP.getMillis());
         assertEquals(result.getExpiresOn().getMillis(), TestConstants.TIMESTAMP.plusDays(1).getMillis());
         assertNull(result.getDownloadUrl());
+        
+        verify(mockS3Client).deleteObject(eq(UPLOAD_BUCKET), eq("test_user/file_id"));
 
         verify(mockS3Client).generatePresignedUrl(requestCaptor.capture());
         GeneratePresignedUrlRequest request = requestCaptor.getValue();


### PR DESCRIPTION
This is a minor fix to make sure a participant can not overwrite a ParticipantFile record while leaving the original file in S3.