### PR TITLE
Improvements to the performance of persisting timeline metadata records.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ target
 .classpath
 .project
 test-output/
+.settings
 dump.rdb
 /bin/
 

--- a/src/main/java/org/sagebionetworks/bridge/config/SpringConfig.java
+++ b/src/main/java/org/sagebionetworks/bridge/config/SpringConfig.java
@@ -571,7 +571,7 @@ public class SpringConfig {
         String url = config.get("hibernate.connection.url");
         // Append SSL props to URL
         boolean useSsl = Boolean.valueOf(config.get("hibernate.connection.useSSL"));
-        url += "?serverTimezone=UTC&requireSSL="+useSsl+"&useSSL="+useSsl+"&verifyServerCertificate="+useSsl;
+        url += "?rewriteBatchedStatements=true&serverTimezone=UTC&requireSSL="+useSsl+"&useSSL="+useSsl+"&verifyServerCertificate="+useSsl;
         
         return url;
     }

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2Dao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2Dao.java
@@ -147,8 +147,7 @@ public class HibernateSchedule2Dao implements Schedule2Dao {
 
             // Although orphanRemoval = true is set for the session collection, they do not
             // delete when removed. So we are manually finding the removed sessions and
-            // deleting
-            // them before persisting the new set.
+            // deleting them before persisting the new set.
             QueryBuilder builder = new QueryBuilder();
             builder.append(DELETE_SESSIONS, GUID, schedule.getGuid());
             if (!sessionGuids.isEmpty()) {
@@ -187,13 +186,10 @@ public class HibernateSchedule2Dao implements Schedule2Dao {
                         + " ms");
             }
 
-            // Hibernate’s session.save() does an insert and then an update operation on
-            // each record, so switching
-            // to JDBC to do an insert only, halves the time it takes to do this operation
-            // even without further batch
-            // optimizations. I was not able to determine why Hibernate is doing this (it’s
-            // not the most frequently
-            // cited culprit, an @Id generator, because we don’t use one).
+            // Hibernate’s session.save() does an insert and then an update operation on each record, so 
+            // switching to JDBC to do an insert only, halves the time it takes to do this operation
+            // even without further batch optimizations. I was not able to determine why Hibernate is doing 
+            // this (it’s not the most frequently cited culprit, an @Id generator, because we don’t use one).
             Stopwatch createMetadataStopwatch = Stopwatch.createStarted();
             session.doWork(persistRecordsInBatches(metadata));
             createMetadataStopwatch.stop();
@@ -206,11 +202,10 @@ public class HibernateSchedule2Dao implements Schedule2Dao {
     }
 
     /**
-     * For batch operations to work efficiently using the MySQL driver,
-     * rewriteBatchedStatements=true must be included in the connector string, auto
-     * commit must be off, and you must use the batch commit method. A batch size of
-     * 100 seems about optimal (values below lose performance but I cannot measure
-     * any benefit to having larger values).
+     * For batch operations to work efficiently using the MySQL driver, rewriteBatchedStatements=true 
+     * must be included in the connector string, auto commit must be off, and you must use the batch 
+     * commit method. A batch size of 100 seems about optimal (values below lose performance but I 
+     * cannot measure any benefit to having larger values).
      */
     protected Work persistRecordsInBatches(List<TimelineMetadata> metadata) {
         return (connection) -> {

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2Dao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2Dao.java
@@ -4,6 +4,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toSet;
 
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -15,6 +18,7 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import org.hibernate.jdbc.Work;
 import org.hibernate.query.NativeQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,7 +36,7 @@ import org.sagebionetworks.bridge.models.schedules2.timelines.TimelineMetadata;
 
 @Component
 public class HibernateSchedule2Dao implements Schedule2Dao {
-    private static final Logger LOG = LoggerFactory.getLogger(HibernateSchedule2Dao.class);
+	private static final Logger LOG = LoggerFactory.getLogger(HibernateSchedule2Dao.class);
 
     static final String SELECT_COUNT = "SELECT count(*) ";
     static final String GET_ALL_SCHEDULES = "FROM Schedule2 WHERE appId=:appId";
@@ -42,11 +46,14 @@ public class HibernateSchedule2Dao implements Schedule2Dao {
     static final String DELETE_ORPHANED_SESSIONS = "DELETE FROM Sessions where scheduleGuid = :guid AND guid NOT IN (:guids)";
     static final String AND_DELETED = "AND deleted = 0";
     static final String AND_NOT_IN_GUIDS = "AND guid NOT IN (:guids)";
+    static final String INSERT = "INSERT INTO TimelineMetadata (appId, assessmentGuid, assessmentId, assessmentInstanceGuid, assessmentRevision, scheduleGuid, scheduleModifiedOn, schedulePublished, sessionGuid, sessionInstanceEndDay, sessionInstanceGuid, sessionInstanceStartDay, sessionStartEventId, timeWindowGuid, timeWindowPersistent, guid) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
     static final String DELETE_TIMELINE_RECORDS = "DELETE FROM TimelineMetadata WHERE scheduleGuid = :scheduleGuid";
+    static final String SELECT_ASSESSMENTS_FOR_SESSION_INSTANCE = "SELECT * FROM TimelineMetadata WHERE sessionInstanceGuid = :instanceGuid AND assessmentInstanceGuid IS NOT NULL";
 
     static final String BATCH_SIZE_PROPERTY = "schedule.batch.size";
 
     static final String APP_ID = "appId";
+    static final String INSTANCE_GUID = "instanceGuid";
     static final String OWNER_ID = "ownerId";
     static final String GUID = "guid";
     static final String GUIDS = "guids";
@@ -66,7 +73,7 @@ public class HibernateSchedule2Dao implements Schedule2Dao {
     }
 
     @Override
-    public PagedResourceList<Schedule2> getSchedules(String appId, int offsetBy, int pageSize, boolean includeDeleted) {
+	public PagedResourceList<Schedule2> getSchedules(String appId, int offsetBy, int pageSize, boolean includeDeleted) {
         checkNotNull(appId);
 
         QueryBuilder query = new QueryBuilder();
@@ -74,8 +81,8 @@ public class HibernateSchedule2Dao implements Schedule2Dao {
         if (!includeDeleted) {
             query.append(AND_DELETED);
         }
-        List<Schedule2> results = hibernateHelper.queryGet(query.getQuery(), query.getParameters(), offsetBy, pageSize,
-                Schedule2.class);
+        List<Schedule2> results = hibernateHelper.queryGet(query.getQuery(), query.getParameters(), 
+        		offsetBy, pageSize, Schedule2.class);
 
         int total = hibernateHelper.queryCount(SELECT_COUNT + query.getQuery(), query.getParameters());
 
@@ -94,8 +101,8 @@ public class HibernateSchedule2Dao implements Schedule2Dao {
             query.append(AND_DELETED);
         }
 
-        List<Schedule2> results = hibernateHelper.queryGet(query.getQuery(), query.getParameters(), offsetBy, pageSize,
-                Schedule2.class);
+        List<Schedule2> results = hibernateHelper.queryGet(query.getQuery(), query.getParameters(), 
+        		offsetBy, pageSize, Schedule2.class);
 
         int total = hibernateHelper.queryCount(SELECT_COUNT + query.getQuery(), query.getParameters());
 
@@ -119,35 +126,11 @@ public class HibernateSchedule2Dao implements Schedule2Dao {
     public Schedule2 createSchedule(Schedule2 schedule) {
         checkNotNull(schedule);
 
-        Timeline timeline = Scheduler.INSTANCE.calculateTimeline(schedule);
-        List<TimelineMetadata> metadata = timeline.getMetadata();
-
         hibernateHelper.executeWithExceptionHandling(schedule, (session) -> {
-            // batch these operations. Improves network performance
-            session.setJdbcBatchSize(batchSize);
-
             session.save(schedule);
-
-            Stopwatch stopwatch = Stopwatch.createStarted();
-            // Batch deleting/recreating rather than updating is 2-3 orders of magnitude faster.
-            NativeQuery<?> query = session.createNativeQuery(DELETE_TIMELINE_RECORDS);
-            query.setParameter(SCHEDULE_GUID, schedule.getGuid());
-            query.executeUpdate();
-
-            for (int i = 0, len = metadata.size(); i < len; i++) {
-                TimelineMetadata meta = metadata.get(i);
-                session.save(meta);
-                if (i > 0 && (i % batchSize) == 0) {
-                    session.flush();
-                    session.clear();
-                }
-            }
-            stopwatch.stop();
-            LOG.info("Persisting " + metadata.size() + " timeline metadata records in "
-                    + stopwatch.elapsed(MILLISECONDS) + " ms (batchSize = " + batchSize + ")");
-
-            return null;
+            return schedule;
         });
+        deleteAndRecreateTimelineMetadataRecords(schedule, false);
         return schedule;
     }
 
@@ -155,55 +138,113 @@ public class HibernateSchedule2Dao implements Schedule2Dao {
     public Schedule2 updateSchedule(Schedule2 schedule) {
         checkNotNull(schedule);
 
-        Timeline timeline = Scheduler.INSTANCE.calculateTimeline(schedule);
-        List<TimelineMetadata> metadata = timeline.getMetadata();
-
-        Set<String> sessionGuids = schedule.getSessions().stream().map(Session::getGuid).collect(toSet());
-
-        // Although orphanRemoval = true is set for the session collection, they do not
-        // delete when removed. So we are manually finding the removed sessions and deleting
-        // them before persisting.
+        // Update the schedule
         hibernateHelper.executeWithExceptionHandling(schedule, (session) -> {
-            // batch these operations. Improves network performance
-            session.setJdbcBatchSize(batchSize);
-
+            Set<String> sessionGuids = schedule.getSessions().stream().map(Session::getGuid).collect(toSet());
+            
+            // Although orphanRemoval = true is set for the session collection, they do not
+            // delete when removed. So we are manually finding the removed sessions and deleting
+            // them before persisting the new set.
             QueryBuilder builder = new QueryBuilder();
             builder.append(DELETE_SESSIONS, GUID, schedule.getGuid());
             if (!sessionGuids.isEmpty()) {
                 builder.append(AND_NOT_IN_GUIDS, GUIDS, sessionGuids);
             }
-            NativeQuery<?> query = session.createNativeQuery(builder.getQuery());
+        	NativeQuery<?> query = session.createNativeQuery(builder.getQuery());
             for (Map.Entry<String, Object> entry : builder.getParameters().entrySet()) {
                 query.setParameter(entry.getKey(), entry.getValue());
             }
             query.executeUpdate();
 
             session.update(schedule);
-
-            Stopwatch stopwatch = Stopwatch.createStarted();
             
-            // Batch deleting/recreating rather than updating is 2-3 orders of magnitude faster.
-            query = session.createNativeQuery(DELETE_TIMELINE_RECORDS);
-            query.setParameter(SCHEDULE_GUID, schedule.getGuid());
-            query.executeUpdate();
-            // Create a new set of records
-            for (int i = 0, len = metadata.size(); i < len; i++) {
-                TimelineMetadata meta = metadata.get(i);
-                session.save(meta);
-                if (i > 0 && (i % batchSize) == 0) {
-                    session.flush();
-                    session.clear();
-                }
-            }
-            stopwatch.stop();
-            LOG.info("Persisting " + metadata.size() + " timeline metadata records in "
-                    + stopwatch.elapsed(MILLISECONDS) + " ms (batchSize = " + batchSize + ")");
-
-            return null;
+            return schedule;
         });
+        deleteAndRecreateTimelineMetadataRecords(schedule, true);
         return schedule;
     }
+    
+    private void deleteAndRecreateTimelineMetadataRecords(Schedule2 schedule, boolean deleteFirst) {
+        Timeline timeline = Scheduler.INSTANCE.calculateTimeline(schedule);
+        List<TimelineMetadata> metadata = timeline.getMetadata();
 
+    	hibernateHelper.executeWithExceptionHandling(schedule, (session) -> {
+            // batch these operations. Improves network performance
+            session.setJdbcBatchSize(batchSize);
+
+            if (deleteFirst) {
+                Stopwatch deleteMetadataStopwatch = Stopwatch.createStarted();
+                NativeQuery<?> query = session.createNativeQuery(DELETE_TIMELINE_RECORDS);
+                query.setParameter(SCHEDULE_GUID, schedule.getGuid());
+                query.executeUpdate();
+                deleteMetadataStopwatch.stop();
+                
+                LOG.info("Batch deleting timeline metadata records in " + deleteMetadataStopwatch.elapsed(MILLISECONDS) + " ms");
+            }
+
+            // Hibernate’s session.save() does an insert and then an update operation on each record, so switching
+            // to JDBC to do an insert only, halves the time it takes to do this operation even without further batch
+            // optimizations. I was not able to determine why Hibernate is doing this (it’s not the most frequently 
+            // cited culprit, an @Id generator, because we don’t use one).
+            Stopwatch createMetadataStopwatch = Stopwatch.createStarted();
+            session.doWork(persistRecordsInBatches(metadata));
+            createMetadataStopwatch.stop();
+            
+            LOG.info("Persisting " + metadata.size() + " timeline metadata records in "
+                    + createMetadataStopwatch.elapsed(MILLISECONDS) + " ms (batchSize = " + batchSize + ")");
+
+            return null;
+        });    	
+    }
+
+    /**
+     * For batch operations to work efficiently using the MySQL driver, rewriteBatchedStatements=true must be 
+     * included in the connector string, auto commit must be off, and you must use the batch commit method. 
+     * A batch size of 100 seems about optimal (values below lose performance but I cannot measure any benefit 
+     * to having larger values). 
+     */
+	protected Work persistRecordsInBatches(List<TimelineMetadata> metadata) {
+		return (connection) -> {
+		    connection.setAutoCommit(false);
+		    PreparedStatement ps = connection.prepareStatement(INSERT);
+		    
+		    for (int i = 0, len = metadata.size(); i < len; i++) {
+		        TimelineMetadata meta = metadata.get(i);
+		        updatePreparedStatement(ps, meta);
+		        if (i > 0 && (i % batchSize) == 0) {
+		        	ps.executeBatch();
+		        }
+		    }
+		    ps.executeBatch();
+	    };
+	}
+	
+	// For testability, removing this to a separate method
+	protected void updatePreparedStatement(PreparedStatement ps, TimelineMetadata meta) throws SQLException {
+		ps.setString(1, meta.getAppId());
+        ps.setString(2, meta.getAssessmentGuid());
+        ps.setString(3, meta.getAssessmentId());
+        ps.setString(4, meta.getAssessmentInstanceGuid());
+        // why does setInt alone not like a null value? Not sure
+        if (meta.getAssessmentRevision() == null) {
+            ps.setNull(5, Types.NULL);
+        } else {
+            ps.setInt(5, meta.getAssessmentRevision());    
+        }
+        ps.setString(6, meta.getScheduleGuid());
+        ps.setLong(7, meta.getScheduleModifiedOn().getMillis());
+        ps.setBoolean(8, meta.isSchedulePublished());
+        ps.setString(9, meta.getSessionGuid());
+        ps.setInt(10, meta.getSessionInstanceEndDay());
+        ps.setString(11, meta.getSessionInstanceGuid());
+        ps.setInt(12, meta.getSessionInstanceStartDay());
+        ps.setString(13, meta.getSessionStartEventId());
+        ps.setString(14, meta.getTimeWindowGuid());
+        ps.setBoolean(15, meta.isTimeWindowPersistent());
+        ps.setString(16, meta.getGuid());
+        ps.addBatch();		
+	}
+    
     @Override
     public void deleteSchedule(Schedule2 schedule) {
         checkNotNull(schedule);
@@ -242,8 +283,7 @@ public class HibernateSchedule2Dao implements Schedule2Dao {
         checkNotNull(instanceGuid);
         
         QueryBuilder builder = new QueryBuilder();
-        builder.append("SELECT * FROM TimelineMetadata WHERE sessionInstanceGuid = :instanceGuid", "instanceGuid", instanceGuid);
-        builder.append("AND assessmentInstanceGuid IS NOT NULL");
+        builder.append(SELECT_ASSESSMENTS_FOR_SESSION_INSTANCE, INSTANCE_GUID, instanceGuid);
         
         return hibernateHelper.nativeQueryGet(builder.getQuery(), builder.getParameters(), null, null, TimelineMetadata.class);
     }

--- a/src/main/java/org/sagebionetworks/bridge/validators/Schedule2Validator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/Schedule2Validator.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.validators;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL;
+import static org.sagebionetworks.bridge.validators.ValidatorUtils.periodInDays;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.periodInMinutes;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.validateFixedLengthLongPeriod;
 
@@ -14,7 +15,10 @@ import org.sagebionetworks.bridge.models.schedules2.Session;
 
 public class Schedule2Validator implements Validator {
     
-    public static final Schedule2Validator INSTANCE = new Schedule2Validator();
+	public static final Schedule2Validator INSTANCE = new Schedule2Validator();
+    
+    public static final long FIVE_YEARS_IN_DAYS = 5 * 52 * 7;
+    static final String CANNOT_BE_LONGER_THAN_FIVE_YEARS = "cannot be longer than five years";
     
     @Override
     public boolean supports(Class<?> clazz) {
@@ -38,6 +42,9 @@ public class Schedule2Validator implements Validator {
             errors.rejectValue("guid", CANNOT_BE_BLANK);
         }
         validateFixedLengthLongPeriod(errors, schedule.getDuration(), "duration", true);
+        if (periodInDays(schedule.getDuration()) > FIVE_YEARS_IN_DAYS) {
+        	errors.rejectValue("duration", CANNOT_BE_LONGER_THAN_FIVE_YEARS);
+        }
         if (schedule.getCreatedOn() == null) {
             errors.rejectValue("createdOn", CANNOT_BE_NULL);
         }

--- a/src/main/java/org/sagebionetworks/bridge/validators/Schedule2Validator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/Schedule2Validator.java
@@ -14,12 +14,12 @@ import org.sagebionetworks.bridge.models.schedules2.Schedule2;
 import org.sagebionetworks.bridge.models.schedules2.Session;
 
 public class Schedule2Validator implements Validator {
-    
-	public static final Schedule2Validator INSTANCE = new Schedule2Validator();
-    
+
+    public static final Schedule2Validator INSTANCE = new Schedule2Validator();
+
     public static final long FIVE_YEARS_IN_DAYS = 5 * 52 * 7;
     static final String CANNOT_BE_LONGER_THAN_FIVE_YEARS = "cannot be longer than five years";
-    
+
     @Override
     public boolean supports(Class<?> clazz) {
         return Schedule2.class.isAssignableFrom(clazz);
@@ -27,8 +27,8 @@ public class Schedule2Validator implements Validator {
 
     @Override
     public void validate(Object object, Errors errors) {
-        Schedule2 schedule = (Schedule2)object;
-        
+        Schedule2 schedule = (Schedule2) object;
+
         if (isBlank(schedule.getName())) {
             errors.rejectValue("name", CANNOT_BE_BLANK);
         }
@@ -43,7 +43,7 @@ public class Schedule2Validator implements Validator {
         }
         validateFixedLengthLongPeriod(errors, schedule.getDuration(), "duration", true);
         if (periodInDays(schedule.getDuration()) > FIVE_YEARS_IN_DAYS) {
-        	errors.rejectValue("duration", CANNOT_BE_LONGER_THAN_FIVE_YEARS);
+            errors.rejectValue("duration", CANNOT_BE_LONGER_THAN_FIVE_YEARS);
         }
         if (schedule.getCreatedOn() == null) {
             errors.rejectValue("createdOn", CANNOT_BE_NULL);
@@ -51,10 +51,10 @@ public class Schedule2Validator implements Validator {
         if (schedule.getModifiedOn() == null) {
             errors.rejectValue("modifiedOn", CANNOT_BE_NULL);
         }
-        for (int i=0; i < schedule.getSessions().size(); i++) {
+        for (int i = 0; i < schedule.getSessions().size(); i++) {
             errors.pushNestedPath("sessions[" + i + "]");
             Session session = schedule.getSessions().get(i);
-            
+
             if (schedule.getDuration() != null) {
                 long durationMin = periodInMinutes(schedule.getDuration());
                 if (session.getDelay() != null) {

--- a/src/main/java/org/sagebionetworks/bridge/validators/Schedule2Validator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/Schedule2Validator.java
@@ -17,7 +17,7 @@ public class Schedule2Validator implements Validator {
 
     public static final Schedule2Validator INSTANCE = new Schedule2Validator();
 
-    public static final long FIVE_YEARS_IN_DAYS = 5 * 52 * 7;
+    public static final long FIVE_YEARS_IN_DAYS = 5 * 365;
     static final String CANNOT_BE_LONGER_THAN_FIVE_YEARS = "cannot be longer than five years";
 
     @Override

--- a/src/main/java/org/sagebionetworks/bridge/validators/ValidatorUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/ValidatorUtils.java
@@ -219,6 +219,14 @@ public class ValidatorUtils {
         return convertPeriod(period, (d) -> d.getStandardMinutes());
     }
     
+    /**
+     * This converts the period to days, but only those fields that have a 
+     * conventional measurement in days (so months and years are ignored).
+     */
+    public static final long periodInDays(Period period) {
+    	return convertPeriod(period, (d) -> d.getStandardDays());
+    }
+    
     private static final long convertPeriod(Period period, Function<Duration,Long> func) {
         if (period == null) {
             return 0L;

--- a/src/main/java/org/sagebionetworks/bridge/validators/ValidatorUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/ValidatorUtils.java
@@ -75,8 +75,7 @@ public class ValidatorUtils {
                 errors.rejectValue("password", "must contain at least one number (0-9)");
             }
             if (passwordPolicy.isSymbolRequired() && !password.matches(".*\\p{Punct}+.*")) {
-                errors.rejectValue("password",
-                        "must contain at least one symbol ( !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~ )");
+                errors.rejectValue("password", "must contain at least one symbol ( !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~ )");
             }
             if (passwordPolicy.isLowerCaseRequired() && !password.matches(".*[a-z]+.*")) {
                 errors.rejectValue("password", "must contain at least one lowercase letter (a-z)");
@@ -235,7 +234,7 @@ public class ValidatorUtils {
         try {
             Duration d = period.toStandardDuration();
             return func.apply(d);
-        } catch (UnsupportedOperationException e) {
+        } catch(UnsupportedOperationException e) {
             return 0L;
         }
     }

--- a/src/main/java/org/sagebionetworks/bridge/validators/ValidatorUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/ValidatorUtils.java
@@ -33,7 +33,7 @@ import org.sagebionetworks.bridge.models.assessments.ColorScheme;
 import org.sagebionetworks.bridge.models.notifications.NotificationMessage;
 
 public class ValidatorUtils {
-    
+
     static final String WRONG_PERIOD = "%s can only specify minute, hour, day, or week duration units";
     static final String WRONG_LONG_PERIOD = "%s can only specify day or week duration units";
     static final String DUPLICATE_LANG = "%s is a duplicate message under the same language code";
@@ -43,19 +43,19 @@ public class ValidatorUtils {
 
     private static final Set<DurationFieldType> FIXED_LENGTH_DURATIONS = ImmutableSet.of(DurationFieldType.minutes(),
             DurationFieldType.hours(), DurationFieldType.days(), DurationFieldType.weeks());
-    
+
     private static final Set<DurationFieldType> FIXED_LENGTH_LONG_DURATIONS = ImmutableSet.of(DurationFieldType.days(),
             DurationFieldType.weeks());
-    
+
     public static boolean participantHasValidIdentifier(StudyParticipant participant) {
         Phone phone = participant.getPhone();
         String email = participant.getEmail();
-        String anyExternalId = participant.getExternalIds().isEmpty() ? null : 
-            Iterables.getFirst(participant.getExternalIds().entrySet(), null).getValue();
+        String anyExternalId = participant.getExternalIds().isEmpty() ? null
+                : Iterables.getFirst(participant.getExternalIds().entrySet(), null).getValue();
         String synapseUserId = participant.getSynapseUserId();
         return (email != null || isNotBlank(anyExternalId) || phone != null || isNotBlank(synapseUserId));
     }
-    
+
     public static boolean accountHasValidIdentifier(Account account) {
         Phone phone = account.getPhone();
         String email = account.getEmail();
@@ -69,13 +69,14 @@ public class ValidatorUtils {
             errors.rejectValue("password", "is required");
         } else {
             if (passwordPolicy.getMinLength() > 0 && password.length() < passwordPolicy.getMinLength()) {
-                errors.rejectValue("password", "must be at least "+passwordPolicy.getMinLength()+" characters");
+                errors.rejectValue("password", "must be at least " + passwordPolicy.getMinLength() + " characters");
             }
             if (passwordPolicy.isNumericRequired() && !password.matches(".*\\d+.*")) {
                 errors.rejectValue("password", "must contain at least one number (0-9)");
             }
             if (passwordPolicy.isSymbolRequired() && !password.matches(".*\\p{Punct}+.*")) {
-                errors.rejectValue("password", "must contain at least one symbol ( !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~ )");
+                errors.rejectValue("password",
+                        "must contain at least one symbol ( !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~ )");
             }
             if (passwordPolicy.isLowerCaseRequired() && !password.matches(".*[a-z]+.*")) {
                 errors.rejectValue("password", "must contain at least one lowercase letter (a-z)");
@@ -85,13 +86,13 @@ public class ValidatorUtils {
             }
         }
     }
-    
+
     private static void validateLanguageSet(Errors errors, List<? extends HasLang> items, String fieldName) {
         Set<String> visited = new HashSet<>();
-        for (int i=0; i < items.size(); i++) {
+        for (int i = 0; i < items.size(); i++) {
             HasLang item = items.get(i);
             errors.pushNestedPath(fieldName + "[" + i + "]");
-            
+
             if (isBlank(item.getLang())) {
                 errors.rejectValue("lang", CANNOT_BE_BLANK);
             } else {
@@ -99,7 +100,7 @@ public class ValidatorUtils {
                     errors.rejectValue("lang", DUPLICATE_LANG);
                 }
                 visited.add(item.getLang());
-                
+
                 Locale locale = new Locale.Builder().setLanguageTag(item.getLang()).build();
                 if (!LocaleUtils.isAvailableLocale(locale)) {
                     errors.rejectValue("lang", INVALID_LANG);
@@ -108,13 +109,13 @@ public class ValidatorUtils {
             errors.popNestedPath();
         }
     }
-    
+
     public static void validateLabels(Errors errors, List<Label> labels) {
         if (labels == null || labels.isEmpty()) {
             return;
         }
-        validateLanguageSet(errors, labels, "labels");    
-        for (int j=0; j < labels.size(); j++) {
+        validateLanguageSet(errors, labels, "labels");
+        for (int j = 0; j < labels.size(); j++) {
             Label label = labels.get(j);
 
             if (isBlank(label.getValue())) {
@@ -124,16 +125,16 @@ public class ValidatorUtils {
             }
         }
     }
-    
+
     public static void validateMessages(Errors errors, List<NotificationMessage> messages) {
         if (messages == null || messages.isEmpty()) {
             return;
         }
         validateLanguageSet(errors, messages, "messages");
         boolean englishDefault = false;
-        for (int j=0; j < messages.size(); j++) {
+        for (int j = 0; j < messages.size(); j++) {
             NotificationMessage message = messages.get(j);
-            
+
             if ("en".equalsIgnoreCase(message.getLang())) {
                 englishDefault = true;
             }
@@ -154,7 +155,7 @@ public class ValidatorUtils {
             }
         }
     }
-    
+
     public static final void validateColorScheme(Errors errors, ColorScheme cs, String fieldName) {
         if (cs != null) {
             errors.pushNestedPath(fieldName);
@@ -173,7 +174,7 @@ public class ValidatorUtils {
             errors.popNestedPath();
         }
     }
-    
+
     public static void validateFixedLengthPeriod(Errors errors, Period period, String fieldName, boolean required) {
         validateDuration(FIXED_LENGTH_DURATIONS, errors, period, fieldName, WRONG_PERIOD, required);
     }
@@ -197,10 +198,10 @@ public class ValidatorUtils {
                 break;
             }
         }
-        // Note that this does not allow any portion to be negative, even 
+        // Note that this does not allow any portion to be negative, even
         // if the sum total is positive.
         int[] values = period.getValues();
-        for (int i=0; i < values.length; i++) {
+        for (int i = 0; i < values.length; i++) {
             if (values[i] < 0) {
                 errors.rejectValue(fieldName, CANNOT_BE_NEGATIVE);
                 break;
@@ -210,31 +211,31 @@ public class ValidatorUtils {
             errors.rejectValue(fieldName, "cannot be of no duration");
         }
     }
-    
+
     /**
-     * This converts the period to minutes, but only those fields that have a 
-     * conventional measurement in minutes (so months and years are ignored).  
+     * This converts the period to minutes, but only those fields that have a
+     * conventional measurement in minutes (so months and years are ignored).
      */
     public static final long periodInMinutes(Period period) {
         return convertPeriod(period, (d) -> d.getStandardMinutes());
     }
-    
+
     /**
-     * This converts the period to days, but only those fields that have a 
+     * This converts the period to days, but only those fields that have a
      * conventional measurement in days (so months and years are ignored).
      */
     public static final long periodInDays(Period period) {
-    	return convertPeriod(period, (d) -> d.getStandardDays());
+        return convertPeriod(period, (d) -> d.getStandardDays());
     }
-    
-    private static final long convertPeriod(Period period, Function<Duration,Long> func) {
+
+    private static final long convertPeriod(Period period, Function<Duration, Long> func) {
         if (period == null) {
             return 0L;
         }
         try {
             Duration d = period.toStandardDuration();
             return func.apply(d);
-        } catch(UnsupportedOperationException e) {
+        } catch (UnsupportedOperationException e) {
             return 0L;
         }
     }

--- a/src/main/resources/BridgeServer2.conf
+++ b/src/main/resources/BridgeServer2.conf
@@ -174,7 +174,8 @@ gbf.order.returns.url = https://www.gbfmedical.com/oap/api/returns
 gbf.ship.confirmation.url = https://www.gbfmedical.com/oap/api/confirm
 gbf.api.key = dummy-value
 
-# Schedule timeline metadata records batch persist
+# Schedule timeline metadata records batch persist. Values above 100 do not seem to 
+# improve performance, but values under 100 start to degrade it a bit.
 schedule.batch.size = 100
 
 # The allowlist of URL query parameters.

--- a/src/main/resources/db/changelog/changelog.sql
+++ b/src/main/resources/db/changelog/changelog.sql
@@ -770,3 +770,8 @@ CREATE TABLE `StudyCustomEvents` (
 
 ALTER TABLE `Accounts`
 ADD COLUMN `clientTimeZone` varchar(64) DEFAULT NULL;
+
+-- changeset bridge:46
+
+ALTER TABLE `TimelineMetadata` 
+ADD INDEX `TimelineMetadata-ScheduleGuid` (scheduleGuid);

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2DaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2DaoTest.java
@@ -56,63 +56,64 @@ import org.sagebionetworks.bridge.models.schedules2.timelines.Timeline;
 import org.sagebionetworks.bridge.models.schedules2.timelines.TimelineMetadata;
 
 public class HibernateSchedule2DaoTest extends Mockito {
-    
+
     @Mock
     HibernateHelper mockHibernateHelper;
-    
+
     @Mock
     Session mockSession;
-    
+
     @Mock
     NativeQuery<Schedule2> mockQuery;
-    
+
     @Mock
     BridgeConfig mockConfig;
 
     @InjectMocks
     HibernateSchedule2Dao dao;
-    
+
     @Captor
     ArgumentCaptor<String> queryCaptor;
-    
+
     @Captor
-    ArgumentCaptor<Map<String,Object>> paramsCaptor;
-    
+    ArgumentCaptor<Map<String, Object>> paramsCaptor;
+
     @BeforeMethod
     public void beforeMethod() {
         MockitoAnnotations.initMocks(this);
-        
+
         when(mockConfig.getInt(BATCH_SIZE_PROPERTY)).thenReturn(10);
-        
+
         dao.setBridgeConfig(mockConfig);
-        
+
         when(mockSession.createNativeQuery(any())).thenReturn(mockQuery);
-        
+
         when(mockHibernateHelper.executeWithExceptionHandling(any(), any())).thenAnswer(args -> {
             Function<Session, Schedule2> func = args.getArgument(1);
             func.apply(mockSession);
             return args.getArgument(0);
         });
     }
-    
+
     @Test
     public void getSchedulesWithoutDeleted() {
         List<Schedule2> list = ImmutableList.of(new Schedule2(), new Schedule2());
         when(mockHibernateHelper.queryGet(any(), any(), any(), any(), eq(Schedule2.class))).thenReturn(list);
         when(mockHibernateHelper.queryCount(any(), any())).thenReturn(2);
-        
+
         PagedResourceList<Schedule2> retValue = dao.getSchedules(TEST_APP_ID, 10, 100, false);
         assertEquals(retValue.getItems(), list);
         assertEquals(retValue.getTotal(), Integer.valueOf(2));
-        
+
         verify(mockHibernateHelper).queryCount(queryCaptor.capture(), paramsCaptor.capture());
-        verify(mockHibernateHelper).queryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(10), eq(100), eq(Schedule2.class));
+        verify(mockHibernateHelper).queryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(10), eq(100),
+                eq(Schedule2.class));
 
         String countQuery = queryCaptor.getAllValues().get(0);
         String getQuery = queryCaptor.getAllValues().get(1);
-        
-        Map<String,Object> countParams = paramsCaptor.getAllValues().get(0);
-        Map<String,Object> getParams = paramsCaptor.getAllValues().get(1);
+
+        Map<String, Object> countParams = paramsCaptor.getAllValues().get(0);
+        Map<String, Object> getParams = paramsCaptor.getAllValues().get(1);
 
         assertEquals(countQuery, SELECT_COUNT + GET_ALL_SCHEDULES + " " + AND_DELETED);
         assertEquals(countParams.get("appId"), TEST_APP_ID);
@@ -126,19 +127,20 @@ public class HibernateSchedule2DaoTest extends Mockito {
         List<Schedule2> list = ImmutableList.of(new Schedule2(), new Schedule2());
         when(mockHibernateHelper.queryGet(any(), any(), any(), any(), eq(Schedule2.class))).thenReturn(list);
         when(mockHibernateHelper.queryCount(any(), any())).thenReturn(20);
-        
+
         PagedResourceList<Schedule2> retValue = dao.getSchedules(TEST_APP_ID, 0, 50, true);
         assertEquals(retValue.getItems(), list);
         assertEquals(retValue.getTotal(), Integer.valueOf(20));
-        
+
         verify(mockHibernateHelper).queryCount(queryCaptor.capture(), paramsCaptor.capture());
-        verify(mockHibernateHelper).queryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(0), eq(50), eq(Schedule2.class));
+        verify(mockHibernateHelper).queryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(0), eq(50),
+                eq(Schedule2.class));
 
         String countQuery = queryCaptor.getAllValues().get(0);
         String getQuery = queryCaptor.getAllValues().get(1);
-        
-        Map<String,Object> countParams = paramsCaptor.getAllValues().get(0);
-        Map<String,Object> getParams = paramsCaptor.getAllValues().get(1);
+
+        Map<String, Object> countParams = paramsCaptor.getAllValues().get(0);
+        Map<String, Object> getParams = paramsCaptor.getAllValues().get(1);
 
         assertEquals(countQuery, SELECT_COUNT + GET_ALL_SCHEDULES);
         assertEquals(countParams.get("appId"), TEST_APP_ID);
@@ -146,25 +148,27 @@ public class HibernateSchedule2DaoTest extends Mockito {
         assertEquals(getQuery, GET_ALL_SCHEDULES);
         assertEquals(getParams.get("appId"), TEST_APP_ID);
     }
-    
+
     @Test
     public void getSchedulesForOrganizationWithoutDeleted() {
         List<Schedule2> list = ImmutableList.of(new Schedule2(), new Schedule2());
         when(mockHibernateHelper.queryGet(any(), any(), any(), any(), eq(Schedule2.class))).thenReturn(list);
         when(mockHibernateHelper.queryCount(any(), any())).thenReturn(2);
-        
-        PagedResourceList<Schedule2> retValue = dao.getSchedulesForOrganization(TEST_APP_ID, TEST_ORG_ID, 10, 100, false);
+
+        PagedResourceList<Schedule2> retValue = dao.getSchedulesForOrganization(TEST_APP_ID, TEST_ORG_ID, 10, 100,
+                false);
         assertEquals(retValue.getItems(), list);
         assertEquals(retValue.getTotal(), Integer.valueOf(2));
-        
+
         verify(mockHibernateHelper).queryCount(queryCaptor.capture(), paramsCaptor.capture());
-        verify(mockHibernateHelper).queryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(10), eq(100), eq(Schedule2.class));
+        verify(mockHibernateHelper).queryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(10), eq(100),
+                eq(Schedule2.class));
 
         String countQuery = queryCaptor.getAllValues().get(0);
         String getQuery = queryCaptor.getAllValues().get(1);
-        
-        Map<String,Object> countParams = paramsCaptor.getAllValues().get(0);
-        Map<String,Object> getParams = paramsCaptor.getAllValues().get(1);
+
+        Map<String, Object> countParams = paramsCaptor.getAllValues().get(0);
+        Map<String, Object> getParams = paramsCaptor.getAllValues().get(1);
 
         assertEquals(countQuery, SELECT_COUNT + GET_ORG_SCHEDULES + " " + AND_DELETED);
         assertEquals(countParams.get("appId"), TEST_APP_ID);
@@ -178,49 +182,50 @@ public class HibernateSchedule2DaoTest extends Mockito {
         List<Schedule2> list = ImmutableList.of(new Schedule2(), new Schedule2());
         when(mockHibernateHelper.queryGet(any(), any(), any(), any(), eq(Schedule2.class))).thenReturn(list);
         when(mockHibernateHelper.queryCount(any(), any())).thenReturn(20);
-        
+
         PagedResourceList<Schedule2> retValue = dao.getSchedulesForOrganization(TEST_APP_ID, TEST_ORG_ID, 0, 50, true);
         assertEquals(retValue.getItems(), list);
         assertEquals(retValue.getTotal(), Integer.valueOf(20));
-        
+
         verify(mockHibernateHelper).queryCount(queryCaptor.capture(), paramsCaptor.capture());
-        verify(mockHibernateHelper).queryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(0), eq(50), eq(Schedule2.class));
+        verify(mockHibernateHelper).queryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(0), eq(50),
+                eq(Schedule2.class));
 
         String countQuery = queryCaptor.getAllValues().get(0);
         String getQuery = queryCaptor.getAllValues().get(1);
-        
-        Map<String,Object> countParams = paramsCaptor.getAllValues().get(0);
-        Map<String,Object> getParams = paramsCaptor.getAllValues().get(1);
+
+        Map<String, Object> countParams = paramsCaptor.getAllValues().get(0);
+        Map<String, Object> getParams = paramsCaptor.getAllValues().get(1);
 
         assertEquals(countQuery, SELECT_COUNT + GET_ORG_SCHEDULES);
         assertEquals(countParams.get("appId"), TEST_APP_ID);
 
         assertEquals(getQuery, GET_ORG_SCHEDULES);
-        assertEquals(getParams.get("appId"), TEST_APP_ID);        
+        assertEquals(getParams.get("appId"), TEST_APP_ID);
     }
-    
+
     @Test
     public void getScheduleSucceeds() {
         Schedule2 schedule = new Schedule2();
         when(mockHibernateHelper.queryGet(any(), any(), any(), any(), eq(Schedule2.class)))
-            .thenReturn(ImmutableList.of(schedule));
-        
+                .thenReturn(ImmutableList.of(schedule));
+
         Optional<Schedule2> retValue = dao.getSchedule(TEST_APP_ID, GUID);
         assertTrue(retValue.isPresent());
         assertEquals(retValue.get(), schedule);
-        
-        verify(mockHibernateHelper).queryGet(
-                queryCaptor.capture(), paramsCaptor.capture(), isNull(), isNull(), eq(Schedule2.class));
+
+        verify(mockHibernateHelper).queryGet(queryCaptor.capture(), paramsCaptor.capture(), isNull(), isNull(),
+                eq(Schedule2.class));
         assertEquals(queryCaptor.getValue(), GET_SCHEDULE);
         assertEquals(paramsCaptor.getValue().get("appId"), TEST_APP_ID);
         assertEquals(paramsCaptor.getValue().get("guid"), GUID);
     }
-    
+
     @Test
     public void getScheduleFails() {
         when(mockHibernateHelper.queryGet(any(), any(), any(), any(), eq(Schedule2.class)))
-            .thenReturn(ImmutableList.of());
-        
+                .thenReturn(ImmutableList.of());
+
         Optional<Schedule2> retValue = dao.getSchedule(TEST_APP_ID, GUID);
         assertFalse(retValue.isPresent());
     }
@@ -228,12 +233,12 @@ public class HibernateSchedule2DaoTest extends Mockito {
     @Test
     public void createSchedule() {
         Schedule2 schedule = Schedule2Test.createValidSchedule();
-        
+
         when(mockSession.createNativeQuery(DELETE_TIMELINE_RECORDS)).thenReturn(mockQuery);
-        
+
         Schedule2 retValue = dao.createSchedule(schedule);
         assertEquals(retValue, schedule);
-        
+
         verify(mockSession).setJdbcBatchSize(10);
         verify(mockSession).save(schedule);
         verify(mockSession).doWork(any());
@@ -242,17 +247,17 @@ public class HibernateSchedule2DaoTest extends Mockito {
     @Test
     public void updateSchedule() {
         Schedule2 schedule = Schedule2Test.createValidSchedule();
-        
+
         org.sagebionetworks.bridge.models.schedules2.Session session1 = SessionTest.createValidSession();
         session1.setGuid(SESSION_GUID_1);
-        
+
         org.sagebionetworks.bridge.models.schedules2.Session session2 = SessionTest.createValidSession();
         session2.setGuid(SESSION_GUID_2);
         schedule.setSessions(ImmutableList.of(session1, session2));
 
         Schedule2 retValue = dao.updateSchedule(schedule);
         assertEquals(retValue, schedule);
-        
+
         verify(mockSession, times(2)).createNativeQuery(queryCaptor.capture());
         assertEquals(queryCaptor.getAllValues().get(0), DELETE_ORPHANED_SESSIONS);
         assertEquals(queryCaptor.getAllValues().get(1), DELETE_TIMELINE_RECORDS);
@@ -262,43 +267,43 @@ public class HibernateSchedule2DaoTest extends Mockito {
         verify(mockSession).update(schedule);
         verify(mockSession).doWork(any());
     }
-    
+
     @Test
     public void persistRecordsInBatches() throws SQLException {
-    	Schedule2 schedule = Schedule2Test.createValidSchedule();
-    	Timeline timeline = Scheduler.INSTANCE.calculateTimeline(schedule);
-    	List<TimelineMetadata> metadata = timeline.getMetadata();
-    	
-    	Work work = dao.persistRecordsInBatches(metadata);
-    	
-    	Connection mockConnection = mock(Connection.class);
-    	PreparedStatement mockStatement = mock(PreparedStatement.class);
-    	when(mockConnection.prepareStatement(INSERT)).thenReturn(mockStatement);
-    	
-    	work.execute(mockConnection);
-    	
-    	// 21 records at a batch size of 10 generates 3 executeBatch statements. The
-    	// content of the statements is tested in updatePreparedStatement().
-    	assertEquals(metadata.size(), 21);
-    	verify(mockConnection).setAutoCommit(false);
-    	verify(mockConnection).prepareStatement(INSERT);
-    	verify(mockStatement, times(3)).executeBatch();
+        Schedule2 schedule = Schedule2Test.createValidSchedule();
+        Timeline timeline = Scheduler.INSTANCE.calculateTimeline(schedule);
+        List<TimelineMetadata> metadata = timeline.getMetadata();
+
+        Work work = dao.persistRecordsInBatches(metadata);
+
+        Connection mockConnection = mock(Connection.class);
+        PreparedStatement mockStatement = mock(PreparedStatement.class);
+        when(mockConnection.prepareStatement(INSERT)).thenReturn(mockStatement);
+
+        work.execute(mockConnection);
+
+        // 21 records at a batch size of 10 generates 3 executeBatch statements. The
+        // content of the statements is tested in updatePreparedStatement().
+        assertEquals(metadata.size(), 21);
+        verify(mockConnection).setAutoCommit(false);
+        verify(mockConnection).prepareStatement(INSERT);
+        verify(mockStatement, times(3)).executeBatch();
     }
-    
+
     @Test
     public void updatePreparedStatement() throws Exception {
-    	PreparedStatement mockStatement = mock(PreparedStatement.class);
-    	
-    	Schedule2 schedule = Schedule2Test.createValidSchedule();
-    	Timeline timeline = Scheduler.INSTANCE.calculateTimeline(schedule);
-    	TimelineMetadata meta = timeline.getMetadata().get(0);
-    	
-    	dao.updatePreparedStatement(mockStatement, meta);
-    	
-		verify(mockStatement).setString(1, meta.getAppId());
-		verify(mockStatement).setString(2, meta.getAssessmentGuid());
-		verify(mockStatement).setString(3, meta.getAssessmentId());
-		verify(mockStatement).setString(4, meta.getAssessmentInstanceGuid());
+        PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        Schedule2 schedule = Schedule2Test.createValidSchedule();
+        Timeline timeline = Scheduler.INSTANCE.calculateTimeline(schedule);
+        TimelineMetadata meta = timeline.getMetadata().get(0);
+
+        dao.updatePreparedStatement(mockStatement, meta);
+
+        verify(mockStatement).setString(1, meta.getAppId());
+        verify(mockStatement).setString(2, meta.getAssessmentGuid());
+        verify(mockStatement).setString(3, meta.getAssessmentId());
+        verify(mockStatement).setString(4, meta.getAssessmentInstanceGuid());
         verify(mockStatement).setNull(5, Types.NULL);
         verify(mockStatement).setString(6, meta.getScheduleGuid());
         verify(mockStatement).setLong(7, meta.getScheduleModifiedOn().getMillis());
@@ -312,16 +317,16 @@ public class HibernateSchedule2DaoTest extends Mockito {
         verify(mockStatement).setBoolean(15, meta.isTimeWindowPersistent());
         verify(mockStatement).setString(16, meta.getGuid());
         verify(mockStatement).addBatch();
-        
+
         reset(mockStatement);
-    	meta = timeline.getMetadata().get(1);
-    	
-    	dao.updatePreparedStatement(mockStatement, meta);
-    	
-    	// this also works
+        meta = timeline.getMetadata().get(1);
+
+        dao.updatePreparedStatement(mockStatement, meta);
+
+        // this also works
         verify(mockStatement).setInt(5, meta.getAssessmentRevision());
     }
-    
+
     @Test
     public void updateScheduleWithNoSessions() {
         Schedule2 schedule = new Schedule2();
@@ -329,21 +334,21 @@ public class HibernateSchedule2DaoTest extends Mockito {
 
         Schedule2 retValue = dao.updateSchedule(schedule);
         assertEquals(retValue, schedule);
-        
+
         verify(mockSession).createNativeQuery(DELETE_TIMELINE_RECORDS);
         verify(mockSession).createNativeQuery(DELETE_SESSIONS);
         verify(mockQuery).setParameter("guid", "ScheduleGuid");
         verify(mockQuery, times(2)).executeUpdate();
         verify(mockSession).update(schedule);
     }
-    
+
     @Test
     public void deleteSchedule() {
         Schedule2 schedule = new Schedule2();
-        
+
         dao.deleteSchedule(schedule);
         assertTrue(schedule.isDeleted());
-        
+
         verify(mockHibernateHelper).update(schedule);
     }
 
@@ -351,47 +356,48 @@ public class HibernateSchedule2DaoTest extends Mockito {
     public void deleteSchedulePermanently() {
         Schedule2 schedule = new Schedule2();
         schedule.setGuid(GUID);
-        
+
         dao.deleteSchedulePermanently(schedule);
-        
+
         verify(mockSession).createNativeQuery(queryCaptor.capture());
         assertEquals(queryCaptor.getValue(), DELETE_SESSIONS);
         verify(mockQuery).setParameter("guid", schedule.getGuid());
         verify(mockQuery).executeUpdate();
         verify(mockSession).remove(schedule);
     }
-    
+
     @Test
     public void getTimelineMetadata() {
-    	TimelineMetadata metadata = new TimelineMetadata();
-    	when(mockHibernateHelper.getById(TimelineMetadata.class, GUID)).thenReturn(metadata);
-    	
-    	Optional<TimelineMetadata> retValue = dao.getTimelineMetadata(GUID);
-    	assertEquals(retValue.get(), metadata);
-    	
-    	verify(mockHibernateHelper).getById(TimelineMetadata.class, GUID);
+        TimelineMetadata metadata = new TimelineMetadata();
+        when(mockHibernateHelper.getById(TimelineMetadata.class, GUID)).thenReturn(metadata);
+
+        Optional<TimelineMetadata> retValue = dao.getTimelineMetadata(GUID);
+        assertEquals(retValue.get(), metadata);
+
+        verify(mockHibernateHelper).getById(TimelineMetadata.class, GUID);
     }
 
     @Test
     public void getTimelineMetadataNull() {
-    	when(mockHibernateHelper.getById(TimelineMetadata.class, GUID)).thenReturn(null);
-    	
-    	Optional<TimelineMetadata> retValue = dao.getTimelineMetadata(GUID);
-    	assertFalse(retValue.isPresent());
+        when(mockHibernateHelper.getById(TimelineMetadata.class, GUID)).thenReturn(null);
+
+        Optional<TimelineMetadata> retValue = dao.getTimelineMetadata(GUID);
+        assertFalse(retValue.isPresent());
     }
-    
+
     @Test
     public void getAssessmentsForSessionInstance() {
-    	List<TimelineMetadata> results = ImmutableList.of();
-    	when(mockHibernateHelper.nativeQueryGet(any(), any(), any(), any(), eq(TimelineMetadata.class))).thenReturn(results);
-    	
-    	List<TimelineMetadata> retValue = dao.getAssessmentsForSessionInstance(GUID);
-    	assertEquals(retValue, results);
-    	
-    	verify(mockHibernateHelper).nativeQueryGet(queryCaptor.capture(), paramsCaptor.capture(), 
-    			isNull(), isNull(), eq(TimelineMetadata.class));
+        List<TimelineMetadata> results = ImmutableList.of();
+        when(mockHibernateHelper.nativeQueryGet(any(), any(), any(), any(), eq(TimelineMetadata.class)))
+                .thenReturn(results);
 
-    	assertEquals(queryCaptor.getValue(), SELECT_ASSESSMENTS_FOR_SESSION_INSTANCE);
-    	assertEquals(paramsCaptor.getValue().get(INSTANCE_GUID), GUID);
+        List<TimelineMetadata> retValue = dao.getAssessmentsForSessionInstance(GUID);
+        assertEquals(retValue, results);
+
+        verify(mockHibernateHelper).nativeQueryGet(queryCaptor.capture(), paramsCaptor.capture(), isNull(), isNull(),
+                eq(TimelineMetadata.class));
+
+        assertEquals(queryCaptor.getValue(), SELECT_ASSESSMENTS_FOR_SESSION_INSTANCE);
+        assertEquals(paramsCaptor.getValue().get(INSTANCE_GUID), GUID);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2DaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2DaoTest.java
@@ -14,11 +14,18 @@ import static org.sagebionetworks.bridge.hibernate.HibernateSchedule2Dao.DELETE_
 import static org.sagebionetworks.bridge.hibernate.HibernateSchedule2Dao.GET_ALL_SCHEDULES;
 import static org.sagebionetworks.bridge.hibernate.HibernateSchedule2Dao.GET_ORG_SCHEDULES;
 import static org.sagebionetworks.bridge.hibernate.HibernateSchedule2Dao.GET_SCHEDULE;
+import static org.sagebionetworks.bridge.hibernate.HibernateSchedule2Dao.INSERT;
+import static org.sagebionetworks.bridge.hibernate.HibernateSchedule2Dao.INSTANCE_GUID;
+import static org.sagebionetworks.bridge.hibernate.HibernateSchedule2Dao.SELECT_ASSESSMENTS_FOR_SESSION_INSTANCE;
 import static org.sagebionetworks.bridge.hibernate.HibernateSchedule2Dao.SELECT_COUNT;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -28,6 +35,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import org.hibernate.Session;
+import org.hibernate.jdbc.Work;
 import org.hibernate.query.NativeQuery;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -38,12 +46,14 @@ import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.schedules2.Schedule2;
 import org.sagebionetworks.bridge.models.schedules2.Schedule2Test;
 import org.sagebionetworks.bridge.models.schedules2.SessionTest;
+import org.sagebionetworks.bridge.models.schedules2.timelines.Scheduler;
+import org.sagebionetworks.bridge.models.schedules2.timelines.Timeline;
+import org.sagebionetworks.bridge.models.schedules2.timelines.TimelineMetadata;
 
 public class HibernateSchedule2DaoTest extends Mockito {
     
@@ -225,12 +235,8 @@ public class HibernateSchedule2DaoTest extends Mockito {
         assertEquals(retValue, schedule);
         
         verify(mockSession).setJdbcBatchSize(10);
-        verify(mockSession).createNativeQuery(DELETE_TIMELINE_RECORDS);
         verify(mockSession).save(schedule);
-        verify(mockQuery).setParameter(HibernateSchedule2Dao.SCHEDULE_GUID, TestConstants.SCHEDULE_GUID);
-        verify(mockQuery).executeUpdate();
-        verify(mockSession, times(2)).flush();
-        verify(mockSession, times(2)).clear();
+        verify(mockSession).doWork(any());
     }
 
     @Test
@@ -254,6 +260,66 @@ public class HibernateSchedule2DaoTest extends Mockito {
         verify(mockQuery).setParameter("guids", ImmutableSet.of(SESSION_GUID_1, SESSION_GUID_2));
         verify(mockQuery, times(2)).executeUpdate();
         verify(mockSession).update(schedule);
+        verify(mockSession).doWork(any());
+    }
+    
+    @Test
+    public void persistRecordsInBatches() throws SQLException {
+    	Schedule2 schedule = Schedule2Test.createValidSchedule();
+    	Timeline timeline = Scheduler.INSTANCE.calculateTimeline(schedule);
+    	List<TimelineMetadata> metadata = timeline.getMetadata();
+    	
+    	Work work = dao.persistRecordsInBatches(metadata);
+    	
+    	Connection mockConnection = mock(Connection.class);
+    	PreparedStatement mockStatement = mock(PreparedStatement.class);
+    	when(mockConnection.prepareStatement(INSERT)).thenReturn(mockStatement);
+    	
+    	work.execute(mockConnection);
+    	
+    	// 21 records at a batch size of 10 generates 3 executeBatch statements. The
+    	// content of the statements is tested in updatePreparedStatement().
+    	assertEquals(metadata.size(), 21);
+    	verify(mockConnection).setAutoCommit(false);
+    	verify(mockConnection).prepareStatement(INSERT);
+    	verify(mockStatement, times(3)).executeBatch();
+    }
+    
+    @Test
+    public void updatePreparedStatement() throws Exception {
+    	PreparedStatement mockStatement = mock(PreparedStatement.class);
+    	
+    	Schedule2 schedule = Schedule2Test.createValidSchedule();
+    	Timeline timeline = Scheduler.INSTANCE.calculateTimeline(schedule);
+    	TimelineMetadata meta = timeline.getMetadata().get(0);
+    	
+    	dao.updatePreparedStatement(mockStatement, meta);
+    	
+		verify(mockStatement).setString(1, meta.getAppId());
+		verify(mockStatement).setString(2, meta.getAssessmentGuid());
+		verify(mockStatement).setString(3, meta.getAssessmentId());
+		verify(mockStatement).setString(4, meta.getAssessmentInstanceGuid());
+        verify(mockStatement).setNull(5, Types.NULL);
+        verify(mockStatement).setString(6, meta.getScheduleGuid());
+        verify(mockStatement).setLong(7, meta.getScheduleModifiedOn().getMillis());
+        verify(mockStatement).setBoolean(8, meta.isSchedulePublished());
+        verify(mockStatement).setString(9, meta.getSessionGuid());
+        verify(mockStatement).setInt(10, meta.getSessionInstanceEndDay());
+        verify(mockStatement).setString(11, meta.getSessionInstanceGuid());
+        verify(mockStatement).setInt(12, meta.getSessionInstanceStartDay());
+        verify(mockStatement).setString(13, meta.getSessionStartEventId());
+        verify(mockStatement).setString(14, meta.getTimeWindowGuid());
+        verify(mockStatement).setBoolean(15, meta.isTimeWindowPersistent());
+        verify(mockStatement).setString(16, meta.getGuid());
+        verify(mockStatement).addBatch();
+        
+        reset(mockStatement);
+    	meta = timeline.getMetadata().get(1);
+    	
+    	dao.updatePreparedStatement(mockStatement, meta);
+    	
+    	// this also works
+        verify(mockStatement).setInt(5, meta.getAssessmentRevision());
     }
     
     @Test
@@ -293,5 +359,39 @@ public class HibernateSchedule2DaoTest extends Mockito {
         verify(mockQuery).setParameter("guid", schedule.getGuid());
         verify(mockQuery).executeUpdate();
         verify(mockSession).remove(schedule);
+    }
+    
+    @Test
+    public void getTimelineMetadata() {
+    	TimelineMetadata metadata = new TimelineMetadata();
+    	when(mockHibernateHelper.getById(TimelineMetadata.class, GUID)).thenReturn(metadata);
+    	
+    	Optional<TimelineMetadata> retValue = dao.getTimelineMetadata(GUID);
+    	assertEquals(retValue.get(), metadata);
+    	
+    	verify(mockHibernateHelper).getById(TimelineMetadata.class, GUID);
+    }
+
+    @Test
+    public void getTimelineMetadataNull() {
+    	when(mockHibernateHelper.getById(TimelineMetadata.class, GUID)).thenReturn(null);
+    	
+    	Optional<TimelineMetadata> retValue = dao.getTimelineMetadata(GUID);
+    	assertFalse(retValue.isPresent());
+    }
+    
+    @Test
+    public void getAssessmentsForSessionInstance() {
+    	List<TimelineMetadata> results = ImmutableList.of();
+    	when(mockHibernateHelper.nativeQueryGet(any(), any(), any(), any(), eq(TimelineMetadata.class))).thenReturn(results);
+    	
+    	List<TimelineMetadata> retValue = dao.getAssessmentsForSessionInstance(GUID);
+    	assertEquals(retValue, results);
+    	
+    	verify(mockHibernateHelper).nativeQueryGet(queryCaptor.capture(), paramsCaptor.capture(), 
+    			isNull(), isNull(), eq(TimelineMetadata.class));
+
+    	assertEquals(queryCaptor.getValue(), SELECT_ASSESSMENTS_FOR_SESSION_INSTANCE);
+    	assertEquals(paramsCaptor.getValue().get(INSTANCE_GUID), GUID);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/validators/Schedule2ValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/Schedule2ValidatorTest.java
@@ -100,7 +100,7 @@ public class Schedule2ValidatorTest extends Mockito {
     @Test
     public void durationTooLong() {
         Schedule2 schedule = createValidSchedule();
-        schedule.setDuration(Period.parse("P260W1D"));
+        schedule.setDuration(Period.parse("P260W6D"));
         assertValidatorMessage(INSTANCE, schedule, "duration", CANNOT_BE_LONGER_THAN_FIVE_YEARS);
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/validators/Schedule2ValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/Schedule2ValidatorTest.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.validators;
 
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 import static org.sagebionetworks.bridge.models.schedules2.Schedule2Test.createValidSchedule;
+import static org.sagebionetworks.bridge.validators.Schedule2Validator.CANNOT_BE_LONGER_THAN_FIVE_YEARS;
 import static org.sagebionetworks.bridge.validators.Schedule2Validator.INSTANCE;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL;
@@ -95,6 +96,13 @@ public class Schedule2ValidatorTest extends Mockito {
         Schedule2 schedule = createValidSchedule();
         schedule.setDuration(Period.parse("P3Y"));
         assertValidatorMessage(INSTANCE, schedule, "duration", WRONG_LONG_PERIOD);
+    }
+    
+    @Test
+    public void durationTooLong() {
+        Schedule2 schedule = createValidSchedule();
+        schedule.setDuration(Period.parse("P260W1D"));
+        assertValidatorMessage(INSTANCE, schedule, "duration", CANNOT_BE_LONGER_THAN_FIVE_YEARS);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/validators/Schedule2ValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/Schedule2ValidatorTest.java
@@ -26,64 +26,63 @@ public class Schedule2ValidatorTest extends Mockito {
         Schedule2 schedule = createValidSchedule();
         Validate.entityThrowingException(INSTANCE, schedule);
     }
-    
+
     @Test
     public void nameBlank() {
         Schedule2 schedule = createValidSchedule();
         schedule.setName(" ");
         assertValidatorMessage(INSTANCE, schedule, "name", CANNOT_BE_BLANK);
     }
-    
+
     @Test
     public void nameNull() {
         Schedule2 schedule = createValidSchedule();
         schedule.setName(null);
         assertValidatorMessage(INSTANCE, schedule, "name", CANNOT_BE_BLANK);
     }
-    
+
     @Test
     public void ownerIdBlank() {
         Schedule2 schedule = createValidSchedule();
         schedule.setOwnerId(" ");
         assertValidatorMessage(INSTANCE, schedule, "ownerId", CANNOT_BE_BLANK);
     }
-    
+
     @Test
     public void ownerIdNull() {
         Schedule2 schedule = createValidSchedule();
         schedule.setOwnerId(null);
         assertValidatorMessage(INSTANCE, schedule, "ownerId", CANNOT_BE_BLANK);
     }
-    
+
     @Test
     public void appIdBlank() {
         Schedule2 schedule = createValidSchedule();
         schedule.setAppId(" ");
         assertValidatorMessage(INSTANCE, schedule, "appId", CANNOT_BE_BLANK);
     }
-    
-    @Test(expectedExceptions = InvalidEntityException.class,
-            expectedExceptionsMessageRegExp = ".*appId cannot be null or blank.*")
+
+    @Test(expectedExceptions = InvalidEntityException.class, expectedExceptionsMessageRegExp = ".*appId cannot be null or blank.*")
     public void appIdNull() {
         Schedule2 schedule = createValidSchedule();
         schedule.setAppId(null);
         Validate.entityThrowingException(INSTANCE, schedule);
     }
-    
+
     @Test
     public void guidBlank() {
         Schedule2 schedule = createValidSchedule();
         schedule.setGuid(" ");
         assertValidatorMessage(INSTANCE, schedule, "guid", CANNOT_BE_BLANK);
     }
-    
+
     @Test
     public void guidNull() {
         Schedule2 schedule = createValidSchedule();
         schedule.setGuid(null);
         assertValidatorMessage(INSTANCE, schedule, "guid", CANNOT_BE_BLANK);
     }
-    
+
     @Test
     public void durationNull() {
         Schedule2 schedule = createValidSchedule();
@@ -97,21 +96,21 @@ public class Schedule2ValidatorTest extends Mockito {
         schedule.setDuration(Period.parse("P3Y"));
         assertValidatorMessage(INSTANCE, schedule, "duration", WRONG_LONG_PERIOD);
     }
-    
+
     @Test
     public void durationTooLong() {
         Schedule2 schedule = createValidSchedule();
         schedule.setDuration(Period.parse("P260W1D"));
         assertValidatorMessage(INSTANCE, schedule, "duration", CANNOT_BE_LONGER_THAN_FIVE_YEARS);
     }
-    
+
     @Test
     public void durationInvalidShortValue() {
         Schedule2 schedule = createValidSchedule();
         schedule.setDuration(Period.parse("PT30M"));
         assertValidatorMessage(INSTANCE, schedule, "duration", WRONG_LONG_PERIOD);
     }
-    
+
     @Test
     public void createdOnNull() {
         Schedule2 schedule = createValidSchedule();
@@ -125,7 +124,7 @@ public class Schedule2ValidatorTest extends Mockito {
         schedule.setModifiedOn(null);
         assertValidatorMessage(INSTANCE, schedule, "modifiedOn", CANNOT_BE_NULL);
     }
-    
+
     @Test
     public void validatesSessions() {
         Schedule2 schedule = createValidSchedule();
@@ -134,25 +133,27 @@ public class Schedule2ValidatorTest extends Mockito {
         Session session2 = spy(SessionTest.createValidSession());
         session2.setName("Session 2");
         schedule.setSessions(ImmutableList.of(session1, session2));
-        
+
         Validate.entityThrowingException(INSTANCE, schedule);
-        
+
         // Actual tests of session validation occur in SessionValidatorTest.
         verify(session1).getName();
         verify(session2).getName();
     }
-    
+
     @Test
     public void sessionDelayCannotBeLongerThanScheduleDuration() {
         Schedule2 schedule = createValidSchedule();
         schedule.getSessions().get(0).setDelay(Period.parse("P8WT2M"));
-        assertValidatorMessage(INSTANCE, schedule, "sessions[0].delay", "cannot be longer than the schedule’s duration");
+        assertValidatorMessage(INSTANCE, schedule, "sessions[0].delay",
+                "cannot be longer than the schedule’s duration");
     }
 
     @Test
     public void sessionIntervalCannotBeLongerThanScheduleDuration() {
         Schedule2 schedule = createValidSchedule();
         schedule.getSessions().get(0).setInterval(Period.parse("P9W"));
-        assertValidatorMessage(INSTANCE, schedule, "sessions[0].interval", "cannot be longer than the schedule’s duration");
+        assertValidatorMessage(INSTANCE, schedule, "sessions[0].interval",
+                "cannot be longer than the schedule’s duration");
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/validators/ValidatorUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/ValidatorUtilsTest.java
@@ -43,18 +43,16 @@ import org.sagebionetworks.bridge.models.notifications.NotificationMessage;
 import org.sagebionetworks.bridge.models.studies.Enrollment;
 
 public class ValidatorUtilsTest extends Mockito {
-    
+
     @Test
     public void participantHasValidIdentifierValidEmail() {
-        StudyParticipant participant = new StudyParticipant.Builder()
-                .withEmail(EMAIL).build();
+        StudyParticipant participant = new StudyParticipant.Builder().withEmail(EMAIL).build();
         assertTrue(ValidatorUtils.participantHasValidIdentifier(participant));
     }
-    
+
     @Test
     public void participantHasValidIdentifierValiPhone() {
-        StudyParticipant participant = new StudyParticipant.Builder()
-                .withPhone(PHONE).build();
+        StudyParticipant participant = new StudyParticipant.Builder().withPhone(PHONE).build();
         assertTrue(ValidatorUtils.participantHasValidIdentifier(participant));
     }
 
@@ -64,20 +62,18 @@ public class ValidatorUtilsTest extends Mockito {
                 .withExternalIds(ImmutableMap.of(TEST_STUDY_ID, "extId")).build();
         assertTrue(ValidatorUtils.participantHasValidIdentifier(participant));
     }
-    
+
     @Test
     public void participantHasValidIdentifierValidSynapseUserId() {
-        StudyParticipant participant = new StudyParticipant.Builder()
-                .withSynapseUserId(SYNAPSE_USER_ID).build();
+        StudyParticipant participant = new StudyParticipant.Builder().withSynapseUserId(SYNAPSE_USER_ID).build();
         assertTrue(ValidatorUtils.participantHasValidIdentifier(participant));
     }
-    
+
     @Test
     public void participantHasValidIdentifierInvalid() {
-        StudyParticipant participant = new StudyParticipant.Builder()
-                .withExternalIds(ImmutableMap.of()).build();
+        StudyParticipant participant = new StudyParticipant.Builder().withExternalIds(ImmutableMap.of()).build();
         assertFalse(ValidatorUtils.participantHasValidIdentifier(participant));
-        
+
         participant = new StudyParticipant.Builder().build();
         assertFalse(ValidatorUtils.participantHasValidIdentifier(participant));
     }
@@ -88,14 +84,14 @@ public class ValidatorUtilsTest extends Mockito {
         account.setEmail(EMAIL);
         assertTrue(ValidatorUtils.accountHasValidIdentifier(account));
     }
-    
+
     @Test
     public void accountHasValidIdentifierValiPhone() {
         Account account = Account.create();
         account.setPhone(PHONE);
         assertTrue(ValidatorUtils.accountHasValidIdentifier(account));
     }
-    
+
     @Test
     public void accountHasValidIdentifierValidEnrollment() {
         Account account = Account.create();
@@ -105,20 +101,20 @@ public class ValidatorUtilsTest extends Mockito {
 
         assertTrue(ValidatorUtils.accountHasValidIdentifier(account));
     }
-    
+
     @Test
     public void accountHasValidIdentifierValidSynapseUserId() {
         Account account = Account.create();
         account.setSynapseUserId(SYNAPSE_USER_ID);
         assertTrue(ValidatorUtils.accountHasValidIdentifier(account));
     }
-    
+
     @Test
     public void accountHasValidIdentifierInvalid() {
         Account account = Account.create();
         account.setEnrollments(null);
         assertFalse(ValidatorUtils.accountHasValidIdentifier(account));
-        
+
         account = Account.create();
         Enrollment en1 = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         account.setEnrollments(ImmutableSet.of(en1));
@@ -128,7 +124,7 @@ public class ValidatorUtilsTest extends Mockito {
         account.setEnrollments(ImmutableSet.of());
         assertFalse(ValidatorUtils.accountHasValidIdentifier(account));
     }
-    
+
     @Test
     public void validateLabels_emptyValid() {
         Errors errors = mock(Errors.class);
@@ -140,14 +136,14 @@ public class ValidatorUtilsTest extends Mockito {
         Errors errors = mock(Errors.class);
         ValidatorUtils.validateLabels(errors, null);
     }
-    
+
     @Test
     public void validateLabels_duplicateLang() {
         Errors errors = mock(Errors.class);
-        
+
         List<Label> list = ImmutableList.of(new Label("en", "foo"), new Label("en", "bar"));
         ValidatorUtils.validateLabels(errors, list);
-        
+
         verify(errors).pushNestedPath("labels[0]");
         verify(errors).rejectValue("lang", DUPLICATE_LANG);
     }
@@ -155,32 +151,32 @@ public class ValidatorUtilsTest extends Mockito {
     @Test
     public void validateLabels_invalidLang() {
         Errors errors = mock(Errors.class);
-        
+
         List<Label> list = ImmutableList.of(new Label("yyyy", "foo"));
         ValidatorUtils.validateLabels(errors, list);
-        
+
         verify(errors).pushNestedPath("labels[0]");
         verify(errors).rejectValue("lang", INVALID_LANG);
     }
-    
+
     @Test
     public void validateLanguageSet_missingLang() {
         Errors errors = mock(Errors.class);
-        
+
         List<Label> list = ImmutableList.of(new Label("", "foo"));
         ValidatorUtils.validateLabels(errors, list);
-        
+
         verify(errors).pushNestedPath("labels[0]");
         verify(errors).rejectValue("lang", CANNOT_BE_BLANK);
     }
-    
+
     @Test
     public void validateLabels_valueBlank() {
         Errors errors = mock(Errors.class);
-        
+
         List<Label> list = ImmutableList.of(new Label("en", ""));
         ValidatorUtils.validateLabels(errors, list);
-        
+
         verify(errors, times(2)).pushNestedPath("labels[0]");
         verify(errors).rejectValue("value", CANNOT_BE_BLANK);
     }
@@ -188,24 +184,25 @@ public class ValidatorUtilsTest extends Mockito {
     @Test
     public void validateLabels_valueNull() {
         Errors errors = mock(Errors.class);
-        
+
         List<Label> list = ImmutableList.of(new Label("en", null));
         ValidatorUtils.validateLabels(errors, list);
 
         verify(errors, times(2)).pushNestedPath("labels[0]");
         verify(errors).rejectValue("value", CANNOT_BE_BLANK);
     }
-    
-    // Only minutes, hours, days, and weeks are allowed for the more fine-grained Duration
+
+    // Only minutes, hours, days, and weeks are allowed for the more fine-grained
+    // Duration
     // fields, and days or weeks for the longer Duration fields.
-    
+
     @Test
     public void validateFixedPeriodMonthsProhibited() {
         Errors errors = mock(Errors.class);
         Period period = Period.parse("P3M");
-        
+
         validateFixedLengthPeriod(errors, period, "period", false);
-        
+
         verify(errors).rejectValue("period", WRONG_PERIOD);
     }
 
@@ -213,9 +210,9 @@ public class ValidatorUtilsTest extends Mockito {
     public void validateFixedPeriodSecondsProhibited() {
         Errors errors = mock(Errors.class);
         Period period = Period.parse("PT180S");
-        
+
         validateFixedLengthPeriod(errors, period, "period", false);
-        
+
         verify(errors).rejectValue("period", WRONG_PERIOD);
     }
 
@@ -223,39 +220,39 @@ public class ValidatorUtilsTest extends Mockito {
     public void validateFixedPeriodYearsProhibited() {
         Errors errors = mock(Errors.class);
         Period period = Period.parse("P3Y");
-        
+
         validateFixedLengthPeriod(errors, period, "period", false);
-        
+
         verify(errors).rejectValue("period", WRONG_PERIOD);
     }
-    
+
     @Test
     public void validateFixedPeriodValid() {
         Errors errors = mock(Errors.class);
         Period period = Period.parse("P2W");
-        
+
         validateFixedLengthPeriod(errors, period, "period", false);
-        
+
         verify(errors, never()).rejectValue(any(), any());
     }
-    
+
     @Test
     public void validateFixedPeriodValidMinutesPeriod() {
         Errors errors = mock(Errors.class);
         Period period = Period.parse("PT30M");
 
         validateFixedLengthPeriod(errors, period, "period", false);
-        
+
         verify(errors, never()).rejectValue(any(), any());
     }
-    
+
     @Test
     public void validateFixedPeriodMixedWorks() {
         Errors errors = mock(Errors.class);
         Period period = Period.parse("P2W3DT30M");
 
         validateFixedLengthPeriod(errors, period, "period", false);
-        
+
         verify(errors, never()).rejectValue(any(), any());
     }
 
@@ -265,7 +262,7 @@ public class ValidatorUtilsTest extends Mockito {
         Period period = Period.parse("P3Y2W3DT30M");
 
         validateFixedLengthPeriod(errors, period, "period", false);
-        
+
         verify(errors).rejectValue("period", WRONG_PERIOD);
     }
 
@@ -274,10 +271,10 @@ public class ValidatorUtilsTest extends Mockito {
         Errors errors = mock(Errors.class);
 
         validateFixedLengthPeriod(errors, null, "period", true);
-        
+
         verify(errors).rejectValue("period", CANNOT_BE_NULL);
     }
-    
+
     @Test
     public void validateFixedPeriodCannotBeNegative() {
         Errors errors = mock(Errors.class);
@@ -285,19 +282,19 @@ public class ValidatorUtilsTest extends Mockito {
 
         validateFixedLengthPeriod(errors, period, "period", true);
 
-        // Despite adding up to a positive value, we don't allow it. 
+        // Despite adding up to a positive value, we don't allow it.
         verify(errors).rejectValue("period", CANNOT_BE_NEGATIVE);
     }
 
     // For the long period, only days and weeks are allowed.
-    
+
     @Test
     public void validateFixedLongPeriodMonthsProhibited() {
         Errors errors = mock(Errors.class);
         Period period = Period.parse("P3M");
-        
+
         validateFixedLengthLongPeriod(errors, period, "period", false);
-        
+
         verify(errors).rejectValue("period", WRONG_LONG_PERIOD);
     }
 
@@ -305,9 +302,9 @@ public class ValidatorUtilsTest extends Mockito {
     public void validateFixedLongPeriodSecondsProhibited() {
         Errors errors = mock(Errors.class);
         Period period = Period.parse("PT180S");
-        
+
         validateFixedLengthLongPeriod(errors, period, "period", false);
-        
+
         verify(errors).rejectValue("period", WRONG_LONG_PERIOD);
     }
 
@@ -315,39 +312,39 @@ public class ValidatorUtilsTest extends Mockito {
     public void validateFixedLongPeriodYearsProhibited() {
         Errors errors = mock(Errors.class);
         Period period = Period.parse("P3Y");
-        
+
         validateFixedLengthLongPeriod(errors, period, "period", false);
-        
+
         verify(errors).rejectValue("period", WRONG_LONG_PERIOD);
     }
-    
+
     @Test
     public void validateFixedLongWeeksValid() {
         Errors errors = mock(Errors.class);
         Period period = Period.parse("P2W");
-        
+
         validateFixedLengthLongPeriod(errors, period, "period", false);
-        
+
         verify(errors, never()).rejectValue(any(), any());
     }
-    
+
     @Test
     public void validateFixedLongDaysValid() {
         Errors errors = mock(Errors.class);
         Period period = Period.parse("P12D");
-        
+
         validateFixedLengthLongPeriod(errors, period, "period", false);
-        
+
         verify(errors, never()).rejectValue(any(), any());
     }
-    
+
     @Test
     public void validateFixedLongPeriodMixedWorks() {
         Errors errors = mock(Errors.class);
         Period period = Period.parse("P2W3D");
 
         validateFixedLengthLongPeriod(errors, period, "period", false);
-        
+
         verify(errors, never()).rejectValue(any(), any());
     }
 
@@ -357,7 +354,7 @@ public class ValidatorUtilsTest extends Mockito {
         Period period = Period.parse("P3Y2W3DT30M");
 
         validateFixedLengthLongPeriod(errors, period, "period", false);
-        
+
         verify(errors).rejectValue("period", WRONG_LONG_PERIOD);
     }
 
@@ -366,10 +363,10 @@ public class ValidatorUtilsTest extends Mockito {
         Errors errors = mock(Errors.class);
 
         validateFixedLengthLongPeriod(errors, null, "period", true);
-        
+
         verify(errors).rejectValue("period", CANNOT_BE_NULL);
     }
-    
+
     @Test
     public void validateFixedLongPeriodCannotBeNegative() {
         Errors errors = mock(Errors.class);
@@ -377,10 +374,10 @@ public class ValidatorUtilsTest extends Mockito {
 
         validateFixedLengthLongPeriod(errors, period, "period", true);
 
-        // Despite adding up to a positive value, we don't allow it. 
+        // Despite adding up to a positive value, we don't allow it.
         verify(errors).rejectValue("period", CANNOT_BE_NEGATIVE);
     }
-    
+
     @Test
     public void validateFixedLongPeriodCannotBeZero() {
         Errors errors = mock(Errors.class);
@@ -390,7 +387,7 @@ public class ValidatorUtilsTest extends Mockito {
 
         verify(errors).rejectValue("period", "cannot be of no duration");
     }
-    
+
     @Test
     public void validateFixedPeriodCannotBeZero() {
         Errors errors = mock(Errors.class);
@@ -400,32 +397,32 @@ public class ValidatorUtilsTest extends Mockito {
 
         verify(errors).rejectValue("period", "cannot be of no duration");
     }
-    
+
     @Test
     public void periodInMinutes() {
         Period period = Period.parse("P3W2DT10H14M"); // 33,734 minutes
         assertEquals(ValidatorUtils.periodInMinutes(period), 33734);
-        
+
         period = Period.parse("P0W0DT0H0M"); // 0 minutes
         assertEquals(ValidatorUtils.periodInMinutes(period), 0);
     }
-    
+
     @Test
     public void periodInDays() {
         Period period = Period.parse("P3W2D"); // 23 days
         assertEquals(ValidatorUtils.periodInDays(period), 23);
-        
+
         period = Period.parse("P0W0DT24H"); // 1 days
         assertEquals(ValidatorUtils.periodInDays(period), 1);
     }
-    
+
     @Test
     public void validatePassword_isBlank() {
         Errors errors = mock(Errors.class);
         validatePassword(errors, DEFAULT_PASSWORD_POLICY, "");
         verify(errors).rejectValue("password", "is required");
     }
-    
+
     @Test
     public void validatePassword_nothingRequired() {
         Errors errors = mock(Errors.class);
@@ -433,7 +430,7 @@ public class ValidatorUtilsTest extends Mockito {
         validatePassword(errors, policy, "m");
         verify(errors, never()).rejectValue(any(), any());
     }
-    
+
     @Test
     public void validatePassword_minLength() {
         Errors errors = mock(Errors.class);
@@ -441,7 +438,7 @@ public class ValidatorUtilsTest extends Mockito {
         validatePassword(errors, policy, "m");
         verify(errors).rejectValue("password", "must be at least 2 characters");
     }
-    
+
     @Test
     public void validatePassword_numericRequired() {
         Errors errors = mock(Errors.class);
@@ -455,7 +452,8 @@ public class ValidatorUtilsTest extends Mockito {
         Errors errors = mock(Errors.class);
         PasswordPolicy policy = new PasswordPolicy(0, false, true, false, false);
         validatePassword(errors, policy, "m");
-        verify(errors).rejectValue("password", "must contain at least one symbol ( !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~ )");
+        verify(errors).rejectValue("password",
+                "must contain at least one symbol ( !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~ )");
     }
 
     @Test
@@ -477,10 +475,8 @@ public class ValidatorUtilsTest extends Mockito {
     @Test
     public void messagesValid() {
         List<NotificationMessage> messages = ImmutableList.of(
-                new NotificationMessage.Builder().withLang("en")
-                    .withSubject("subject").withMessage("message").build(),
-                new NotificationMessage.Builder().withLang("de")
-                    .withSubject("subject").withMessage("message").build());
+                new NotificationMessage.Builder().withLang("en").withSubject("subject").withMessage("message").build(),
+                new NotificationMessage.Builder().withLang("de").withSubject("subject").withMessage("message").build());
         Errors errors = mock(Errors.class);
         ValidatorUtils.validateMessages(errors, messages);
         verify(errors, never()).rejectValue(any(), any());
@@ -492,162 +488,157 @@ public class ValidatorUtilsTest extends Mockito {
         ValidatorUtils.validateMessages(errors, null);
         verify(errors, never()).rejectValue(any(), any());
     }
-    
+
     @Test
     public void messagesEmptyOK() {
         Errors errors = mock(Errors.class);
         ValidatorUtils.validateMessages(errors, ImmutableList.of());
         verify(errors, never()).rejectValue(any(), any());
     }
-    
+
     @Test
     public void messagesMustContainEnglishDefault() {
-        List<NotificationMessage> messages = ImmutableList.of(
-            new NotificationMessage.Builder().withLang("fr").build(),
-            new NotificationMessage.Builder().withLang("de").build());
+        List<NotificationMessage> messages = ImmutableList.of(new NotificationMessage.Builder().withLang("fr").build(),
+                new NotificationMessage.Builder().withLang("de").build());
         Errors errors = mock(Errors.class);
         ValidatorUtils.validateMessages(errors, messages);
-        verify(errors, times(2)).rejectValue("messages", 
-                "must include an English-language message as a default");
+        verify(errors, times(2)).rejectValue("messages", "must include an English-language message as a default");
     }
-    
+
     @Test
     public void messageLanguageBlank() {
-        List<NotificationMessage> messages = ImmutableList.of(
-            new NotificationMessage.Builder().withLang("").build(),
-            new NotificationMessage.Builder().withLang("en").build());
+        List<NotificationMessage> messages = ImmutableList.of(new NotificationMessage.Builder().withLang("").build(),
+                new NotificationMessage.Builder().withLang("en").build());
         Errors errors = mock(Errors.class);
         ValidatorUtils.validateMessages(errors, messages);
         verify(errors, times(2)).pushNestedPath("messages[0]");
         verify(errors).rejectValue("lang", CANNOT_BE_BLANK);
     }
-    
+
     @Test
     public void messageLanguageNull() {
-        List<NotificationMessage> messages = ImmutableList.of(
-            new NotificationMessage.Builder().withLang(null).build(),
-            new NotificationMessage.Builder().withLang("en").build());
+        List<NotificationMessage> messages = ImmutableList.of(new NotificationMessage.Builder().withLang(null).build(),
+                new NotificationMessage.Builder().withLang("en").build());
         Errors errors = mock(Errors.class);
         ValidatorUtils.validateMessages(errors, messages);
         verify(errors, times(2)).pushNestedPath("messages[0]");
         verify(errors).rejectValue("lang", CANNOT_BE_BLANK);
     }
-    
+
     @Test
     public void messageLanguageCodeDuplicated() throws Exception {
-        List<NotificationMessage> messages = ImmutableList.of(
-            new NotificationMessage.Builder().withLang("en").build(),
-            new NotificationMessage.Builder().withLang("en").build());
+        List<NotificationMessage> messages = ImmutableList.of(new NotificationMessage.Builder().withLang("en").build(),
+                new NotificationMessage.Builder().withLang("en").build());
         Errors errors = mock(Errors.class);
         ValidatorUtils.validateMessages(errors, messages);
         verify(errors, times(2)).pushNestedPath("messages[1]");
         verify(errors).rejectValue("lang", DUPLICATE_LANG);
     }
-    
+
     @Test
     public void messsageLanguageCodeInvalid() {
-        List<NotificationMessage> messages = ImmutableList.of(
-            new NotificationMessage.Builder().withLang("yyy").build());
+        List<NotificationMessage> messages = ImmutableList
+                .of(new NotificationMessage.Builder().withLang("yyy").build());
         Errors errors = mock(Errors.class);
         ValidatorUtils.validateMessages(errors, messages);
         verify(errors, times(2)).pushNestedPath("messages[0]");
         verify(errors).rejectValue("lang", INVALID_LANG);
     }
-    
+
     @Test
     public void messageSubjectBlank() {
-        List<NotificationMessage> messages = ImmutableList.of(
-                new NotificationMessage.Builder().withLang("en").withSubject("\t\n").build());
+        List<NotificationMessage> messages = ImmutableList
+                .of(new NotificationMessage.Builder().withLang("en").withSubject("\t\n").build());
         Errors errors = mock(Errors.class);
         ValidatorUtils.validateMessages(errors, messages);
         verify(errors, times(2)).pushNestedPath("messages[0]");
         verify(errors).rejectValue("subject", CANNOT_BE_BLANK);
     }
-    
+
     @Test
     public void messageSubjectNull() {
-        List<NotificationMessage> messages = ImmutableList.of(
-                new NotificationMessage.Builder().withLang("en").withSubject(null).build());
+        List<NotificationMessage> messages = ImmutableList
+                .of(new NotificationMessage.Builder().withLang("en").withSubject(null).build());
         Errors errors = mock(Errors.class);
         ValidatorUtils.validateMessages(errors, messages);
         verify(errors, times(2)).pushNestedPath("messages[0]");
         verify(errors).rejectValue("subject", CANNOT_BE_BLANK);
     }
-    
+
     @Test
     public void messageSubjectTooLong() {
-        List<NotificationMessage> messages = ImmutableList.of(
-            new NotificationMessage.Builder().withLang("en")
-                .withSubject(StringUtils.repeat("X", 100)).build());
+        List<NotificationMessage> messages = ImmutableList
+                .of(new NotificationMessage.Builder().withLang("en").withSubject(StringUtils.repeat("X", 100)).build());
         Errors errors = mock(Errors.class);
         ValidatorUtils.validateMessages(errors, messages);
         verify(errors, times(2)).pushNestedPath("messages[0]");
         verify(errors).rejectValue("subject", "must be 40 characters or less");
     }
-    
+
     @Test
     public void messageBlank() {
         List<NotificationMessage> messages = ImmutableList.of(
-                new NotificationMessage.Builder().withLang("en")
-                .withSubject("subject").withMessage("\n\t").build());
+                new NotificationMessage.Builder().withLang("en").withSubject("subject").withMessage("\n\t").build());
         Errors errors = mock(Errors.class);
         ValidatorUtils.validateMessages(errors, messages);
         verify(errors, times(2)).pushNestedPath("messages[0]");
         verify(errors).rejectValue("message", CANNOT_BE_BLANK);
     }
-    
+
     @Test
     public void messageNull() {
-        List<NotificationMessage> messages = ImmutableList.of(
-                new NotificationMessage.Builder().withLang("en").withMessage(null).build());
+        List<NotificationMessage> messages = ImmutableList
+                .of(new NotificationMessage.Builder().withLang("en").withMessage(null).build());
         Errors errors = mock(Errors.class);
         ValidatorUtils.validateMessages(errors, messages);
         verify(errors, times(2)).pushNestedPath("messages[0]");
         verify(errors).rejectValue("message", CANNOT_BE_BLANK);
     }
-    
+
     @Test
     public void messageTooLong() {
-        List<NotificationMessage> messages = ImmutableList.of(
-                new NotificationMessage.Builder().withLang("en")
-                .withSubject("subject")
-                .withMessage(StringUtils.repeat("X", 100)).build());
+        List<NotificationMessage> messages = ImmutableList.of(new NotificationMessage.Builder().withLang("en")
+                .withSubject("subject").withMessage(StringUtils.repeat("X", 100)).build());
         Errors errors = mock(Errors.class);
         ValidatorUtils.validateMessages(errors, messages);
         verify(errors, times(2)).pushNestedPath("messages[0]");
         verify(errors).rejectValue("message", "must be 60 characters or less");
     }
+
     @Test
     public void backgroundColorInValid() {
         ColorScheme scheme = new ColorScheme("#FFFF1G", null, null, null);
-        
+
         Errors errors = mock(Errors.class);
         ValidatorUtils.validateColorScheme(errors, scheme, "colorScheme");
         verify(errors).pushNestedPath("colorScheme");
         verify(errors).rejectValue("background", INVALID_HEX_TRIPLET);
     }
+
     @Test
     public void foregroundColorInValid() {
         ColorScheme scheme = new ColorScheme(null, "#FFF", null, null);
-        
+
         Errors errors = mock(Errors.class);
         ValidatorUtils.validateColorScheme(errors, scheme, "colorScheme");
         verify(errors).pushNestedPath("colorScheme");
         verify(errors).rejectValue("foreground", INVALID_HEX_TRIPLET);
     }
+
     @Test
     public void activatedColorInValid() {
         ColorScheme scheme = new ColorScheme(null, null, "000", null);
-        
+
         Errors errors = mock(Errors.class);
         ValidatorUtils.validateColorScheme(errors, scheme, "colorScheme");
         verify(errors).pushNestedPath("colorScheme");
         verify(errors).rejectValue("activated", INVALID_HEX_TRIPLET);
     }
+
     @Test
     public void inactivatedColorInValid() {
         ColorScheme scheme = new ColorScheme(null, null, null, "cccccc");
-        
+
         Errors errors = mock(Errors.class);
         ValidatorUtils.validateColorScheme(errors, scheme, "colorScheme");
         verify(errors).pushNestedPath("colorScheme");

--- a/src/test/java/org/sagebionetworks/bridge/validators/ValidatorUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/ValidatorUtilsTest.java
@@ -411,6 +411,15 @@ public class ValidatorUtilsTest extends Mockito {
     }
     
     @Test
+    public void periodInDays() {
+        Period period = Period.parse("P3W2D"); // 23 days
+        assertEquals(ValidatorUtils.periodInDays(period), 23);
+        
+        period = Period.parse("P0W0DT24H"); // 1 days
+        assertEquals(ValidatorUtils.periodInDays(period), 1);
+    }
+    
+    @Test
     public void validatePassword_isBlank() {
         Errors errors = mock(Errors.class);
         validatePassword(errors, DEFAULT_PASSWORD_POLICY, "");


### PR DESCRIPTION
See BRIDGE-3078:

1. Added an index for TimelineMetadata scheduleGuid, although this had a marginal impact on the call time because the deletion was not the majority of the time being spent on the call (it was about 10 seconds of deleting and over a minute of record insertions).
2. Switched to JDBC to avoid a Hibernate behavior of inserting and then updating each record, which I could not prevent. This halved insert time;
3. Properly implemented batch calls by rewriting insert statements to concatenate them in the SQL, which halved the insert time again (times reduced to approximately 5s and 15s, respectively);
4. Used validation to limit the duration of a schedule to five years (the example that triggered this issue was ten years long—no study that has been proposed that I’m aware of has been ten years long). This brings the total call time down to under 3s, which is acceptable.