### PR TITLE
Fix Exporter Principal IDs

### DIFF
--- a/src/main/resources/BridgeServer2.conf
+++ b/src/main/resources/BridgeServer2.conf
@@ -23,7 +23,10 @@ synapse.api.key = yours-synapse-api-key
 
 exporter.synapse.user = your-exporter-synapse-user
 exporter.synapse.api.key = your-exporter-synapse-api-key
-exporter.synapse.id = 3325672
+local.exporter.synapse.id = 3330889
+dev.exporter.synapse.id = 3330889
+uat.exporter.synapse.id = 3327942
+prod.exporter.synapse.id = 3325672
 test.synapse.user.id = 3348228
 
 


### PR DESCRIPTION
We configured Bridge Server with the prod principal ID for Exporter Synapse accounts. This causes a weird thing where Dev will create the project then immediately set its permissions to the prod account, and then the project becomes unusable.