### PR TITLE
Disable Exporter 3.0 for Upload Redrives

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/UploadService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/UploadService.java
@@ -448,9 +448,10 @@ public class UploadService {
         }
 
         // kick off upload validation
+        // Note: Exporter 3.0 is disabled for redrive. See https://sagebionetworks.jira.com/browse/BRIDGE-3080
         App app = appService.getApp(appId);
         Exporter3Configuration exporter3Config = app.getExporter3Configuration();
-        if (app.isExporter3Enabled() && exporter3Config != null && exporter3Config.isConfigured()) {
+        if (!redrive && app.isExporter3Enabled() && exporter3Config != null && exporter3Config.isConfigured()) {
             exporter3Service.completeUpload(app, upload);
         }
 

--- a/src/test/java/org/sagebionetworks/bridge/services/UploadServiceUploadCompleteTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/UploadServiceUploadCompleteTest.java
@@ -240,6 +240,9 @@ public class UploadServiceUploadCompleteTest {
 
     @Test
     public void redrive() {
+        // Enable Exporter 3. It still won't be run anyway because Exporter is disabled for redrive.
+        app.setExporter3Enabled(true);
+
         // Create upload that's already marked as succeeded.
         DynamoUpload2 upload = new DynamoUpload2();
         upload.setUploadId(TEST_UPLOAD_ID);
@@ -252,6 +255,9 @@ public class UploadServiceUploadCompleteTest {
 
         // execute
         svc.uploadComplete(TEST_APP_ID, APP, upload, true);
+
+        // Verify that we DO NOT call Exporter 3.0
+        verify(mockExporter3Service, never()).completeUpload(any(), any());
 
         // Verify upload DAO and validation.
         verify(mockUploadDao).uploadComplete(APP, upload);


### PR DESCRIPTION
Exporter 3.0 breaks for redrives because the record already exists. This causes UploadService to fail, which causes the Exporter 2.0 stuff to also fail.