### PR TITLE
Fixing how a couple of error conditions are reported back to the user.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/hibernate/AccountPersistenceExceptionConverter.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/AccountPersistenceExceptionConverter.java
@@ -27,6 +27,7 @@ public class AccountPersistenceExceptionConverter implements PersistenceExceptio
     private static final Logger LOG = LoggerFactory.getLogger(AccountPersistenceExceptionConverter.class);
 
     static final String NON_UNIQUE_MSG = "This account has already been associated to the study (possibly through another external ID).";
+    static final String ENROLLED_BY_CONSTRAINT_MSG = "Cannot delete account because it has been recorded as enrolling another account.";
     
     private final AccountDao accountDao;
 
@@ -94,6 +95,9 @@ public class AccountPersistenceExceptionConverter implements PersistenceExceptio
                 } else if (message.matches(".*a foreign key constraint fails.*REFERENCES `Organizations`.*")) {
                     // This happens when the orgMembership key is not a real organization
                     return new EntityNotFoundException(Organization.class);
+                } else if (message.matches(".*a foreign key constraint fails.*enrolledBy.*")) {
+                    return new ConstraintViolationException.Builder()
+                            .withMessage(ENROLLED_BY_CONSTRAINT_MSG).build();
                 }
                 if (eae != null) {
                     return eae;

--- a/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
@@ -44,6 +44,8 @@ public class EnrollmentService {
     
     private EnrollmentDao enrollmentDao;
     
+    private StudyService studyService;
+    
     @Autowired
     final void setAccountService(AccountService accountService) {
         this.accountService = accountService;
@@ -52,6 +54,11 @@ public class EnrollmentService {
     @Autowired
     final void setEnrollmentDao(EnrollmentDao enrollmentDao) {
         this.enrollmentDao = enrollmentDao;
+    }
+    
+    @Autowired
+    final void setStudyService(StudyService studyService) {
+        this.studyService = studyService;
     }
     
     protected DateTime getEnrollmentDateTime() {
@@ -71,6 +78,8 @@ public class EnrollmentService {
         checkNotNull(appId);
         checkNotNull(studyId);
         
+        studyService.getStudy(appId, studyId, true);
+        
         CAN_EDIT_STUDY_PARTICIPANTS.checkAndThrow(STUDY_ID, studyId);
 
         if (offsetBy != null && offsetBy < 0) {
@@ -89,6 +98,8 @@ public class EnrollmentService {
         checkNotNull(appId);
         checkNotNull(userIdToken);
         
+        studyService.getStudy(appId, studyId, true);
+        
         // We want all enrollments, even withdrawn enrollments, so don't filter here.
         AccountId accountId = BridgeUtils.parseAccountId(appId, userIdToken);
         Account account = accountService.getAccount(accountId)
@@ -104,7 +115,9 @@ public class EnrollmentService {
 
         // verify this has appId and accountId
         Validate.entityThrowingException(INSTANCE, enrollment);
-        
+
+        studyService.getStudy(enrollment.getAppId(), enrollment.getStudyId(), true);
+
         // Verify that the caller has access to this study
         CAN_EDIT_ENROLLMENTS.checkAndThrow(STUDY_ID, enrollment.getStudyId(), USER_ID,
                 enrollment.getAccountId());
@@ -131,6 +144,8 @@ public class EnrollmentService {
         checkNotNull(newEnrollment);
         
         Validate.entityThrowingException(INSTANCE, newEnrollment);
+        
+        studyService.getStudy(newEnrollment.getAppId(), newEnrollment.getStudyId(), true);
         
         CAN_EDIT_ENROLLMENTS.checkAndThrow(STUDY_ID, newEnrollment.getStudyId(), USER_ID, account.getId());
 
@@ -173,6 +188,8 @@ public class EnrollmentService {
         
         Validate.entityThrowingException(INSTANCE, enrollment);
         
+        studyService.getStudy(enrollment.getAppId(), enrollment.getStudyId(), true);
+        
         final EnrollmentHolder holder = new EnrollmentHolder();
         AccountId accountId = AccountId.forId(enrollment.getAppId(), enrollment.getAccountId());
         accountService.editAccount(accountId, (acct) -> {
@@ -189,6 +206,8 @@ public class EnrollmentService {
         checkNotNull(enrollment);
         
         Validate.entityThrowingException(INSTANCE, enrollment);
+        
+        studyService.getStudy(enrollment.getAppId(), enrollment.getStudyId(), true);
         
         CAN_EDIT_ENROLLMENTS.checkAndThrow(STUDY_ID, enrollment.getStudyId(), USER_ID, account.getId());
         

--- a/src/test/java/org/sagebionetworks/bridge/services/EnrollmentServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/EnrollmentServiceTest.java
@@ -55,6 +55,7 @@ import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.studies.Enrollment;
 import org.sagebionetworks.bridge.models.studies.EnrollmentDetail;
 import org.sagebionetworks.bridge.models.studies.EnrollmentFilter;
+import org.sagebionetworks.bridge.models.studies.Study;
 
 public class EnrollmentServiceTest extends Mockito {
 
@@ -63,6 +64,9 @@ public class EnrollmentServiceTest extends Mockito {
     
     @Mock
     SponsorService mockSponsorService;
+    
+    @Mock
+    StudyService mockStudyService;
     
     @Mock
     EnrollmentDao mockEnrollmentDao;
@@ -571,5 +575,50 @@ public class EnrollmentServiceTest extends Mockito {
         enrollment.setAccountId(null);
 
         service.unenroll(enrollment);
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class,
+            expectedExceptionsMessageRegExp = "Study not found.")
+    public void getEnrollmentsForStudyStudyNotFound() {
+        when(mockStudyService.getStudy(TEST_APP_ID, TEST_STUDY_ID, true))
+            .thenThrow(new EntityNotFoundException(Study.class));
+        
+        service.getEnrollmentsForStudy(TEST_APP_ID, TEST_STUDY_ID, null, false, null, null);
+    }
+
+    @Test(expectedExceptions = EntityNotFoundException.class,
+            expectedExceptionsMessageRegExp = "Study not found.")
+    public void getEnrollmentsForUserStudyNotFound() {
+        when(mockStudyService.getStudy(TEST_APP_ID, TEST_STUDY_ID, true))
+            .thenThrow(new EntityNotFoundException(Study.class));
+    
+        service.getEnrollmentsForUser(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
+    }
+
+    @Test(expectedExceptions = EntityNotFoundException.class,
+            expectedExceptionsMessageRegExp = "Study not found.")
+    public void enrollStudyNotFound() {
+        when(mockStudyService.getStudy(TEST_APP_ID, TEST_STUDY_ID, true))
+            .thenThrow(new EntityNotFoundException(Study.class));
+
+        service.enroll(Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID));
+    }
+
+    @Test(expectedExceptions = EntityNotFoundException.class,
+            expectedExceptionsMessageRegExp = "Study not found.")
+    public void addEnrollmentStudyNotFound() {
+        when(mockStudyService.getStudy(TEST_APP_ID, TEST_STUDY_ID, true))
+            .thenThrow(new EntityNotFoundException(Study.class));
+        
+        service.addEnrollment(Account.create(), Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID));
+    }
+
+    @Test(expectedExceptions = EntityNotFoundException.class,
+            expectedExceptionsMessageRegExp = "Study not found.")
+    public void unenrollAccountStudyNotFound() {
+        when(mockStudyService.getStudy(TEST_APP_ID, TEST_STUDY_ID, true))
+            .thenThrow(new EntityNotFoundException(Study.class));
+        
+        service.unenroll(Account.create(), Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID));
     }
 }


### PR DESCRIPTION
1) enrolling someone in a non-existent study gave a strange exception, but now returns ENFE for a study (BRIDGE-3058);
2) deleting an account that was used to enroll another account threw a cryptic exception, it now explains that the account is being used that way and so cannot be deleted (found by me and fixed before filed).
