### PR TITLE
Cleaning up scoped schedules.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/models/studies/StudyPhase.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/studies/StudyPhase.java
@@ -1,5 +1,11 @@
 package org.sagebionetworks.bridge.models.studies;
 
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
 public enum StudyPhase {
     /**
      * If not set, the study is in the LEGACY phase, and no domain logic will be
@@ -50,4 +56,20 @@ public enum StudyPhase {
     public String label() {
         return "“" + this.name().toLowerCase() + "”";
     }
+    
+    public static final Map<StudyPhase, Set<StudyPhase>> ALLOWED_PHASE_TRANSITIONS = new ImmutableMap.Builder<StudyPhase, Set<StudyPhase>>()
+            .put(LEGACY, ImmutableSet.of(DESIGN))
+            .put(DESIGN, ImmutableSet.of(RECRUITMENT, WITHDRAWN))
+            .put(RECRUITMENT, ImmutableSet.of(IN_FLIGHT, WITHDRAWN))
+            .put(IN_FLIGHT, ImmutableSet.of(RECRUITMENT, ANALYSIS, WITHDRAWN))
+            .put(ANALYSIS, ImmutableSet.of(RECRUITMENT, IN_FLIGHT, COMPLETED, WITHDRAWN))
+            .put(COMPLETED, ImmutableSet.of())
+            .put(WITHDRAWN, ImmutableSet.of()).build();
+    
+    // Legacy studies, and studies created in the design phase, are fully editable/deletable, which was
+    // their legacy behavior. In later phases, these no longer become possible. 
+    public static final Set<StudyPhase> CAN_EDIT_STUDY_METADATA = ImmutableSet.of(LEGACY, DESIGN, RECRUITMENT, IN_FLIGHT);
+    public static final Set<StudyPhase> CAN_EDIT_STUDY_CORE = ImmutableSet.of(LEGACY, DESIGN);
+    public static final Set<StudyPhase> CAN_DELETE_STUDY = ImmutableSet.of(LEGACY, DESIGN, COMPLETED, WITHDRAWN);
+
 }

--- a/src/main/java/org/sagebionetworks/bridge/services/Schedule2Service.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/Schedule2Service.java
@@ -19,7 +19,6 @@ import static org.sagebionetworks.bridge.models.ResourceList.PAGE_SIZE;
 import static org.sagebionetworks.bridge.validators.Schedule2Validator.INSTANCE;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -48,7 +47,10 @@ import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.validators.Validate;
 
 /**
- * Bridge v2 schedules. These replace the older SchedulePlans and their APIs.
+ * Bridge v2 schedules. These replace the older SchedulePlans and their APIs. The 
+ * lifecycle of a schedule is now closely related to the one study it is referenced
+ * by, so the Schedule2Service is always called by the study service and that 
+ * service will prevent changes once a study is in production.
  */
 @Component
 public class Schedule2Service {
@@ -179,10 +181,6 @@ public class Schedule2Service {
         checkNotNull(study);
         checkNotNull(schedule);
         
-        if (!StudyService.CAN_EDIT_CORE.contains(study.getPhase())) {
-            throw new BadRequestException("Study schedule cannot be changed or removed during phase " 
-                    + study.getPhase().label() + ".");
-        }
         Schedule2 existing = null;
         if (study.getScheduleGuid() != null) {
             // this shouldn't come back null if it's set in the study, that would be strange.

--- a/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
@@ -12,15 +12,17 @@ import static org.sagebionetworks.bridge.BridgeConstants.PAGE_SIZE_ERROR;
 import static org.sagebionetworks.bridge.models.ResourceList.INCLUDE_DELETED;
 import static org.sagebionetworks.bridge.models.ResourceList.OFFSET_BY;
 import static org.sagebionetworks.bridge.models.ResourceList.PAGE_SIZE;
+import static org.sagebionetworks.bridge.models.studies.StudyPhase.ALLOWED_PHASE_TRANSITIONS;
 import static org.sagebionetworks.bridge.models.studies.StudyPhase.ANALYSIS;
+import static org.sagebionetworks.bridge.models.studies.StudyPhase.CAN_DELETE_STUDY;
+import static org.sagebionetworks.bridge.models.studies.StudyPhase.CAN_EDIT_STUDY_CORE;
+import static org.sagebionetworks.bridge.models.studies.StudyPhase.CAN_EDIT_STUDY_METADATA;
 import static org.sagebionetworks.bridge.models.studies.StudyPhase.COMPLETED;
 import static org.sagebionetworks.bridge.models.studies.StudyPhase.DESIGN;
 import static org.sagebionetworks.bridge.models.studies.StudyPhase.IN_FLIGHT;
-import static org.sagebionetworks.bridge.models.studies.StudyPhase.LEGACY;
 import static org.sagebionetworks.bridge.models.studies.StudyPhase.RECRUITMENT;
 import static org.sagebionetworks.bridge.models.studies.StudyPhase.WITHDRAWN;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -45,25 +47,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 
 @Component
 public class StudyService {
-    
-    private static final Map<StudyPhase, Set<StudyPhase>> ALLOWED_PHASE_TRANSITIONS = new ImmutableMap.Builder<StudyPhase, Set<StudyPhase>>()
-            .put(LEGACY, ImmutableSet.of(DESIGN))
-            .put(DESIGN, ImmutableSet.of(RECRUITMENT, WITHDRAWN))
-            .put(RECRUITMENT, ImmutableSet.of(IN_FLIGHT, WITHDRAWN))
-            .put(IN_FLIGHT, ImmutableSet.of(RECRUITMENT, ANALYSIS, WITHDRAWN))
-            .put(ANALYSIS, ImmutableSet.of(RECRUITMENT, IN_FLIGHT, COMPLETED, WITHDRAWN))
-            .put(COMPLETED, ImmutableSet.of())
-            .put(WITHDRAWN, ImmutableSet.of()).build();
-    
-    // Legacy studies, and studies created in the design phase, are fully editable/deletable, which was
-    // their legacy behavior. In later phases, these no longer become possible. 
-    public static final Set<StudyPhase> CAN_EDIT_METADATA = ImmutableSet.of(LEGACY, DESIGN, RECRUITMENT, IN_FLIGHT);
-    public static final Set<StudyPhase> CAN_EDIT_CORE = ImmutableSet.of(LEGACY, DESIGN);
-    public static final Set<StudyPhase> CAN_DELETE = ImmutableSet.of(LEGACY, DESIGN, COMPLETED, WITHDRAWN);
     
     private StudyDao studyDao;
     
@@ -189,11 +175,11 @@ public class StudyService {
         if (study.isDeleted() && existing.isDeleted()) {
             throw new EntityNotFoundException(Study.class);
         }
-        if (!CAN_EDIT_METADATA.contains(existing.getPhase())) {
+        if (!CAN_EDIT_STUDY_METADATA.contains(existing.getPhase())) {
             throw new BadRequestException("Study cannot be changed during phase " 
                     + existing.getPhase().label() + ".");
         }
-        if (!CAN_EDIT_CORE.contains(existing.getPhase()) &&
+        if (!CAN_EDIT_STUDY_CORE.contains(existing.getPhase()) &&
                 !Objects.equals(study.getScheduleGuid(), existing.getScheduleGuid())) {
             throw new BadRequestException("Study schedule cannot be changed or removed during phase " 
                     + existing.getPhase().label() + ".");
@@ -202,6 +188,9 @@ public class StudyService {
         study.setCreatedOn(existing.getCreatedOn());
         study.setModifiedOn(DateTime.now());
         study.setPhase(existing.getPhase());
+        if (existing.getScheduleGuid() != null) {
+            study.setScheduleGuid(existing.getScheduleGuid());    
+        }
         Validate.entityThrowingException(StudyValidator.INSTANCE, study);
         
         VersionHolder keys = studyDao.updateStudy(study);
@@ -218,7 +207,7 @@ public class StudyService {
         
         Study existing = getStudy(appId, studyId, true);
         
-        if (!CAN_DELETE.contains(existing.getPhase())) {
+        if (!CAN_DELETE_STUDY.contains(existing.getPhase())) {
             throw new BadRequestException("Study cannot be deleted during phase " 
                     + existing.getPhase().label());
         }
@@ -235,9 +224,13 @@ public class StudyService {
         checkNotNull(studyId);
         
         // Throws exception if the element does not exist.
-        getStudy(appId, studyId, true);
-        studyDao.deleteStudyPermanently(appId, studyId);
+        Study study = getStudy(appId, studyId, true);
+        String scheduleGuid = study.getScheduleGuid();
         
+        studyDao.deleteStudyPermanently(appId, studyId);
+        if (scheduleGuid != null) {
+            scheduleService.deleteSchedulePermanently(appId, scheduleGuid);    
+        }
         CacheKey cacheKey = CacheKey.publicStudy(appId, studyId);
         cacheProvider.removeObject(cacheKey);
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/Schedule2Controller.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/Schedule2Controller.java
@@ -1,112 +1,93 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
-import static org.sagebionetworks.bridge.AuthEvaluatorField.ORG_ID;
-import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_SCHEDULES;
-import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.STUDY_ID;
+import static org.sagebionetworks.bridge.AuthUtils.CAN_READ_STUDIES;
+import static org.sagebionetworks.bridge.AuthUtils.CAN_UPDATE_STUDIES;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.STUDY_DESIGNER;
-import static org.springframework.http.HttpStatus.CREATED;
+import static org.sagebionetworks.bridge.models.studies.StudyPhase.CAN_EDIT_STUDY_CORE;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import org.sagebionetworks.bridge.BridgeUtils;
-import org.sagebionetworks.bridge.models.PagedResourceList;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
+import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.StatusMessage;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.schedules2.Schedule2;
 import org.sagebionetworks.bridge.models.schedules2.timelines.Timeline;
+import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.services.Schedule2Service;
+import org.sagebionetworks.bridge.services.StudyService;
 
 @CrossOrigin
 @RestController
 public class Schedule2Controller extends BaseController {
 
     static final StatusMessage DELETED_MSG = new StatusMessage("Schedule deleted.");
-    static final StatusMessage PUBLISHED_MSG = new StatusMessage("Schedule published.");
     
     private Schedule2Service service;
+    
+    private StudyService studyService;
     
     @Autowired
     final void setScheduleService(Schedule2Service service) {
         this.service = service;
     }
     
-    @GetMapping("/v5/schedules")
-    public PagedResourceList<Schedule2> getSchedules(@RequestParam(required = false) String offsetBy,
-            @RequestParam(required = false) String pageSize,
-            @RequestParam(required = false) String includeDeleted) {
+    @Autowired
+    final void setStudyService(StudyService studyService) {
+        this.studyService = studyService;
+    }
+    
+    @GetMapping("/v5/studies/{studyId}/schedule")
+    public Schedule2 getSchedule(@PathVariable String studyId) {
+        UserSession session = getAuthenticatedSession(STUDY_DESIGNER, DEVELOPER);
+        
+        Study study = studyService.getStudy(session.getAppId(), studyId, true);
+        CAN_READ_STUDIES.checkAndThrow(STUDY_ID, studyId);
+        
+        return service.getScheduleForStudy(session.getAppId(), study);
+    }
+    
+    @PostMapping("/v5/studies/{studyId}/schedule")
+    public ResponseEntity<Schedule2> createOrUpdateSchedule(@PathVariable String studyId) {
+        UserSession session = getAuthenticatedSession(STUDY_DESIGNER, DEVELOPER);
+        
+        Schedule2 schedule = parseJson(Schedule2.class);
+        schedule.setAppId(session.getAppId());
+        
+        Study study = studyService.getStudy(session.getAppId(), studyId, true);
+        CAN_UPDATE_STUDIES.checkAndThrow(STUDY_ID, studyId);
+        
+        if (!CAN_EDIT_STUDY_CORE.contains(study.getPhase())) {
+            throw new BadRequestException("Study schedule cannot be changed during phase " 
+                    + study.getPhase().label() + ".");
+        }
+        int status = (study.getScheduleGuid() == null) ? 201: 200;
+        Schedule2 retValue = service.createOrUpdateStudySchedule(study, schedule);
+        
+        return ResponseEntity.status(status).body(retValue);
+    }
+
+    @GetMapping("/v5/studies/{studyId}/timeline")
+    public Timeline getTimeline(@PathVariable String studyId) {
         UserSession session = getAdministrativeSession();
         
-        int offsetByInt = BridgeUtils.getIntOrDefault(offsetBy, 0); 
-        int pageSizeInt = BridgeUtils.getIntOrDefault(pageSize, API_DEFAULT_PAGE_SIZE);
-        boolean includeDeletedBool = Boolean.valueOf(includeDeleted);
+        Study study = studyService.getStudy(session.getAppId(), studyId, true);
+        CAN_READ_STUDIES.checkAndThrow(STUDY_ID, studyId);
         
-        if (session.isInRole(DEVELOPER)) {
-            return service.getSchedules(session.getAppId(), offsetByInt, pageSizeInt, includeDeletedBool);
+        if (study.getScheduleGuid() == null) {
+            throw new EntityNotFoundException(Schedule2.class);
         }
-        return service.getSchedulesForOrganization(session.getAppId(), session.getParticipant().getOrgMembership(), 
-                offsetByInt, pageSizeInt, includeDeletedBool);
-    }
-    
-    @PostMapping("/v5/schedules")
-    @ResponseStatus(CREATED)
-    public Schedule2 createSchedule() {
-        UserSession session = getAuthenticatedSession(STUDY_DESIGNER, DEVELOPER);
-        
-        Schedule2 schedule = parseJson(Schedule2.class);
-        schedule.setAppId(session.getAppId());
-        
-        return service.createSchedule(schedule);
-    }
-    
-    @GetMapping("/v5/schedules/{guid}")
-    public Schedule2 getSchedule(@PathVariable String guid) {
-        UserSession session = getAuthenticatedSession(STUDY_DESIGNER, DEVELOPER);
-        
-        return service.getSchedule(session.getAppId(), guid);
-    }
-    
-    @GetMapping("/v5/schedules/{guid}/timeline")
-    public Timeline getTimelineForSchedule(@PathVariable String guid) {
-        UserSession session = getAuthenticatedSession(STUDY_DESIGNER, DEVELOPER);
-        
-        // when schedules are associated to studies, we’ll verify that a consented
-        // user is enrolled in a study that uses this timeline.
-        
-        return service.getTimelineForSchedule(session.getAppId(), guid);
-    }
-    
-    @PostMapping("/v5/schedules/{guid}")
-    public Schedule2 updateSchedule(@PathVariable String guid) {
-        UserSession session = getAuthenticatedSession(STUDY_DESIGNER, DEVELOPER);
-        
-        Schedule2 schedule = parseJson(Schedule2.class);
-        schedule.setGuid(guid);
-        schedule.setAppId(session.getAppId());
-        
-        Schedule2 existing = service.getSchedule(schedule.getAppId(), schedule.getGuid());
-        
-        CAN_EDIT_SCHEDULES.checkAndThrow(ORG_ID, existing.getOwnerId());
-        
-        return service.updateSchedule(existing, schedule);
-    }
-    
-    @PostMapping("/v5/schedules/{guid}/publish")
-    public StatusMessage publishSchedule(@PathVariable String guid) {
-        UserSession session = getAuthenticatedSession(STUDY_DESIGNER, DEVELOPER);
-        
-        service.publishSchedule(session.getAppId(), guid);
-        
-        return PUBLISHED_MSG;
+        return service.getTimelineForSchedule(session.getAppId(), study.getScheduleGuid());
     }
     
     @DeleteMapping("/v5/schedules/{guid}")

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyController.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -38,11 +37,8 @@ import org.sagebionetworks.bridge.models.VersionHolder;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.files.FileMetadata;
 import org.sagebionetworks.bridge.models.files.FileRevision;
-import org.sagebionetworks.bridge.models.schedules2.Schedule2;
-import org.sagebionetworks.bridge.models.schedules2.timelines.Timeline;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.services.FileService;
-import org.sagebionetworks.bridge.services.Schedule2Service;
 import org.sagebionetworks.bridge.services.StudyService;
 
 @CrossOrigin
@@ -55,8 +51,6 @@ public class StudyController extends BaseController {
     
     private FileService fileService;
 
-    private Schedule2Service scheduleService;
-
     @Autowired
     final void setStudyService(StudyService studyService) {
         this.service = studyService;
@@ -65,11 +59,6 @@ public class StudyController extends BaseController {
     @Autowired
     final void setFileService(FileService fileService) {
         this.fileService = fileService;
-    }
-    
-    @Autowired
-    final void setScheduleService(Schedule2Service scheduleService) {
-        this.scheduleService = scheduleService;
     }
     
     @GetMapping(path = {"/v5/studies", "/v3/substudies"})
@@ -238,44 +227,5 @@ public class StudyController extends BaseController {
         UserSession session = getAdministrativeSession();
        
         return service.transitionToWithdrawn(session.getAppId(), studyId);
-    }
-    
-    @GetMapping("/v5/studies/{studyId}/schedule")
-    public Schedule2 getSchedule(@PathVariable String studyId) {
-        UserSession session = getAuthenticatedSession(STUDY_DESIGNER, DEVELOPER);
-        
-        Study study = service.getStudy(session.getAppId(), studyId, true);
-        CAN_READ_STUDIES.checkAndThrow(STUDY_ID, studyId);
-        
-        return scheduleService.getScheduleForStudy(session.getAppId(), study);
-    }
-    
-    @PostMapping("/v5/studies/{studyId}/schedule")
-    public ResponseEntity<Schedule2> createOrUpdateSchedule(@PathVariable String studyId) {
-        UserSession session = getAuthenticatedSession(STUDY_DESIGNER, DEVELOPER);
-        
-        Schedule2 schedule = parseJson(Schedule2.class);
-        schedule.setAppId(session.getAppId());
-        
-        Study study = service.getStudy(session.getAppId(), studyId, true);
-        CAN_UPDATE_STUDIES.checkAndThrow(STUDY_ID, studyId);
-        
-        int status = (study.getScheduleGuid() == null) ? 201: 200;
-        Schedule2 retValue = scheduleService.createOrUpdateStudySchedule(study, schedule);
-        
-        return ResponseEntity.status(status).body(retValue);
-    }
-
-    @GetMapping("/v5/studies/{studyId}/timeline")
-    public Timeline getTimeline(@PathVariable String studyId) {
-        UserSession session = getAdministrativeSession();
-        
-        Study study = service.getStudy(session.getAppId(), studyId, true);
-        CAN_READ_STUDIES.checkAndThrow(STUDY_ID, studyId);
-        
-        if (study.getScheduleGuid() == null) {
-            throw new EntityNotFoundException(Schedule2.class);
-        }
-        return scheduleService.getTimelineForSchedule(session.getAppId(), study.getScheduleGuid());
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/Schedule2ServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/Schedule2ServiceTest.java
@@ -17,7 +17,6 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.TestUtils.getClientData;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventUpdateType.MUTABLE;
 import static org.sagebionetworks.bridge.models.studies.StudyPhase.DESIGN;
-import static org.sagebionetworks.bridge.models.studies.StudyPhase.RECRUITMENT;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -63,7 +62,6 @@ import org.sagebionetworks.bridge.models.schedules2.TimeWindow;
 import org.sagebionetworks.bridge.models.schedules2.timelines.Timeline;
 import org.sagebionetworks.bridge.models.schedules2.timelines.TimelineMetadata;
 import org.sagebionetworks.bridge.models.studies.Study;
-import org.sagebionetworks.bridge.models.studies.StudyPhase;
 
 public class Schedule2ServiceTest extends Mockito {
     
@@ -852,19 +850,6 @@ public class Schedule2ServiceTest extends Mockito {
         assertSame(retValue, results);
         
         verify(mockDao).getAssessmentsForSessionInstance(GUID);
-    }
-    
-    @Test(expectedExceptions = BadRequestException.class)
-    public void createOrUpdateStudySchedule_studyPhaseWrong() {
-        App app = App.create();
-        when(mockAppService.getApp(TEST_APP_ID)).thenReturn(app);
-        
-        Study study = Study.create();
-        study.setPhase(RECRUITMENT);
-        
-        Schedule2 schedule = new Schedule2();
-        
-        service.createOrUpdateStudySchedule(study, schedule);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/Schedule2ControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/Schedule2ControllerTest.java
@@ -1,29 +1,23 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
-import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.RequestContext.NULL_INSTANCE;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
-import static org.sagebionetworks.bridge.Roles.STUDY_COORDINATOR;
 import static org.sagebionetworks.bridge.Roles.STUDY_DESIGNER;
-import static org.sagebionetworks.bridge.TestConstants.GUID;
+import static org.sagebionetworks.bridge.TestConstants.SCHEDULE_GUID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
-import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
-import static org.sagebionetworks.bridge.TestUtils.assertCreate;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertCrossOrigin;
 import static org.sagebionetworks.bridge.TestUtils.assertDelete;
 import static org.sagebionetworks.bridge.TestUtils.assertGet;
 import static org.sagebionetworks.bridge.TestUtils.assertPost;
-import static org.sagebionetworks.bridge.TestUtils.mockRequestBody;
+import static org.sagebionetworks.bridge.models.studies.StudyPhase.DESIGN;
+import static org.sagebionetworks.bridge.models.studies.StudyPhase.RECRUITMENT;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertSame;
-
-import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import org.mockito.ArgumentCaptor;
@@ -33,22 +27,30 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
+import org.springframework.http.ResponseEntity;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.RequestContext;
-import org.sagebionetworks.bridge.models.PagedResourceList;
+import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.exceptions.BadRequestException;
+import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.StatusMessage;
-import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.schedules2.Schedule2;
+import org.sagebionetworks.bridge.models.schedules2.timelines.Timeline;
+import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.services.Schedule2Service;
+import org.sagebionetworks.bridge.services.StudyService;
 
 public class Schedule2ControllerTest extends Mockito {
     
     @Mock
     Schedule2Service mockService;
+    
+    @Mock
+    StudyService mockStudyService;
     
     @Mock
     HttpServletRequest mockRequest;
@@ -88,177 +90,144 @@ public class Schedule2ControllerTest extends Mockito {
     @Test
     public void verifyAnnotations() throws Exception {
         assertCrossOrigin(Schedule2Controller.class);
-        assertGet(Schedule2Controller.class, "getSchedules");
         assertGet(Schedule2Controller.class, "getSchedule");
-        assertCreate(Schedule2Controller.class, "createSchedule");
-        assertPost(Schedule2Controller.class, "updateSchedule");
-        assertPost(Schedule2Controller.class, "publishSchedule");
+        assertPost(Schedule2Controller.class, "createOrUpdateSchedule");
+        assertGet(Schedule2Controller.class, "getTimeline");
         assertDelete(Schedule2Controller.class, "deleteSchedule");
-    }
-    
-    private void permitAsDeveloper() {
-        RequestContext.set(new RequestContext.Builder()
-                .withCallerRoles(ImmutableSet.of(DEVELOPER))
-                .build());
-        session.setParticipant(new StudyParticipant.Builder()
-                .withRoles(ImmutableSet.of(DEVELOPER)).build());
-    }
-    
-    private void permitAsStudyCoordinator() {
-        RequestContext.set(new RequestContext.Builder()
-                .withCallerOrgMembership(TEST_ORG_ID)
-                .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR))
-                .build());
-        session.setParticipant(new StudyParticipant.Builder()
-                .withOrgMembership(TEST_ORG_ID)
-                .withRoles(ImmutableSet.of(STUDY_COORDINATOR)).build());
-    }
-    
-    @Test
-    public void getSchedulesForDeveloper() {
-        permitAsDeveloper();
-        
-        List<Schedule2> list = ImmutableList.of(new Schedule2(), new Schedule2());
-        PagedResourceList<Schedule2> page = new PagedResourceList<>(list, 10, true);
-        
-        when(mockService.getSchedules(any(), anyInt(), anyInt(), anyBoolean())).thenReturn(page);
-        
-        PagedResourceList<Schedule2> retValue = controller.getSchedules("100", "50", "true");
-        assertEquals(retValue, page);
-        
-        verify(mockService).getSchedules(TEST_APP_ID, 100, 50, true);
-    }
-    
-    @Test
-    public void getSchedulesForStudyCoordinator() {
-        permitAsStudyCoordinator();
-        
-        List<Schedule2> list = ImmutableList.of(new Schedule2(), new Schedule2());
-        PagedResourceList<Schedule2> page = new PagedResourceList<>(list, 10, true);
-        when(mockService.getSchedulesForOrganization(any(), any(), anyInt(), anyInt(), anyBoolean())).thenReturn(page);
-        
-        PagedResourceList<Schedule2> retValue = controller.getSchedules("100", "50", "true");
-        assertEquals(retValue, page);
-        
-        verify(mockService).getSchedulesForOrganization(TEST_APP_ID, TEST_ORG_ID, 100, 50, true);
-    }
-    
-    @Test
-    public void getSchedulesDefaultsValuesForDeveloper() {
-        permitAsDeveloper();
-        
-        List<Schedule2> list = ImmutableList.of(new Schedule2(), new Schedule2());
-        PagedResourceList<Schedule2> page = new PagedResourceList<>(list, 10, true);
-        when(mockService.getSchedules(any(), anyInt(), anyInt(), anyBoolean())).thenReturn(page);
-        
-        PagedResourceList<Schedule2> retValue = controller.getSchedules(null, null, null);
-        assertSame(retValue, page);
-        
-        verify(mockService).getSchedules(TEST_APP_ID, 0, API_DEFAULT_PAGE_SIZE, false);
-    }
-    
-    @Test
-    public void getSchedulesDefaultsValuesForStudyCoordinator() {
-        permitAsStudyCoordinator();
-        
-        List<Schedule2> list = ImmutableList.of(new Schedule2(), new Schedule2());
-        PagedResourceList<Schedule2> page = new PagedResourceList<>(list, 10, true);
-        when(mockService.getSchedulesForOrganization(any(), any(), anyInt(), anyInt(), anyBoolean())).thenReturn(page);
-
-        PagedResourceList<Schedule2> retValue = controller.getSchedules(null, null, null);
-        assertSame(retValue, page);
-        
-        verify(mockService).getSchedulesForOrganization(
-                TEST_APP_ID, TEST_ORG_ID, 0, API_DEFAULT_PAGE_SIZE, false);
-    }
-    
-    @Test
-    public void getSchedulesWithMultipleRolesBehavesAsDeveloper() {
-        RequestContext.set(new RequestContext.Builder()
-                .withCallerOrgMembership(TEST_ORG_ID)
-                .withCallerRoles(ImmutableSet.of(DEVELOPER, STUDY_COORDINATOR))
-                .build());
-        session.setParticipant(new StudyParticipant.Builder()
-                .withRoles(ImmutableSet.of(DEVELOPER, STUDY_COORDINATOR))
-                .build());
-        
-        // This caller will be treated as a developer
-        controller.getSchedules(null, null, null);
-        
-        verify(mockService).getSchedules(TEST_APP_ID, 0, API_DEFAULT_PAGE_SIZE, false);
-    }
-    
-    @Test
-    public void createSchedule() throws Exception {
-        Schedule2 schedule = new Schedule2();
-        mockRequestBody(mockRequest, schedule);
-        
-        Schedule2 created = new Schedule2();
-        created.setGuid(GUID);
-        when(mockService.createSchedule(any())).thenReturn(created);
-        
-        Schedule2 retValue = controller.createSchedule();
-        assertEquals(retValue.getGuid(), GUID);
-        
-        verify(mockService).createSchedule(scheduleCaptor.capture());
-        assertEquals(scheduleCaptor.getValue().getAppId(), TEST_APP_ID);
-    }
-    
-    @Test
-    public void getSchedule() {
-        Schedule2 schedule = new Schedule2();
-        when(mockService.getSchedule(TEST_APP_ID, GUID)).thenReturn(schedule);
-        
-        Schedule2 retValue = controller.getSchedule(GUID);
-        assertEquals(retValue, schedule);
-        
-        verify(mockService).getSchedule(TEST_APP_ID, GUID);
-    }
-    
-    @Test
-    public void updateSchedule() throws Exception {
-        RequestContext.set(new RequestContext.Builder()
-                .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
-
-        Schedule2 existing = new Schedule2();
-        existing.setVersion(100L);
-        when(mockService.updateSchedule(any(), any())).thenReturn(existing);
-        
-        when(mockService.getSchedule(TEST_APP_ID, GUID)).thenReturn(existing);
-        
-        Schedule2 schedule = new Schedule2();
-        mockRequestBody(mockRequest, schedule);
-        
-        Schedule2 retValue = controller.updateSchedule(GUID);
-        assertEquals(retValue, existing);
-        
-        verify(mockService).updateSchedule(eq(existing), scheduleCaptor.capture());
-        
-        Schedule2 persisted = scheduleCaptor.getValue();
-        assertEquals(persisted.getGuid(), GUID);
-        assertEquals(persisted.getAppId(), TEST_APP_ID);
-    }
-    
-    @Test
-    public void publishSchedule() {
-        StatusMessage retValue = controller.publishSchedule(GUID);
-        assertSame(retValue, Schedule2Controller.PUBLISHED_MSG);
-        
-        verify(mockService).publishSchedule(TEST_APP_ID, GUID);
     }
     
     @Test
     public void deleteSchedule() {
-        StatusMessage retValue = controller.deleteSchedule(GUID);
-        assertSame(retValue, Schedule2Controller.DELETED_MSG);
+        doReturn(session).when(controller).getAuthenticatedSession(ADMIN);
         
-        verify(mockService).deleteSchedulePermanently(TEST_APP_ID, GUID);
+        StatusMessage retValue = controller.deleteSchedule(SCHEDULE_GUID);
+        assertEquals(retValue, Schedule2Controller.DELETED_MSG);
+        
+        verify(mockService).deleteSchedulePermanently(TEST_APP_ID, SCHEDULE_GUID);
     }
     
     @Test
-    public void getTimelineForSchedule() { 
-        controller.getTimelineForSchedule(GUID);
-        verify(mockService).getTimelineForSchedule(TEST_APP_ID, GUID);
+    public void getSchedule() {
+        RequestContext.set(new RequestContext.Builder()
+                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
+                .withCallerRoles(ImmutableSet.of(STUDY_DESIGNER))
+                .build());
+        doReturn(session).when(controller).getAuthenticatedSession(STUDY_DESIGNER, DEVELOPER);
+        
+        Study study = Study.create();
+        when(mockStudyService.getStudy(TEST_APP_ID, TEST_STUDY_ID, true)).thenReturn(study);
+        
+        Schedule2 schedule = new Schedule2();
+        when(mockService.getScheduleForStudy(TEST_APP_ID, study)).thenReturn(schedule);
+        
+        Schedule2 retValue = controller.getSchedule(TEST_STUDY_ID);
+        assertEquals(retValue, schedule);
     }
     
+    @Test
+    public void createOrUpdateSchedule_create() throws Exception {
+        RequestContext.set(new RequestContext.Builder()
+                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
+                .withCallerRoles(ImmutableSet.of(STUDY_DESIGNER))
+                .build());
+        doReturn(session).when(controller).getAuthenticatedSession(STUDY_DESIGNER, DEVELOPER);        
+
+        Study study = Study.create();
+        study.setPhase(DESIGN);
+        when(mockStudyService.getStudy(TEST_APP_ID, TEST_STUDY_ID, true)).thenReturn(study);
+        
+        Schedule2 schedule = new Schedule2();
+        schedule.setName("Test");
+        TestUtils.mockRequestBody(mockRequest, schedule);
+        
+        when(mockService.createOrUpdateStudySchedule(any(), any())).thenReturn(schedule);
+        
+        ResponseEntity<Schedule2> retValue = controller.createOrUpdateSchedule(TEST_STUDY_ID);
+        assertEquals(retValue.getBody().getName(), "Test");
+        assertEquals(retValue.getStatusCodeValue(), 201);
+        
+        verify(mockService).createOrUpdateStudySchedule(any(), scheduleCaptor.capture());
+        // This has been set from the session.
+        assertEquals(scheduleCaptor.getValue().getAppId(), TEST_APP_ID);
+    }
+    
+    @Test
+    public void createOrUpdateSchedule_update() throws Exception {
+        RequestContext.set(new RequestContext.Builder()
+                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
+                .withCallerRoles(ImmutableSet.of(STUDY_DESIGNER))
+                .build());
+        doReturn(session).when(controller).getAuthenticatedSession(STUDY_DESIGNER, DEVELOPER);        
+
+        Study study = Study.create();
+        study.setScheduleGuid(SCHEDULE_GUID);
+        study.setPhase(DESIGN);
+        when(mockStudyService.getStudy(TEST_APP_ID, TEST_STUDY_ID, true)).thenReturn(study);
+        
+        Schedule2 schedule = new Schedule2();
+        schedule.setName("Test");
+        TestUtils.mockRequestBody(mockRequest, schedule);
+        
+        when(mockService.createOrUpdateStudySchedule(any(), any())).thenReturn(schedule);
+        
+        ResponseEntity<Schedule2> retValue = controller.createOrUpdateSchedule(TEST_STUDY_ID);
+        assertEquals(retValue.getStatusCodeValue(), 200);
+    }
+    
+    @Test(expectedExceptions = BadRequestException.class,
+            expectedExceptionsMessageRegExp = ".*Study schedule cannot be changed.*")
+    public void createOrUpdateSchedule_studyInWrongPhase() throws Exception {
+        RequestContext.set(new RequestContext.Builder()
+                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
+                .withCallerRoles(ImmutableSet.of(STUDY_DESIGNER))
+                .build());
+        doReturn(session).when(controller).getAuthenticatedSession(STUDY_DESIGNER, DEVELOPER);        
+
+        Study study = Study.create();
+        study.setScheduleGuid(SCHEDULE_GUID);
+        study.setPhase(RECRUITMENT);
+        when(mockStudyService.getStudy(TEST_APP_ID, TEST_STUDY_ID, true)).thenReturn(study);
+        
+        Schedule2 schedule = new Schedule2();
+        schedule.setName("Test");
+        TestUtils.mockRequestBody(mockRequest, schedule);
+        
+        when(mockService.createOrUpdateStudySchedule(any(), any())).thenReturn(schedule);
+        
+        ResponseEntity<Schedule2> retValue = controller.createOrUpdateSchedule(TEST_STUDY_ID);
+        assertEquals(retValue.getStatusCodeValue(), 200);        
+    }
+    
+    @Test
+    public void getTimeline() {
+        Study study = Study.create();
+        study.setScheduleGuid(SCHEDULE_GUID);
+        when(mockStudyService.getStudy(TEST_APP_ID, TEST_STUDY_ID, true)).thenReturn(study);
+        
+        RequestContext.set(new RequestContext.Builder()
+                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
+                .withCallerRoles(ImmutableSet.of(STUDY_DESIGNER))
+                .build());
+        doReturn(session).when(controller).getAdministrativeSession();
+        
+        Timeline timeline = new Timeline.Builder().build();
+        when(mockService.getTimelineForSchedule(TEST_APP_ID, SCHEDULE_GUID)).thenReturn(timeline);
+        
+        Timeline retValue = controller.getTimeline(TEST_STUDY_ID);
+        assertEquals(retValue, timeline);
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void getTimeline_studyHasNoSchedule() {
+        Study study = Study.create();
+        when(mockStudyService.getStudy(TEST_APP_ID, TEST_STUDY_ID, true)).thenReturn(study);
+        
+        RequestContext.set(new RequestContext.Builder()
+                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
+                .withCallerRoles(ImmutableSet.of(STUDY_DESIGNER))
+                .build());
+        doReturn(session).when(controller).getAdministrativeSession();
+        
+        controller.getTimeline(TEST_STUDY_ID);
+    }    
 }


### PR DESCRIPTION
- be sure that study updates don't delete the link to a schedule (in essence, Study.scheduleGuid is read-only);
- delete a schedule when you delete a study permanently
- move the schedule methods from StudyController to Schedule2Controller, where they replace the original API