### PR TITLE
Use custom events as they are defined on studies for study-scoped event APIs (not app-scoped custom events)

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
@@ -6,6 +6,7 @@ import static java.lang.Integer.parseInt;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_READ_STUDY_ASSOCIATIONS;
 import static org.sagebionetworks.bridge.AuthEvaluatorField.ORG_ID;
 import static org.sagebionetworks.bridge.AuthEvaluatorField.STUDY_ID;
@@ -726,22 +727,24 @@ public class BridgeUtils {
      * confusing and discouraged).
      */
     public static String formatActivityEventId(Set<String> activityEventIds, String id) {
-        if (id != null) {
-            String lowerCased = id.toLowerCase();
-            if (lowerCased.startsWith("custom:")) {
+        if (isNotBlank(id)) {
+            boolean declaredCustom = id.toLowerCase().startsWith("custom:");
+            if (declaredCustom) {
                 id = id.substring(7);
+            }
+            if (!declaredCustom) {
+                try {
+                    String[] parts = id.split(":");
+                    ActivityEventObjectType.valueOf(parts[0].toUpperCase());
+                    return id;
+                } catch(IllegalArgumentException e) {
+                }
             }
             if (activityEventIds.contains(id)) {
                 return "custom:" + id;
             }
-            try {
-                String[] parts = id.split(":");
-                ActivityEventObjectType.valueOf(parts[0].toUpperCase());
-            } catch(IllegalArgumentException e) {
-                return null;
-            }
         }
-        return (id == null) ? null : id;
+        return null;
     }
     
     /**

--- a/src/main/java/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/studies/Study.java
@@ -6,12 +6,17 @@ import org.joda.time.LocalDate;
 import org.sagebionetworks.bridge.hibernate.HibernateStudy;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.BridgeEntity;
+import org.sagebionetworks.bridge.models.activities.ActivityEventUpdateType;
 import org.sagebionetworks.bridge.models.assessments.ColorScheme;
 
+import static java.util.stream.Collectors.toMap;
+
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -30,6 +35,12 @@ public interface Study extends BridgeEntity {
     
     public static Study create() {
         return new HibernateStudy();
+    }
+
+    @JsonIgnore
+    default Map<String, ActivityEventUpdateType> getCustomEventsMap() {
+        return getCustomEvents().stream().collect(
+            toMap(StudyCustomEvent::getEventId, StudyCustomEvent::getUpdateType));
     }
 
     String getIdentifier();

--- a/src/main/java/org/sagebionetworks/bridge/services/Schedule2Service.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/Schedule2Service.java
@@ -35,7 +35,6 @@ import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.PublishedEntityException;
 import org.sagebionetworks.bridge.models.PagedResourceList;
-import org.sagebionetworks.bridge.models.apps.App;
 import org.sagebionetworks.bridge.models.schedules2.HasGuid;
 import org.sagebionetworks.bridge.models.schedules2.Schedule2;
 import org.sagebionetworks.bridge.models.schedules2.Session;
@@ -55,18 +54,11 @@ import org.sagebionetworks.bridge.validators.Validate;
 @Component
 public class Schedule2Service {
     
-    private AppService appService;
-    
     private OrganizationService organizationService;
     
     private StudyService studyService;
     
     private Schedule2Dao dao;
-    
-    @Autowired
-    final void setAppService(AppService appService) {
-        this.appService = appService;
-    }
     
     @Autowired
     final void setOrganizationService(OrganizationService organizationService) {
@@ -192,9 +184,9 @@ public class Schedule2Service {
             // with keys and all, to the update API, and at some point we have to check that
             // we're talking about the same object.
             schedule.setGuid(study.getScheduleGuid());
-            return updateSchedule(existing, schedule);
+            return updateSchedule(study, existing, schedule);
         }
-        schedule = createSchedule(schedule);
+        schedule = createSchedule(study, schedule);
         study.setScheduleGuid(schedule.getGuid());
         studyService.updateStudy(schedule.getAppId(), study);
         return schedule;
@@ -204,7 +196,7 @@ public class Schedule2Service {
      * Create a schedule. The schedule will be owned by the caller’s organization (unless
      * an admin or superadmin is making the call and they have specified an organization).
      */
-    public Schedule2 createSchedule(Schedule2 schedule) {
+    public Schedule2 createSchedule(Study study, Schedule2 schedule) {
         checkNotNull(schedule);
         
         CAN_CREATE_SCHEDULES.checkAndThrow();
@@ -212,7 +204,6 @@ public class Schedule2Service {
         String callerAppId = RequestContext.get().getCallerAppId();
         String callerOrgMembership = RequestContext.get().getCallerOrgMembership();
         boolean isAdmin = RequestContext.get().isInRole(ADMIN, SUPERADMIN);
-        App app = appService.getApp(callerAppId);
         
         DateTime createdOn = getCreatedOn();
         schedule.setAppId(callerAppId);
@@ -236,7 +227,7 @@ public class Schedule2Service {
         if (schedule.getOwnerId() != null) {
             organizationService.getOrganization(schedule.getAppId(), schedule.getOwnerId());    
         }
-        preValidationCleanup(app, schedule, (hasGuid) -> hasGuid.setGuid(generateGuid()));
+        preValidationCleanup(study, schedule, (hasGuid) -> hasGuid.setGuid(generateGuid()));
         
         Validate.entityThrowingException(INSTANCE, schedule);
         
@@ -247,7 +238,7 @@ public class Schedule2Service {
      * Update a schedule. Will throw an exception once the schedule is published. Ownership
      * cannot be changed once a schedule is created.
      */
-    public Schedule2 updateSchedule(Schedule2 existing, Schedule2 schedule) {
+    public Schedule2 updateSchedule(Study study, Schedule2 existing, Schedule2 schedule) {
         checkNotNull(existing);
         checkNotNull(schedule);
         
@@ -258,13 +249,11 @@ public class Schedule2Service {
             throw new PublishedEntityException(existing);
         }
         
-        App app = appService.getApp(existing.getAppId());
-        
         schedule.setCreatedOn(existing.getCreatedOn());
         schedule.setModifiedOn(getModifiedOn());
         schedule.setOwnerId(existing.getOwnerId());
         schedule.setPublished(false);
-        preValidationCleanup(app, schedule, (hasGuid) -> {
+        preValidationCleanup(study, schedule, (hasGuid) -> {
           if (hasGuid.getGuid() == null) {
               hasGuid.setGuid(generateGuid());
           }
@@ -353,11 +342,11 @@ public class Schedule2Service {
      * Set GUIDs on objects that don't have them; clean up event keys or set
      * them to null if they're not valid, so they will fail validation.
      */
-    void preValidationCleanup(App app, Schedule2 schedule, Consumer<HasGuid> consumer) {
-        checkNotNull(app);
+    void preValidationCleanup(Study study, Schedule2 schedule, Consumer<HasGuid> consumer) {
+        checkNotNull(study);
         checkNotNull(schedule);
         
-        Set<String> keys = app.getCustomEvents().keySet();
+        Set<String> keys = study.getCustomEventsMap().keySet();
         for (Session session : schedule.getSessions()) {
             consumer.accept(session);
             session.setSchedule(schedule);

--- a/src/main/java/org/sagebionetworks/bridge/services/StudyActivityEventService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyActivityEventService.java
@@ -7,12 +7,10 @@ import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.NEGATIVE_OFFSET_ERROR;
 import static org.sagebionetworks.bridge.BridgeConstants.PAGE_SIZE_ERROR;
 import static org.sagebionetworks.bridge.BridgeUtils.formatActivityEventId;
-import static org.sagebionetworks.bridge.BridgeUtils.parseAutoEventValue;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.CREATED_ON;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.CUSTOM;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.ENROLLMENT;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.INSTALL_LINK_SENT;
-import static org.sagebionetworks.bridge.models.activities.ActivityEventUpdateType.MUTABLE;
 import static org.sagebionetworks.bridge.validators.StudyActivityEventValidator.DELETE_INSTANCE;
 import static org.sagebionetworks.bridge.validators.Validate.INVALID_EVENT_ID;
 import static org.sagebionetworks.bridge.validators.StudyActivityEventValidator.CREATE_INSTANCE;
@@ -22,10 +20,8 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 import org.joda.time.DateTime;
-import org.joda.time.Period;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -34,12 +30,10 @@ import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.ResourceList;
-import org.sagebionetworks.bridge.models.Tuple;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.activities.StudyActivityEvent;
 import org.sagebionetworks.bridge.models.activities.StudyActivityEventRequest;
-import org.sagebionetworks.bridge.models.apps.App;
 import org.sagebionetworks.bridge.models.studies.Enrollment;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.validators.Validate;

--- a/src/main/java/org/sagebionetworks/bridge/validators/StudyValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/StudyValidator.java
@@ -14,7 +14,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.sagebionetworks.bridge.models.accounts.Phone;
-import org.sagebionetworks.bridge.models.activities.ActivityEventObjectType;
 import org.sagebionetworks.bridge.models.studies.Contact;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.studies.StudyCustomEvent;

--- a/src/main/java/org/sagebionetworks/bridge/validators/StudyValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/StudyValidator.java
@@ -92,11 +92,6 @@ public class StudyValidator implements Validator {
             } else {
                 uniqueIds.add(customEvent.getEventId());    
             }
-            for (ActivityEventObjectType type : ActivityEventObjectType.class.getEnumConstants()) {
-                if (type.name().equalsIgnoreCase(customEvent.getEventId())) {
-                    errors.rejectValue("eventId", "is a reserved system event ID");
-                }
-            }
             if (customEvent.getUpdateType() == null) {
                 errors.rejectValue("updateType", CANNOT_BE_NULL);
             }

--- a/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -1043,6 +1043,24 @@ public class BridgeUtilsTest {
     }
     
     @Test
+    public void formatActivityEventIdCustomShadowsSystemEvent() {
+        String retValue = BridgeUtils.formatActivityEventId(ImmutableSet.of("timeline_retrieved"), "custom:timeline_retrieved");
+        assertEquals(retValue, "custom:timeline_retrieved");
+    }
+    
+    @Test
+    public void formatActivityEventIdSystemEventCorrectlyInterpreted() {
+        String retValue = BridgeUtils.formatActivityEventId(ImmutableSet.of("timeline_retrieved"), "timeline_retrieved");
+        assertEquals(retValue, "timeline_retrieved");
+    }
+    
+    @Test
+    public void formatActivityEventIdDeclaredCustomIsNotPresent() {
+        String retValue = BridgeUtils.formatActivityEventId(ImmutableSet.of("foo"), "custom:bar");
+        assertNull(retValue);
+    }
+    
+    @Test
     public void selectByLang_selectPreferredLanguage() {
         List<Label> items = ImmutableList.of(LABEL_ES, LABEL_JA);
         

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateStudyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateStudyTest.java
@@ -7,6 +7,7 @@ import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.activities.ActivityEventUpdateType;
 import org.sagebionetworks.bridge.models.studies.Contact;
 import org.sagebionetworks.bridge.models.studies.SignInType;
 import org.sagebionetworks.bridge.models.studies.Study;
@@ -15,6 +16,7 @@ import org.sagebionetworks.bridge.models.studies.StudyCustomEvent;
 import static org.sagebionetworks.bridge.TestConstants.COLOR_SCHEME;
 import static org.sagebionetworks.bridge.TestConstants.GUID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
+import static org.sagebionetworks.bridge.models.activities.ActivityEventUpdateType.FUTURE_ONLY;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventUpdateType.IMMUTABLE;
 import static org.sagebionetworks.bridge.models.studies.IrbDecisionType.APPROVED;
 import static org.sagebionetworks.bridge.models.studies.SignInType.EMAIL_MESSAGE;
@@ -27,6 +29,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -44,6 +47,18 @@ public class HibernateStudyTest {
     private static final LocalDate EXPIRES_ON = DateTime.now().plusDays(10).toLocalDate();
     private static final List<SignInType> TYPES = ImmutableList.of(EMAIL_MESSAGE, EMAIL_PASSWORD);
     
+    @Test
+    public void getCustomEventsMap() {
+        Study study = Study.create();
+        study.setCustomEvents(ImmutableList.of(new StudyCustomEvent("event1", IMMUTABLE), 
+                new StudyCustomEvent("event2", FUTURE_ONLY)));
+        
+        Map<String, ActivityEventUpdateType> map = study.getCustomEventsMap();
+        assertEquals(map.size(), 2);
+        assertEquals(map.get("event1"), IMMUTABLE);
+        assertEquals(map.get("event2"), FUTURE_ONLY);
+    }
+
     @Test
     public void shortConstructor() {
         HibernateStudy study = new HibernateStudy("name", "identifier", "appId", 

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateStudyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateStudyTest.java
@@ -57,6 +57,10 @@ public class HibernateStudyTest {
         assertEquals(map.size(), 2);
         assertEquals(map.get("event1"), IMMUTABLE);
         assertEquals(map.get("event2"), FUTURE_ONLY);
+        
+        study = Study.create();
+        map = study.getCustomEventsMap();
+        assertTrue(map.isEmpty());
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/Schedule2ServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/Schedule2ServiceTest.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Optional;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import org.joda.time.LocalTime;
@@ -62,6 +61,7 @@ import org.sagebionetworks.bridge.models.schedules2.TimeWindow;
 import org.sagebionetworks.bridge.models.schedules2.timelines.Timeline;
 import org.sagebionetworks.bridge.models.schedules2.timelines.TimelineMetadata;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.studies.StudyCustomEvent;
 
 public class Schedule2ServiceTest extends Mockito {
     
@@ -337,7 +337,9 @@ public class Schedule2ServiceTest extends Mockito {
         schedule.setPublished(true);
         schedule.setVersion(1L);
         
-        Schedule2 retValue = service.createSchedule(schedule);
+        Study study = Study.create();
+        
+        Schedule2 retValue = service.createSchedule(study, schedule);
         assertEquals(retValue, schedule);
 
         verify(mockDao).createSchedule(scheduleCaptor.capture());
@@ -368,7 +370,9 @@ public class Schedule2ServiceTest extends Mockito {
         
         Schedule2 schedule = new Schedule2();
         
-        service.createSchedule(schedule);
+        Study study = Study.create();
+        
+        service.createSchedule(study, schedule);
     }
     
     @Test
@@ -391,7 +395,9 @@ public class Schedule2ServiceTest extends Mockito {
         schedule.setClientData(getClientData());
         schedule.setOwnerId("this-will-be-ignored");
         
-        service.createSchedule(schedule);        
+        Study study = Study.create();
+        
+        service.createSchedule(study, schedule);        
     }
     
     @Test(expectedExceptions = InvalidEntityException.class, 
@@ -413,7 +419,9 @@ public class Schedule2ServiceTest extends Mockito {
         schedule.setDuration(Period.parse("P2W"));
         schedule.setClientData(getClientData());
         
-        service.createSchedule(schedule);        
+        Study study = Study.create();
+        
+        service.createSchedule(study, schedule);        
     }
 
     @Test(expectedExceptions = InvalidEntityException.class)
@@ -435,7 +443,9 @@ public class Schedule2ServiceTest extends Mockito {
         schedule.setClientData(getClientData());
         schedule.setOwnerId(TEST_ORG_ID);
         
-        service.createSchedule(schedule);        
+        Study study = Study.create();
+        
+        service.createSchedule(study, schedule);        
     }
     
     @Test
@@ -468,10 +478,9 @@ public class Schedule2ServiceTest extends Mockito {
         
         when(mockDao.updateSchedule(any())).thenReturn(existing);
         
-        App app = App.create();
-        when(mockAppService.getApp(TEST_APP_ID)).thenReturn(app);
+        Study study = Study.create();
         
-        Schedule2 retValue = service.updateSchedule(existing, schedule);
+        Schedule2 retValue = service.updateSchedule(study, existing, schedule);
         assertEquals(retValue, existing);
         
         verify(mockDao).updateSchedule(scheduleCaptor.capture());
@@ -500,7 +509,9 @@ public class Schedule2ServiceTest extends Mockito {
         
         when(mockDao.updateSchedule(any())).thenReturn(existing);
         
-        service.updateSchedule(existing, schedule);
+        Study study = Study.create();
+        
+        service.updateSchedule(study, existing, schedule);
     }
     
     @Test(expectedExceptions = InvalidEntityException.class)
@@ -508,13 +519,12 @@ public class Schedule2ServiceTest extends Mockito {
         Schedule2 existing = new Schedule2();
         existing.setAppId(TEST_APP_ID);
         
-        App app = App.create();
-        when(mockAppService.getApp(TEST_APP_ID)).thenReturn(app);
+        Study study = Study.create();
 
         Schedule2 schedule = new Schedule2();
         schedule.setAppId(TEST_APP_ID);
         schedule.setGuid(GUID);
-        service.updateSchedule(existing, schedule);
+        service.updateSchedule(study, existing, schedule);
     }
    
     @Test(expectedExceptions = EntityNotFoundException.class,
@@ -546,7 +556,9 @@ public class Schedule2ServiceTest extends Mockito {
         
         when(mockDao.updateSchedule(any())).thenReturn(existing);
         
-        service.updateSchedule(existing, schedule);
+        Study study = Study.create();
+        
+        service.updateSchedule(study, existing, schedule);
     }
     
     @Test
@@ -699,7 +711,9 @@ public class Schedule2ServiceTest extends Mockito {
         
         Schedule2 schedule = Schedule2Test.createValidSchedule();
         
-        service.createSchedule(schedule);
+        Study study = Study.create();
+        
+        service.createSchedule(study, schedule);
         
         assertEquals(schedule.getGuid(), "otherGuid");
         schedule.getSessions().forEach(session -> {
@@ -746,7 +760,9 @@ public class Schedule2ServiceTest extends Mockito {
 
         doReturn("otherGuid").when(service).generateGuid();
         
-        service.updateSchedule(existing, schedule);
+        Study study = Study.create();
+        
+        service.updateSchedule(study, existing, schedule);
         
         assertEquals(schedule.getSessions().get(0).getGuid(), SESSION_GUID_1);
         assertEquals(schedule.getSessions().get(0).getTimeWindows().get(0).getGuid(), SESSION_WINDOW_GUID_1);
@@ -762,24 +778,22 @@ public class Schedule2ServiceTest extends Mockito {
                 .withCallerAppId(TEST_APP_ID)
                 .build());
 
-        App app = App.create();
-        app.setCustomEvents(ImmutableMap.of("event1", MUTABLE));
-        when(mockAppService.getApp(TEST_APP_ID)).thenReturn(app);
+        Study study = Study.create();
+        study.setCustomEvents(ImmutableList.of(new StudyCustomEvent("event1", MUTABLE)));
         
         Schedule2 schedule = Schedule2Test.createValidSchedule();
         // This will fail validation unless the app declares it as a custom event
         schedule.getSessions().get(0).setStartEventId("event1");
         
-        service.createSchedule(schedule);
+        service.createSchedule(study, schedule);
         
         assertEquals(schedule.getSessions().get(0).getStartEventId(), "custom:event1");
     }
     
     @Test
     public void cleanupEventIdsOnUpdate() {
-        App app = App.create();
-        app.setCustomEvents(ImmutableMap.of("event1", MUTABLE));
-        when(mockAppService.getApp(TEST_APP_ID)).thenReturn(app);
+        Study study = Study.create();
+        study.setCustomEvents(ImmutableList.of(new StudyCustomEvent("event1", MUTABLE)));
         
         Schedule2 schedule = Schedule2Test.createValidSchedule();
         schedule.setDeleted(false);
@@ -789,7 +803,7 @@ public class Schedule2ServiceTest extends Mockito {
         
         Schedule2 existing = Schedule2Test.createValidSchedule();
         existing.setPublished(false);
-        service.updateSchedule(existing, schedule);
+        service.updateSchedule(study, existing, schedule);
         
         assertEquals(schedule.getSessions().get(0).getStartEventId(), "custom:event1");
     }

--- a/src/test/java/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -232,15 +232,6 @@ public class StudyValidatorTest {
     }
     
     @Test
-    public void customEvents_eventIdReservedKeyword() {
-        StudyCustomEvent event = new StudyCustomEvent("Timeline_Retrieved", MUTABLE);
-        study = createStudy();
-        study.getCustomEvents().add(event);
-        
-        assertValidatorMessage(INSTANCE, study, CUSTOM_EVENTS_FIELD + "[0].eventId", "is a reserved system event ID");
-    }
-    
-    @Test
     public void customEvents_updateTypeNull() {
         StudyCustomEvent event = new StudyCustomEvent("event", null);
         study = createStudy();


### PR DESCRIPTION
BRIDGE-3044. Automatic custom events will be replaced with some kind of support for study bursts, that will probably generate these events dynamically without persisting them.