### PR TITLE
Multiple events assignable to each schedule session.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/Session.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/Session.java
@@ -42,7 +42,6 @@ public class Session implements BridgeEntity, HasGuid {
     @JsonIgnore
     private int position;
     private String name;
-    private String startEventId;
     @Convert(converter = PeriodToStringConverter.class)
     @Column(name = "delayPeriod")
     private Period delay;
@@ -73,6 +72,13 @@ public class Session implements BridgeEntity, HasGuid {
     @Column(columnDefinition = "text", name = "labels", nullable = true)
     @Convert(converter = LabelListConverter.class)
     private List<Label> labels;
+    
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "SessionStartEvents", 
+        joinColumns = @JoinColumn(name = "sessionGuid", nullable = false))
+    @OrderColumn(name = "position")
+    @Column(name = "eventId")
+    private List<String> startEventIds;
 
     public Schedule2 getSchedule() {
         return schedule;
@@ -107,11 +113,14 @@ public class Session implements BridgeEntity, HasGuid {
     public void setLabels(List<Label> labels) {
         this.labels = labels;
     }
-    public String getStartEventId() {
-        return startEventId;
+    public List<String> getStartEventIds() {
+        if (startEventIds == null) {
+            startEventIds = new ArrayList<>();
+        }
+        return startEventIds;
     }
-    public void setStartEventId(String startEventId) {
-        this.startEventId = startEventId;
+    public void setStartEventIds(List<String> startEventIds) {
+        this.startEventIds = startEventIds;
     }
     public Period getDelay() {
         return delay;

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/ScheduledSession.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/ScheduledSession.java
@@ -104,7 +104,7 @@ public class ScheduledSession {
         private Session session;
         private TimeWindow window;
         
-        public Builder copy() { 
+        public Builder copyWithoutAssessments() { 
             ScheduledSession.Builder builder = new ScheduledSession.Builder();
             builder.instanceGuid = instanceGuid;
             builder.startEventId = startEventId;

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/ScheduledSession.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/ScheduledSession.java
@@ -18,6 +18,7 @@ import org.sagebionetworks.bridge.models.schedules2.TimeWindow;
 public class ScheduledSession {
 
     private String instanceGuid;
+    private String startEventId;
     private int startDay;
     private int endDay;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
@@ -32,21 +33,20 @@ public class ScheduledSession {
     private final Session session;
     private final TimeWindow window;
     
-    private ScheduledSession(String instanceGuid, int startDay, int endDay, LocalTime startTime, Period delayTime,
-            Period expiration, Boolean persistent, List<ScheduledAssessment> assessments, Session session,
-            TimeWindow window) {
-        this.instanceGuid = instanceGuid;
-        this.startDay = startDay;
-        this.endDay = endDay;
-        this.delayTime = delayTime;
-        this.startTime = startTime;
-        this.expiration = expiration;
-        this.session = session;
-        this.window = window;
-        if (TRUE.equals(persistent)) {
+    private ScheduledSession(ScheduledSession.Builder builder) {
+        this.instanceGuid = builder.instanceGuid;
+        this.startEventId = builder.startEventId;
+        this.startDay = builder.startDay;
+        this.endDay = builder.endDay;
+        this.delayTime = builder.delayTime;
+        this.startTime = builder.startTime;
+        this.expiration = builder.expiration;
+        this.session = builder.session;
+        this.window = builder.window;
+        if (TRUE.equals(builder.persistent)) {
             this.persistent = TRUE;    
         }
-        this.assessments = assessments;
+        this.assessments = builder.assessments;
     }
     
     public String getRefGuid() {
@@ -54,6 +54,9 @@ public class ScheduledSession {
     }
     public String getInstanceGuid() {
         return instanceGuid;
+    }
+    public String getStartEventId() {
+        return startEventId;
     }
     public int getStartDay() {
         return startDay;
@@ -90,6 +93,7 @@ public class ScheduledSession {
     
     public static class Builder {
         private String instanceGuid;
+        private String startEventId;
         private int startDay;
         private int endDay;
         private Period delayTime;
@@ -99,9 +103,28 @@ public class ScheduledSession {
         private List<ScheduledAssessment> assessments = new ArrayList<>();
         private Session session;
         private TimeWindow window;
-
+        
+        public Builder copy() { 
+            ScheduledSession.Builder builder = new ScheduledSession.Builder();
+            builder.instanceGuid = instanceGuid;
+            builder.startEventId = startEventId;
+            builder.startDay = startDay;
+            builder.endDay= endDay;
+            builder.delayTime = delayTime;
+            builder.startTime = startTime;
+            builder.expiration = expiration;
+            builder.persistent = persistent;
+            builder.assessments = new ArrayList<>();
+            builder.session = session;
+            builder.window = window;
+            return builder;
+        }
         public Builder withInstanceGuid(String instanceGuid) {
             this.instanceGuid = instanceGuid;
+            return this;
+        }
+        public Builder withStartEventId(String startEventId) {
+            this.startEventId = startEventId;
             return this;
         }
         public Builder withStartDay(int startDay) {
@@ -144,8 +167,7 @@ public class ScheduledSession {
             checkNotNull(session);
             checkNotNull(window);
             
-            return new ScheduledSession(instanceGuid, startDay, endDay, startTime, 
-                    delayTime, expiration, persistent, assessments, session, window);
+            return new ScheduledSession(this);
         }
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Scheduler.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Scheduler.java
@@ -131,8 +131,9 @@ public class Scheduler {
             // all of them.
             
             for (String oneEventId : session.getStartEventIds()) {
-                // Clear the state that is set in each iteration
-                scheduledSession = scheduledSession.copy();
+                // Clear the assessments that are calculated in each iteration. Other fields calculated 
+                // in this loop will be reset.
+                scheduledSession = scheduledSession.copyWithoutAssessments();
 
                 // The position of an assessment in a session is used to differentiate repeated assessments
                 // in a single session. Assessments can be configured differently, but if they are exactly
@@ -170,7 +171,8 @@ public class Scheduler {
      * from a Schedule. It should look like a GUID and not a compound identifier, as client developers 
      * have (in the past) parsed compound identifiers, and we want to discourage this.
      */
-    String generateSessionInstanceGuid(String scheduleGuid, String sessionGuid, String eventId, int startDay, String windowGuid) {
+    String generateSessionInstanceGuid(String scheduleGuid, String sessionGuid, String eventId, int startDay,
+            String windowGuid) {
         Hasher hc = HASHER.newHasher();
         hc.putString(scheduleGuid, Charsets.UTF_8);
         hc.putString(":", Charsets.UTF_8);

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Scheduler.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Scheduler.java
@@ -127,31 +127,38 @@ public class Scheduler {
             if (startDay == 0 && delay != null && delay.toStandardDays().getDays() == 0) {
                 scheduledSession.withDelayTime(delay);
             }
+            // Add a scheduled session with a different GUID for each event, and one SessionInfo object for
+            // all of them.
             
-            // scheduleGuid:sessionGuid:startDay:windowGuid
-            String sessionInstanceGuid = generateSessionInstanceGuid(
-                    schedule.getGuid(), session.getGuid(), startDay, window.getGuid());
-            scheduledSession.withInstanceGuid(sessionInstanceGuid);
+            for (String oneEventId : session.getStartEventIds()) {
+                // Clear the state that is set in each iteration
+                scheduledSession = scheduledSession.copy();
 
-            // The position of an assessment in a session is used to differentiate repeated assessments
-            // in a single session. Assessments can be configured differently, but if they are exactly
-            // the same, we still generate a unique ID.
-            ids.clear();
-            for (AssessmentReference ref : session.getAssessments()) {
-                ids.add(ref.getGuid());
+                // The position of an assessment in a session is used to differentiate repeated assessments
+                // in a single session. Assessments can be configured differently, but if they are exactly
+                // the same, we still generate a unique ID.
+                ids.clear();
+                for (AssessmentReference ref : session.getAssessments()) {
+                    ids.add(ref.getGuid());
+                    
+                    // scheduleGuid:sessionGuid:startDay:windowGuid:assessmentGuid:asmtOccurrentCount
+                    String asmtInstanceGuid = generateAssessmentInstanceGuid(schedule.getGuid(), session.getGuid(),
+                            oneEventId, startDay, window.getGuid(), ref.getGuid(), ids.count(ref.getGuid()));
+                 
+                    AssessmentInfo asmtInfo = AssessmentInfo.create(ref);
+                    builder.withAssessmentInfo(asmtInfo);
+                    
+                    ScheduledAssessment schAsmt = new ScheduledAssessment(asmtInfo.getKey(), asmtInstanceGuid, ref);
+                    scheduledSession.withScheduledAssessment(schAsmt);
+                }
                 
-                // scheduleGuid:sessionGuid:startDay:windowGuid:assessmentGuid:asmtOccurrentCount
-                String asmtInstanceGuid = generateAssessmentInstanceGuid(schedule.getGuid(), session.getGuid(),
-                        startDay, window.getGuid(), ref.getGuid(), ids.count(ref.getGuid()));
-             
-                AssessmentInfo asmtInfo = AssessmentInfo.create(ref);
-                builder.withAssessmentInfo(asmtInfo);
-                
-                ScheduledAssessment schAsmt = new ScheduledAssessment(asmtInfo.getKey(), asmtInstanceGuid, ref);
-                scheduledSession.withScheduledAssessment(schAsmt);
+                // scheduleGuid:sessionGuid:eventId:startDay:windowGuid
+                String sessionInstanceGuid = generateSessionInstanceGuid(
+                        schedule.getGuid(), session.getGuid(), oneEventId, startDay, window.getGuid());
+                scheduledSession.withInstanceGuid(sessionInstanceGuid);
+                scheduledSession.withStartEventId(oneEventId);
+                builder.withScheduledSession(scheduledSession.build());
             }
-            builder.withScheduledSession(scheduledSession.build());
-      
             startDay += intervalInDays;
             occurrenceCount++;
             
@@ -163,11 +170,13 @@ public class Scheduler {
      * from a Schedule. It should look like a GUID and not a compound identifier, as client developers 
      * have (in the past) parsed compound identifiers, and we want to discourage this.
      */
-    String generateSessionInstanceGuid(String scheduleGuid, String sessionGuid, int startDay, String windowGuid) {
+    String generateSessionInstanceGuid(String scheduleGuid, String sessionGuid, String eventId, int startDay, String windowGuid) {
         Hasher hc = HASHER.newHasher();
         hc.putString(scheduleGuid, Charsets.UTF_8);
         hc.putString(":", Charsets.UTF_8);
         hc.putString(sessionGuid, Charsets.UTF_8);
+        hc.putString(":", Charsets.UTF_8);
+        hc.putString(eventId, Charsets.UTF_8);
         hc.putString(":", Charsets.UTF_8);
         hc.putInt(startDay);
         hc.putString(":", Charsets.UTF_8);
@@ -180,12 +189,14 @@ public class Scheduler {
      * from a Schedule. It should look like a GUID and not a compound identifier, as client developers 
      * have (in the past) parsed compound identifiers, and we want to discourage this.
      */
-    String generateAssessmentInstanceGuid(String scheduleGuid, String sessionGuid, 
+    String generateAssessmentInstanceGuid(String scheduleGuid, String sessionGuid, String eventId, 
             int startDay, String windowGuid, String assessmentGuid, int assessmentOccurrence) {
         Hasher hc = HASHER.newHasher();
         hc.putString(scheduleGuid, Charsets.UTF_8);
         hc.putString(":", Charsets.UTF_8);
         hc.putString(sessionGuid, Charsets.UTF_8);
+        hc.putString(":", Charsets.UTF_8);
+        hc.putString(eventId, Charsets.UTF_8);
         hc.putString(":", Charsets.UTF_8);
         hc.putInt(startDay);
         hc.putString(":", Charsets.UTF_8);

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionInfo.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionInfo.java
@@ -16,7 +16,6 @@ public class SessionInfo {
 
     private String guid;
     private String label;
-    private String startEventId;
     private PerformanceOrder performanceOrder;
     private Integer minutesToComplete;
     private List<String> timeWindowGuids;
@@ -36,7 +35,6 @@ public class SessionInfo {
         SessionInfo info = new SessionInfo();
         info.guid = session.getGuid();
         info.label = label.getValue();
-        info.startEventId = session.getStartEventId();
         info.performanceOrder = session.getPerformanceOrder();
         info.timeWindowGuids = session.getTimeWindows().stream()
                 .map(TimeWindow::getGuid)
@@ -55,9 +53,6 @@ public class SessionInfo {
     }
     public String getLabel() {
         return label;
-    }
-    public String getStartEventId() {
-        return startEventId;
     }
     public PerformanceOrder getPerformanceOrder() {
         return performanceOrder;

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Timeline.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Timeline.java
@@ -109,7 +109,7 @@ public class Timeline {
             sessionMeta.setSchedulePublished(schedule.isPublished());
             sessionMeta.setSessionInstanceGuid(schSession.getInstanceGuid());
             sessionMeta.setSessionGuid(schSession.getSession().getGuid());
-            sessionMeta.setSessionStartEventId(schSession.getSession().getStartEventId());
+            sessionMeta.setSessionStartEventId(schSession.getStartEventId());
             sessionMeta.setSessionInstanceStartDay(schSession.getStartDay());
             sessionMeta.setSessionInstanceEndDay(schSession.getEndDay());
             sessionMeta.setTimeWindowGuid(schSession.getTimeWindow().getGuid());

--- a/src/main/java/org/sagebionetworks/bridge/services/Schedule2Service.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/Schedule2Service.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.services;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.stream.Collectors.toList;
 import static org.sagebionetworks.bridge.AuthEvaluatorField.ORG_ID;
 import static org.sagebionetworks.bridge.AuthEvaluatorField.STUDY_ID;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_CREATE_SCHEDULES;
@@ -22,7 +23,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
@@ -367,7 +367,7 @@ public class Schedule2Service {
             }
             List<String> events = session.getStartEventIds().stream()
                 .map(s -> formatActivityEventId(keys, s))
-                .collect(Collectors.toList());
+                .collect(toList());
             session.setStartEventIds(events);
         }
     }

--- a/src/main/java/org/sagebionetworks/bridge/services/Schedule2Service.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/Schedule2Service.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
@@ -364,7 +365,10 @@ public class Schedule2Service {
             for (TimeWindow window : session.getTimeWindows()) {
                 consumer.accept(window);
             }
-            session.setStartEventId(formatActivityEventId(keys, session.getStartEventId()));
+            List<String> events = session.getStartEventIds().stream()
+                .map(s -> formatActivityEventId(keys, s))
+                .collect(Collectors.toList());
+            session.setStartEventIds(events);
         }
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/validators/SessionValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/SessionValidator.java
@@ -2,9 +2,9 @@ package org.sagebionetworks.bridge.validators;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
+import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_EMPTY;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL_OR_EMPTY;
-import static org.sagebionetworks.bridge.validators.Validate.INVALID_EVENT_ID;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.periodInMinutes;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.validateColorScheme;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.validateFixedLengthLongPeriod;
@@ -44,7 +44,7 @@ public class SessionValidator implements Validator {
     static final String OCCURRENCES_FIELD = "occurrences";
     static final String OFFSET_FIELD = "offset";
     static final String PERFORMANCE_ORDER_FIELD = "performanceOrder";
-    static final String START_EVENT_ID_FIELD = "startEventId";
+    static final String START_EVENT_IDS_FIELD = "startEventIds";
     static final String START_TIME_FIELD = "startTime";
     static final String TIME_WINDOWS_FIELD = "timeWindows";
     
@@ -93,8 +93,19 @@ public class SessionValidator implements Validator {
         if (isBlank(session.getName())) {
             errors.rejectValue(NAME_FIELD, CANNOT_BE_BLANK);
         }
-        if (isBlank(session.getStartEventId())) {
-            errors.rejectValue(START_EVENT_ID_FIELD, INVALID_EVENT_ID);
+        if (session.getStartEventIds().isEmpty()) {
+            errors.rejectValue(START_EVENT_IDS_FIELD, CANNOT_BE_EMPTY);
+        } else {
+            for (int i=0; i < session.getStartEventIds().size(); i++) {
+                String oneEventId = session.getStartEventIds().get(i);
+                errors.pushNestedPath(START_EVENT_IDS_FIELD + '[' + i + ']');
+                if (oneEventId == null) {
+                    errors.rejectValue("", CANNOT_BE_NULL);
+                } else if (isBlank(oneEventId)) {
+                    errors.rejectValue("", CANNOT_BE_BLANK);
+                }                
+                errors.popNestedPath();
+            }
         }
         if (session.getOccurrences() != null && session.getOccurrences() < 1) {
             errors.rejectValue(OCCURRENCES_FIELD, LESS_THAN_ONE_ERROR);

--- a/src/main/resources/db/changelog/changelog.sql
+++ b/src/main/resources/db/changelog/changelog.sql
@@ -652,6 +652,7 @@ CREATE TABLE `StudyActivityEvents` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 -- changeset bridge:34
+
 ALTER TABLE `Sessions`
 DROP COLUMN `reminderPeriod`,
 DROP COLUMN `messages`,
@@ -770,3 +771,16 @@ CREATE TABLE `StudyCustomEvents` (
 
 ALTER TABLE `Accounts`
 ADD COLUMN `clientTimeZone` varchar(64) DEFAULT NULL;
+
+-- changeset bridge:44
+
+ALTER TABLE `Sessions`
+DROP COLUMN `startEventId`;
+
+CREATE TABLE `SessionStartEvents` (
+  `sessionGuid` varchar(60) NOT NULL,
+  `position` int(10) signed,
+  `eventId` varchar(255),
+  PRIMARY KEY (`sessionGuid`, `position`),
+  CONSTRAINT `SessionEvents-Session-Constraint` FOREIGN KEY (`sessionGuid`) REFERENCES `Sessions` (`guid`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2DaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2DaoTest.java
@@ -229,8 +229,8 @@ public class HibernateSchedule2DaoTest extends Mockito {
         verify(mockSession).save(schedule);
         verify(mockQuery).setParameter(HibernateSchedule2Dao.SCHEDULE_GUID, TestConstants.SCHEDULE_GUID);
         verify(mockQuery).executeUpdate();
-        verify(mockSession, times(2)).flush();
-        verify(mockSession, times(2)).clear();
+        verify(mockSession, times(4)).flush();
+        verify(mockSession, times(4)).clear();
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/SessionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/SessionTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import org.joda.time.LocalTime;
 import org.joda.time.Period;
 import org.testng.annotations.Test;
+import org.testng.collections.Lists;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.Label;
@@ -32,7 +33,7 @@ public class SessionTest {
         session.setLabels(LABELS);
         session.setName("Do weekly survey");
         session.setGuid(SESSION_GUID_1);
-        session.setStartEventId("activities_retrieved");
+        session.setStartEventIds(Lists.newArrayList("custom:activities_retrieved", "custom:timeline_retrieved"));
         session.setDelay(Period.parse("P1W"));
         session.setOccurrences(19);
         session.setInterval(Period.parse("P7D"));
@@ -86,7 +87,8 @@ public class SessionTest {
         assertEquals(node.size(), 12);
         assertEquals(node.get("guid").textValue(), SESSION_GUID_1);
         assertEquals(node.get("name").textValue(), "Do weekly survey");
-        assertEquals(node.get("startEventId").textValue(), "activities_retrieved");
+        assertEquals(node.get("startEventIds").get(0).textValue(), "custom:activities_retrieved");
+        assertEquals(node.get("startEventIds").get(1).textValue(), "custom:timeline_retrieved");
         assertEquals(node.get("delay").textValue(), "P1W");
         assertEquals(node.get("occurrences").intValue(), 19);
         assertEquals(node.get("interval").textValue(), "P7D");
@@ -143,7 +145,8 @@ public class SessionTest {
         
         assertEquals(deser.getGuid(), SESSION_GUID_1);
         assertEquals(deser.getName(), "Do weekly survey");
-        assertEquals(deser.getStartEventId(), "activities_retrieved");
+        assertEquals(deser.getStartEventIds().get(0), "custom:activities_retrieved");
+        assertEquals(deser.getStartEventIds().get(1), "custom:timeline_retrieved");
         assertEquals(deser.getDelay(), Period.parse("P1W"));
         assertEquals(deser.getOccurrences(), Integer.valueOf(19));
         assertEquals(deser.getInterval(), Period.parse("P7D"));

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/ScheduledSessionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/ScheduledSessionTest.java
@@ -77,4 +77,44 @@ public class ScheduledSessionTest extends Mockito {
         assertEquals(node.get("assessments").size(), 0);
         assertEquals(node.get("type").textValue(), "ScheduledSession");
     }
+    
+    @Test
+    public void copyWithoutAssessments() {
+        Session session = new Session();
+        session.setGuid(SESSION_GUID_1);
+        session.setStartEventIds(ImmutableList.of("enrollment"));
+        
+        TimeWindow window = new TimeWindow();
+        window.setGuid(SESSION_WINDOW_GUID_1);
+        
+        ScheduledAssessment asmt = new ScheduledAssessment("ref", "instanceGuid", null);
+        
+        ScheduledSession.Builder builder = new ScheduledSession.Builder()
+                .withSession(session)
+                .withTimeWindow(window)
+                .withStartEventId("timeline_retrieved")
+                .withInstanceGuid("instanceGuid")
+                .withStartDay(10)
+                .withEndDay(13)
+                .withDelayTime(Period.parse("PT3H"))
+                .withStartTime(LocalTime.parse("17:00"))
+                .withExpiration(Period.parse("PT30M"))
+                .withPersistent(true)
+                .withScheduledAssessment(asmt);
+        
+        ScheduledSession.Builder copy = builder.copyWithoutAssessments();
+        ScheduledSession schSession = copy.build();
+        
+        assertEquals(schSession.getRefGuid(), SESSION_GUID_1);
+        assertEquals(schSession.getInstanceGuid(), "instanceGuid");
+        assertEquals(schSession.getStartEventId(), "timeline_retrieved");
+        assertEquals(schSession.getStartDay(), 10);
+        assertEquals(schSession.getEndDay(), 13);
+        assertEquals(schSession.getStartTime(), LocalTime.parse("17:00"));
+        assertEquals(schSession.getDelayTime(), Period.parse("PT3H"));
+        assertEquals(schSession.getExpiration(), Period.parse("PT30M"));
+        assertEquals(schSession.getTimeWindow(), window);
+        assertTrue(schSession.isPersistent());
+        assertTrue(schSession.getAssessments().isEmpty());
+    }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/ScheduledSessionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/ScheduledSessionTest.java
@@ -6,6 +6,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
 
 import org.joda.time.LocalTime;
 import org.joda.time.Period;
@@ -22,7 +23,7 @@ public class ScheduledSessionTest extends Mockito {
     public void canSerialize() throws Exception {
         Session session = new Session();
         session.setGuid(SESSION_GUID_1);
-        session.setStartEventId("enrollment");
+        session.setStartEventIds(ImmutableList.of("enrollment"));
         
         TimeWindow window = new TimeWindow();
         window.setGuid(SESSION_WINDOW_GUID_1);
@@ -32,6 +33,7 @@ public class ScheduledSessionTest extends Mockito {
         ScheduledSession schSession = new ScheduledSession.Builder()
                 .withSession(session)
                 .withTimeWindow(window)
+                .withStartEventId("timeline_retrieved")
                 .withInstanceGuid("instanceGuid")
                 .withStartDay(10)
                 .withEndDay(13)
@@ -45,6 +47,7 @@ public class ScheduledSessionTest extends Mockito {
         JsonNode node = BridgeObjectMapper.get().valueToTree(schSession);
         assertEquals(node.get("refGuid").textValue(), SESSION_GUID_1);
         assertEquals(node.get("instanceGuid").textValue(), "instanceGuid");
+        assertEquals(node.get("startEventId").textValue(), "timeline_retrieved");
         assertEquals(node.get("startDay").intValue(), 10);
         assertEquals(node.get("endDay").intValue(), 13);
         assertEquals(node.get("startTime").textValue(), "17:00");

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/SchedulerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/SchedulerTest.java
@@ -242,7 +242,6 @@ public class SchedulerTest extends Mockito {
         SessionInfo sessionInfo = timeline.getSessions().get(0);
         assertEquals(sessionInfo.getGuid(), SESSION_GUID_3);
         assertEquals(sessionInfo.getLabel(), "One Time Session");
-        assertEquals(sessionInfo.getStartEventId(), "enrollment");
         assertEquals(sessionInfo.getMinutesToComplete(), Integer.valueOf(10));
         
         AssessmentInfo asmtInfo = timeline.getAssessments().get(0);
@@ -698,15 +697,15 @@ public class SchedulerTest extends Mockito {
     
     @Test
     public void sessionInstanceGuidsAreCorrect() {
-        String guid = INSTANCE.generateSessionInstanceGuid(SCHEDULE_GUID, SESSION_GUID_1, 3, SESSION_WINDOW_GUID_1);
+        String guid = INSTANCE.generateSessionInstanceGuid(SCHEDULE_GUID, SESSION_GUID_1, "event1", 3, SESSION_WINDOW_GUID_1);
         // window guid, window occurrence, session guid, schedule guid
-        assertEquals(guid, "U9uuOEIBzUaw0sKTjgaT-Q");
+        assertEquals(guid, "ciAzJI2y3i2RpN0EF9WOZQ");
     }
     
     @Test
     public void assessmentInstanceGuidsAreCorrect() {
-        String guid = INSTANCE.generateAssessmentInstanceGuid(SCHEDULE_GUID, SESSION_GUID_1, 3, SESSION_WINDOW_GUID_1, ASSESSMENT_1_GUID, 5);
-        assertEquals(guid, "BREAKQLN7ZoBo1lF0iLT4Q");
+        String guid = INSTANCE.generateAssessmentInstanceGuid(SCHEDULE_GUID, SESSION_GUID_1, "oneEventId", 3, SESSION_WINDOW_GUID_1, ASSESSMENT_1_GUID, 5);
+        assertEquals(guid, "3eK3LXt_5NAc7qhVjhN-ag");
     }
     
     @Test
@@ -1014,7 +1013,7 @@ public class SchedulerTest extends Mockito {
         
         Session session = new Session();
         session.setGuid(SESSION_GUID_1);
-        session.setStartEventId("enrollment");
+        session.setStartEventIds(ImmutableList.of("enrollment"));
         session.setName("Sessions repeating weekly");
         session.setInterval(Period.parse("P1W"));
         session.setPerformanceOrder(SEQUENTIAL);
@@ -1035,6 +1034,54 @@ public class SchedulerTest extends Mockito {
         assertEquals(timeline.getSchedule().size(), 3);
     }
     
+    @Test
+    public void multipleEventIdsGenerateSeparateScheduledSessions() {
+        TimeWindow timeWindow = new TimeWindow();
+        timeWindow.setGuid(SESSION_WINDOW_GUID_1);
+        timeWindow.setStartTime(LocalTime.parse("08:00"));
+        timeWindow.setExpiration(Period.parse("PT12H"));
+        
+        Session session = new Session();
+        session.setGuid(SESSION_GUID_1);
+        session.setStartEventIds(ImmutableList.of("enrollment", "timeline_retrieved"));
+        session.setName("Sessions repeating weekly");
+        session.setInterval(Period.parse("P1D"));
+        session.setPerformanceOrder(SEQUENTIAL);
+        session.setTimeWindows(ImmutableList.of(timeWindow));
+        session.setAssessments(ImmutableList.of(createAssessmentRef("AAA")));
+        
+        Schedule2 schedule = new Schedule2();
+        schedule.setGuid(SCHEDULE_GUID);
+        schedule.setDuration(Period.parse("P2D"));
+        schedule.setSessions(ImmutableList.of(session));
+        
+        Timeline timeline = INSTANCE.calculateTimeline(schedule);
+        assertEquals(timeline.getSchedule().size(), 4);
+        
+        assertEquals(timeline.getSchedule().stream()
+                .map(ScheduledSession::getInstanceGuid).collect(toSet()).size(), 4);
+        
+        ScheduledSession schSession = timeline.getSchedule().get(0); 
+        assertEquals(schSession.getStartEventId(), "enrollment");
+        assertEquals(schSession.getRefGuid(), SESSION_GUID_1);
+        assertEquals(schSession.getStartDay(), 0);
+        
+        schSession = timeline.getSchedule().get(1); 
+        assertEquals(schSession.getStartEventId(), "timeline_retrieved");
+        assertEquals(schSession.getRefGuid(), SESSION_GUID_1);
+        assertEquals(schSession.getStartDay(), 0);
+
+        schSession = timeline.getSchedule().get(2); 
+        assertEquals(schSession.getStartEventId(), "enrollment");
+        assertEquals(schSession.getRefGuid(), SESSION_GUID_1);
+        assertEquals(schSession.getStartDay(), 1);
+        
+        schSession = timeline.getSchedule().get(3); 
+        assertEquals(schSession.getStartEventId(), "timeline_retrieved");
+        assertEquals(schSession.getRefGuid(), SESSION_GUID_1);
+        assertEquals(schSession.getStartDay(), 1);
+    }
+    
     /* ============================================================ */
     /* Many helper methods to construct a schedule */
     /* ============================================================ */
@@ -1052,7 +1099,7 @@ public class SchedulerTest extends Mockito {
     
     private Session createOneTimeSession(String delay) {
         Session session = new Session();
-        session.setStartEventId("enrollment");
+        session.setStartEventIds(ImmutableList.of("enrollment"));
         if (delay != null) {
             session.setDelay(Period.parse(delay));    
         }
@@ -1074,7 +1121,7 @@ public class SchedulerTest extends Mockito {
             interval = "P1D";
         }
         Session session = new Session();
-        session.setStartEventId("enrollment");
+        session.setStartEventIds(ImmutableList.of("enrollment"));
         if (delay != null) {
             session.setDelay(Period.parse(delay));    
         }
@@ -1134,7 +1181,7 @@ public class SchedulerTest extends Mockito {
         Session session1 = new Session();
         session1.setGuid(SESSION_GUID_1);
         session1.setName("Session #1");
-        session1.setStartEventId("activities_retrieved");
+        session1.setStartEventIds(ImmutableList.of("activities_retrieved"));
         session1.setInterval(Period.parse("P2D"));
         session1.setPerformanceOrder(SEQUENTIAL);
         session1.setAssessments(ImmutableList.of(createAssessmentRef(ASSESSMENT_1_GUID)));
@@ -1148,7 +1195,7 @@ public class SchedulerTest extends Mockito {
         Session session2 = new Session();
         session2.setGuid(SESSION_GUID_2);
         session2.setName("Session #2");
-        session2.setStartEventId("enrollment");
+        session2.setStartEventIds(ImmutableList.of("enrollment"));
         session2.setInterval(Period.parse("P1D"));
         session2.setPerformanceOrder(SEQUENTIAL);
         session2.setAssessments(ImmutableList.of(createAssessmentRef(ASSESSMENT_2_GUID)));

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionInfoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionInfoTest.java
@@ -25,7 +25,6 @@ public class SessionInfoTest extends Mockito {
         JsonNode node = BridgeObjectMapper.get().valueToTree(info);
         assertEquals(node.get("guid").textValue(), SESSION_GUID_1);
         assertEquals(node.get("label").textValue(), "English");
-        assertEquals(node.get("startEventId").textValue(), "activities_retrieved");
         assertEquals(node.get("performanceOrder").textValue(), "randomized");
         assertEquals(node.get("timeWindowGuids").get(0).textValue(), SESSION_WINDOW_GUID_1);
         // this combines the minutes from two assessments, correctly

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineTest.java
@@ -42,10 +42,10 @@ public class TimelineTest extends Mockito {
         assertNull(node.get("lang"));
         assertEquals(node.get("type").textValue(), "Timeline");
         
-        assertEquals(node.get("schedule").size(), 2);
+        assertEquals(node.get("schedule").size(), 4);
         JsonNode schNode = node.get("schedule").get(0);
         assertEquals(schNode.get("refGuid").textValue(), SESSION_GUID_1);
-        assertEquals(schNode.get("instanceGuid").textValue(), "XPnIpiOvQMtil857X_ihUw");
+        assertEquals(schNode.get("instanceGuid").textValue(), "4SzmL5rYNrw8BWmZKlDOLw");
         assertEquals(schNode.get("startDay").intValue(), 7);
         assertEquals(schNode.get("endDay").intValue(), 7);
         assertEquals(schNode.get("startTime").textValue(), "08:00");
@@ -53,7 +53,7 @@ public class TimelineTest extends Mockito {
         assertTrue(schNode.get("persistent").booleanValue());
         assertEquals(schNode.get("type").textValue(), "ScheduledSession");
         assertEquals(schNode.get("assessments")
-                .get(0).get("instanceGuid").textValue(), "Lfi4aAVfepdR5DFKYv_H1Q");
+                .get(0).get("instanceGuid").textValue(), "oX_MhjkxENiafHwVILSEpQ");
         assertEquals(schNode.get("assessments")
                 .get(0).get("refKey").textValue(), "646f8c04646f8c04");
         assertEquals(schNode.get("assessments")
@@ -73,7 +73,6 @@ public class TimelineTest extends Mockito {
         JsonNode sessNode = node.get("sessions").get(0);
         assertEquals(sessNode.get("guid").textValue(), SESSION_GUID_1);
         assertEquals(sessNode.get("label").textValue(), "English");
-        assertEquals(sessNode.get("startEventId").textValue(), "activities_retrieved");
         assertEquals(sessNode.get("performanceOrder").textValue(), "randomized");
         assertEquals(sessNode.get("minutesToComplete").intValue(), 8);
         
@@ -96,7 +95,7 @@ public class TimelineTest extends Mockito {
         
         // This is the session record
         TimelineMetadata meta1 = metadata.get(0);
-        String sessionInstanceGuid = "XPnIpiOvQMtil857X_ihUw";
+        String sessionInstanceGuid = "4SzmL5rYNrw8BWmZKlDOLw";
         assertEquals(meta1.getGuid(), sessionInstanceGuid);
         assertNull(meta1.getAssessmentInstanceGuid());
         assertNull(meta1.getAssessmentGuid());
@@ -104,7 +103,7 @@ public class TimelineTest extends Mockito {
         assertNull(meta1.getAssessmentRevision());
         assertEquals(meta1.getSessionInstanceGuid(), sessionInstanceGuid);
         assertEquals(meta1.getSessionGuid(), SESSION_GUID_1);
-        assertEquals(meta1.getSessionStartEventId(), "activities_retrieved");
+        assertEquals(meta1.getSessionStartEventId(), "custom:activities_retrieved");
         assertEquals(meta1.getSessionInstanceStartDay(), Integer.valueOf(7));
         assertEquals(meta1.getSessionInstanceEndDay(), Integer.valueOf(7));
         assertEquals(meta1.getTimeWindowGuid(), SESSION_WINDOW_GUID_1);
@@ -115,7 +114,7 @@ public class TimelineTest extends Mockito {
 
         // This is the assessment #1 record
         TimelineMetadata meta2 = metadata.get(1);
-        String asmtInstanceGuid = "Lfi4aAVfepdR5DFKYv_H1Q";
+        String asmtInstanceGuid = "oX_MhjkxENiafHwVILSEpQ";
         assertEquals(meta2.getGuid(), asmtInstanceGuid);
         assertEquals(meta2.getAssessmentInstanceGuid(), asmtInstanceGuid);
         assertEquals(meta2.getAssessmentGuid(), ASSESSMENT_1_GUID);
@@ -123,7 +122,7 @@ public class TimelineTest extends Mockito {
         assertEquals(meta2.getAssessmentRevision(), Integer.valueOf(100));
         assertEquals(meta2.getSessionInstanceGuid(), sessionInstanceGuid);
         assertEquals(meta2.getSessionGuid(), SESSION_GUID_1);
-        assertEquals(meta2.getSessionStartEventId(), "activities_retrieved");
+        assertEquals(meta2.getSessionStartEventId(), "custom:activities_retrieved");
         assertEquals(meta2.getSessionInstanceStartDay(), Integer.valueOf(7));
         assertEquals(meta2.getSessionInstanceEndDay(), Integer.valueOf(7));
         assertEquals(meta2.getTimeWindowGuid(), SESSION_WINDOW_GUID_1);
@@ -134,7 +133,7 @@ public class TimelineTest extends Mockito {
         
         // This is the assessment #2 record
         TimelineMetadata meta3 = metadata.get(2);
-        asmtInstanceGuid = "5R2D-mJ434Lj0xyym66x-g";
+        asmtInstanceGuid = "ppFjj6HsB-T0y6MVjejWNA";
         assertEquals(meta3.getGuid(), asmtInstanceGuid);
         assertEquals(meta3.getAssessmentInstanceGuid(), asmtInstanceGuid);
         assertEquals(meta3.getAssessmentGuid(), ASSESSMENT_2_GUID);
@@ -142,7 +141,7 @@ public class TimelineTest extends Mockito {
         assertEquals(meta3.getAssessmentRevision(), Integer.valueOf(200));
         assertEquals(meta3.getSessionInstanceGuid(), sessionInstanceGuid);
         assertEquals(meta3.getSessionGuid(), SESSION_GUID_1);
-        assertEquals(meta3.getSessionStartEventId(), "activities_retrieved");
+        assertEquals(meta3.getSessionStartEventId(), "custom:activities_retrieved");
         assertEquals(meta3.getSessionInstanceStartDay(), Integer.valueOf(7));
         assertEquals(meta3.getSessionInstanceEndDay(), Integer.valueOf(7));
         assertEquals(meta3.getTimeWindowGuid(), SESSION_WINDOW_GUID_1);
@@ -198,19 +197,19 @@ public class TimelineTest extends Mockito {
         
         Timeline timeline = Scheduler.INSTANCE.calculateTimeline(schedule);
         
-        // seven session each taking 8 minutes = 56 minutes;
-        assertEquals(timeline.getTotalMinutes(), 56);
+        // seven session with two events, each taking 8 minutes = 112 minutes;
+        assertEquals(timeline.getTotalMinutes(), 112);
         
         // each session has one notification, 7 notifications
-        assertEquals(timeline.getTotalNotifications(), 7);
+        assertEquals(timeline.getTotalNotifications(), 14);
         
         // Alter the schedule so the notification repeats every 2 days within the 
-        // time window of 7 days, so that is 1 notification + 3 from the 
-        // interval = 4 per window, or 28 total notifications.
+        // time window of 7 days, with 2 events triggering it, so that is 1 
+        // notification + 3 from the interval = 4 per window, or 56 total notifications.
         schedule.getSessions().get(0).getNotifications().get(0).setInterval(Period.parse("P2D"));
         schedule.getSessions().get(0).getTimeWindows().get(0).setExpiration(Period.parse("P6D"));
         timeline = Scheduler.INSTANCE.calculateTimeline(schedule);
         
-        assertEquals(timeline.getTotalNotifications(), 28);
+        assertEquals(timeline.getTotalNotifications(), 56);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/Schedule2ServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/Schedule2ServiceTest.java
@@ -768,11 +768,11 @@ public class Schedule2ServiceTest extends Mockito {
         
         Schedule2 schedule = Schedule2Test.createValidSchedule();
         // This will fail validation unless the app declares it as a custom event
-        schedule.getSessions().get(0).setStartEventId("event1");
+        schedule.getSessions().get(0).getStartEventIds().add(0, "event1");
         
         service.createSchedule(schedule);
         
-        assertEquals(schedule.getSessions().get(0).getStartEventId(), "custom:event1");
+        assertEquals(schedule.getSessions().get(0).getStartEventIds().get(0), "custom:event1");
     }
     
     @Test
@@ -785,13 +785,13 @@ public class Schedule2ServiceTest extends Mockito {
         schedule.setDeleted(false);
         schedule.setPublished(false);
         // This will fail validation unless the app declares it as a custom event
-        schedule.getSessions().get(0).setStartEventId("event1");
+        schedule.getSessions().get(0).getStartEventIds().set(0, "event1");
         
         Schedule2 existing = Schedule2Test.createValidSchedule();
         existing.setPublished(false);
         service.updateSchedule(existing, schedule);
         
-        assertEquals(schedule.getSessions().get(0).getStartEventId(), "custom:event1");
+        assertEquals(schedule.getSessions().get(0).getStartEventIds().get(0), "custom:event1");
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/validators/SessionValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/SessionValidatorTest.java
@@ -18,15 +18,15 @@ import static org.sagebionetworks.bridge.validators.SessionValidator.NAME_FIELD;
 import static org.sagebionetworks.bridge.validators.SessionValidator.NOTIFICATIONS_FIELD;
 import static org.sagebionetworks.bridge.validators.SessionValidator.OCCURRENCES_FIELD;
 import static org.sagebionetworks.bridge.validators.SessionValidator.PERFORMANCE_ORDER_FIELD;
-import static org.sagebionetworks.bridge.validators.SessionValidator.START_EVENT_ID_FIELD;
+import static org.sagebionetworks.bridge.validators.SessionValidator.START_EVENT_IDS_FIELD;
 import static org.sagebionetworks.bridge.validators.SessionValidator.TIME_WINDOWS_FIELD;
 import static org.sagebionetworks.bridge.validators.SessionValidator.START_TIME_COMPARATOR;
 import static org.sagebionetworks.bridge.validators.SessionValidator.WINDOW_OVERLAPS_ERROR;
 import static org.sagebionetworks.bridge.validators.SessionValidator.WINDOW_SHORTER_THAN_DAY_ERROR;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
+import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_EMPTY;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL_OR_EMPTY;
-import static org.sagebionetworks.bridge.validators.Validate.INVALID_EVENT_ID;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.DUPLICATE_LANG;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.WRONG_LONG_PERIOD;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.WRONG_PERIOD;
@@ -85,17 +85,31 @@ public class SessionValidatorTest extends Mockito {
     }
 
     @Test
-    public void startEventIdBlank() {
+    public void startEventIdsNull() {
         Session session = createValidSession();
-        session.setStartEventId("");
-        assertValidatorMessage(INSTANCE, session, START_EVENT_ID_FIELD, INVALID_EVENT_ID);
+        session.setStartEventIds(null);
+        assertValidatorMessage(INSTANCE, session, START_EVENT_IDS_FIELD, CANNOT_BE_EMPTY);
     }
     
     @Test
-    public void startEventIdNull() {
+    public void startEventIdsEmpty() {
         Session session = createValidSession();
-        session.setStartEventId(null);
-        assertValidatorMessage(INSTANCE, session, START_EVENT_ID_FIELD, INVALID_EVENT_ID);
+        session.setStartEventIds(ImmutableList.of());
+        assertValidatorMessage(INSTANCE, session, START_EVENT_IDS_FIELD, CANNOT_BE_EMPTY);
+    }
+    
+    @Test
+    public void startEventIdsMemberNull() {
+        Session session = createValidSession();
+        session.setStartEventIds(Lists.newArrayList((String)null));
+        assertValidatorMessage(INSTANCE, session, START_EVENT_IDS_FIELD + "[0]", CANNOT_BE_NULL);
+    }
+    
+    @Test
+    public void startEventIdsMemberEmpty() {
+        Session session = createValidSession();
+        session.setStartEventIds(Lists.newArrayList("\t"));
+        assertValidatorMessage(INSTANCE, session, START_EVENT_IDS_FIELD + "[0]", CANNOT_BE_BLANK);
     }
     
     @Test


### PR DESCRIPTION
BRIDGE-3059. In addition, the timeline structure changes so that the event ID for a specific session instance is in the ScheduledSession object, not the SessionInfo object.