### PR TITLE
Fix creation of public buckets.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/S3Initializer.java
+++ b/src/main/java/org/sagebionetworks/bridge/S3Initializer.java
@@ -138,12 +138,11 @@ public class S3Initializer {
                     String policy = resolveTemplate(type.policy, ImmutableMap.of("bucketName", bucketName));
                     s3Client.setBucketPolicy(bucketName, policy);
                 }
-                // For public buckets to serve for HTTP downloads, they must also be set as 
-                // web hosting buckets. (This folder hosts files like study icons and unsigned
-                // consent documents).
+                // For public buckets to serve for retrieving documents via HTTP, they 
+                // must also be configured as web hosting buckets. index file is required, 
+                // but does not need to exist (and does not exist) 
                 if (type.policy == PUBLIC_ACCESS_POLICY) {
                     BucketWebsiteConfiguration config = new BucketWebsiteConfiguration();
-                    // index file is required, but does not need to exist (and does not exist)
                     config.setIndexDocumentSuffix("index.html"); 
                     s3Client.setBucketWebsiteConfiguration(bucketName, config);
                 }

--- a/src/main/java/org/sagebionetworks/bridge/services/FileService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/FileService.java
@@ -7,7 +7,8 @@ import static org.joda.time.DateTimeZone.UTC;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.PAGE_SIZE_ERROR;
-import static org.sagebionetworks.bridge.config.Environment.LOCAL;
+import static org.sagebionetworks.bridge.config.Environment.PROD;
+import static org.sagebionetworks.bridge.config.Environment.UAT;
 import static org.sagebionetworks.bridge.models.files.FileDispositionType.ATTACHMENT;
 import static org.sagebionetworks.bridge.models.files.FileRevisionStatus.AVAILABLE;
 import static org.sagebionetworks.bridge.models.files.FileRevisionStatus.PENDING;
@@ -236,7 +237,7 @@ public class FileService {
     }
     
     protected String getDownloadURL(FileRevision revision) {
-        String protocol = (env == LOCAL) ? "http" : "https";
+        String protocol = (env == PROD || env == UAT) ? "https" : "http";
         String fileName = getFileName(revision);
         return protocol + "://" + documentWebsiteUrl + "/" + fileName;
     }

