### PR TITLE
design -> withdrawn publishes the schedule to freeze it.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
@@ -286,10 +286,18 @@ public class StudyService {
     /**
      * Moves a study to the withdrawn state. No further enrollments will be allowed,
      * and data collected for this study should not be uploaded as part of the data
-     * set.  
+     * set. If this was previously in design, the schedule will be published in order
+     * to freeze it from further changes.
      */
     public Study transitionToWithdrawn(String appId, String studyId) {
-        return phaseTransition(appId, studyId, WITHDRAWN, null);
+        return phaseTransition(appId, studyId, WITHDRAWN, (study) -> {
+            if (study.getScheduleGuid() != null) {
+                Schedule2 schedule = scheduleService.getSchedule(appId, study.getScheduleGuid());
+                if (!schedule.isPublished()) {
+                    scheduleService.publishSchedule(appId, study.getScheduleGuid());
+                }
+            }
+        });
     }
     
     /**

--- a/src/test/java/org/sagebionetworks/bridge/services/StudyServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/StudyServiceTest.java
@@ -627,6 +627,51 @@ public class StudyServiceTest {
                 .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR)).build());
         Study study = Study.create();
         study.setPhase(DESIGN);
+        study.setScheduleGuid(SCHEDULE_GUID);
+        study.setIdentifier(TEST_STUDY_ID);
+        when(mockStudyDao.getStudy(TEST_APP_ID, TEST_STUDY_ID)).thenReturn(study);
+        
+        Schedule2 schedule = new Schedule2();
+        when(mockScheduleService.getSchedule(TEST_APP_ID, SCHEDULE_GUID)).thenReturn(schedule);
+
+        service.transitionToWithdrawn(TEST_APP_ID, TEST_STUDY_ID);
+        
+        verify(mockStudyDao).updateStudy(study);
+        assertEquals(study.getPhase(), WITHDRAWN);
+        
+        verify(mockScheduleService).publishSchedule(TEST_APP_ID, SCHEDULE_GUID);
+    }
+    
+    @Test
+    public void transitionToWithdrawnScheduleAlreadyPublished() {
+        RequestContext.set(new RequestContext.Builder()
+                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
+                .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR)).build());
+        Study study = Study.create();
+        study.setPhase(DESIGN);
+        study.setIdentifier(TEST_STUDY_ID);
+        study.setScheduleGuid(SCHEDULE_GUID);
+        when(mockStudyDao.getStudy(TEST_APP_ID, TEST_STUDY_ID)).thenReturn(study);
+        
+        Schedule2 schedule = new Schedule2();
+        schedule.setPublished(true);
+        when(mockScheduleService.getSchedule(TEST_APP_ID, SCHEDULE_GUID)).thenReturn(schedule);
+        
+        service.transitionToWithdrawn(TEST_APP_ID, TEST_STUDY_ID);
+        
+        verify(mockStudyDao).updateStudy(study);
+        assertEquals(study.getPhase(), WITHDRAWN);
+        
+        verify(mockScheduleService, never()).publishSchedule(any(), any());
+    }
+    
+    @Test
+    public void transitionToWithdrawnWithNoSchedule() {
+        RequestContext.set(new RequestContext.Builder()
+                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
+                .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR)).build());
+        Study study = Study.create();
+        study.setPhase(DESIGN);
         study.setIdentifier(TEST_STUDY_ID);
         when(mockStudyDao.getStudy(TEST_APP_ID, TEST_STUDY_ID)).thenReturn(study);
         
@@ -634,6 +679,9 @@ public class StudyServiceTest {
         
         verify(mockStudyDao).updateStudy(study);
         assertEquals(study.getPhase(), WITHDRAWN);
+        assertNull(study.getScheduleGuid());
+
+        verifyZeroInteractions(mockScheduleService);
     }
     
     // As all the phase transition methods use the same code, I'm only goind to write the error


### PR DESCRIPTION
BRIDGE-3064, if you take a study in design and withdraw it, you can currently still change the schedule. I think you want to freeze it entirely, so publish the schedule when transitioning to withdrawn.