### PR TITLE
Refactor editAccount() so it's more generally useful

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
@@ -295,11 +295,9 @@ public class AccountService {
      * Load, and if it exists, edit and save an account. Note that constraints are not
      * enforced here (which is intentional).
      */
-    public void editAccount(String appId, String userId, Consumer<Account> accountEdits) {
-        checkNotNull(appId);
-        checkNotNull(userId);
+    public void editAccount(AccountId accountId, Consumer<Account> accountEdits) {
+        checkNotNull(accountId);
         
-        AccountId accountId = AccountId.forId(appId, userId);
         Account account = accountDao.getAccount(accountId).orElse(null);
         if (account != null) {
             accountEdits.accept(account);

--- a/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
@@ -295,12 +295,12 @@ public class AccountService {
      * Load, and if it exists, edit and save an account. Note that constraints are not
      * enforced here (which is intentional).
      */
-    public void editAccount(String appId, String healthCode, Consumer<Account> accountEdits) {
+    public void editAccount(String appId, String userId, Consumer<Account> accountEdits) {
         checkNotNull(appId);
-        checkNotNull(healthCode);
+        checkNotNull(userId);
         
-        AccountId accountId = AccountId.forHealthCode(appId, healthCode);
-        Account account = getAccount(accountId);
+        AccountId accountId = AccountId.forId(appId, userId);
+        Account account = accountDao.getAccount(accountId).orElse(null);
         if (account != null) {
             accountEdits.accept(account);
             accountDao.updateAccount(account);

--- a/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
@@ -298,11 +298,11 @@ public class AccountService {
     public void editAccount(AccountId accountId, Consumer<Account> accountEdits) {
         checkNotNull(accountId);
         
-        Account account = accountDao.getAccount(accountId).orElse(null);
-        if (account != null) {
-            accountEdits.accept(account);
-            accountDao.updateAccount(account);
-        }
+        Account account = accountDao.getAccount(accountId)
+                .orElseThrow(() -> new EntityNotFoundException(Account.class));
+
+        accountEdits.accept(account);
+        accountDao.updateAccount(account);
     }
     
     /**

--- a/src/main/java/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -520,7 +520,7 @@ public class AuthenticationService {
                     .withLanguages(context.getLanguages()).build();
             
             // Note that the context does not have the healthCode, you must use the participant
-            AccountId accountId = AccountId.forId(app.getIdentifier(), participant.getId());
+            AccountId accountId = AccountId.forHealthCode(app.getIdentifier(), participant.getHealthCode());
             accountService.editAccount(accountId,
                     accountToEdit -> accountToEdit.setLanguages(context.getLanguages()));
         }

--- a/src/main/java/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -520,7 +520,8 @@ public class AuthenticationService {
                     .withLanguages(context.getLanguages()).build();
             
             // Note that the context does not have the healthCode, you must use the participant
-            accountService.editAccount(app.getIdentifier(), participant.getId(),
+            AccountId accountId = AccountId.forId(app.getIdentifier(), participant.getId());
+            accountService.editAccount(accountId,
                     accountToEdit -> accountToEdit.setLanguages(context.getLanguages()));
         }
 

--- a/src/main/java/org/sagebionetworks/bridge/services/AuthenticationService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AuthenticationService.java
@@ -526,7 +526,7 @@ public class AuthenticationService {
                     .withLanguages(context.getLanguages()).build();
             
             // Note that the context does not have the healthCode, you must use the participant
-            accountService.editAccount(app.getIdentifier(), participant.getHealthCode(),
+            accountService.editAccount(app.getIdentifier(), participant.getId(),
                     accountToEdit -> accountToEdit.setLanguages(context.getLanguages()));
         }
 

--- a/src/main/java/org/sagebionetworks/bridge/services/FPHSService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/FPHSService.java
@@ -40,9 +40,9 @@ public class FPHSService {
         fphsDao.verifyExternalId(externalId);
     }
 
-    public void registerExternalIdentifier(String appId, String healthCode, ExternalIdentifier externalId) {
+    public void registerExternalIdentifier(String appId, String userId, ExternalIdentifier externalId) {
         checkNotNull(appId);
-        checkNotNull(healthCode);
+        checkNotNull(userId);
         checkNotNull(externalId);
         
         if (isBlank(externalId.getIdentifier())) {
@@ -52,7 +52,7 @@ public class FPHSService {
         
         fphsDao.registerExternalId(externalId);
 
-        accountService.editAccount(appId, healthCode, account -> {
+        accountService.editAccount(appId, userId, account -> {
             Enrollment enrollment = Enrollment.create(appId, "harvard", account.getId(), externalId.getIdentifier());
             account.getDataGroups().add("football_player");
             account.getEnrollments().add(enrollment);

--- a/src/main/java/org/sagebionetworks/bridge/services/FPHSService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/FPHSService.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import org.sagebionetworks.bridge.dao.FPHSExternalIdentifierDao;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.ExternalIdentifier;
 import org.sagebionetworks.bridge.models.accounts.FPHSExternalIdentifier;
 import org.sagebionetworks.bridge.models.studies.Enrollment;
@@ -52,7 +53,8 @@ public class FPHSService {
         
         fphsDao.registerExternalId(externalId);
 
-        accountService.editAccount(appId, userId, account -> {
+        AccountId accountId = AccountId.forId(appId, userId);
+        accountService.editAccount(accountId, account -> {
             Enrollment enrollment = Enrollment.create(appId, "harvard", account.getId(), externalId.getIdentifier());
             account.getDataGroups().add("football_player");
             account.getEnrollments().add(enrollment);

--- a/src/main/java/org/sagebionetworks/bridge/services/FPHSService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/FPHSService.java
@@ -41,9 +41,9 @@ public class FPHSService {
         fphsDao.verifyExternalId(externalId);
     }
 
-    public void registerExternalIdentifier(String appId, String userId, ExternalIdentifier externalId) {
+    public void registerExternalIdentifier(String appId, String healthCode, ExternalIdentifier externalId) {
         checkNotNull(appId);
-        checkNotNull(userId);
+        checkNotNull(healthCode);
         checkNotNull(externalId);
         
         if (isBlank(externalId.getIdentifier())) {
@@ -53,7 +53,7 @@ public class FPHSService {
         
         fphsDao.registerExternalId(externalId);
 
-        AccountId accountId = AccountId.forId(appId, userId);
+        AccountId accountId = AccountId.forHealthCode(appId, healthCode);
         accountService.editAccount(accountId, account -> {
             Enrollment enrollment = Enrollment.create(appId, "harvard", account.getId(), externalId.getIdentifier());
             account.getDataGroups().add("football_player");

--- a/src/main/java/org/sagebionetworks/bridge/services/OrganizationService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/OrganizationService.java
@@ -34,6 +34,7 @@ import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.AccountSummarySearch;
 import org.sagebionetworks.bridge.models.PagedResourceList;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.AccountSummary;
 import org.sagebionetworks.bridge.models.organizations.Organization;
 import org.sagebionetworks.bridge.validators.Validate;
@@ -223,7 +224,8 @@ public class OrganizationService {
         
         CAN_EDIT_MEMBERS.checkAndThrow(ORG_ID, identifier);
         
-        accountService.editAccount(appId, userId, (acct) -> {
+        AccountId accountId = AccountId.forId(appId, userId);
+        accountService.editAccount(accountId, (acct) -> {
             RequestContext context = RequestContext.get();
             if (!context.isInRole(ADMIN) && acct.getOrgMembership() != null) {
                 throw new BadRequestException("Account already assigned to an organization.");
@@ -240,7 +242,8 @@ public class OrganizationService {
         
         CAN_EDIT_MEMBERS.checkAndThrow(ORG_ID, identifier);
 
-        accountService.editAccount(appId, userId, (acct) -> {
+        AccountId accountId = AccountId.forId(appId, userId);
+        accountService.editAccount(accountId, (acct) -> {
             if (acct.getOrgMembership() == null || !acct.getOrgMembership().equals(identifier)) {
                 throw new BadRequestException("Account is not a member of organization " + identifier);
             }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/BaseController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/BaseController.java
@@ -288,7 +288,7 @@ public abstract class BaseController {
         RequestContext reqContext = RequestContext.get();
         List<String> languages = reqContext.getCallerLanguages();
         if (!languages.isEmpty()) {
-            AccountId accountId = AccountId.forId(session.getAppId(), session.getId());
+            AccountId accountId = AccountId.forHealthCode(session.getAppId(), session.getHealthCode());
             accountService.editAccount(accountId, account -> account.setLanguages(languages));
 
             CriteriaContext newContext = new CriteriaContext.Builder()

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/BaseController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/BaseController.java
@@ -42,6 +42,7 @@ import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.Metrics;
 import org.sagebionetworks.bridge.models.RequestInfo;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.apps.App;
@@ -287,8 +288,8 @@ public abstract class BaseController {
         RequestContext reqContext = RequestContext.get();
         List<String> languages = reqContext.getCallerLanguages();
         if (!languages.isEmpty()) {
-            accountService.editAccount(session.getAppId(), session.getId(),
-                    account -> account.setLanguages(languages));
+            AccountId accountId = AccountId.forId(session.getAppId(), session.getId());
+            accountService.editAccount(accountId, account -> account.setLanguages(languages));
 
             CriteriaContext newContext = new CriteriaContext.Builder()
                 .withLanguages(languages)

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/BaseController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/BaseController.java
@@ -287,7 +287,7 @@ public abstract class BaseController {
         RequestContext reqContext = RequestContext.get();
         List<String> languages = reqContext.getCallerLanguages();
         if (!languages.isEmpty()) {
-            accountService.editAccount(session.getAppId(), session.getHealthCode(),
+            accountService.editAccount(session.getAppId(), session.getId(),
                     account -> account.setLanguages(languages));
 
             CriteriaContext newContext = new CriteriaContext.Builder()

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ConsentController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ConsentController.java
@@ -172,7 +172,7 @@ public class ConsentController extends BaseController {
     private JsonNode changeSharingScope(SharingScope sharingScope, String message) {
         UserSession session = getAuthenticatedAndConsentedSession();
         
-        AccountId accountId = AccountId.forId(session.getAppId(), session.getId());
+        AccountId accountId = AccountId.forHealthCode(session.getAppId(), session.getHealthCode());
         accountService.editAccount(accountId, account -> account.setSharingScope(sharingScope));
 
         sessionUpdateService.updateSharingScope(session, sharingScope);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ConsentController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ConsentController.java
@@ -171,7 +171,7 @@ public class ConsentController extends BaseController {
     private JsonNode changeSharingScope(SharingScope sharingScope, String message) {
         UserSession session = getAuthenticatedAndConsentedSession();
         
-        accountService.editAccount(session.getAppId(), session.getHealthCode(),
+        accountService.editAccount(session.getAppId(), session.getId(),
                 account -> account.setSharingScope(sharingScope));
 
         sessionUpdateService.updateSharingScope(session, sharingScope);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ConsentController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ConsentController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.StatusMessage;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.ConsentStatus;
 import org.sagebionetworks.bridge.models.accounts.SharingOption;
 import org.sagebionetworks.bridge.models.accounts.SharingScope;
@@ -171,8 +172,8 @@ public class ConsentController extends BaseController {
     private JsonNode changeSharingScope(SharingScope sharingScope, String message) {
         UserSession session = getAuthenticatedAndConsentedSession();
         
-        accountService.editAccount(session.getAppId(), session.getId(),
-                account -> account.setSharingScope(sharingScope));
+        AccountId accountId = AccountId.forId(session.getAppId(), session.getId());
+        accountService.editAccount(accountId, account -> account.setSharingScope(sharingScope));
 
         sessionUpdateService.updateSharingScope(session, sharingScope);
         

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/EmailController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/EmailController.java
@@ -59,13 +59,7 @@ public class EmailController extends BaseController {
                 throw new BadRequestException("Email not found.");
             }
             
-            // This should always return an ID under normal circumstances. We could eliminate
-            // this and just call editAccount but there would be no bad request if the email
-            // is invalid.
-            String userId = accountService.getAccountId(app.getIdentifier(), "email:"+email)
-                    .orElseThrow(() -> new BadRequestException("Email not found."));
-
-            AccountId accountId = AccountId.forId(app.getIdentifier(), userId);
+            AccountId accountId = AccountId.forEmail(app.getIdentifier(), email);
             accountService.editAccount(accountId, account -> account.setNotifyByEmail(false));
             
             return "You have been unsubscribed from future email.";

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/EmailController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/EmailController.java
@@ -59,7 +59,9 @@ public class EmailController extends BaseController {
                 throw new BadRequestException("Email not found.");
             }
             
-            // This should always return a healthCode under normal circumstances.
+            // This should always return an ID under normal circumstances. We could eliminate
+            // this and just call editAccount but there would be no bad request if the email
+            // is invalid.
             String userId = accountService.getAccountId(app.getIdentifier(), "email:"+email)
                     .orElseThrow(() -> new BadRequestException("Email not found."));
 

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/EmailController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/EmailController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.apps.App;
 
 @CrossOrigin
@@ -62,7 +63,8 @@ public class EmailController extends BaseController {
             String userId = accountService.getAccountId(app.getIdentifier(), "email:"+email)
                     .orElseThrow(() -> new BadRequestException("Email not found."));
 
-            accountService.editAccount(app.getIdentifier(), userId, account -> account.setNotifyByEmail(false));
+            AccountId accountId = AccountId.forId(app.getIdentifier(), userId);
+            accountService.editAccount(accountId, account -> account.setNotifyByEmail(false));
             
             return "You have been unsubscribed from future email.";
         } catch(Throwable throwable) {

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/EmailController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/EmailController.java
@@ -59,10 +59,10 @@ public class EmailController extends BaseController {
             }
             
             // This should always return a healthCode under normal circumstances.
-            String healthCode = accountService.getAccountHealthCode(app.getIdentifier(), "email:"+email)
+            String userId = accountService.getAccountId(app.getIdentifier(), "email:"+email)
                     .orElseThrow(() -> new BadRequestException("Email not found."));
 
-            accountService.editAccount(app.getIdentifier(), healthCode, account -> account.setNotifyByEmail(false));
+            accountService.editAccount(app.getIdentifier(), userId, account -> account.setNotifyByEmail(false));
             
             return "You have been unsubscribed from future email.";
         } catch(Throwable throwable) {

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentController.java
@@ -98,13 +98,14 @@ public class EnrollmentController extends BaseController {
         List<EnrollmentMigration> migrations = parseJson(new TypeReference<List<EnrollmentMigration>>() {});
         
         AccountId accountId = BridgeUtils.parseAccountId(session.getAppId(), userId);
-        Account acct = accountService.getAccount(accountId);
-        if (acct == null) {
+        
+        Account account = accountService.getAccount(accountId);
+        if (account == null) {
             throw new EntityNotFoundException(Account.class);
         }
-        accountService.editAccount(session.getAppId(), acct.getId(), (account) -> {
-            account.getEnrollments().clear();
-            account.getEnrollments().addAll(migrations.stream().map(m -> m.asEnrollment()).collect(toSet()));
+        accountService.editAccount(accountId, (acct) -> {
+            acct.getEnrollments().clear();
+            acct.getEnrollments().addAll(migrations.stream().map(m -> m.asEnrollment()).collect(toSet()));
         });
         return new StatusMessage("Enrollments updated.");
     }    

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentController.java
@@ -102,7 +102,7 @@ public class EnrollmentController extends BaseController {
         if (acct == null) {
             throw new EntityNotFoundException(Account.class);
         }
-        accountService.editAccount(session.getAppId(), acct.getHealthCode(), (account) -> {
+        accountService.editAccount(session.getAppId(), acct.getId(), (account) -> {
             account.getEnrollments().clear();
             account.getEnrollments().addAll(migrations.stream().map(m -> m.asEnrollment()).collect(toSet()));
         });

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentController.java
@@ -98,11 +98,6 @@ public class EnrollmentController extends BaseController {
         List<EnrollmentMigration> migrations = parseJson(new TypeReference<List<EnrollmentMigration>>() {});
         
         AccountId accountId = BridgeUtils.parseAccountId(session.getAppId(), userId);
-        
-        Account account = accountService.getAccount(accountId);
-        if (account == null) {
-            throw new EntityNotFoundException(Account.class);
-        }
         accountService.editAccount(accountId, (acct) -> {
             acct.getEnrollments().clear();
             acct.getEnrollments().addAll(migrations.stream().map(m -> m.asEnrollment()).collect(toSet()));

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/FPHSController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/FPHSController.java
@@ -56,7 +56,7 @@ public class FPHSController extends BaseController {
         UserSession session = getAuthenticatedSession();
         
         ExternalIdentifier externalId = parseJson(ExternalIdentifier.class);
-        fphsService.registerExternalIdentifier(session.getAppId(), session.getHealthCode(), externalId);
+        fphsService.registerExternalIdentifier(session.getAppId(), session.getId(), externalId);
 
         // The service saves the external identifier and saves this as an option. We also need 
         // to update the user's session.

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/FPHSController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/FPHSController.java
@@ -56,7 +56,7 @@ public class FPHSController extends BaseController {
         UserSession session = getAuthenticatedSession();
         
         ExternalIdentifier externalId = parseJson(ExternalIdentifier.class);
-        fphsService.registerExternalIdentifier(session.getAppId(), session.getId(), externalId);
+        fphsService.registerExternalIdentifier(session.getAppId(), session.getHealthCode(), externalId);
 
         // The service saves the external identifier and saves this as an option. We also need 
         // to update the user's session.

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/MembershipController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/MembershipController.java
@@ -14,11 +14,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.models.AccountSummarySearch;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.StatusMessage;
-import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.AccountSummary;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.services.OrganizationService;
@@ -51,8 +49,7 @@ public class MembershipController extends BaseController {
         
         // organization membership checked in service
         
-        AccountId accountId = BridgeUtils.parseAccountId(session.getAppId(), userId);
-        organizationService.addMember(session.getAppId(), orgId, accountId);
+        organizationService.addMember(session.getAppId(), orgId, userId);
         
         return new StatusMessage("User added as a member.");
     }
@@ -63,8 +60,7 @@ public class MembershipController extends BaseController {
 
         // organization membership checked in service
         
-        AccountId accountId = BridgeUtils.parseAccountId(session.getAppId(), userId);
-        organizationService.removeMember(session.getAppId(), orgId, accountId);
+        organizationService.removeMember(session.getAppId(), orgId, userId);
         
         return new StatusMessage("User removed as a member.");
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ScheduledActivityController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ScheduledActivityController.java
@@ -37,6 +37,7 @@ import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
 import org.sagebionetworks.bridge.models.RequestInfo;
 import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.StatusMessage;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.apps.App;
 import org.sagebionetworks.bridge.models.schedules.ActivityType;
@@ -261,8 +262,8 @@ public class ScheduledActivityController extends BaseController {
     }
 
     DateTimeZone persistTimeZone(UserSession session, DateTimeZone timeZone) {
-        accountService.editAccount(session.getAppId(), session.getId(),
-                account -> account.setTimeZone(timeZone));
+        AccountId accountId = AccountId.forId(session.getAppId(), session.getId());
+        accountService.editAccount(accountId, account -> account.setTimeZone(timeZone));
         sessionUpdateService.updateTimeZone(session, timeZone);
         return timeZone;
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ScheduledActivityController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ScheduledActivityController.java
@@ -261,7 +261,7 @@ public class ScheduledActivityController extends BaseController {
     }
 
     DateTimeZone persistTimeZone(UserSession session, DateTimeZone timeZone) {
-        accountService.editAccount(session.getAppId(), session.getHealthCode(),
+        accountService.editAccount(session.getAppId(), session.getId(),
                 account -> account.setTimeZone(timeZone));
         sessionUpdateService.updateTimeZone(session, timeZone);
         return timeZone;

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ScheduledActivityController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ScheduledActivityController.java
@@ -262,7 +262,7 @@ public class ScheduledActivityController extends BaseController {
     }
 
     DateTimeZone persistTimeZone(UserSession session, DateTimeZone timeZone) {
-        AccountId accountId = AccountId.forId(session.getAppId(), session.getId());
+        AccountId accountId = AccountId.forHealthCode(session.getAppId(), session.getHealthCode());
         accountService.editAccount(accountId, account -> account.setTimeZone(timeZone));
         sessionUpdateService.updateTimeZone(session, timeZone);
         return timeZone;

--- a/src/test/java/org/sagebionetworks/bridge/TestConstants.java
+++ b/src/test/java/org/sagebionetworks/bridge/TestConstants.java
@@ -64,6 +64,7 @@ public class TestConstants {
     public static final String MOCK_MD5_HEX_ENCODED = "980ae2db198f5cf7458ad2a90bf226c3";
 
     public static final AccountId ACCOUNT_ID = AccountId.forId(TEST_APP_ID, TEST_USER_ID);
+    public static final AccountId ACCOUNT_ID_WITH_HEALTHCODE = AccountId.forHealthCode(TEST_APP_ID, HEALTH_CODE);
     public static final CriteriaContext TEST_CONTEXT = new CriteriaContext.Builder()
             .withUserId("user-id").withAppId(TEST_APP_ID).build();
 

--- a/src/test/java/org/sagebionetworks/bridge/TestUtils.java
+++ b/src/test/java/org/sagebionetworks/bridge/TestUtils.java
@@ -273,10 +273,10 @@ public class TestUtils {
         Mockito.mockingDetails(mockAccountService).isMock();
         Mockito.mockingDetails(mockAccount).isMock();
         doAnswer(invocation -> {
-            Consumer<Account> accountEdits = (Consumer<Account>)invocation.getArgument(2);
+            Consumer<Account> accountEdits = (Consumer<Account>)invocation.getArgument(1);
             accountEdits.accept(mockAccount);
             return null;
-        }).when(mockAccountService).editAccount(any(), any(), any());
+        }).when(mockAccountService).editAccount(any(), any());
     }
 
     public static void assertDatesWithTimeZoneEqual(DateTime date1, DateTime date2) {

--- a/src/test/java/org/sagebionetworks/bridge/TestUtils.java
+++ b/src/test/java/org/sagebionetworks/bridge/TestUtils.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
@@ -41,7 +42,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 import org.apache.commons.lang3.RandomStringUtils;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import com.google.common.collect.Maps;
 
@@ -276,7 +276,7 @@ public class TestUtils {
             Consumer<Account> accountEdits = (Consumer<Account>)invocation.getArgument(2);
             accountEdits.accept(mockAccount);
             return null;
-        }).when(mockAccountService).editAccount(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any());
+        }).when(mockAccountService).editAccount(any(), any(), any());
     }
 
     public static void assertDatesWithTimeZoneEqual(DateTime date1, DateTime date2) {

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
@@ -304,9 +304,12 @@ public class AccountServiceTest extends Mockito {
 
     @Test
     public void editAccountWhenAccountNotFound() throws Exception {
-        AccountId accountId = AccountId.forId(TEST_APP_ID, "bad-user-id");
-        service.editAccount(accountId, mockConsumer);
-
+        try {
+            AccountId accountId = AccountId.forHealthCode(TEST_APP_ID, "bad-health-code");
+            service.editAccount(accountId, mockConsumer);    
+            fail("Should have thrown exception");
+        } catch(EntityNotFoundException e) {
+        }
         verify(mockConsumer, never()).accept(any());
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
@@ -1069,21 +1069,9 @@ public class AccountServiceTest extends Mockito {
         service.authenticate(app, phoneSignIn);
     }
 
-    @Test
-    public void editAccountFailsAcrossStudies() throws Exception {
-        RequestContext.set(new RequestContext.Builder()
-                .withCallerUserId("some-other-id")
-                .withOrgSponsoredStudies(CALLER_STUDIES).build());
-
-        Account persistedAccount = mockGetAccountById(ACCOUNT_ID, false);
-        persistedAccount.setEnrollments(Sets.newHashSet(ACCOUNT_ENROLLMENTS));
-        when(mockAccountDao.getAccount(any())).thenReturn(Optional.of(persistedAccount));
-
-        service.editAccount(TEST_APP_ID, HEALTH_CODE, (account) -> fail("Should have thrown exception"));
-
-        verify(mockAccountDao, never()).updateAccount(any());
-        RequestContext.set(null);
-    }
+    // The editAccountFailsAcrossStudies test was removed because editAccount no longer enforces 
+    // authorization checks. It's intended to be used internally, not as a result of a direct
+    // operation by an API caller.
     
     @Test
     public void getAccountMatchesStudies() throws Exception {

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
@@ -6,7 +6,6 @@ import static org.joda.time.DateTimeZone.UTC;
 import static org.sagebionetworks.bridge.RequestContext.NULL_INSTANCE;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.STUDY_COORDINATOR;
-import static org.sagebionetworks.bridge.TestConstants.ACCOUNT_ID;
 import static org.sagebionetworks.bridge.TestConstants.EMAIL;
 import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
 import static org.sagebionetworks.bridge.TestConstants.PHONE;
@@ -58,7 +57,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.RequestContext;
-import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.AccountSecretDao;
 import org.sagebionetworks.bridge.exceptions.AccountDisabledException;
@@ -97,7 +95,6 @@ public class AccountServiceTest extends Mockito {
     private static final String STUDY_B = "studyB";
     private static final Set<Enrollment> ACCOUNT_ENROLLMENTS = ImmutableSet
             .of(Enrollment.create(TEST_APP_ID, STUDY_A, TEST_USER_ID));
-    private static final ImmutableSet<String> CALLER_STUDIES = ImmutableSet.of(STUDY_B);    
     
     private static final SignIn PASSWORD_SIGNIN = new SignIn.Builder().withAppId(TEST_APP_ID).withEmail(EMAIL)
             .withPassword(DUMMY_PASSWORD).build();

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
@@ -297,14 +297,15 @@ public class AccountServiceTest extends Mockito {
         AccountId accountId = AccountId.forId(TEST_APP_ID, TEST_USER_ID);
         Account account = mockGetAccountById(accountId, false);
 
-        service.editAccount(TEST_APP_ID, TEST_USER_ID, mockConsumer);
+        service.editAccount(ACCOUNT_ID, mockConsumer);
 
         verify(mockConsumer).accept(account);
     }
 
     @Test
     public void editAccountWhenAccountNotFound() throws Exception {
-        service.editAccount(TEST_APP_ID, "bad-user-id", mockConsumer);
+        AccountId accountId = AccountId.forId(TEST_APP_ID, "bad-user-id");
+        service.editAccount(accountId, mockConsumer);
 
         verify(mockConsumer, never()).accept(any());
     }

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
@@ -6,6 +6,7 @@ import static org.joda.time.DateTimeZone.UTC;
 import static org.sagebionetworks.bridge.RequestContext.NULL_INSTANCE;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.STUDY_COORDINATOR;
+import static org.sagebionetworks.bridge.TestConstants.ACCOUNT_ID;
 import static org.sagebionetworks.bridge.TestConstants.EMAIL;
 import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
 import static org.sagebionetworks.bridge.TestConstants.PHONE;
@@ -57,6 +58,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.RequestContext;
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.AccountSecretDao;
 import org.sagebionetworks.bridge.exceptions.AccountDisabledException;
@@ -294,8 +296,7 @@ public class AccountServiceTest extends Mockito {
 
     @Test
     public void editAccount() throws Exception {
-        AccountId accountId = AccountId.forId(TEST_APP_ID, TEST_USER_ID);
-        Account account = mockGetAccountById(accountId, false);
+        Account account = mockGetAccountById(ACCOUNT_ID, false);
 
         service.editAccount(ACCOUNT_ID, mockConsumer);
 

--- a/src/test/java/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -18,6 +18,7 @@ import static org.sagebionetworks.bridge.Roles.STUDY_COORDINATOR;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestConstants.USER_STUDY_IDS;
 import static org.sagebionetworks.bridge.models.accounts.AccountSecretType.REAUTH;
 import static org.testng.Assert.assertEquals;
@@ -976,12 +977,12 @@ public class AuthenticationServiceTest {
         doReturn(mockAccount).when(accountService).getAccount(any());
         
         // No languages.
-        StudyParticipant participant = new StudyParticipant.Builder().withHealthCode("healthCode").build();
+        StudyParticipant participant = new StudyParticipant.Builder().withId(USER_ID).build();
         doReturn(participant).when(participantService).getParticipant(app, mockAccount, false);
         
         service.getSession(app, context);
         
-        verify(accountService).editAccount(eq(TEST_APP_ID), eq("healthCode"), any());
+        verify(accountService).editAccount(eq(TEST_APP_ID), eq(USER_ID), any());
         verify(mockAccount).setLanguages(ImmutableList.copyOf(LANGUAGES));
     }
 
@@ -1442,7 +1443,7 @@ public class AuthenticationServiceTest {
         when(accountService.authenticate(app, EMAIL_PASSWORD_SIGN_IN)).thenReturn(account);
         
         StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT)
-                .withHealthCode(HEALTH_CODE).build();
+                .withId(TEST_USER_ID).build();
         
         when(participantService.getParticipant(app, account, false)).thenReturn(participant);
         when(consentService.getConsentStatuses(any(), any())).thenReturn(CONSENTED_STATUS_MAP);
@@ -1456,7 +1457,7 @@ public class AuthenticationServiceTest {
         assertEquals(session.getParticipant().getLanguages(), TestConstants.LANGUAGES);
         
         // Note that the context does not have the healthCode, you must use the participant
-        verify(accountService).editAccount(eq(TEST_APP_ID), eq(HEALTH_CODE), any());
+        verify(accountService).editAccount(eq(TEST_APP_ID), eq(TEST_USER_ID), any());
    }
     
    @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -141,9 +141,10 @@ public class AuthenticationServiceTest {
     private static final CriteriaContext CONTEXT = new CriteriaContext.Builder()
             .withAppId(TEST_APP_ID).build();
     private static final StudyParticipant PARTICIPANT = new StudyParticipant.Builder().withId(USER_ID).build();
-    private static final AccountId ACCOUNT_ID = AccountId.forId(TEST_APP_ID, USER_ID);
     private static final String EXTERNAL_ID = "ext-id";
     private static final String HEALTH_CODE = "health-code";
+    private static final AccountId ACCOUNT_ID = AccountId.forId(TEST_APP_ID, USER_ID);
+    private static final AccountId ACCOUNT_ID_WITH_HEALTHCODE = AccountId.forHealthCode(TEST_APP_ID, HEALTH_CODE);
 
     private static final StudyParticipant PARTICIPANT_WITH_ATTRIBUTES = new StudyParticipant.Builder().withId(USER_ID)
             .withHealthCode(HEALTH_CODE).withDataGroups(DATA_GROUP_SET).withStudyIds(TestConstants.USER_STUDY_IDS)
@@ -977,12 +978,12 @@ public class AuthenticationServiceTest {
         doReturn(mockAccount).when(accountService).getAccount(any());
         
         // No languages.
-        StudyParticipant participant = new StudyParticipant.Builder().withId(USER_ID).build();
+        StudyParticipant participant = new StudyParticipant.Builder().withHealthCode(HEALTH_CODE).build();
         doReturn(participant).when(participantService).getParticipant(app, mockAccount, false);
         
         service.getSession(app, context);
         
-        verify(accountService).editAccount(eq(ACCOUNT_ID), any());
+        verify(accountService).editAccount(eq(ACCOUNT_ID_WITH_HEALTHCODE), any());
         verify(mockAccount).setLanguages(ImmutableList.copyOf(LANGUAGES));
     }
 
@@ -1443,7 +1444,7 @@ public class AuthenticationServiceTest {
         when(accountService.authenticate(app, EMAIL_PASSWORD_SIGN_IN)).thenReturn(account);
         
         StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT)
-                .withId(USER_ID).build();
+                .withHealthCode(HEALTH_CODE).build();
         
         when(participantService.getParticipant(app, account, false)).thenReturn(participant);
         when(consentService.getConsentStatuses(any(), any())).thenReturn(CONSENTED_STATUS_MAP);
@@ -1457,7 +1458,7 @@ public class AuthenticationServiceTest {
         assertEquals(session.getParticipant().getLanguages(), TestConstants.LANGUAGES);
         
         // Note that the context does not have the healthCode, you must use the participant
-        verify(accountService).editAccount(eq(ACCOUNT_ID), any());
+        verify(accountService).editAccount(eq(ACCOUNT_ID_WITH_HEALTHCODE), any());
    }
     
    @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AuthenticationServiceTest.java
@@ -971,8 +971,8 @@ public class AuthenticationServiceTest {
         // This specifically has to be a mock to easily mock the editAccount method on the DAO.
         Account mockAccount = mock(Account.class);
 
-        CriteriaContext context = new CriteriaContext.Builder().withLanguages(LANGUAGES).withUserId(USER_ID)
-                .withAppId(TEST_APP_ID).build();
+        CriteriaContext context = new CriteriaContext.Builder().withLanguages(LANGUAGES)
+                .withUserId(USER_ID).withAppId(TEST_APP_ID).build();
         TestUtils.mockEditAccount(accountService, mockAccount);
         doReturn(mockAccount).when(accountService).getAccount(any());
         
@@ -982,7 +982,7 @@ public class AuthenticationServiceTest {
         
         service.getSession(app, context);
         
-        verify(accountService).editAccount(eq(TEST_APP_ID), eq(USER_ID), any());
+        verify(accountService).editAccount(eq(ACCOUNT_ID), any());
         verify(mockAccount).setLanguages(ImmutableList.copyOf(LANGUAGES));
     }
 
@@ -1434,7 +1434,7 @@ public class AuthenticationServiceTest {
         
         assertEquals(session.getParticipant().getLanguages(), TestConstants.LANGUAGES);
         
-        verify(accountService, never()).editAccount(any(), any(), any());
+        verify(accountService, never()).editAccount(any(), any());
    }
     
     @Test
@@ -1443,7 +1443,7 @@ public class AuthenticationServiceTest {
         when(accountService.authenticate(app, EMAIL_PASSWORD_SIGN_IN)).thenReturn(account);
         
         StudyParticipant participant = new StudyParticipant.Builder().copyOf(PARTICIPANT)
-                .withId(TEST_USER_ID).build();
+                .withId(USER_ID).build();
         
         when(participantService.getParticipant(app, account, false)).thenReturn(participant);
         when(consentService.getConsentStatuses(any(), any())).thenReturn(CONSENTED_STATUS_MAP);
@@ -1457,7 +1457,7 @@ public class AuthenticationServiceTest {
         assertEquals(session.getParticipant().getLanguages(), TestConstants.LANGUAGES);
         
         // Note that the context does not have the healthCode, you must use the participant
-        verify(accountService).editAccount(eq(TEST_APP_ID), eq(TEST_USER_ID), any());
+        verify(accountService).editAccount(eq(ACCOUNT_ID), any());
    }
     
    @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/OrganizationServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/OrganizationServiceTest.java
@@ -6,6 +6,7 @@ import static org.sagebionetworks.bridge.BridgeConstants.NEGATIVE_OFFSET_ERROR;
 import static org.sagebionetworks.bridge.BridgeConstants.PAGE_SIZE_ERROR;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.ORG_ADMIN;
+import static org.sagebionetworks.bridge.TestConstants.ACCOUNT_ID;
 import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
 import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
@@ -367,7 +368,7 @@ public class OrganizationServiceTest extends Mockito {
         
         service.addMember(TEST_APP_ID, IDENTIFIER, TEST_USER_ID);
         
-        verify(mockAccountService).editAccount(eq(TEST_APP_ID), eq(TEST_USER_ID), any());
+        verify(mockAccountService).editAccount(eq(ACCOUNT_ID), any());
         assertEquals(account.getOrgMembership(), IDENTIFIER);
         
         verify(mockSessionUpdateService).updateOrgMembership(TEST_USER_ID, IDENTIFIER);
@@ -384,7 +385,7 @@ public class OrganizationServiceTest extends Mockito {
         
         service.addMember(TEST_APP_ID, IDENTIFIER, TEST_USER_ID);
         
-        verify(mockAccountService).editAccount(eq(TEST_APP_ID), eq(TEST_USER_ID), any());
+        verify(mockAccountService).editAccount(eq(ACCOUNT_ID), any());
         assertEquals(account.getOrgMembership(), IDENTIFIER);
     }
     
@@ -403,7 +404,7 @@ public class OrganizationServiceTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());
 
         doThrow(new EntityNotFoundException(Account.class)).when(mockAccountService)
-            .editAccount(any(), any(), any());
+            .editAccount(any(), any());
         
         service.addMember(TEST_APP_ID, IDENTIFIER, TEST_USER_ID);
     }
@@ -432,7 +433,7 @@ public class OrganizationServiceTest extends Mockito {
 
         service.addMember(TEST_APP_ID, IDENTIFIER, TEST_USER_ID);
         
-        verify(mockAccountService).editAccount(eq(TEST_APP_ID), eq(TEST_USER_ID), any());
+        verify(mockAccountService).editAccount(eq(ACCOUNT_ID), any());
         assertEquals(account.getOrgMembership(), IDENTIFIER);
     }
     
@@ -467,7 +468,7 @@ public class OrganizationServiceTest extends Mockito {
 
         service.removeMember(TEST_APP_ID, IDENTIFIER, TEST_USER_ID);
         
-        verify(mockAccountService).editAccount(eq(TEST_APP_ID), eq(TEST_USER_ID), any());
+        verify(mockAccountService).editAccount(eq(ACCOUNT_ID), any());
         assertNull(account.getOrgMembership());
         
         verify(mockSessionUpdateService).updateOrgMembership(TEST_USER_ID, null);
@@ -484,7 +485,7 @@ public class OrganizationServiceTest extends Mockito {
 
         service.removeMember(TEST_APP_ID, IDENTIFIER, TEST_USER_ID);
         
-        verify(mockAccountService).editAccount(eq(TEST_APP_ID), eq(TEST_USER_ID), any());
+        verify(mockAccountService).editAccount(eq(ACCOUNT_ID), any());
         assertNull(account.getOrgMembership());
     }
 
@@ -520,7 +521,7 @@ public class OrganizationServiceTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());
         
         doThrow(new EntityNotFoundException(Account.class))
-            .when(mockAccountService).editAccount(any(), any(), any());
+            .when(mockAccountService).editAccount(any(), any());
 
         service.removeMember(TEST_APP_ID, IDENTIFIER, TEST_USER_ID);
     }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/BaseControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/BaseControllerTest.java
@@ -7,6 +7,7 @@ import static org.sagebionetworks.bridge.BridgeConstants.STRING_SET_TYPEREF;
 import static org.sagebionetworks.bridge.BridgeConstants.WARN_NO_ACCEPT_LANGUAGE;
 import static org.sagebionetworks.bridge.BridgeConstants.X_REQUEST_ID_HEADER;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
+import static org.sagebionetworks.bridge.TestConstants.ACCOUNT_ID;
 import static org.sagebionetworks.bridge.TestConstants.CONSENTED_STATUS_MAP;
 import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
 import static org.sagebionetworks.bridge.TestConstants.IP_ADDRESS;
@@ -186,6 +187,7 @@ public class BaseControllerTest extends Mockito {
         session.setAuthenticated(true);
         session.setAppId(TEST_APP_ID);
         session.setConsentStatuses(CONSENTED_STATUS_MAP);
+        session.setParticipant(new StudyParticipant.Builder().withId(TEST_USER_ID).build());
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
         when(mockRequest.getHeader(X_REQUEST_ID_HEADER)).thenReturn(REQUEST_ID);
 
@@ -206,6 +208,7 @@ public class BaseControllerTest extends Mockito {
         session.setAuthenticated(true);
         session.setAppId(TEST_APP_ID);
         session.setConsentStatuses(UNCONSENTED_STATUS_MAP);
+        session.setParticipant(new StudyParticipant.Builder().withId(TEST_USER_ID).build());
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
         when(mockRequest.getHeader(X_REQUEST_ID_HEADER)).thenReturn(REQUEST_ID);
 
@@ -219,7 +222,8 @@ public class BaseControllerTest extends Mockito {
     public void getAuthenticatedSessionRolesSucceeds() {
         session.setAuthenticated(true);
         session.setAppId(TEST_APP_ID);
-        session.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.DEVELOPER)).build());
+        session.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.DEVELOPER))
+                .withId(TEST_USER_ID).build());
         session.setConsentStatuses(CONSENTED_STATUS_MAP);
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
         when(mockRequest.getHeader(X_REQUEST_ID_HEADER)).thenReturn(REQUEST_ID);
@@ -235,8 +239,9 @@ public class BaseControllerTest extends Mockito {
     public void getAuthenticatedSessionRolesFailsRolesMismatched() {
         session.setAuthenticated(true);
         session.setAppId(TEST_APP_ID);
-        session.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.ADMIN)).build());
         session.setConsentStatuses(CONSENTED_STATUS_MAP);
+        session.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.ADMIN))
+                .withId(TEST_USER_ID).build());
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
         when(mockRequest.getHeader(X_REQUEST_ID_HEADER)).thenReturn(REQUEST_ID);
 
@@ -251,6 +256,7 @@ public class BaseControllerTest extends Mockito {
         session.setAuthenticated(true);
         session.setAppId(TEST_APP_ID);
         session.setConsentStatuses(CONSENTED_STATUS_MAP);
+        session.setParticipant(new StudyParticipant.Builder().withId(TEST_USER_ID).build());
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
         when(mockRequest.getHeader(X_REQUEST_ID_HEADER)).thenReturn(REQUEST_ID);
 
@@ -285,7 +291,8 @@ public class BaseControllerTest extends Mockito {
     public void getSessionEitherConsentedOrInRoleSucceedsOnRole() {
         session.setAuthenticated(true);
         session.setAppId(TEST_APP_ID);
-        session.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.DEVELOPER)).build());
+        session.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.DEVELOPER))
+                .withId(TEST_USER_ID).build());
         session.setConsentStatuses(UNCONSENTED_STATUS_MAP);
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
         when(mockRequest.getHeader(X_REQUEST_ID_HEADER)).thenReturn(REQUEST_ID);
@@ -302,6 +309,7 @@ public class BaseControllerTest extends Mockito {
         session.setAuthenticated(true);
         session.setAppId(TEST_APP_ID);
         session.setConsentStatuses(CONSENTED_STATUS_MAP);
+        session.setParticipant(new StudyParticipant.Builder().withId(TEST_USER_ID).build());
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
         when(mockRequest.getHeader(X_REQUEST_ID_HEADER)).thenReturn(REQUEST_ID);
 
@@ -316,7 +324,8 @@ public class BaseControllerTest extends Mockito {
     public void getSessionEitherConsentedOrInRoleFails() {
         session.setAuthenticated(true);
         session.setAppId(TEST_APP_ID);
-        session.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.RESEARCHER)).build());
+        session.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.RESEARCHER))
+                .withId(TEST_USER_ID).build());
         session.setConsentStatuses(UNCONSENTED_STATUS_MAP);
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
         when(mockRequest.getHeader(X_REQUEST_ID_HEADER)).thenReturn(REQUEST_ID);
@@ -360,7 +369,7 @@ public class BaseControllerTest extends Mockito {
         
         controller.getLanguages(session);
         
-        verify(mockAccountService).editAccount(eq(TEST_APP_ID), eq(TEST_USER_ID), any());
+        verify(mockAccountService).editAccount(eq(ACCOUNT_ID), any());
         verify(mockSessionUpdateService).updateLanguage(eq(session), contextCaptor.capture());
         
         CriteriaContext context = contextCaptor.getValue();
@@ -378,7 +387,7 @@ public class BaseControllerTest extends Mockito {
         List<String> returnedLangs = controller.getLanguages(session);
         assertEquals(returnedLangs, ImmutableList.of("fr"));
         
-        verify(mockAccountService, never()).editAccount(any(), any(), any());
+        verify(mockAccountService, never()).editAccount(any(), any());
         verify(mockSessionUpdateService, never()).updateLanguage(any(), any());
     }
 
@@ -478,6 +487,7 @@ public class BaseControllerTest extends Mockito {
     public void updateRequestInfoFromSessionTest() {
         session.setSessionToken(SESSION_TOKEN);
         session.setAppId(TEST_APP_ID);
+        session.setParticipant(new StudyParticipant.Builder().withId(TEST_USER_ID).build());
         when(mockBridgeConfig.getEnvironment()).thenReturn(Environment.LOCAL);
         
         controller.updateRequestInfoFromSession(session);
@@ -560,6 +570,7 @@ public class BaseControllerTest extends Mockito {
     public void roleEnforcedWhenRetrievingSession() throws Exception {
         // Mock participant and session.
         StudyParticipant participant = new StudyParticipant.Builder()
+                .withId(TEST_USER_ID)
                 .withRoles(Sets.newHashSet(Roles.RESEARCHER)).build();
         
         session.setAuthenticated(true);
@@ -614,10 +625,10 @@ public class BaseControllerTest extends Mockito {
     public void canGetLanguagesWhenInHeader() throws Exception {
         Account account = Account.create();
         doAnswer(invocation -> {
-            Consumer<Account> consumer = invocation.getArgument(2);
+            Consumer<Account> consumer = invocation.getArgument(1);
             consumer.accept(account);
             return null;
-        }).when(mockAccountService).editAccount(any(), any(), any());
+        }).when(mockAccountService).editAccount(any(), any());
         
         // Set up mocks.
         when(mockRequest.getHeader(ACCEPT_LANGUAGE)).thenReturn("en,fr");
@@ -631,7 +642,7 @@ public class BaseControllerTest extends Mockito {
         assertEquals(LANGUAGES, languages);
 
         // Verify we saved the language to the account.
-        verify(mockAccountService).editAccount(eq(TEST_APP_ID), eq(TEST_USER_ID), any());
+        verify(mockAccountService).editAccount(eq(ACCOUNT_ID), any());
         assertEquals(account.getLanguages(), LANGUAGES);
 
         // Verify we call through to the session update service. (This updates both the cache and the participant, as
@@ -751,7 +762,7 @@ public class BaseControllerTest extends Mockito {
     @Test
     public void getSessionWithRoleSucceed() {
         StudyParticipant participant = new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.DEVELOPER))
-                .build();
+                .withId(TEST_USER_ID).build();
         session.setAuthenticated(true);
         session.setParticipant(participant);
         session.setAppId(TEST_APP_ID);
@@ -811,6 +822,7 @@ public class BaseControllerTest extends Mockito {
     public void getSessionWithNoRolesConsentedOrRoleFails() {
         session.setAuthenticated(true);
         session.setAppId(TEST_APP_ID);
+        session.setParticipant(new StudyParticipant.Builder().withId(TEST_USER_ID).build());
         
         doReturn(session).when(controller).getSessionIfItExists();
         when(mockAppService.getApp(TEST_APP_ID)).thenReturn(app);
@@ -822,7 +834,7 @@ public class BaseControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class)
     public void getSessionWithNoConsentConsentedOrRoleFails() {
         StudyParticipant participant = new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.RESEARCHER))
-                .build();
+                .withId(TEST_USER_ID).build();
         session.setAuthenticated(true);
         session.setParticipant(participant);
         session.setAppId(TEST_APP_ID);
@@ -836,7 +848,7 @@ public class BaseControllerTest extends Mockito {
     @Test
     public void getSessionWithConsentedUserNotInRoleSuccess() {
         StudyParticipant participant = new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.RESEARCHER))
-                .build();
+                .withId(TEST_USER_ID).build();
         session.setAuthenticated(true);
         session.setConsentStatuses(CONSENTED_STATUS_MAP);
         session.setParticipant(participant);
@@ -852,7 +864,7 @@ public class BaseControllerTest extends Mockito {
     @Test
     public void getSessionWithConsentedUserInRoleSuccess() {
         StudyParticipant participant = new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.DEVELOPER))
-                .build();
+                .withId(TEST_USER_ID).build();
         session.setAuthenticated(true);
         session.setConsentStatuses(CONSENTED_STATUS_MAP);
         session.setParticipant(participant);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/BaseControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/BaseControllerTest.java
@@ -354,13 +354,13 @@ public class BaseControllerTest extends Mockito {
     @Test
     public void getLanguagesInits() {
         session.setAppId(TEST_APP_ID);
-        session.setParticipant(new StudyParticipant.Builder().withHealthCode(HEALTH_CODE).build());
+        session.setParticipant(new StudyParticipant.Builder().withId(TEST_USER_ID).build());
         when(mockRequest.getHeader(ACCEPT_LANGUAGE))
                 .thenReturn("fr-fr;q=0.4,fr;q=0.2,en-ca,en;q=0.8,en-us;q=0.6");
         
         controller.getLanguages(session);
         
-        verify(mockAccountService).editAccount(eq(TEST_APP_ID), eq(HEALTH_CODE), any());
+        verify(mockAccountService).editAccount(eq(TEST_APP_ID), eq(TEST_USER_ID), any());
         verify(mockSessionUpdateService).updateLanguage(eq(session), contextCaptor.capture());
         
         CriteriaContext context = contextCaptor.getValue();
@@ -371,7 +371,7 @@ public class BaseControllerTest extends Mockito {
     public void getLanguagesDoesNotOverwrite() {
         session.setAppId(TEST_APP_ID);
         session.setParticipant(new StudyParticipant.Builder().withLanguages(ImmutableList.of("fr"))
-                .withHealthCode(HEALTH_CODE).build());
+                .withId(TEST_USER_ID).build());
         when(mockRequest.getHeader(ACCEPT_LANGUAGE))
                 .thenReturn("de-de;q=0.4,de;q=0.2,en-ca,en;q=0.8,en-us;q=0.6");
         
@@ -621,7 +621,7 @@ public class BaseControllerTest extends Mockito {
         
         // Set up mocks.
         when(mockRequest.getHeader(ACCEPT_LANGUAGE)).thenReturn("en,fr");
-        session.setParticipant(new StudyParticipant.Builder().withHealthCode(HEALTH_CODE)
+        session.setParticipant(new StudyParticipant.Builder().withId(TEST_USER_ID)
                 .withLanguages(ImmutableList.of()).build());
         session.setSessionToken(SESSION_TOKEN);
         session.setAppId(TEST_APP_ID);
@@ -631,7 +631,7 @@ public class BaseControllerTest extends Mockito {
         assertEquals(LANGUAGES, languages);
 
         // Verify we saved the language to the account.
-        verify(mockAccountService).editAccount(eq(TEST_APP_ID), eq(HEALTH_CODE), any());
+        verify(mockAccountService).editAccount(eq(TEST_APP_ID), eq(TEST_USER_ID), any());
         assertEquals(account.getLanguages(), LANGUAGES);
 
         // Verify we call through to the session update service. (This updates both the cache and the participant, as

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/BaseControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/BaseControllerTest.java
@@ -8,6 +8,7 @@ import static org.sagebionetworks.bridge.BridgeConstants.WARN_NO_ACCEPT_LANGUAGE
 import static org.sagebionetworks.bridge.BridgeConstants.X_REQUEST_ID_HEADER;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.TestConstants.ACCOUNT_ID;
+import static org.sagebionetworks.bridge.TestConstants.ACCOUNT_ID_WITH_HEALTHCODE;
 import static org.sagebionetworks.bridge.TestConstants.CONSENTED_STATUS_MAP;
 import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
 import static org.sagebionetworks.bridge.TestConstants.IP_ADDRESS;
@@ -63,6 +64,7 @@ import org.testng.annotations.Test;
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.Roles;
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.BridgeConfig;
@@ -187,7 +189,7 @@ public class BaseControllerTest extends Mockito {
         session.setAuthenticated(true);
         session.setAppId(TEST_APP_ID);
         session.setConsentStatuses(CONSENTED_STATUS_MAP);
-        session.setParticipant(new StudyParticipant.Builder().withId(TEST_USER_ID).build());
+        session.setParticipant(new StudyParticipant.Builder().withHealthCode(HEALTH_CODE).build());
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
         when(mockRequest.getHeader(X_REQUEST_ID_HEADER)).thenReturn(REQUEST_ID);
 
@@ -208,7 +210,7 @@ public class BaseControllerTest extends Mockito {
         session.setAuthenticated(true);
         session.setAppId(TEST_APP_ID);
         session.setConsentStatuses(UNCONSENTED_STATUS_MAP);
-        session.setParticipant(new StudyParticipant.Builder().withId(TEST_USER_ID).build());
+        session.setParticipant(new StudyParticipant.Builder().withHealthCode(HEALTH_CODE).build());
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
         when(mockRequest.getHeader(X_REQUEST_ID_HEADER)).thenReturn(REQUEST_ID);
 
@@ -223,7 +225,7 @@ public class BaseControllerTest extends Mockito {
         session.setAuthenticated(true);
         session.setAppId(TEST_APP_ID);
         session.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.DEVELOPER))
-                .withId(TEST_USER_ID).build());
+                .withHealthCode(HEALTH_CODE).build());
         session.setConsentStatuses(CONSENTED_STATUS_MAP);
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
         when(mockRequest.getHeader(X_REQUEST_ID_HEADER)).thenReturn(REQUEST_ID);
@@ -241,7 +243,7 @@ public class BaseControllerTest extends Mockito {
         session.setAppId(TEST_APP_ID);
         session.setConsentStatuses(CONSENTED_STATUS_MAP);
         session.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.ADMIN))
-                .withId(TEST_USER_ID).build());
+                .withHealthCode(HEALTH_CODE).build());
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
         when(mockRequest.getHeader(X_REQUEST_ID_HEADER)).thenReturn(REQUEST_ID);
 
@@ -256,7 +258,7 @@ public class BaseControllerTest extends Mockito {
         session.setAuthenticated(true);
         session.setAppId(TEST_APP_ID);
         session.setConsentStatuses(CONSENTED_STATUS_MAP);
-        session.setParticipant(new StudyParticipant.Builder().withId(TEST_USER_ID).build());
+        session.setParticipant(new StudyParticipant.Builder().withHealthCode(HEALTH_CODE).build());
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
         when(mockRequest.getHeader(X_REQUEST_ID_HEADER)).thenReturn(REQUEST_ID);
 
@@ -292,7 +294,7 @@ public class BaseControllerTest extends Mockito {
         session.setAuthenticated(true);
         session.setAppId(TEST_APP_ID);
         session.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.DEVELOPER))
-                .withId(TEST_USER_ID).build());
+                .withHealthCode(HEALTH_CODE).build());
         session.setConsentStatuses(UNCONSENTED_STATUS_MAP);
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
         when(mockRequest.getHeader(X_REQUEST_ID_HEADER)).thenReturn(REQUEST_ID);
@@ -309,7 +311,7 @@ public class BaseControllerTest extends Mockito {
         session.setAuthenticated(true);
         session.setAppId(TEST_APP_ID);
         session.setConsentStatuses(CONSENTED_STATUS_MAP);
-        session.setParticipant(new StudyParticipant.Builder().withId(TEST_USER_ID).build());
+        session.setParticipant(new StudyParticipant.Builder().withHealthCode(HEALTH_CODE).build());
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
         when(mockRequest.getHeader(X_REQUEST_ID_HEADER)).thenReturn(REQUEST_ID);
 
@@ -325,7 +327,7 @@ public class BaseControllerTest extends Mockito {
         session.setAuthenticated(true);
         session.setAppId(TEST_APP_ID);
         session.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.RESEARCHER))
-                .withId(TEST_USER_ID).build());
+                .withHealthCode(HEALTH_CODE).build());
         session.setConsentStatuses(UNCONSENTED_STATUS_MAP);
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
         when(mockRequest.getHeader(X_REQUEST_ID_HEADER)).thenReturn(REQUEST_ID);
@@ -363,13 +365,13 @@ public class BaseControllerTest extends Mockito {
     @Test
     public void getLanguagesInits() {
         session.setAppId(TEST_APP_ID);
-        session.setParticipant(new StudyParticipant.Builder().withId(TEST_USER_ID).build());
+        session.setParticipant(new StudyParticipant.Builder().withHealthCode(HEALTH_CODE).build());
         when(mockRequest.getHeader(ACCEPT_LANGUAGE))
                 .thenReturn("fr-fr;q=0.4,fr;q=0.2,en-ca,en;q=0.8,en-us;q=0.6");
         
         controller.getLanguages(session);
         
-        verify(mockAccountService).editAccount(eq(ACCOUNT_ID), any());
+        verify(mockAccountService).editAccount(eq(ACCOUNT_ID_WITH_HEALTHCODE), any());
         verify(mockSessionUpdateService).updateLanguage(eq(session), contextCaptor.capture());
         
         CriteriaContext context = contextCaptor.getValue();
@@ -487,7 +489,7 @@ public class BaseControllerTest extends Mockito {
     public void updateRequestInfoFromSessionTest() {
         session.setSessionToken(SESSION_TOKEN);
         session.setAppId(TEST_APP_ID);
-        session.setParticipant(new StudyParticipant.Builder().withId(TEST_USER_ID).build());
+        session.setParticipant(new StudyParticipant.Builder().withHealthCode(HEALTH_CODE).build());
         when(mockBridgeConfig.getEnvironment()).thenReturn(Environment.LOCAL);
         
         controller.updateRequestInfoFromSession(session);
@@ -570,7 +572,7 @@ public class BaseControllerTest extends Mockito {
     public void roleEnforcedWhenRetrievingSession() throws Exception {
         // Mock participant and session.
         StudyParticipant participant = new StudyParticipant.Builder()
-                .withId(TEST_USER_ID)
+                .withHealthCode(HEALTH_CODE)
                 .withRoles(Sets.newHashSet(Roles.RESEARCHER)).build();
         
         session.setAuthenticated(true);
@@ -632,7 +634,7 @@ public class BaseControllerTest extends Mockito {
         
         // Set up mocks.
         when(mockRequest.getHeader(ACCEPT_LANGUAGE)).thenReturn("en,fr");
-        session.setParticipant(new StudyParticipant.Builder().withId(TEST_USER_ID)
+        session.setParticipant(new StudyParticipant.Builder().withHealthCode(HEALTH_CODE)
                 .withLanguages(ImmutableList.of()).build());
         session.setSessionToken(SESSION_TOKEN);
         session.setAppId(TEST_APP_ID);
@@ -642,7 +644,7 @@ public class BaseControllerTest extends Mockito {
         assertEquals(LANGUAGES, languages);
 
         // Verify we saved the language to the account.
-        verify(mockAccountService).editAccount(eq(ACCOUNT_ID), any());
+        verify(mockAccountService).editAccount(eq(ACCOUNT_ID_WITH_HEALTHCODE), any());
         assertEquals(account.getLanguages(), LANGUAGES);
 
         // Verify we call through to the session update service. (This updates both the cache and the participant, as
@@ -762,7 +764,7 @@ public class BaseControllerTest extends Mockito {
     @Test
     public void getSessionWithRoleSucceed() {
         StudyParticipant participant = new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.DEVELOPER))
-                .withId(TEST_USER_ID).build();
+                .withHealthCode(HEALTH_CODE).build();
         session.setAuthenticated(true);
         session.setParticipant(participant);
         session.setAppId(TEST_APP_ID);
@@ -822,7 +824,7 @@ public class BaseControllerTest extends Mockito {
     public void getSessionWithNoRolesConsentedOrRoleFails() {
         session.setAuthenticated(true);
         session.setAppId(TEST_APP_ID);
-        session.setParticipant(new StudyParticipant.Builder().withId(TEST_USER_ID).build());
+        session.setParticipant(new StudyParticipant.Builder().withHealthCode(HEALTH_CODE).build());
         
         doReturn(session).when(controller).getSessionIfItExists();
         when(mockAppService.getApp(TEST_APP_ID)).thenReturn(app);
@@ -834,7 +836,7 @@ public class BaseControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class)
     public void getSessionWithNoConsentConsentedOrRoleFails() {
         StudyParticipant participant = new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.RESEARCHER))
-                .withId(TEST_USER_ID).build();
+                .withHealthCode(HEALTH_CODE).build();
         session.setAuthenticated(true);
         session.setParticipant(participant);
         session.setAppId(TEST_APP_ID);
@@ -848,7 +850,7 @@ public class BaseControllerTest extends Mockito {
     @Test
     public void getSessionWithConsentedUserNotInRoleSuccess() {
         StudyParticipant participant = new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.RESEARCHER))
-                .withId(TEST_USER_ID).build();
+                .withHealthCode(HEALTH_CODE).build();
         session.setAuthenticated(true);
         session.setConsentStatuses(CONSENTED_STATUS_MAP);
         session.setParticipant(participant);
@@ -864,7 +866,7 @@ public class BaseControllerTest extends Mockito {
     @Test
     public void getSessionWithConsentedUserInRoleSuccess() {
         StudyParticipant participant = new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.DEVELOPER))
-                .withId(TEST_USER_ID).build();
+                .withHealthCode(HEALTH_CODE).build();
         session.setAuthenticated(true);
         session.setConsentStatuses(CONSENTED_STATUS_MAP);
         session.setParticipant(participant);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ConsentControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ConsentControllerTest.java
@@ -163,7 +163,7 @@ public class ConsentControllerTest extends Mockito {
         UserSession retrievedSession = BridgeObjectMapper.get().treeToValue(result, UserSession.class);
         assertEquals(retrievedSession.getSessionToken(), ORIGINAL_SESSION_TOKEN);
         
-        verify(mockAccountService).editAccount(eq(TEST_APP_ID), eq(HEALTH_CODE), accountConsumerCaptor.capture());
+        verify(mockAccountService).editAccount(eq(TEST_APP_ID), eq(TEST_USER_ID), accountConsumerCaptor.capture());
         verify(mockSessionUpdateService).updateSharingScope(session, SharingScope.ALL_QUALIFIED_RESEARCHERS);
         
         // This works as a verification because the lambda carries a closure that includes the correct sharing 
@@ -398,7 +398,7 @@ public class ConsentControllerTest extends Mockito {
 
         verify(account).setSharingScope(SharingScope.NO_SHARING);
         
-        verify(mockAccountService).editAccount(eq(TEST_APP_ID), eq(HEALTH_CODE), any());
+        verify(mockAccountService).editAccount(eq(TEST_APP_ID), eq(TEST_USER_ID), any());
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ConsentControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ConsentControllerTest.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
+import static org.sagebionetworks.bridge.TestConstants.ACCOUNT_ID;
 import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
 import static org.sagebionetworks.bridge.TestConstants.SESSION_TOKEN;
 import static org.sagebionetworks.bridge.TestConstants.SIGNATURE;
@@ -163,7 +164,7 @@ public class ConsentControllerTest extends Mockito {
         UserSession retrievedSession = BridgeObjectMapper.get().treeToValue(result, UserSession.class);
         assertEquals(retrievedSession.getSessionToken(), ORIGINAL_SESSION_TOKEN);
         
-        verify(mockAccountService).editAccount(eq(TEST_APP_ID), eq(TEST_USER_ID), accountConsumerCaptor.capture());
+        verify(mockAccountService).editAccount(eq(TestConstants.ACCOUNT_ID), accountConsumerCaptor.capture());
         verify(mockSessionUpdateService).updateSharingScope(session, SharingScope.ALL_QUALIFIED_RESEARCHERS);
         
         // This works as a verification because the lambda carries a closure that includes the correct sharing 
@@ -398,7 +399,7 @@ public class ConsentControllerTest extends Mockito {
 
         verify(account).setSharingScope(SharingScope.NO_SHARING);
         
-        verify(mockAccountService).editAccount(eq(TEST_APP_ID), eq(TEST_USER_ID), any());
+        verify(mockAccountService).editAccount(eq(ACCOUNT_ID), any());
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ConsentControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ConsentControllerTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
 import static org.sagebionetworks.bridge.TestConstants.ACCOUNT_ID;
+import static org.sagebionetworks.bridge.TestConstants.ACCOUNT_ID_WITH_HEALTHCODE;
 import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
 import static org.sagebionetworks.bridge.TestConstants.SESSION_TOKEN;
 import static org.sagebionetworks.bridge.TestConstants.SIGNATURE;
@@ -164,7 +165,7 @@ public class ConsentControllerTest extends Mockito {
         UserSession retrievedSession = BridgeObjectMapper.get().treeToValue(result, UserSession.class);
         assertEquals(retrievedSession.getSessionToken(), ORIGINAL_SESSION_TOKEN);
         
-        verify(mockAccountService).editAccount(eq(TestConstants.ACCOUNT_ID), accountConsumerCaptor.capture());
+        verify(mockAccountService).editAccount(eq(ACCOUNT_ID_WITH_HEALTHCODE), accountConsumerCaptor.capture());
         verify(mockSessionUpdateService).updateSharingScope(session, SharingScope.ALL_QUALIFIED_RESEARCHERS);
         
         // This works as a verification because the lambda carries a closure that includes the correct sharing 
@@ -399,7 +400,7 @@ public class ConsentControllerTest extends Mockito {
 
         verify(account).setSharingScope(SharingScope.NO_SHARING);
         
-        verify(mockAccountService).editAccount(eq(ACCOUNT_ID), any());
+        verify(mockAccountService).editAccount(eq(ACCOUNT_ID_WITH_HEALTHCODE), any());
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/EmailControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/EmailControllerTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestUtils.mockEditAccount;
 import static org.testng.Assert.assertEquals;
 
@@ -30,7 +31,6 @@ public class EmailControllerTest extends Mockito {
 
     private static final String EMAIL = "email";
     private static final String DATA_BRACKET_EMAIL = "data[email]";
-    private static final String HEALTH_CODE = "healthCode";
     private static final String UNSUBSCRIBE_TOKEN = "unsubscribeToken";
     private static final String TOKEN = "token";
     private static final String STUDY = "study";
@@ -65,8 +65,8 @@ public class EmailControllerTest extends Mockito {
     public void before() {
         MockitoAnnotations.initMocks(this);
         when(mockConfig.getEmailUnsubscribeToken()).thenReturn(UNSUBSCRIBE_TOKEN);
-        when(mockAccountService.getAccountHealthCode(TEST_APP_ID, "email:"+EMAIL_ADDRESS))
-            .thenReturn(Optional.of(HEALTH_CODE));
+        when(mockAccountService.getAccountId(TEST_APP_ID, "email:"+EMAIL_ADDRESS))
+            .thenReturn(Optional.of(TEST_USER_ID));
         doReturn(mockRequest).when(controller).request();
         doReturn(mockResponse).when(controller).response();
         mockEditAccount(mockAccountService, mockAccount);
@@ -134,7 +134,7 @@ public class EmailControllerTest extends Mockito {
     public void noAccountThrowsException() throws Exception {
         mockContext(DATA_BRACKET_EMAIL, EMAIL_ADDRESS, STUDY, TEST_APP_ID, TOKEN, UNSUBSCRIBE_TOKEN);
         doReturn(Optional.empty()).when(mockAccountService)
-            .getAccountHealthCode(TEST_APP_ID, "email:"+EMAIL_ADDRESS);
+            .getAccountId(TEST_APP_ID, "email:"+EMAIL_ADDRESS);
 
         String result = controller.unsubscribeFromEmail();
         assertEquals(result, "Email not found.");

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/EmailControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/EmailControllerTest.java
@@ -130,15 +130,7 @@ public class EmailControllerTest extends Mockito {
         assertEquals(result, "Email not found.");
     }
 
-    @Test
-    public void noAccountThrowsException() throws Exception {
-        mockContext(DATA_BRACKET_EMAIL, EMAIL_ADDRESS, STUDY, TEST_APP_ID, TOKEN, UNSUBSCRIBE_TOKEN);
-        doReturn(Optional.empty()).when(mockAccountService)
-            .getAccountId(TEST_APP_ID, "email:"+EMAIL_ADDRESS);
-
-        String result = controller.unsubscribeFromEmail();
-        assertEquals(result, "Email not found.");
-    }
+    // noAccountThrowsException is now handled by the call to editAccount
 
     @Test
     public void missingTokenThrowsException() throws Exception {

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentControllerTest.java
@@ -201,23 +201,7 @@ public class EnrollmentControllerTest extends Mockito {
         assertEquals(enrollments.size(), 1);
     }
     
-    @Test(expectedExceptions = EntityNotFoundException.class)
-    public void updateUserEnrollmentsAccountNotFound() throws Exception {
-        UserSession session = new UserSession();
-        session.setAppId(TEST_APP_ID);
-        session.setParticipant(new StudyParticipant.Builder().withId(TEST_USER_ID).build());
-        doReturn(session).when(controller).getAuthenticatedSession(SUPERADMIN);
-
-        Enrollment newEnrollment = Enrollment.create(TEST_APP_ID, "anotherStudy", TEST_USER_ID);
-        mockRequestBody(mockRequest, ImmutableSet.of(EnrollmentMigration.create(newEnrollment)));
-        
-        AccountService mockAccountService = mock(AccountService.class);
-        controller.setAccountService(mockAccountService);
-        
-        when(mockAccountService.getAccount(any())).thenReturn(null);
-        
-        controller.updateUserEnrollments(TEST_USER_ID);
-    }
+    // updateUserEnrollmentsAccountNotFound now happens in the accountService.editAccount
     
     @Test
     public void updateUserEnrollmentsRemovingAll() throws Exception {

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentControllerTest.java
@@ -46,6 +46,7 @@ import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.StatusMessage;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
+import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.studies.Enrollment;
 import org.sagebionetworks.bridge.models.studies.EnrollmentDetail;
@@ -204,6 +205,7 @@ public class EnrollmentControllerTest extends Mockito {
     public void updateUserEnrollmentsAccountNotFound() throws Exception {
         UserSession session = new UserSession();
         session.setAppId(TEST_APP_ID);
+        session.setParticipant(new StudyParticipant.Builder().withId(TEST_USER_ID).build());
         doReturn(session).when(controller).getAuthenticatedSession(SUPERADMIN);
 
         Enrollment newEnrollment = Enrollment.create(TEST_APP_ID, "anotherStudy", TEST_USER_ID);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/MembershipControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/MembershipControllerTest.java
@@ -142,10 +142,7 @@ public class MembershipControllerTest extends Mockito {
         
         controller.addMember(TEST_ORG_ID, TEST_USER_ID);
         
-        verify(mockOrganizationService).addMember(eq(TEST_APP_ID), eq(TEST_ORG_ID), accountIdCaptor.capture());
-        AccountId accountId = accountIdCaptor.getValue();
-        assertEquals(TEST_APP_ID, accountId.getAppId());
-        assertEquals(TEST_USER_ID, accountId.getId());
+        verify(mockOrganizationService).addMember(TEST_APP_ID, TEST_ORG_ID, TEST_USER_ID);
     }
 
     @Test
@@ -154,10 +151,7 @@ public class MembershipControllerTest extends Mockito {
         
         controller.removeMember(TEST_ORG_ID, TEST_USER_ID);
         
-        verify(mockOrganizationService).removeMember(eq(TEST_APP_ID), eq(TEST_ORG_ID), accountIdCaptor.capture());
-        AccountId accountId = accountIdCaptor.getValue();
-        assertEquals(TEST_APP_ID, accountId.getAppId());
-        assertEquals(TEST_USER_ID, accountId.getId());
+        verify(mockOrganizationService).removeMember(TEST_APP_ID, TEST_ORG_ID, TEST_USER_ID);
     }
 
     @Test


### PR DESCRIPTION
Basically instead of healthCode, take AccountId, which allows us to use ID, healthCode, or whatever else is available.

Remove accesses of AccountDao that circumvent AccountService. Unfortunately due to the way we organized our code in the early days, we can't use Java packages to enforce this, but we want all access of accounts to go through the AccountService.