--- a/src/main/java/org/sagebionetworks/bridge/services/FileService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/FileService.java
@@ -42,6 +42,8 @@ import org.sagebionetworks.bridge.validators.Validate;
 @Component
 public class FileService {
     
+    static final String DOCS_WEBSITE_URL_CONFIG_PROPERTY = "docs.website.url";
+
     static final int EXPIRATION_IN_MINUTES = 10;
     
     private FileMetadataDao fileMetadataDao;
@@ -51,6 +53,8 @@ public class FileService {
     private Environment env;
     
     private String revisionsBucket;
+    
+    private String documentWebsiteUrl;
     
     private AmazonS3 s3Client;
     
@@ -68,10 +72,11 @@ public class FileService {
     final void setConfig(BridgeConfig config) {
         revisionsBucket = config.getHostnameWithPostfix("docs");
         env = config.getEnvironment();
+        documentWebsiteUrl = config.get(DOCS_WEBSITE_URL_CONFIG_PROPERTY);
     }
     
     @Resource(name = "fileUploadS3Client")
-    public void setS3Client(AmazonS3 s3Client) {
+    final void setS3Client(AmazonS3 s3Client) {
         this.s3Client = s3Client;
     }
     
@@ -228,7 +233,7 @@ public class FileService {
     protected String getDownloadURL(FileRevision revision) {
         String protocol = (env == LOCAL) ? "http" : "https";
         String fileName = getFileName(revision);
-        return protocol + "://" + revisionsBucket + "/" + fileName;
+        return protocol + "://" + documentWebsiteUrl + "/" + fileName;
     }
 
     protected String getFileName(FileRevision revision) {

--- a/src/main/resources/BridgeServer2.conf
+++ b/src/main/resources/BridgeServer2.conf
@@ -189,9 +189,9 @@ participant-file.bucket = org-sagebridge-participantfile-${bucket.suffix}
 docs.bucket = docs${host.postfix}
 
 # In production, the bucket name and domain name are the same because we can configure 
-# the domain name in Route 53. In local and development environments, we do not (can 
-# not?) configure DNS entries local and development environments because they are in 
-# a separate AWS account. So we use the full S3 website hosting URL.
+# the domain name in Route 53. In local, development, and staging environments, we do 
+# not (can not?) configure DNS entries because they are in a separate AWS account. 
+# So we use the full S3 website hosting URL.
 docs.website.url = ${docs.bucket}
 local.docs.website.url = docs-${bridge.user}.sagebridge.org.s3-website-us-east-1.amazonaws.com
 dev.docs.website.url = docs-devdevelop.sagebridge.org.s3-website-us-east-1.amazonaws.com

--- a/src/main/resources/BridgeServer2.conf
+++ b/src/main/resources/BridgeServer2.conf
@@ -188,10 +188,10 @@ participant-file.bucket = org-sagebridge-participantfile-${bucket.suffix}
 # Public documents folder
 docs.bucket = docs${host.postfix}
 
-# In staging and production, the bucket name and domain name are the same because we 
-# can configured the domain name in Route 53. In local and development environments, we
-# do not (can not?) configure DNS entries local and development environments because 
-# they are in a separate AWS account. So we use the full S3 website hosting URL.
+# In production, the bucket name and domain name are the same because we can configure 
+# the domain name in Route 53. In local and development environments, we do not (can 
+# not?) configure DNS entries local and development environments because they are in 
+# a separate AWS account. So we use the full S3 website hosting URL.
 docs.website.url = ${docs.bucket}
 local.docs.website.url = docs-${bridge.user}.sagebridge.org.s3-website-us-east-1.amazonaws.com
 dev.docs.website.url = docs-devdevelop.sagebridge.org.s3-website-us-east-1.amazonaws.com

--- a/src/main/resources/BridgeServer2.conf
+++ b/src/main/resources/BridgeServer2.conf
@@ -193,6 +193,6 @@ docs.bucket = docs${host.postfix}
 # do not (can not?) configure DNS entries local and development environments because 
 # they are in a separate AWS account. So we use the full S3 website hosting URL.
 docs.website.url = ${docs.bucket}
+local.docs.website.url = docs-${bridge.user}.sagebridge.org.s3-website-us-east-1.amazonaws.com
 dev.docs.website.url = docs-devdevelop.sagebridge.org.s3-website-us-east-1.amazonaws.com
-
-
+uat.docs.website.url = docs-devstaging.sagebridge.org.s3-website-us-east-1.amazonaws.com

--- a/src/main/resources/BridgeServer2.conf
+++ b/src/main/resources/BridgeServer2.conf
@@ -189,9 +189,9 @@ participant-file.bucket = org-sagebridge-participantfile-${bucket.suffix}
 docs.bucket = docs${host.postfix}
 
 # In staging and production, the bucket name and domain name are the same because we 
-# have configured the DNS name in Route 53. In local and development environments, we
-# do not (can not?) configure a DNS entry for the development AWS ccount. So we use
-# the full S3 website hosting URL.
+# can configured the domain name in Route 53. In local and development environments, we
+# do not (can not?) configure DNS entries local and development environments because 
+# they are in a separate AWS account. So we use the full S3 website hosting URL.
 docs.website.url = ${docs.bucket}
 dev.docs.website.url = docs-devdevelop.sagebridge.org.s3-website-us-east-1.amazonaws.com
 

--- a/src/main/resources/BridgeServer2.conf
+++ b/src/main/resources/BridgeServer2.conf
@@ -195,4 +195,3 @@ docs.bucket = docs${host.postfix}
 docs.website.url = ${docs.bucket}
 local.docs.website.url = docs-${bridge.user}.sagebridge.org.s3-website-us-east-1.amazonaws.com
 dev.docs.website.url = docs-devdevelop.sagebridge.org.s3-website-us-east-1.amazonaws.com
-uat.docs.website.url = docs-devstaging.sagebridge.org.s3-website-us-east-1.amazonaws.com

--- a/src/main/resources/BridgeServer2.conf
+++ b/src/main/resources/BridgeServer2.conf
@@ -187,3 +187,12 @@ participant-file.bucket = org-sagebridge-participantfile-${bucket.suffix}
 
 # Public documents folder
 docs.bucket = docs${host.postfix}
+
+# In staging and production, the bucket name and domain name are the same because we 
+# have configured the DNS name in Route 53. In local and development environments, we
+# do not (can not?) configure a DNS entry for the development AWS ccount. So we use
+# the full S3 website hosting URL.
+docs.website.url = ${docs.bucket}
+dev.docs.website.url = docs-devdevelop.sagebridge.org.s3-website-us-east-1.amazonaws.com
+
+

--- a/src/test/java/org/sagebionetworks/bridge/S3InitializerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/S3InitializerTest.java
@@ -106,12 +106,19 @@ public class S3InitializerTest extends Mockito {
         verify(mockS3Client).createBucket(requestCaptor.capture());
         verify(mockS3Client).setBucketPolicy(BUCKET_NAME, resolvedPolicy);
         verify(mockS3Client).setBucketWebsiteConfiguration(eq(BUCKET_NAME), websiteConfigCaptor.capture());
+        verify(mockS3Client).setBucketCrossOriginConfiguration(eq(BUCKET_NAME), corsConfigCaptor.capture());
         
         assertEquals(requestCaptor.getValue().getBucketName(), BUCKET_NAME);
         
         // Not a lot to check here, but
         BucketWebsiteConfiguration config = websiteConfigCaptor.getValue();
         assertEquals(config.getIndexDocumentSuffix(), "index.html");
+        
+        CORSRule rule = corsConfigCaptor.getValue().getRules().get(0);
+        assertEquals(rule.getAllowedHeaders(), ImmutableList.of("*"));
+        assertEquals(rule.getAllowedOrigins(), ImmutableList.of("*"));
+        assertEquals(rule.getAllowedMethods(), ImmutableList.of(AllowedMethods.PUT));
+        assertEquals(rule.getMaxAgeSeconds(), 3000);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/S3InitializerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/S3InitializerTest.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.BucketCrossOriginConfiguration;
+import com.amazonaws.services.s3.model.BucketWebsiteConfiguration;
 import com.amazonaws.services.s3.model.CORSRule;
 import com.amazonaws.services.s3.model.CORSRule.AllowedMethods;
 import com.amazonaws.services.s3.model.CreateBucketRequest;
@@ -42,6 +43,9 @@ public class S3InitializerTest extends Mockito {
     
     @Captor
     ArgumentCaptor<BucketCrossOriginConfiguration> corsConfigCaptor;
+    
+    @Captor
+    ArgumentCaptor<BucketWebsiteConfiguration> websiteConfigCaptor;
     
     @BeforeMethod
     public void beforeMethod() {
@@ -101,8 +105,13 @@ public class S3InitializerTest extends Mockito {
         
         verify(mockS3Client).createBucket(requestCaptor.capture());
         verify(mockS3Client).setBucketPolicy(BUCKET_NAME, resolvedPolicy);
+        verify(mockS3Client).setBucketWebsiteConfiguration(eq(BUCKET_NAME), websiteConfigCaptor.capture());
         
         assertEquals(requestCaptor.getValue().getBucketName(), BUCKET_NAME);
+        
+        // Not a lot to check here, but
+        BucketWebsiteConfiguration config = websiteConfigCaptor.getValue();
+        assertEquals(config.getIndexDocumentSuffix(), "index.html");
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/FileServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/FileServiceTest.java
@@ -7,6 +7,7 @@ import static org.sagebionetworks.bridge.config.Environment.PROD;
 import static org.sagebionetworks.bridge.config.Environment.UAT;
 import static org.sagebionetworks.bridge.models.files.FileRevisionStatus.AVAILABLE;
 import static org.sagebionetworks.bridge.models.files.FileRevisionStatus.PENDING;
+import static org.sagebionetworks.bridge.services.FileService.DOCS_WEBSITE_URL_CONFIG_PROPERTY;
 import static org.sagebionetworks.bridge.services.FileService.EXPIRATION_IN_MINUTES;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -48,9 +49,10 @@ public class FileServiceTest extends Mockito {
 
     private static final String UPLOAD_BUCKET = "docs.sagebridge.org";
     private static final String UPLOAD_BUCKET_STAGING = "docs-staging.sagebridge.org";
+    private static final String UPLOAD_WEBSITE = "docs-website.sagebridge.org";
     private static final String NAME = "oneName";
-    private static final String DOWNLOAD_URL_1 = "https://docs.sagebridge.org/oneGuid.1422319112486";
-    private static final String DOWNLOAD_URL_2 = "https://docs.sagebridge.org/oneGuid.1422311912486";
+    private static final String DOWNLOAD_URL_1 = "https://docs-website.sagebridge.org/oneGuid.1422319112486";
+    private static final String DOWNLOAD_URL_2 = "https://docs-website.sagebridge.org/oneGuid.1422311912486";
     
     @Mock
     FileMetadataDao mockFileDao;
@@ -82,6 +84,7 @@ public class FileServiceTest extends Mockito {
         MockitoAnnotations.initMocks(this);
         
         when(mockConfig.getHostnameWithPostfix("docs")).thenReturn(UPLOAD_BUCKET);
+        when(mockConfig.get(DOCS_WEBSITE_URL_CONFIG_PROPERTY)).thenReturn(UPLOAD_WEBSITE);
         when(mockConfig.getEnvironment()).thenReturn(PROD);
         service.setConfig(mockConfig);
         
@@ -323,7 +326,7 @@ public class FileServiceTest extends Mockito {
         assertEquals(returned.getCreatedOn(), TIMESTAMP);
         assertEquals(returned.getStatus(), PENDING);
         assertEquals(returned.getUploadURL(), "https://" + UPLOAD_BUCKET);
-        assertEquals(returned.getDownloadURL(), "https://docs.sagebridge.org/oneGuid.1422319112486");
+        assertEquals(returned.getDownloadURL(), DOWNLOAD_URL_1);
         
         verify(mockS3Client).generatePresignedUrl(requestCaptor.capture());
         GeneratePresignedUrlRequest request = requestCaptor.getValue();
@@ -359,7 +362,7 @@ public class FileServiceTest extends Mockito {
     public void createFileRevisionInStaging() throws Exception {
         reset(mockConfig);
         when(mockConfig.getEnvironment()).thenReturn(UAT);
-        when(mockConfig.getHostnameWithPostfix("docs")).thenReturn(UPLOAD_BUCKET_STAGING);
+        when(mockConfig.get(DOCS_WEBSITE_URL_CONFIG_PROPERTY)).thenReturn(UPLOAD_BUCKET_STAGING);
         service.setConfig(mockConfig);
         
         FileMetadata metadata = new FileMetadata();


### PR DESCRIPTION
BRIDGE-3032

There were multiple issues here discovered during manual testing of a study logo upload feature:

- To download these files as public files, you need to enable S3 static website hosting;
- the buckets are named after the domain names in Route 53 and Cloud Front, however, I do not see any straightforward way to configure a domain name in the production AWS account for an S3 bucket in the development AWS account. So for local, development, and staging buckets, it is easier to use the hostname provided by S3 bucket static website hosting. Adjusted the configuration file so it is possible to override this for local/development
- To upload files to the public bucket from a web browser, you need to enable PUT CORS permissions.
