### PR TITLE
Permission changes

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
@@ -21,13 +21,17 @@ import java.util.Set;
  * All methods throw UnauthorizedException if they fail.
  */
 public class AuthUtils {
+    
+    public static final AuthEvaluator CAN_READ_ORGANIZATIONS = new AuthEvaluator()
+            .hasAnyRole(ADMIN);
+
     /**
      * Is this scoped to specific studies? It should have one of the study-scoped
      * roles, and no roles that are app scoped that we would allow wider latitude
      * when using the APIs.
      */
     public static final AuthEvaluator CAN_READ_ORG_SPONSORED_STUDIES = new AuthEvaluator()
-            .hasAnyRole(ORG_ADMIN, STUDY_COORDINATOR).hasNoRole(DEVELOPER, RESEARCHER, ADMIN, WORKER);
+            .hasAnyRole(ORG_ADMIN, STUDY_DESIGNER, STUDY_COORDINATOR).hasNoRole(DEVELOPER, RESEARCHER, ADMIN, WORKER);
 
     /**
      * Can the caller edit assessments? Must be a study designer in the organization that 

--- a/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
@@ -22,9 +22,6 @@ import java.util.Set;
  */
 public class AuthUtils {
     
-    public static final AuthEvaluator CAN_READ_ORGANIZATIONS = new AuthEvaluator()
-            .hasAnyRole(ADMIN);
-
     /**
      * Is this scoped to specific studies? It should have one of the study-scoped
      * roles, and no roles that are app scoped that we would allow wider latitude

--- a/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
@@ -30,12 +30,6 @@ public class AuthUtils {
             .hasAnyRole(ORG_ADMIN, STUDY_COORDINATOR).hasNoRole(DEVELOPER, RESEARCHER, ADMIN, WORKER);
 
     /**
-     * Can the caller delete an organization?
-     */
-    public static final AuthEvaluator CAN_DELETE_ORG = new AuthEvaluator()
-            .hasAnyRole(ADMIN);
-    
-    /**
      * Can the caller edit assessments? Must be a study designer in the organization that 
      * owns the assessment, or a developer.
      */
@@ -58,6 +52,22 @@ public class AuthUtils {
             .isInOrg().hasAnyRole(ORG_ADMIN).or()
             .hasAnyRole(ADMIN);
 
+    /**
+     * Can the caller and/remove organization members? Must be the organizations's admin. Note 
+     * that this check is currently also used for sponsors...which are not members.
+     */
+    public static final AuthEvaluator CAN_READ_ORG = new AuthEvaluator()
+            .isInOrg().or()
+            .hasAnyRole(ADMIN);
+
+    /**
+     * Can the caller and/remove organization members? Must be the organizations's admin. Note 
+     * that this check is currently also used for sponsors...which are not members.
+     */
+    public static final AuthEvaluator CAN_EDIT_ORG = new AuthEvaluator()
+            .isInOrg().hasAnyRole(ORG_ADMIN).or()
+            .hasAnyRole(ADMIN);
+    
     /**
      * Can the caller edit accounts? For the APIs to work with administrative accounts, 
      * the caller must be operating on self (and in the correct organization), or an 

--- a/src/main/java/org/sagebionetworks/bridge/services/OrganizationService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/OrganizationService.java
@@ -24,8 +24,8 @@ import org.sagebionetworks.bridge.exceptions.ConstraintViolationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import org.sagebionetworks.bridge.AuthUtils;
 import org.sagebionetworks.bridge.RequestContext;
+import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.cache.CacheKey;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.dao.OrganizationDao;
@@ -91,7 +91,7 @@ public class OrganizationService {
             throw new BadRequestException(PAGE_SIZE_ERROR);
         }
         
-        if (!AuthUtils.CAN_READ_ORGANIZATIONS.check()) {
+        if (!RequestContext.get().isInRole(Roles.ADMIN)) {
             List<Organization> list = ImmutableList.of();
             String orgId = RequestContext.get().getCallerOrgMembership();
             if (orgId != null) {

--- a/src/main/java/org/sagebionetworks/bridge/services/OrganizationService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/OrganizationService.java
@@ -12,6 +12,7 @@ import static org.sagebionetworks.bridge.models.ResourceList.OFFSET_BY;
 import static org.sagebionetworks.bridge.models.ResourceList.PAGE_SIZE;
 import static org.sagebionetworks.bridge.validators.OrganizationValidator.INSTANCE;
 
+import java.util.List;
 import java.util.Optional;
 
 import com.google.common.collect.ImmutableList;
@@ -89,12 +90,16 @@ public class OrganizationService {
         if (pageSize != null && (pageSize < API_MINIMUM_PAGE_SIZE || pageSize > API_MAXIMUM_PAGE_SIZE)) {
             throw new BadRequestException(PAGE_SIZE_ERROR);
         }
+        
         if (!AuthUtils.CAN_READ_ORGANIZATIONS.check()) {
+            List<Organization> list = ImmutableList.of();
             String orgId = RequestContext.get().getCallerOrgMembership();
-            Organization org = orgDao.getOrganization(appId, orgId)
-                    .orElseThrow(() -> new EntityNotFoundException(Organization.class));        
-
-            return new PagedResourceList<>(ImmutableList.of(org), 1, true)
+            if (orgId != null) {
+                Organization org = orgDao.getOrganization(appId, orgId)
+                        .orElseThrow(() -> new EntityNotFoundException(Organization.class));        
+                list = ImmutableList.of(org); 
+            }
+            return new PagedResourceList<>(list, list.size(), true)
                     .withRequestParam(OFFSET_BY, offsetBy)
                     .withRequestParam(PAGE_SIZE, pageSize);
         }

--- a/src/main/java/org/sagebionetworks/bridge/services/OrganizationService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/OrganizationService.java
@@ -3,9 +3,6 @@ package org.sagebionetworks.bridge.services;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.sagebionetworks.bridge.AuthEvaluatorField.ORG_ID;
-import static org.sagebionetworks.bridge.AuthUtils.CAN_DELETE_ORG;
-import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_MEMBERS;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.NEGATIVE_OFFSET_ERROR;
@@ -126,8 +123,6 @@ public class OrganizationService {
      */
     public Organization updateOrganization(Organization organization) {
         checkNotNull(organization);
-
-        CAN_EDIT_MEMBERS.checkAndThrow(ORG_ID, organization.getIdentifier());
         
         Validate.entityThrowingException(INSTANCE, organization);
         
@@ -171,8 +166,6 @@ public class OrganizationService {
         checkArgument(isNotBlank(appId));
         checkArgument(isNotBlank(identifier));
         
-        CAN_DELETE_ORG.checkAndThrow();
-        
         Organization existing = orgDao.getOrganization(appId, identifier)
                 .orElseThrow(() -> new EntityNotFoundException(Organization.class));        
         if (assessmentDao.hasAssessmentFromOrg(appId, identifier)) {
@@ -192,8 +185,6 @@ public class OrganizationService {
         checkArgument(isNotBlank(appId));
         checkArgument(isNotBlank(identifier));
         checkNotNull(search);
-        
-        CAN_EDIT_MEMBERS.checkAndThrow(ORG_ID, identifier);
         
         AccountSummarySearch scopedSearch = search.toBuilder()
                 // only needed for legacy APIs
@@ -222,8 +213,6 @@ public class OrganizationService {
         checkArgument(isNotBlank(identifier));
         checkArgument(isNotBlank(userId));
         
-        CAN_EDIT_MEMBERS.checkAndThrow(ORG_ID, identifier);
-        
         AccountId accountId = AccountId.forId(appId, userId);
         accountService.editAccount(accountId, (acct) -> {
             RequestContext context = RequestContext.get();
@@ -239,8 +228,6 @@ public class OrganizationService {
         checkArgument(isNotBlank(appId));
         checkArgument(isNotBlank(identifier));
         checkArgument(isNotBlank(userId));
-        
-        CAN_EDIT_MEMBERS.checkAndThrow(ORG_ID, identifier);
 
         AccountId accountId = AccountId.forId(appId, userId);
         accountService.editAccount(accountId, (acct) -> {

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AccountsController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AccountsController.java
@@ -91,9 +91,12 @@ public class AccountsController extends BaseController  {
         // is a superset of Account. That includes password, which we want to expose
         // in the SDK version of Account.
         StudyParticipant participant = parseJson(StudyParticipant.class);
-        participant = new StudyParticipant.Builder().copyOf(participant)
-                .withOrgMembership(orgId).build();
-        
+        // Admins can set someone in any organization, but others must create accounts
+        // in their own organization (particularly, org administrators).
+        if (!session.isInRole(ImmutableSet.of(ADMIN))) {
+            participant = new StudyParticipant.Builder().copyOf(participant)
+                    .withOrgMembership(orgId).build();
+        }
         App app = appService.getApp(session.getAppId());
         return participantService.createParticipant(app, participant, true);
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/MembershipController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/MembershipController.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
 import static org.sagebionetworks.bridge.AuthEvaluatorField.ORG_ID;
+import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_MEMBERS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_READ_MEMBERS;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.ORG_ADMIN;
@@ -47,7 +48,7 @@ public class MembershipController extends BaseController {
     public StatusMessage addMember(@PathVariable String orgId, @PathVariable String userId) {
         UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
         
-        // organization membership checked in service
+        CAN_EDIT_MEMBERS.checkAndThrow(ORG_ID, orgId);
         
         organizationService.addMember(session.getAppId(), orgId, userId);
         
@@ -58,7 +59,7 @@ public class MembershipController extends BaseController {
     public StatusMessage removeMember(@PathVariable String orgId, @PathVariable String userId) {
         UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
 
-        // organization membership checked in service
+        CAN_EDIT_MEMBERS.checkAndThrow(ORG_ID, orgId);
         
         organizationService.removeMember(session.getAppId(), orgId, userId);
         

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/OrganizationController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/OrganizationController.java
@@ -1,5 +1,8 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
+import static org.sagebionetworks.bridge.AuthEvaluatorField.ORG_ID;
+import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_ORG;
+import static org.sagebionetworks.bridge.AuthUtils.CAN_READ_ORG;
 import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.ORG_ADMIN;
@@ -61,11 +64,13 @@ public class OrganizationController extends BaseController {
         // A study admin caller will also be able to edit some fields of their own organization.
         // The association of accounts to organizations has to be completed first.
         UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
-        
+
+        CAN_EDIT_ORG.checkAndThrow(ORG_ID, orgId);
+
         Organization organization = parseJson(Organization.class);
         organization.setAppId(session.getAppId());
         organization.setIdentifier(orgId);
-        
+
         return service.updateOrganization(organization);
     }
     
@@ -75,12 +80,15 @@ public class OrganizationController extends BaseController {
         // The association of accounts to organizations has to be completed first.
         UserSession session = getAdministrativeSession();
         
+        CAN_READ_ORG.checkAndThrow(ORG_ID, orgId);
+        
         return service.getOrganization(session.getAppId(), orgId);
     }
     
     @DeleteMapping("/v1/organizations/{orgId}")
     public StatusMessage deleteOrganization(@PathVariable String orgId) {
         UserSession session = getAuthenticatedSession(ADMIN);
+        
         service.deleteOrganization(session.getAppId(), orgId);
         return new StatusMessage("Organization deleted.");
     }

--- a/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
@@ -10,7 +10,6 @@ import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_SHARED_ASSESSMENTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_ENROLLMENTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_READ_STUDY_ASSOCIATIONS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_READ_EXTERNAL_IDS;
-import static org.sagebionetworks.bridge.AuthUtils.CAN_READ_ORGANIZATIONS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_STUDY_PARTICIPANTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_READ_PARTICIPANTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_PARTICIPANTS;
@@ -643,18 +642,32 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canReadOrganizationsSucceedsForAdmin() {
+    public void canReadOrg() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerRoles(ImmutableSet.of(ADMIN)).build());
-                
-        CAN_READ_ORGANIZATIONS.checkAndThrow();
+                .withCallerOrgMembership(TEST_ORG_ID).build());
+        AuthUtils.CAN_READ_ORG.checkAndThrow(ORG_ID, TEST_ORG_ID);
     }
-
+    
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void canReadOrganizationsFailsForOrgAdmin() {
+    public void canReadOrgFails() { 
         RequestContext.set(new RequestContext.Builder()
-                .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
-                
-        CAN_READ_ORGANIZATIONS.checkAndThrow();
+                .withCallerOrgMembership("some-other-org").build());
+        AuthUtils.CAN_READ_ORG.checkAndThrow(ORG_ID, TEST_ORG_ID);
+    }
+    
+    @Test
+    public void canEditOrg() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
+                .withCallerOrgMembership(TEST_ORG_ID).build());
+        AuthUtils.CAN_EDIT_ORG.checkAndThrow(ORG_ID, TEST_ORG_ID);
+    }
+    
+    @Test(expectedExceptions = UnauthorizedException.class)
+    public void canEditOrgFailes() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(STUDY_DESIGNER))
+                .withCallerOrgMembership(TEST_ORG_ID).build());
+        AuthUtils.CAN_EDIT_ORG.checkAndThrow(ORG_ID, TEST_ORG_ID);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
@@ -10,6 +10,7 @@ import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_SHARED_ASSESSMENTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_ENROLLMENTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_READ_STUDY_ASSOCIATIONS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_READ_EXTERNAL_IDS;
+import static org.sagebionetworks.bridge.AuthUtils.CAN_READ_ORGANIZATIONS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_STUDY_PARTICIPANTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_READ_PARTICIPANTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_PARTICIPANTS;
@@ -640,4 +641,20 @@ public class AuthUtilsTest extends Mockito {
                 
         CAN_EDIT_SCHEDULES.checkAndThrow(ORG_ID, TEST_ORG_ID);
     }
- }
+    
+    @Test
+    public void canReadOrganizationsSucceedsForAdmin() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(ADMIN)).build());
+                
+        CAN_READ_ORGANIZATIONS.checkAndThrow();
+    }
+
+    @Test(expectedExceptions = UnauthorizedException.class)
+    public void canReadOrganizationsFailsForOrgAdmin() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
+                
+        CAN_READ_ORGANIZATIONS.checkAndThrow();
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/services/OrganizationServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/OrganizationServiceTest.java
@@ -10,6 +10,7 @@ import static org.sagebionetworks.bridge.TestConstants.ACCOUNT_ID;
 import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
 import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
 import static org.sagebionetworks.bridge.TestConstants.USER_DATA_GROUPS;
 import static org.sagebionetworks.bridge.TestUtils.mockEditAccount;
 import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
@@ -94,6 +95,8 @@ public class OrganizationServiceTest extends Mockito {
     
     @Test
     public void getOrganizations() {
+        RequestContext.set(new RequestContext.Builder().withCallerRoles(ImmutableSet.of(ADMIN)).build());
+
         PagedResourceList<Organization> page = new PagedResourceList<>(
                 ImmutableList.of(Organization.create(), Organization.create()), 10);
         when(mockOrgDao.getOrganizations(TEST_APP_ID, 100, 20)).thenReturn(page);
@@ -106,7 +109,26 @@ public class OrganizationServiceTest extends Mockito {
     }
     
     @Test
+    public void getOrganizationsOnlyReturnsMemberOrgForNonAdmins() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
+                .withCallerOrgMembership(TEST_ORG_ID).build());
+        
+        Organization org = Organization.create();
+        when(mockOrgDao.getOrganization(TEST_APP_ID, TEST_ORG_ID))
+            .thenReturn(Optional.of(org));
+        
+        PagedResourceList<Organization> retList = service.getOrganizations(TEST_APP_ID, 100, 20);
+        assertEquals(retList.getRequestParams().get("offsetBy"), 100);
+        assertEquals(retList.getRequestParams().get("pageSize"), 20);
+        assertEquals(retList.getTotal(), Integer.valueOf(1));
+        assertEquals(retList.getItems().size(), 1);
+        assertEquals(retList.getItems().get(0), org);
+    }
+    @Test
     public void getOrganizationsNullArguments() {
+        RequestContext.set(new RequestContext.Builder().withCallerRoles(ImmutableSet.of(ADMIN)).build());
+        
         PagedResourceList<Organization> page = new PagedResourceList<>(
                 ImmutableList.of(Organization.create(), Organization.create()), 10);
         when(mockOrgDao.getOrganizations(TEST_APP_ID, null, null)).thenReturn(page);

--- a/src/test/java/org/sagebionetworks/bridge/services/OrganizationServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/OrganizationServiceTest.java
@@ -125,6 +125,19 @@ public class OrganizationServiceTest extends Mockito {
         assertEquals(retList.getItems().size(), 1);
         assertEquals(retList.getItems().get(0), org);
     }
+
+    @Test
+    public void getOrganizationsReturnsNothingForNonOrgMembers() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
+        
+        PagedResourceList<Organization> retList = service.getOrganizations(TEST_APP_ID, 100, 20);
+        assertEquals(retList.getRequestParams().get("offsetBy"), 100);
+        assertEquals(retList.getRequestParams().get("pageSize"), 20);
+        assertEquals(retList.getTotal(), Integer.valueOf(0));
+        assertEquals(retList.getItems().size(), 0);
+    }
+
     @Test
     public void getOrganizationsNullArguments() {
         RequestContext.set(new RequestContext.Builder().withCallerRoles(ImmutableSet.of(ADMIN)).build());

--- a/src/test/java/org/sagebionetworks/bridge/services/OrganizationServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/OrganizationServiceTest.java
@@ -43,7 +43,6 @@ import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
-import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.AccountSummarySearch;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
@@ -344,19 +343,6 @@ public class OrganizationServiceTest extends Mockito {
         assertSame(retValue, page);
     }
 
-    @Test(expectedExceptions = UnauthorizedException.class)
-    public void getMembersNotAuthorized() {
-        when(mockOrgDao.getOrganization(TEST_APP_ID, IDENTIFIER)).thenReturn(Optional.of(Organization.create()));
-        
-        PagedResourceList<AccountSummary> page = new PagedResourceList<>(ImmutableList.of(), 0); 
-        when(mockAccountService.getPagedAccountSummaries(eq(TEST_APP_ID), any())).thenReturn(page);
-        
-        AccountSummarySearch search = new AccountSummarySearch.Builder().withLanguage("en").build();        
-        
-        service.getMembers(TEST_APP_ID, IDENTIFIER, search);
-    }
-    
-    @Test
     public void addMember() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(IDENTIFIER)
@@ -387,14 +373,6 @@ public class OrganizationServiceTest extends Mockito {
         
         verify(mockAccountService).editAccount(eq(ACCOUNT_ID), any());
         assertEquals(account.getOrgMembership(), IDENTIFIER);
-    }
-    
-    @Test(expectedExceptions = UnauthorizedException.class)
-    public void addMemberUnauthorized() {
-        RequestContext.set(new RequestContext.Builder()
-                .withCallerOrgMembership("not-org-id").build());
-        
-        service.addMember(TEST_APP_ID, IDENTIFIER, TEST_USER_ID);
     }
     
     @Test(expectedExceptions = EntityNotFoundException.class, 
@@ -526,15 +504,6 @@ public class OrganizationServiceTest extends Mockito {
         service.removeMember(TEST_APP_ID, IDENTIFIER, TEST_USER_ID);
     }
 
-    @Test(expectedExceptions = UnauthorizedException.class)
-    public void removeMemberNotAuthorized() {
-        Account account = Account.create();
-        account.setOrgMembership(IDENTIFIER);
-        mockEditAccount(mockAccountService, account);
-
-        service.removeMember(TEST_APP_ID, IDENTIFIER, TEST_USER_ID);
-    }
-    
     @Test
     public void deleteAllOrganizations() {
         service.deleteAllOrganizations(TEST_APP_ID);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/MembershipControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/MembershipControllerTest.java
@@ -18,6 +18,7 @@ import java.util.function.Consumer;
 import javax.servlet.http.HttpServletRequest;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -31,6 +32,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.RequestContext;
+import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.AccountSummarySearch;
 import org.sagebionetworks.bridge.models.PagedResourceList;
@@ -138,6 +140,8 @@ public class MembershipControllerTest extends Mockito {
     
     @Test
     public void addMember() {
+        setContext(b -> b.withCallerOrgMembership(TEST_ORG_ID)
+                .withCallerRoles(ImmutableSet.of(Roles.ORG_ADMIN)));
         doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
         
         controller.addMember(TEST_ORG_ID, TEST_USER_ID);
@@ -147,6 +151,8 @@ public class MembershipControllerTest extends Mockito {
 
     @Test
     public void removeMember() {
+        setContext(b -> b.withCallerOrgMembership(TEST_ORG_ID)
+                .withCallerRoles(ImmutableSet.of(Roles.ORG_ADMIN)));
         doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
         
         controller.removeMember(TEST_ORG_ID, TEST_USER_ID);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/OrganizationControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/OrganizationControllerTest.java
@@ -16,6 +16,7 @@ import static org.testng.Assert.assertSame;
 import javax.servlet.http.HttpServletRequest;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -27,6 +28,7 @@ import org.mockito.Spy;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.models.AccountSummarySearch;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.StatusMessage;
@@ -132,6 +134,8 @@ public class OrganizationControllerTest extends Mockito {
     
     @Test
     public void updateOrganization() throws Exception {
+        RequestContext.set(RequestContext.get().toBuilder()
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
         
         Organization org = Organization.create();
@@ -154,6 +158,9 @@ public class OrganizationControllerTest extends Mockito {
     
     @Test
     public void getOrganization() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerOrgMembership(IDENTIFIER)
+                .build());
         doReturn(session).when(controller).getAdministrativeSession();
         
         Organization org = Organization.create();


### PR DESCRIPTION
Some changes in security to accommodate the MTB designs:

- Any administrative account can get all organizations, but only admins will see all organizations, everyone else gets back only their own organization;
- Admins can create an account in any organization when they create an account (very useful for me when onboarding accounts);
- Everyone can see the members of their own organization (and sometimes they can edit these accounts, depending on their own role).
- Study designers can see the studies their organization sponsors