### PR TITLE
Making app delete more robust

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/dao/AccountDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dao/AccountDao.java
@@ -66,4 +66,6 @@ public interface AccountDao {
      */
     PagedResourceList<ExternalIdentifierInfo> getPagedExternalIds(String appId, String studyId, String idFilter,
             Integer offsetBy, Integer pageSize);
+    
+    void deleteAllAccounts(String appId);
 }    

--- a/src/main/java/org/sagebionetworks/bridge/dao/AssessmentDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dao/AssessmentDao.java
@@ -57,4 +57,6 @@ public interface AssessmentDao {
      * name of the organization; otherwise returns false.
      */
     boolean hasAssessmentFromOrg(String appId, String orgId);
+    
+    void deleteAllAssessments(String appId);
 }

--- a/src/main/java/org/sagebionetworks/bridge/dao/AssessmentResourceDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dao/AssessmentResourceDao.java
@@ -21,5 +21,7 @@ public interface AssessmentResourceDao {
     List<AssessmentResource> saveResources(String appId, String assessmentId, List<AssessmentResource> resources);
     
     void deleteResource(String appId, AssessmentResource resource);
+    
+    void deleteAllAssessmentResources(String appId);
 
 }

--- a/src/main/java/org/sagebionetworks/bridge/dao/Schedule2Dao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dao/Schedule2Dao.java
@@ -28,4 +28,6 @@ public interface Schedule2Dao {
     Optional<TimelineMetadata> getTimelineMetadata(String instanceGuid);
     
     List<TimelineMetadata> getAssessmentsForSessionInstance(String instanceGuid);
+    
+    void deleteAllSchedules(String appId);
 }

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDao.java
@@ -59,12 +59,13 @@ import org.sagebionetworks.bridge.models.apps.App;
 /** Hibernate implementation of Account Dao. */
 @Component
 public class HibernateAccountDao implements AccountDao {
-    
     private static final Logger LOG = LoggerFactory.getLogger(HibernateAccountDao.class);
 
     static final String ID_QUERY = "SELECT acct.id FROM HibernateAccount AS acct";
     static final String FULL_QUERY = "SELECT acct FROM HibernateAccount AS acct";
     static final String COUNT_QUERY = "SELECT COUNT(DISTINCT acct.id) FROM HibernateAccount AS acct";
+    static final String DELETE_ALL_ACCOUNTS_QUERY = "DELETE FROM Accounts WHERE studyId = :appId";
+    static final String APP_IDS_FOR_USER_QUERY = "SELECT DISTINCT acct.appId FROM HibernateAccount AS acct WHERE synapseUserId = :synapseUserId";
     
     static final String EXTID_BASE_QUERY = "from HibernateEnrollment as en "
             + "WHERE en.appId = :appId AND en.studyId = :studyId "
@@ -91,9 +92,7 @@ public class HibernateAccountDao implements AccountDao {
             return ImmutableList.of();
         }
         QueryBuilder query = new QueryBuilder();
-        query.append(
-            "SELECT DISTINCT acct.appId FROM HibernateAccount AS acct WHERE synapseUserId = :synapseUserId",
-            "synapseUserId", synapseUserId);
+        query.append(APP_IDS_FOR_USER_QUERY, "synapseUserId", synapseUserId);
         return hibernateHelper.queryGet(query.getQuery(), query.getParameters(), null, null, String.class);
     }
     
@@ -323,5 +322,15 @@ public class HibernateAccountDao implements AccountDao {
         int count = hibernateHelper.queryCount("SELECT count(en) " + query.getQuery(), query.getParameters());
 
         return new PagedResourceList<>(infos, count, true);
+    }
+    
+    @Override
+    public void deleteAllAccounts(String appId) {
+        checkNotNull(appId);
+        
+        QueryBuilder builder = new QueryBuilder();
+        builder.append(DELETE_ALL_ACCOUNTS_QUERY, "appId", appId);
+        
+        hibernateHelper.nativeQueryUpdate(builder.getQuery(), builder.getParameters());
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAssessmentDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAssessmentDao.java
@@ -25,8 +25,6 @@ import org.sagebionetworks.bridge.models.assessments.config.HibernateAssessmentC
 
 @Component
 class HibernateAssessmentDao implements AssessmentDao {
-    static final String DELETE_RESOURCES_SQL = "DELETE FROM ExternalResources where appId = :appId AND assessmentId = :assessmentId";
-    static final String DELETE_CONFIG_SQL = "DELETE FROM AssessmentConfigs where guid = :guid";
     static final String APP_ID = "appId";
     static final String ASSESSMENT_ID = "assessmentId";
     static final String IDENTIFIER = "identifier";
@@ -46,6 +44,9 @@ class HibernateAssessmentDao implements AssessmentDao {
     static final String GET_REVISIONS2 = "ORDER BY revision DESC";
     static final String EXCLUDE_DELETED = "AND deleted = 0";
     static final String LIMIT_TO_OWNER = "AND ownerId = :ownerId";
+    static final String DELETE_ALL_ASSESSMENTS_SQL = "DELETE FROM Assessments WHERE appId = :appId";
+    static final String DELETE_RESOURCES_SQL = "DELETE FROM ExternalResources where appId = :appId AND assessmentId = :assessmentId";
+    static final String DELETE_CONFIG_SQL = "DELETE FROM AssessmentConfigs where guid = :guid";
 
     private HibernateHelper hibernateHelper;
     
@@ -242,5 +243,13 @@ class HibernateAssessmentDao implements AssessmentDao {
         params.put(OWNER_ID, appId + ":" + orgId);
         resultCount = hibernateHelper.queryCount(builder.getQuery(), builder.getParameters());
         return resultCount != 0;
+    }
+    
+    @Override
+    public void deleteAllAssessments(String appId) {
+        QueryBuilder builder = new QueryBuilder();
+        builder.append(DELETE_ALL_ASSESSMENTS_SQL, APP_ID, appId);
+        
+        hibernateHelper.nativeQueryUpdate(builder.getQuery(), builder.getParameters());
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAssessmentResourceDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAssessmentResourceDao.java
@@ -23,6 +23,7 @@ import org.sagebionetworks.bridge.models.assessments.ResourceCategory;
 @Component
 public class HibernateAssessmentResourceDao implements AssessmentResourceDao {
     static final String DELETE_QUERY = "DELETE FROM ExternalResources WHERE appId = :appId AND guid = :guid";
+    static final String DELETE_ALL_QUERY = "DELETE FROM ExternalResources WHERE appId = :appId";
     static final String ALL_RESOURCES_QUERY = "from HibernateAssessmentResource WHERE appId = :appId " + 
             "AND assessmentId = :assessmentId AND deleted = 0";
     private HibernateHelper hibernateHelper;
@@ -115,5 +116,13 @@ public class HibernateAssessmentResourceDao implements AssessmentResourceDao {
             query.executeUpdate();
             return null;
         });
+    }
+    
+    @Override
+    public void deleteAllAssessmentResources(String appId) {
+        QueryBuilder builder = new QueryBuilder();
+        builder.append(DELETE_ALL_QUERY, "appId", appId);
+        
+        hibernateHelper.nativeQueryUpdate(builder.getQuery(), builder.getParameters());
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2Dao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2Dao.java
@@ -52,7 +52,7 @@ public class HibernateSchedule2Dao implements Schedule2Dao {
             + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
     static final String DELETE_TIMELINE_RECORDS = "DELETE FROM TimelineMetadata WHERE scheduleGuid = :scheduleGuid";
     static final String SELECT_ASSESSMENTS_FOR_SESSION_INSTANCE = "SELECT * FROM TimelineMetadata WHERE sessionInstanceGuid = :instanceGuid AND assessmentInstanceGuid IS NOT NULL";
-
+    static final String DELETE_ALL_SCHEDULES = "DELETE FROM Schedules WHERE appId = :appId";
     static final String BATCH_SIZE_PROPERTY = "schedule.batch.size";
 
     static final String APP_ID = "appId";
@@ -292,5 +292,15 @@ public class HibernateSchedule2Dao implements Schedule2Dao {
 
         return hibernateHelper.nativeQueryGet(builder.getQuery(), builder.getParameters(), null, null,
                 TimelineMetadata.class);
+    }
+    
+    @Override
+    public void deleteAllSchedules(String appId) {
+        checkNotNull(appId);
+
+        QueryBuilder builder = new QueryBuilder();
+        builder.append(DELETE_ALL_SCHEDULES, APP_ID, appId);
+
+        hibernateHelper.nativeQueryUpdate(builder.getQuery(), builder.getParameters());
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
@@ -383,6 +383,12 @@ public class AccountService {
         return accountDao.getPagedExternalIds(appId, studyId, idFilter, offsetBy, pageSize);
     }
     
+    public void deleteAllAccounts(String appId) {
+        checkNotNull(appId);
+        
+        accountDao.deleteAllAccounts(appId);
+    }
+    
     protected Account authenticateInternal(App app, Account account, SignIn signIn) {
         // Auth successful, you can now leak further information about the account through other exceptions.
         // For email/phone sign ins, the specific credential must have been verified (unless we've disabled

--- a/src/main/java/org/sagebionetworks/bridge/services/AppService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AppService.java
@@ -129,6 +129,7 @@ public class AppService {
     private TemplateService templateService;
     private FileService fileService;
     private OrganizationService organizationService;
+    private Schedule2Service scheduleService;
     private AccountService accountService;
     private AssessmentService assessmentService;
     private AssessmentResourceService assessmentResourceService;
@@ -228,6 +229,10 @@ public class AppService {
     @Autowired
     final void setOrganizationService(OrganizationService organizationService) {
         this.organizationService = organizationService;
+    }
+    @Autowired
+    final void setSchedule2Service(Schedule2Service scheduleService) {
+        this.scheduleService = scheduleService;
     }
     @Autowired
     final void setAccountService(AccountService accountService) {
@@ -648,21 +653,22 @@ public class AppService {
             }
             appDao.deactivateApp(existing.getIdentifier());
         } else {
-            // actual delete
-            appDao.deleteApp(existing);
-
             // delete app data
             accountService.deleteAllAccounts(existing.getIdentifier());
+            studyService.deleteAllStudies(existing.getIdentifier());
+            scheduleService.deleteAllSchedules(existing.getIdentifier());
             assessmentResourceService.deleteAllAssessmentResources(existing.getIdentifier());
             assessmentService.deleteAllAssessments(existing.getIdentifier());
-            studyService.deleteAllStudies(existing.getIdentifier());
             organizationService.deleteAllOrganizations(existing.getIdentifier());
-            templateService.deleteTemplatesForApp(existing.getIdentifier());
+            templateService.deleteAllTemplates(existing.getIdentifier());
             compoundActivityDefinitionService.deleteAllCompoundActivityDefinitionsInApp(
                     existing.getIdentifier());
             subpopService.deleteAllSubpopulations(existing.getIdentifier());
             topicService.deleteAllTopics(existing.getIdentifier());
             fileService.deleteAllAppFiles(existing.getIdentifier());
+            
+            // actual delete
+            appDao.deleteApp(existing);
         }
 
         cacheProvider.removeApp(identifier);

--- a/src/main/java/org/sagebionetworks/bridge/services/AppService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AppService.java
@@ -129,6 +129,9 @@ public class AppService {
     private TemplateService templateService;
     private FileService fileService;
     private OrganizationService organizationService;
+    private AccountService accountService;
+    private AssessmentService assessmentService;
+    private AssessmentResourceService assessmentResourceService;
 
     // Not defaults, if you wish to change these, change in source. Not configurable per app
     private String appEmailVerificationTemplate;
@@ -225,6 +228,18 @@ public class AppService {
     @Autowired
     final void setOrganizationService(OrganizationService organizationService) {
         this.organizationService = organizationService;
+    }
+    @Autowired
+    final void setAccountService(AccountService accountService) {
+        this.accountService = accountService;
+    }
+    @Autowired
+    final void setAssessmentService(AssessmentService assessmentService) {
+        this.assessmentService = assessmentService;
+    }
+    @Autowired
+    final void setAssessmentResourceService(AssessmentResourceService assessmentResourceService) {
+        this.assessmentResourceService = assessmentResourceService;
     }
     
     public App getApp(String identifier, boolean includeDeleted) {
@@ -637,6 +652,9 @@ public class AppService {
             appDao.deleteApp(existing);
 
             // delete app data
+            accountService.deleteAllAccounts(existing.getIdentifier());
+            assessmentResourceService.deleteAllAssessmentResources(existing.getIdentifier());
+            assessmentService.deleteAllAssessments(existing.getIdentifier());
             studyService.deleteAllStudies(existing.getIdentifier());
             organizationService.deleteAllOrganizations(existing.getIdentifier());
             templateService.deleteTemplatesForApp(existing.getIdentifier());

--- a/src/main/java/org/sagebionetworks/bridge/services/AssessmentResourceService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AssessmentResourceService.java
@@ -225,6 +225,12 @@ public class AssessmentResourceService {
         return copyResources(appId, SHARED_APP_ID, assessment, guids);
     }
     
+    public void deleteAllAssessmentResources(String appId) {
+        checkArgument(isNotBlank(appId));
+        
+        dao.deleteAllAssessmentResources(appId);
+    }
+    
     List<AssessmentResource> copyResources(String originId, String targetId, Assessment assessment, Set<String> guids) {
         checkArgument(isNotBlank(originId));
         checkArgument(isNotBlank(targetId));

--- a/src/main/java/org/sagebionetworks/bridge/services/AssessmentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AssessmentService.java
@@ -381,6 +381,12 @@ public class AssessmentService {
             dao.deleteAssessment(appId, assessment);
         }
     }
+    
+    public void deleteAllAssessments(String appId) {
+        checkArgument(isNotBlank(appId));
+        
+        dao.deleteAllAssessments(appId);
+    }
 
     private Assessment createAssessmentInternal(String appId, Assessment assessment) {
         checkArgument(isNotBlank(appId));

--- a/src/main/java/org/sagebionetworks/bridge/services/Schedule2Service.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/Schedule2Service.java
@@ -339,6 +339,12 @@ public class Schedule2Service {
         return dao.getAssessmentsForSessionInstance(instanceGuid);
     }
     
+    public void deleteAllSchedules(String appId) {
+        checkNotNull(appId);
+        
+        dao.deleteAllSchedules(appId);
+    }
+    
     /**
      * Set GUIDs on objects that don't have them; clean up event keys or set
      * them to null if they're not valid, so they will fail validation.

--- a/src/main/java/org/sagebionetworks/bridge/services/TemplateService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/TemplateService.java
@@ -398,7 +398,7 @@ public class TemplateService {
         criteriaDao.deleteCriteria(getKey(template));
     }
     
-    public void deleteTemplatesForApp(String appId) {
+    public void deleteAllTemplates(String appId) {
         templateDao.deleteTemplatesForApp(appId);
     }
 

--- a/src/main/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandler.java
@@ -47,7 +47,6 @@ public class BridgeExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<String> handleException(HttpServletRequest request, Exception ex) throws JsonProcessingException {
-        ex.printStackTrace();
         logException(request, ex);
 
         return getResult(ex);

--- a/src/main/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandler.java
@@ -47,6 +47,7 @@ public class BridgeExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<String> handleException(HttpServletRequest request, Exception ex) throws JsonProcessingException {
+        ex.printStackTrace();
         logException(request, ex);
 
         return getResult(ex);

--- a/src/main/java/org/sagebionetworks/bridge/validators/AssessmentValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/AssessmentValidator.java
@@ -98,7 +98,7 @@ public class AssessmentValidator implements Validator {
                 ownerAppId = appId;
                 ownerOrgId = assessment.getOwnerId();
             }
-            if (organizationService.getOrganization(ownerAppId, ownerOrgId) == null) {
+            if (!organizationService.getOrganizationOpt(ownerAppId, ownerOrgId).isPresent()) {
                 errors.rejectValue("ownerId", "is not a valid organization ID");
             }
         }

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAccountDaoTest.java
@@ -13,6 +13,8 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_NOTE;
 import static org.sagebionetworks.bridge.dao.AccountDao.MIGRATION_VERSION;
+import static org.sagebionetworks.bridge.hibernate.HibernateAccountDao.APP_IDS_FOR_USER_QUERY;
+import static org.sagebionetworks.bridge.hibernate.HibernateAccountDao.DELETE_ALL_ACCOUNTS_QUERY;
 import static org.sagebionetworks.bridge.hibernate.HibernateAccountDao.FULL_QUERY;
 import static org.sagebionetworks.bridge.models.SearchTermPredicate.AND;
 import static org.sagebionetworks.bridge.models.StringSearchPosition.INFIX;
@@ -1220,8 +1222,7 @@ public class HibernateAccountDaoTest extends Mockito {
         List<String> results = dao.getAppIdForUser(SYNAPSE_USER_ID);
         assertEquals(results, queryResult);
         
-        verify(mockHibernateHelper).queryGet(eq("SELECT DISTINCT acct.appId FROM HibernateAccount AS acct WHERE "+
-                "synapseUserId = :synapseUserId"), paramCaptor.capture(), eq(null), eq(null), eq(String.class));
+        verify(mockHibernateHelper).queryGet(eq(APP_IDS_FOR_USER_QUERY), paramCaptor.capture(), eq(null), eq(null), eq(String.class));
         Map<String,Object> params = paramCaptor.getValue();
         assertEquals(params.get("synapseUserId"), SYNAPSE_USER_ID);
     }
@@ -1299,6 +1300,14 @@ public class HibernateAccountDaoTest extends Mockito {
         assertEquals(params2.get("appId"), TEST_APP_ID);
         assertEquals(params2.get("studyId"), TEST_STUDY_ID);
         assertNull(params1.get("idFilter"));        
+    }
+    
+    @Test
+    public void deleteAllAccounts() {
+        dao.deleteAllAccounts(TEST_APP_ID);
+        
+        verify(mockHibernateHelper).nativeQueryUpdate(eq(DELETE_ALL_ACCOUNTS_QUERY), paramCaptor.capture());
+        assertEquals(paramCaptor.getValue().get("appId"), TEST_APP_ID);
     }
 
     private void verifyCreatedHealthCode() {

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAssessmentDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAssessmentDaoTest.java
@@ -2,7 +2,9 @@ package org.sagebionetworks.bridge.hibernate;
 
 import static org.sagebionetworks.bridge.TestConstants.GUID;
 import static org.sagebionetworks.bridge.TestConstants.IDENTIFIER;
+import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
+import static org.sagebionetworks.bridge.hibernate.HibernateAssessmentDao.DELETE_ALL_ASSESSMENTS_SQL;
 import static org.sagebionetworks.bridge.hibernate.HibernateAssessmentDao.DELETE_CONFIG_SQL;
 import static org.sagebionetworks.bridge.hibernate.HibernateAssessmentDao.DELETE_RESOURCES_SQL;
 import static org.testng.Assert.assertEquals;
@@ -33,7 +35,6 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
 import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.assessments.Assessment;
@@ -86,10 +87,8 @@ public class HibernateAssessmentDaoTest extends Mockito {
     private static final String QUERY_COUNT_FROM_ORG = "SELECT COUNT(*) FROM HibernateAssessment WHERE " +
             "(appId = :appId AND ownerId = :ownerId)";
     
-    private static final String APP_ID_VALUE = "appId";
     private static final String ID_VALUE = "identifier";
     private static final String GUID_VALUE = "guid";
-    private static final String ORG_ID = "test-org";
     private static final int REV_VALUE = 3;
     private static final HibernateAssessment HIBERNATE_ASSESSMENT = new HibernateAssessment();
     
@@ -139,12 +138,12 @@ public class HibernateAssessmentDaoTest extends Mockito {
         when(mockHelper.nativeQueryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(0), eq(20), eq(HibernateAssessment.class)))
                 .thenReturn(list);
         
-        PagedResourceList<Assessment> page = dao.getAssessments(APP_ID_VALUE, null, 0, 20, null, false);
+        PagedResourceList<Assessment> page = dao.getAssessments(TEST_APP_ID, null, 0, 20, null, false);
         assertEquals(queryCaptor.getAllValues().get(0), "SELECT COUNT(*) " + QUERY_SQL_EXC_DELETED);
         assertEquals(queryCaptor.getAllValues().get(1), "SELECT * " + QUERY_SQL_EXC_DELETED);
         
         Map<String,Object> params = paramsCaptor.getValue();
-        assertEquals(params.get("appId"), APP_ID_VALUE);
+        assertEquals(params.get("appId"), TEST_APP_ID);
         assertEquals(page.getItems().size(), 5);
         assertEquals(page.getTotal(), Integer.valueOf(5));
     }
@@ -157,12 +156,12 @@ public class HibernateAssessmentDaoTest extends Mockito {
         when(mockHelper.nativeQueryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(0), eq(20), eq(HibernateAssessment.class)))
                 .thenReturn(list);
         
-        PagedResourceList<Assessment> page = dao.getAssessments(APP_ID_VALUE, TEST_ORG_ID, 0, 20, null, false);
+        PagedResourceList<Assessment> page = dao.getAssessments(TEST_APP_ID, TEST_ORG_ID, 0, 20, null, false);
         assertEquals(queryCaptor.getAllValues().get(0), "SELECT COUNT(*) " + QUERY_SQL_WITH_OWNERID_EXC_DELETED);
         assertEquals(queryCaptor.getAllValues().get(1), "SELECT * " + QUERY_SQL_WITH_OWNERID_EXC_DELETED);
         
         Map<String,Object> params = paramsCaptor.getValue();
-        assertEquals(params.get("appId"), APP_ID_VALUE);
+        assertEquals(params.get("appId"), TEST_APP_ID);
         assertEquals(params.get("ownerId"), TEST_ORG_ID);
         assertEquals(page.getItems().size(), 5);
         assertEquals(page.getTotal(), Integer.valueOf(5));
@@ -174,7 +173,7 @@ public class HibernateAssessmentDaoTest extends Mockito {
         when(mockHelper.nativeQueryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(0), eq(20), eq(HibernateAssessment.class)))
                 .thenReturn(ImmutableList.of());
         
-        dao.getAssessments(APP_ID_VALUE, null, 0, 20, null, true);
+        dao.getAssessments(TEST_APP_ID, null, 0, 20, null, true);
         assertEquals(queryCaptor.getAllValues().get(0), "SELECT COUNT(*) " + QUERY_SQL_INC_DELETED);
         assertEquals(queryCaptor.getAllValues().get(1), "SELECT * " + QUERY_SQL_INC_DELETED);
     }
@@ -185,7 +184,7 @@ public class HibernateAssessmentDaoTest extends Mockito {
         when(mockHelper.nativeQueryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(0), eq(20), eq(HibernateAssessment.class)))
                 .thenReturn(ImmutableList.of());
         
-        dao.getAssessments(APP_ID_VALUE, null, 0, 20, ImmutableSet.of("tagA", "tagB"), false);
+        dao.getAssessments(TEST_APP_ID, null, 0, 20, ImmutableSet.of("tagA", "tagB"), false);
         assertEquals(queryCaptor.getAllValues().get(0), "SELECT COUNT(*) " + QUERY_SQL_WITH_TAGS);
         assertEquals(queryCaptor.getAllValues().get(1), "SELECT * " + QUERY_SQL_WITH_TAGS);
     }
@@ -197,14 +196,14 @@ public class HibernateAssessmentDaoTest extends Mockito {
         when(mockHelper.queryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(0), eq(20), eq(HibernateAssessment.class)))
             .thenReturn(ImmutableList.of(HIBERNATE_ASSESSMENT, HIBERNATE_ASSESSMENT, HIBERNATE_ASSESSMENT));
         
-        PagedResourceList<Assessment> page = dao.getAssessmentRevisions(APP_ID_VALUE, null, ID_VALUE, 0, 20, true);
+        PagedResourceList<Assessment> page = dao.getAssessmentRevisions(TEST_APP_ID, null, ID_VALUE, 0, 20, true);
         assertEquals(page.getItems().size(), 3);
         assertEquals(page.getTotal(), Integer.valueOf(100));
         
         assertEquals(queryCaptor.getValue(), QUERY_GET_REVISIONS_INC_DELETED);
         
         Map<String,Object> params = paramsCaptor.getValue();
-        assertEquals(params.get("appId"), APP_ID_VALUE);
+        assertEquals(params.get("appId"), TEST_APP_ID);
         assertEquals(params.get("identifier"), ID_VALUE);
         assertNull(params.get("ownerId"));
     }
@@ -216,14 +215,14 @@ public class HibernateAssessmentDaoTest extends Mockito {
         when(mockHelper.queryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(0), eq(20), eq(HibernateAssessment.class)))
             .thenReturn(ImmutableList.of(HIBERNATE_ASSESSMENT, HIBERNATE_ASSESSMENT, HIBERNATE_ASSESSMENT));
         
-        PagedResourceList<Assessment> page = dao.getAssessmentRevisions(APP_ID_VALUE, TEST_ORG_ID, ID_VALUE, 0, 20, true);
+        PagedResourceList<Assessment> page = dao.getAssessmentRevisions(TEST_APP_ID, TEST_ORG_ID, ID_VALUE, 0, 20, true);
         assertEquals(page.getItems().size(), 3);
         assertEquals(page.getTotal(), Integer.valueOf(100));
         
         assertEquals(queryCaptor.getValue(), QUERY_GET_REVISIONS_WITH_OWNERID_INC_DELETED);
         
         Map<String,Object> params = paramsCaptor.getValue();
-        assertEquals(params.get("appId"), APP_ID_VALUE);
+        assertEquals(params.get("appId"), TEST_APP_ID);
         assertEquals(params.get("identifier"), ID_VALUE);
         assertEquals(params.get("ownerId"), TEST_ORG_ID);
     }
@@ -233,7 +232,7 @@ public class HibernateAssessmentDaoTest extends Mockito {
         when(mockHelper.queryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(0), eq(20), eq(HibernateAssessment.class)))
             .thenReturn(ImmutableList.of());
         
-        dao.getAssessmentRevisions(APP_ID_VALUE, null, ID_VALUE, 0, 20, false);
+        dao.getAssessmentRevisions(TEST_APP_ID, null, ID_VALUE, 0, 20, false);
         assertEquals(queryCaptor.getValue(), QUERY_GET_REVISIONS_EXC_DELETED);
         assertNull(paramsCaptor.getValue().get("ownerId"));
     }
@@ -243,7 +242,7 @@ public class HibernateAssessmentDaoTest extends Mockito {
         when(mockHelper.queryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(0), eq(20), eq(HibernateAssessment.class)))
             .thenReturn(ImmutableList.of());
         
-        dao.getAssessmentRevisions(APP_ID_VALUE, TEST_ORG_ID, ID_VALUE, 0, 20, false);
+        dao.getAssessmentRevisions(TEST_APP_ID, TEST_ORG_ID, ID_VALUE, 0, 20, false);
         assertEquals(queryCaptor.getValue(), QUERY_GET_REVISIONS_WITH_OWNERID_EXC_DELETED);
         assertEquals(paramsCaptor.getValue().get("ownerId"), TEST_ORG_ID);
     }
@@ -253,13 +252,13 @@ public class HibernateAssessmentDaoTest extends Mockito {
         when(mockHelper.queryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(null), eq(null), eq(HibernateAssessment.class)))
             .thenReturn(ImmutableList.of(HIBERNATE_ASSESSMENT));
         
-        Optional<Assessment> retValue = dao.getAssessment(APP_ID_VALUE, TEST_ORG_ID, GUID_VALUE);
+        Optional<Assessment> retValue = dao.getAssessment(TEST_APP_ID, TEST_ORG_ID, GUID_VALUE);
         assertTrue(retValue.isPresent());
         
         assertEquals(queryCaptor.getValue(), HibernateAssessmentDao.GET_BY_GUID + " AND ownerId = :ownerId");
         
         Map<String,Object> params = paramsCaptor.getValue();
-        assertEquals(params.get("appId"), APP_ID_VALUE);
+        assertEquals(params.get("appId"), TEST_APP_ID);
         assertEquals(params.get("guid"), GUID_VALUE);
         assertEquals(params.get("ownerId"), TEST_ORG_ID);
     }
@@ -269,13 +268,13 @@ public class HibernateAssessmentDaoTest extends Mockito {
         when(mockHelper.queryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(null), eq(null), eq(HibernateAssessment.class)))
             .thenReturn(ImmutableList.of(HIBERNATE_ASSESSMENT));
         
-        Optional<Assessment> retValue = dao.getAssessment(APP_ID_VALUE, null, GUID_VALUE);
+        Optional<Assessment> retValue = dao.getAssessment(TEST_APP_ID, null, GUID_VALUE);
         assertTrue(retValue.isPresent());
         
         assertEquals(queryCaptor.getValue(), HibernateAssessmentDao.GET_BY_GUID);
         
         Map<String,Object> params = paramsCaptor.getValue();
-        assertEquals(params.get("appId"), APP_ID_VALUE);
+        assertEquals(params.get("appId"), TEST_APP_ID);
         assertEquals(params.get("guid"), GUID_VALUE);
     }
     
@@ -284,7 +283,7 @@ public class HibernateAssessmentDaoTest extends Mockito {
         when(mockHelper.queryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(null), eq(null), eq(HibernateAssessment.class)))
             .thenReturn(ImmutableList.of());
     
-        Optional<Assessment> retValue = dao.getAssessment(APP_ID_VALUE, null, GUID_VALUE);
+        Optional<Assessment> retValue = dao.getAssessment(TEST_APP_ID, null, GUID_VALUE);
         assertFalse(retValue.isPresent());
     }
 
@@ -293,13 +292,13 @@ public class HibernateAssessmentDaoTest extends Mockito {
         when(mockHelper.queryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(null), eq(null), eq(HibernateAssessment.class)))
             .thenReturn(ImmutableList.of(HIBERNATE_ASSESSMENT));
         
-        Optional<Assessment> retValue = dao.getAssessment(APP_ID_VALUE, null, ID_VALUE, REV_VALUE);
+        Optional<Assessment> retValue = dao.getAssessment(TEST_APP_ID, null, ID_VALUE, REV_VALUE);
         assertTrue(retValue.isPresent());
         
         assertEquals(queryCaptor.getValue(), HibernateAssessmentDao.GET_BY_IDENTIFIER);
         
         Map<String,Object> params = paramsCaptor.getValue();
-        assertEquals(params.get("appId"), APP_ID_VALUE);
+        assertEquals(params.get("appId"), TEST_APP_ID);
         assertEquals(params.get("identifier"), ID_VALUE);
         assertEquals(params.get("revision"), REV_VALUE);
     }
@@ -309,13 +308,13 @@ public class HibernateAssessmentDaoTest extends Mockito {
         when(mockHelper.queryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(null), eq(null), eq(HibernateAssessment.class)))
             .thenReturn(ImmutableList.of(HIBERNATE_ASSESSMENT));
         
-        Optional<Assessment> retValue = dao.getAssessment(APP_ID_VALUE, TEST_ORG_ID, ID_VALUE, REV_VALUE);
+        Optional<Assessment> retValue = dao.getAssessment(TEST_APP_ID, TEST_ORG_ID, ID_VALUE, REV_VALUE);
         assertTrue(retValue.isPresent());
         
         assertEquals(queryCaptor.getValue(), HibernateAssessmentDao.GET_BY_IDENTIFIER + " AND ownerId = :ownerId");
         
         Map<String,Object> params = paramsCaptor.getValue();
-        assertEquals(params.get("appId"), APP_ID_VALUE);
+        assertEquals(params.get("appId"), TEST_APP_ID);
         assertEquals(params.get("identifier"), ID_VALUE);
         assertEquals(params.get("revision"), REV_VALUE);
         assertEquals(params.get("ownerId"), TEST_ORG_ID);
@@ -326,7 +325,7 @@ public class HibernateAssessmentDaoTest extends Mockito {
         when(mockHelper.queryGet(queryCaptor.capture(), paramsCaptor.capture(), eq(null), eq(null), eq(HibernateAssessment.class)))
             .thenReturn(ImmutableList.of());
         
-        Optional<Assessment> retValue = dao.getAssessment(APP_ID_VALUE, null, ID_VALUE, REV_VALUE);
+        Optional<Assessment> retValue = dao.getAssessment(TEST_APP_ID, null, ID_VALUE, REV_VALUE);
         assertFalse(retValue.isPresent());
     }
     
@@ -336,9 +335,9 @@ public class HibernateAssessmentDaoTest extends Mockito {
         AssessmentConfig config = new AssessmentConfig();
         
         when(mockSession.merge(any())).thenReturn(
-                HibernateAssessment.create(APP_ID_VALUE, assessment));
+                HibernateAssessment.create(TEST_APP_ID, assessment));
         
-        Assessment retValue = dao.createAssessment(APP_ID_VALUE, assessment, config);
+        Assessment retValue = dao.createAssessment(TEST_APP_ID, assessment, config);
         assertEquals(retValue.getGuid(), GUID);
         
         verify(mockSession).persist(configCaptor.capture());
@@ -352,7 +351,7 @@ public class HibernateAssessmentDaoTest extends Mockito {
     public void updateAssessment() throws Exception {
         when(mockSession.merge(any())).thenReturn(HIBERNATE_ASSESSMENT);
         
-        Assessment returnValue = dao.updateAssessment(APP_ID_VALUE, new Assessment());
+        Assessment returnValue = dao.updateAssessment(TEST_APP_ID, new Assessment());
         assertNotNull(returnValue);
         
         verify(mockSession).merge(any(HibernateAssessment.class));
@@ -371,7 +370,7 @@ public class HibernateAssessmentDaoTest extends Mockito {
         
         when(mockSession.merge(any())).thenThrow(new OptimisticLockException());
         
-        dao.createAssessment(APP_ID_VALUE, new Assessment(), new AssessmentConfig());
+        dao.createAssessment(TEST_APP_ID, new Assessment(), new AssessmentConfig());
     }
 
     @Test(expectedExceptions = ConcurrentModificationException.class)
@@ -385,19 +384,19 @@ public class HibernateAssessmentDaoTest extends Mockito {
         
         when(mockSession.merge(any())).thenThrow(new OptimisticLockException());
         
-        dao.updateAssessment(APP_ID_VALUE, new Assessment());
+        dao.updateAssessment(TEST_APP_ID, new Assessment());
     }
     
     @Test
     public void deleteAssessmentLeaveResources() throws Exception {
         PagedResourceList<Assessment> page = new PagedResourceList<>(ImmutableList.of(), 2);
-        doReturn(page).when(dao).getAssessmentRevisions(APP_ID_VALUE, null, IDENTIFIER, 0, 1, true);
+        doReturn(page).when(dao).getAssessmentRevisions(TEST_APP_ID, null, IDENTIFIER, 0, 1, true);
         
         when(mockSession.createNativeQuery(DELETE_CONFIG_SQL)).thenReturn(mockDelConfigQuery);
         
         Assessment assessment = AssessmentTest.createAssessment();
         
-        dao.deleteAssessment(APP_ID_VALUE, assessment);
+        dao.deleteAssessment(TEST_APP_ID, assessment);
         
         verify(mockDelResourcesQuery, never()).executeUpdate();
         verify(mockDelConfigQuery).setParameter("guid", GUID);
@@ -408,15 +407,15 @@ public class HibernateAssessmentDaoTest extends Mockito {
     @Test
     public void deleteAssessmentWithResources() throws Exception {
         PagedResourceList<Assessment> page = new PagedResourceList<>(ImmutableList.of(), 1);
-        doReturn(page).when(dao).getAssessmentRevisions(APP_ID_VALUE, null, IDENTIFIER, 0, 1, true);
+        doReturn(page).when(dao).getAssessmentRevisions(TEST_APP_ID, null, IDENTIFIER, 0, 1, true);
         
         when(mockSession.createNativeQuery(DELETE_RESOURCES_SQL)).thenReturn(mockDelResourcesQuery);
         when(mockSession.createNativeQuery(DELETE_CONFIG_SQL)).thenReturn(mockDelConfigQuery);
         Assessment assessment = AssessmentTest.createAssessment();
         
-        dao.deleteAssessment(APP_ID_VALUE, assessment);
+        dao.deleteAssessment(TEST_APP_ID, assessment);
         
-        verify(mockDelResourcesQuery).setParameter("appId", APP_ID_VALUE);
+        verify(mockDelResourcesQuery).setParameter("appId", TEST_APP_ID);
         verify(mockDelResourcesQuery).setParameter("assessmentId", IDENTIFIER);
         verify(mockDelResourcesQuery).executeUpdate();
         
@@ -433,7 +432,7 @@ public class HibernateAssessmentDaoTest extends Mockito {
         AssessmentConfig originConfig = new AssessmentConfig();
         when(mockSession.merge(any())).thenReturn(new HibernateAssessment());
         
-        Assessment retValue = dao.publishAssessment(APP_ID_VALUE, original, assessmentToPublish, originConfig);
+        Assessment retValue = dao.publishAssessment(TEST_APP_ID, original, assessmentToPublish, originConfig);
         assertNotNull(retValue);
         
         verify(mockHelper).executeWithExceptionHandling(any(HibernateAssessment.class), any());
@@ -446,7 +445,7 @@ public class HibernateAssessmentDaoTest extends Mockito {
         Assessment assessmentToImport = AssessmentTest.createAssessment();
         AssessmentConfig configToImport = new AssessmentConfig();
         
-        Assessment retValue = dao.importAssessment(APP_ID_VALUE, assessmentToImport, configToImport);
+        Assessment retValue = dao.importAssessment(TEST_APP_ID, assessmentToImport, configToImport);
         assertNotNull(retValue);
         
         verify(mockHelper).executeWithExceptionHandling(any(HibernateAssessment.class), any());
@@ -457,16 +456,16 @@ public class HibernateAssessmentDaoTest extends Mockito {
     @Test
     public void hasAssessmentFromOrg() {
         when(mockHelper.queryCount(any(), any())).thenReturn(1);
-        assertTrue(dao.hasAssessmentFromOrg(APP_ID_VALUE, ORG_ID));
+        assertTrue(dao.hasAssessmentFromOrg(TEST_APP_ID, TEST_ORG_ID));
         verify(mockHelper).queryCount(any(), any());
 
         when(mockHelper.queryCount(any(), any())).thenReturn(0, 0);
-        assertFalse(dao.hasAssessmentFromOrg(APP_ID_VALUE, ORG_ID));
+        assertFalse(dao.hasAssessmentFromOrg(TEST_APP_ID, TEST_ORG_ID));
         // Mockito remembers the total count of times method called, so here's 1 + 2 = 3.
         verify(mockHelper, times(3)).queryCount(any(), any());
 
         when(mockHelper.queryCount(any(), any())).thenReturn(0, 3);
-        assertTrue(dao.hasAssessmentFromOrg(APP_ID_VALUE, ORG_ID));
+        assertTrue(dao.hasAssessmentFromOrg(TEST_APP_ID, TEST_ORG_ID));
         // Mockito remembers the total count of times method called, so here's 1 + 2 = 3.
         verify(mockHelper, times(5)).queryCount(queryCaptor.capture(), paramsCaptor.capture());
 
@@ -477,9 +476,17 @@ public class HibernateAssessmentDaoTest extends Mockito {
         }
         Map<String, Object> privateMap = paramsList.get(0);
         Map<String, Object> publishedMap = paramsList.get(1);
-        assertEquals(APP_ID_VALUE, privateMap.get("appId"));
-        assertEquals(ORG_ID, privateMap.get("ownerId"));
+        assertEquals(TEST_APP_ID, privateMap.get("appId"));
+        assertEquals(TEST_ORG_ID, privateMap.get("ownerId"));
         assertEquals("shared", publishedMap.get("appId"));
-        assertEquals(APP_ID_VALUE + ":" + ORG_ID, publishedMap.get("ownerId"));
+        assertEquals(TEST_APP_ID + ":" + TEST_ORG_ID, publishedMap.get("ownerId"));
+    }
+    
+    @Test
+    public void deleteAllAssessments() {
+        dao.deleteAllAssessments(TEST_APP_ID);
+        
+        verify(mockHelper).nativeQueryUpdate(eq(DELETE_ALL_ASSESSMENTS_SQL), paramsCaptor.capture());
+        assertEquals(paramsCaptor.getValue().get("appId"), TEST_APP_ID);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAssessmentResourceDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAssessmentResourceDaoTest.java
@@ -4,6 +4,7 @@ import static org.sagebionetworks.bridge.TestConstants.ASSESSMENT_ID;
 import static org.sagebionetworks.bridge.TestConstants.GUID;
 import static org.sagebionetworks.bridge.TestConstants.RESOURCE_CATEGORIES;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
+import static org.sagebionetworks.bridge.hibernate.HibernateAssessmentResourceDao.DELETE_ALL_QUERY;
 import static org.sagebionetworks.bridge.hibernate.HibernateAssessmentResourceDao.DELETE_QUERY;
 import static org.sagebionetworks.bridge.models.assessments.HibernateAssessmentResourceTest.createHibernateAssessmentResource;
 import static org.testng.Assert.assertEquals;
@@ -211,5 +212,13 @@ public class HibernateAssessmentResourceDaoTest extends Mockito {
         assertEquals(retValue.get(0).getGuid(), GUID+"1");
         assertEquals(retValue.get(1).getGuid(), GUID+"2");
         assertEquals(retValue.get(2).getGuid(), GUID+"3");
+    }
+    
+    @Test
+    public void deleteAllAssessmentResources() {
+        dao.deleteAllAssessmentResources(TEST_APP_ID);
+        
+        verify(mockHelper).nativeQueryUpdate(eq(DELETE_ALL_QUERY), paramsCaptor.capture());
+        assertEquals(paramsCaptor.getValue().get("appId"), TEST_APP_ID);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2DaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2DaoTest.java
@@ -8,6 +8,7 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
 import static org.sagebionetworks.bridge.hibernate.HibernateSchedule2Dao.AND_DELETED;
 import static org.sagebionetworks.bridge.hibernate.HibernateSchedule2Dao.BATCH_SIZE_PROPERTY;
+import static org.sagebionetworks.bridge.hibernate.HibernateSchedule2Dao.DELETE_ALL_SCHEDULES;
 import static org.sagebionetworks.bridge.hibernate.HibernateSchedule2Dao.DELETE_ORPHANED_SESSIONS;
 import static org.sagebionetworks.bridge.hibernate.HibernateSchedule2Dao.DELETE_SESSIONS;
 import static org.sagebionetworks.bridge.hibernate.HibernateSchedule2Dao.DELETE_TIMELINE_RECORDS;
@@ -400,5 +401,13 @@ public class HibernateSchedule2DaoTest extends Mockito {
 
         assertEquals(queryCaptor.getValue(), SELECT_ASSESSMENTS_FOR_SESSION_INSTANCE);
         assertEquals(paramsCaptor.getValue().get(INSTANCE_GUID), GUID);
+    }
+    
+    @Test
+    public void deleteAllSchedules() {
+        dao.deleteAllSchedules(TEST_APP_ID);
+        
+        verify(mockHibernateHelper).nativeQueryUpdate(eq(DELETE_ALL_SCHEDULES), paramsCaptor.capture());
+        assertEquals(paramsCaptor.getValue().get("appId"), TEST_APP_ID);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
@@ -1175,6 +1175,12 @@ public class AccountServiceTest extends Mockito {
         assertSame(retValue, page);
     }
 
+    @Test
+    public void deleteAllAccounts() { 
+        service.deleteAllAccounts(TEST_APP_ID);
+        verify(mockAccountDao).deleteAllAccounts(TEST_APP_ID);
+    }
+    
     private Account mockGetAccountById(AccountId accountId, boolean generatePasswordHash) throws Exception {
         Account account = Account.create();
         account.setAppId(TEST_APP_ID);

--- a/src/test/java/org/sagebionetworks/bridge/services/AppServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AppServiceTest.java
@@ -158,6 +158,12 @@ public class AppServiceTest extends Mockito {
     OrganizationService mockOrgService;
     @Mock
     StudyService mockStudyService;
+    @Mock
+    AccountService mockAccountService;
+    @Mock
+    AssessmentService mockAssessmentService;
+    @Mock
+    AssessmentResourceService mockAssessmentResourceService;
 
     @Captor
     ArgumentCaptor<Project> projectCaptor;
@@ -724,6 +730,10 @@ public class AppServiceTest extends Mockito {
 
         // verify we called the correct dependent services
         verify(mockAppDao).deleteApp(app);
+        
+        verify(mockAccountService).deleteAllAccounts(app.getIdentifier());
+        verify(mockAssessmentResourceService).deleteAllAssessmentResources(app.getIdentifier());
+        verify(mockAssessmentService).deleteAllAssessments(app.getIdentifier());
         verify(mockStudyService).deleteAllStudies(app.getIdentifier());
         verify(mockOrgService).deleteAllOrganizations(app.getIdentifier());
         verify(mockCompoundActivityDefinitionService).deleteAllCompoundActivityDefinitionsInApp(
@@ -1667,6 +1677,9 @@ public class AppServiceTest extends Mockito {
         verify(mockCacheProvider).setApp(updatedApp);
         verify(mockCacheProvider).removeApp(app.getIdentifier());
 
+        verify(mockAccountService).deleteAllAccounts(app.getIdentifier());
+        verify(mockAssessmentResourceService).deleteAllAssessmentResources(app.getIdentifier());
+        verify(mockAssessmentService).deleteAllAssessments(app.getIdentifier());
         verify(mockAppDao).deleteApp(updatedApp);
         verify(mockCompoundActivityDefinitionService)
                 .deleteAllCompoundActivityDefinitionsInApp(updatedApp.getIdentifier());

--- a/src/test/java/org/sagebionetworks/bridge/services/AppServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AppServiceTest.java
@@ -164,6 +164,8 @@ public class AppServiceTest extends Mockito {
     AssessmentService mockAssessmentService;
     @Mock
     AssessmentResourceService mockAssessmentResourceService;
+    @Mock
+    Schedule2Service mockScheduleService;
 
     @Captor
     ArgumentCaptor<Project> projectCaptor;
@@ -741,7 +743,7 @@ public class AppServiceTest extends Mockito {
         verify(mockSubpopService).deleteAllSubpopulations(app.getIdentifier());
         verify(mockTopicService).deleteAllTopics(app.getIdentifier());
         verify(mockCacheProvider).removeApp(TEST_APP_ID);
-        verify(mockTemplateService).deleteTemplatesForApp(TEST_APP_ID);
+        verify(mockTemplateService).deleteAllTemplates(TEST_APP_ID);
         verify(mockFileService).deleteAllAppFiles(TEST_APP_ID);
     }
 
@@ -1678,13 +1680,18 @@ public class AppServiceTest extends Mockito {
         verify(mockCacheProvider).removeApp(app.getIdentifier());
 
         verify(mockAccountService).deleteAllAccounts(app.getIdentifier());
+        verify(mockStudyService).deleteAllStudies(app.getIdentifier());
+        verify(mockScheduleService).deleteAllSchedules(app.getIdentifier());
         verify(mockAssessmentResourceService).deleteAllAssessmentResources(app.getIdentifier());
         verify(mockAssessmentService).deleteAllAssessments(app.getIdentifier());
-        verify(mockAppDao).deleteApp(updatedApp);
+        verify(mockOrgService).deleteAllOrganizations(app.getIdentifier());
+        verify(mockTemplateService).deleteAllTemplates(app.getIdentifier());
         verify(mockCompoundActivityDefinitionService)
                 .deleteAllCompoundActivityDefinitionsInApp(updatedApp.getIdentifier());
         verify(mockSubpopService).deleteAllSubpopulations(updatedApp.getIdentifier());
         verify(mockTopicService).deleteAllTopics(updatedApp.getIdentifier());
+        verify(mockFileService).deleteAllAppFiles(app.getIdentifier());
+        verify(mockAppDao).deleteApp(app);
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/AssessmentResourceServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AssessmentResourceServiceTest.java
@@ -687,6 +687,12 @@ public class AssessmentResourceServiceTest extends Mockito {
         service.publishAssessmentResources("otherAppContext", ASSESSMENT_ID, guids);
     }
     
+    @Test
+    public void deleteAllAssessmentResources() {
+        service.deleteAllAssessmentResources(TEST_APP_ID);
+        verify(mockDao).deleteAllAssessmentResources(TEST_APP_ID);
+    }
+    
     private AssessmentResource makeResource(String appId, String guid) {
         AssessmentResource ar = AssessmentResourceTest.createAssessmentResource();
         ar.setGuid(guid);

--- a/src/test/java/org/sagebionetworks/bridge/services/AssessmentServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AssessmentServiceTest.java
@@ -153,8 +153,8 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void createAssessment() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
-                .thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, TEST_OWNER_ID))
+                .thenReturn(Optional.of(mockOrganization));
         when(mockDao.getAssessmentRevisions(any(), any(), any(), anyInt(), anyInt(), anyBoolean()))
             .thenReturn(EMPTY_LIST);
         
@@ -181,8 +181,8 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void createAssessmentAdjustsOsNameAlias() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
-            .thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, TEST_OWNER_ID))
+            .thenReturn(Optional.of(mockOrganization));
         when(mockDao.getAssessmentRevisions(any(), any(), any(), anyInt(), anyInt(), anyBoolean()))
             .thenReturn(EMPTY_LIST);
         
@@ -202,8 +202,8 @@ public class AssessmentServiceTest extends Mockito {
         when(mockDao.getAssessmentRevisions(TEST_APP_ID, null, IDENTIFIER, 0, 1, true))
             .thenReturn(new PagedResourceList<>(ImmutableList.of(), 0));
         
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, "orgD"))
-            .thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, "orgD"))
+            .thenReturn(Optional.of(mockOrganization));
         
         Assessment assessment = AssessmentTest.createAssessment();
         service.createAssessment(TEST_APP_ID, assessment);
@@ -239,8 +239,8 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void createAssessmentScrubsMarkup() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
-            .thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, TEST_OWNER_ID))
+            .thenReturn(Optional.of(mockOrganization));
         when(mockDao.getAssessmentRevisions(any(), any(), any(), anyInt(), anyInt(), anyBoolean()))
             .thenReturn(EMPTY_LIST);
         
@@ -254,8 +254,8 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void createAssessmentSetsOwnerIdToCallerOrg() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, "orgD"))
-            .thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, "orgD"))
+            .thenReturn(Optional.of(mockOrganization));
         when(mockDao.getAssessmentRevisions(any(), any(), any(), anyInt(), anyInt(), anyBoolean()))
             .thenReturn(EMPTY_LIST);
         
@@ -272,8 +272,8 @@ public class AssessmentServiceTest extends Mockito {
 
     @Test
     public void createAssessmentAllowsAdminsToSetOwnerId() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
-            .thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, TEST_OWNER_ID))
+            .thenReturn(Optional.of(mockOrganization));
         when(mockDao.getAssessmentRevisions(any(), any(), any(), anyInt(), anyInt(), anyBoolean()))
             .thenReturn(EMPTY_LIST);
     
@@ -290,8 +290,8 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void createAssessmentRevision() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
-                .thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, TEST_OWNER_ID))
+                .thenReturn(Optional.of(mockOrganization));
         when(mockDao.getAssessment(TEST_APP_ID, TEST_OWNER_ID, GUID))
             .thenReturn(Optional.of(AssessmentTest.createAssessment()));
         
@@ -323,8 +323,8 @@ public class AssessmentServiceTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership("studyD").build());
         
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, "studyD"))
-            .thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, "studyD"))
+            .thenReturn(Optional.of(mockOrganization));
         
         Assessment existing = AssessmentTest.createAssessment();
         existing.setOwnerId(TEST_OWNER_ID);
@@ -365,8 +365,8 @@ public class AssessmentServiceTest extends Mockito {
 
     @Test
     public void createAssessmentRevisionScrubsMarkup() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
-            .thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, TEST_OWNER_ID))
+            .thenReturn(Optional.of(mockOrganization));
         Assessment existing = AssessmentTest.createAssessment();
         when(mockDao.getAssessment(TEST_APP_ID, TEST_OWNER_ID, GUID))
             .thenReturn(Optional.of(existing));
@@ -381,7 +381,8 @@ public class AssessmentServiceTest extends Mockito {
 
     @Test
     public void updateAssessment() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID)).thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, TEST_OWNER_ID))
+            .thenReturn(Optional.of(mockOrganization));
         
         // Fill out only the fields needed to pass validation, leaving the rest to be
         // filled in by the existing assessment
@@ -409,7 +410,8 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void updateAssessmentAdjustsOsNameAlias() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID)).thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, TEST_OWNER_ID))
+            .thenReturn(Optional.of(mockOrganization));
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setOsName("Both");
@@ -426,7 +428,8 @@ public class AssessmentServiceTest extends Mockito {
 
     @Test
     public void updateAssessmentSomeFieldsImmutable() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID)).thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, TEST_OWNER_ID))
+            .thenReturn(Optional.of(mockOrganization));
         
         Assessment existing = AssessmentTest.createAssessment();
         when(mockDao.getAssessment(TEST_APP_ID, TEST_OWNER_ID, GUID))
@@ -470,7 +473,8 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void updateAssessmentCanDelete() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID)).thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, TEST_OWNER_ID))
+            .thenReturn(Optional.of(mockOrganization));
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setDeleted(true);
@@ -487,7 +491,8 @@ public class AssessmentServiceTest extends Mockito {
 
     @Test
     public void updateAssessmentCanUndelete() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID)).thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, TEST_OWNER_ID))
+            .thenReturn(Optional.of(mockOrganization));
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setDeleted(false);
@@ -518,7 +523,8 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void updateAssessmentScrubsMarkup() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID)).thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, TEST_OWNER_ID))
+            .thenReturn(Optional.of(mockOrganization));
 
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setDeleted(false);
@@ -539,8 +545,8 @@ public class AssessmentServiceTest extends Mockito {
                 .withCallerOrgMembership(TEST_OWNER_ID)
                 .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
         
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
-            .thenReturn(Organization.create());
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, TEST_OWNER_ID))
+            .thenReturn(Optional.of(Organization.create()));
         
         Assessment existing = AssessmentTest.createAssessment();
         existing.setOriginGuid("unusualGuid");
@@ -568,8 +574,8 @@ public class AssessmentServiceTest extends Mockito {
                 .withCallerOrgMembership(TEST_OWNER_ID)
                 .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
         
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
-            .thenReturn(Organization.create());
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, TEST_OWNER_ID))
+            .thenReturn(Optional.of(Organization.create()));
         
         Assessment existing = AssessmentTest.createAssessment();
         existing.setDeleted(false);
@@ -593,8 +599,8 @@ public class AssessmentServiceTest extends Mockito {
                 .withCallerOrgMembership(TEST_OWNER_ID)
                 .withCallerRoles(ImmutableSet.of(STUDY_DESIGNER)).build());
         
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID))
-            .thenReturn(Organization.create());
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, TEST_OWNER_ID))
+            .thenReturn(Optional.of(Organization.create()));
         
         Assessment existing = AssessmentTest.createAssessment();
         existing.setOwnerId(ownerIdInShared);
@@ -665,8 +671,8 @@ public class AssessmentServiceTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(SUPERADMIN))
                 .withCallerAppId(TEST_APP_ID).build());
-        when(mockOrganizationService.getOrganization(
-                TEST_APP_ID, TEST_OWNER_ID)).thenReturn(Organization.create());
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, TEST_OWNER_ID))
+            .thenReturn(Optional.of(Organization.create()));
         
         Assessment existing = AssessmentTest.createAssessment();
         existing.setDeleted(false);
@@ -701,8 +707,9 @@ public class AssessmentServiceTest extends Mockito {
 
     @Test
     public void updateSharedAssessmentCanDelete() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID)).thenReturn(mockOrganization);
-        
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, TEST_OWNER_ID))
+            .thenReturn(Optional.of(mockOrganization));
+                
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setDeleted(true);
         
@@ -720,7 +727,8 @@ public class AssessmentServiceTest extends Mockito {
     
     @Test
     public void updateSharedAssessmentCanUndelete() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID)).thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, TEST_OWNER_ID))
+            .thenReturn(Optional.of(mockOrganization));
         
         Assessment assessment = AssessmentTest.createAssessment();
         assessment.setDeleted(false);
@@ -1265,8 +1273,8 @@ public class AssessmentServiceTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership("orgD").build());
         
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, "orgD"))
-            .thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, "orgD"))
+            .thenReturn(Optional.of(mockOrganization));
         
         when(mockDao.getAssessmentRevisions(TEST_APP_ID, null, IDENTIFIER, 0, 1, true))
             .thenReturn(new PagedResourceList<>(ImmutableList.of(), 0));
@@ -1281,8 +1289,8 @@ public class AssessmentServiceTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership("orgD").build());
         
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, "orgD"))
-            .thenReturn(mockOrganization);
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, "orgD"))
+            .thenReturn(Optional.of(mockOrganization));
         
         Assessment existing = AssessmentTest.createAssessment();
         when(mockDao.getAssessment(TEST_APP_ID, TEST_OWNER_ID, GUID)).thenReturn(Optional.of(existing));
@@ -1344,6 +1352,12 @@ public class AssessmentServiceTest extends Mockito {
         service.updateSharedAssessment(sharedAssessment);
     }
 
+    @Test
+    public void deleteAllAssessments() {
+        service.deleteAllAssessments(TEST_APP_ID);
+        verify(mockDao).deleteAllAssessments(TEST_APP_ID);
+    }
+    
     @Test(expectedExceptions = UnauthorizedException.class)
     public void updateSharedAssessmentChecksOwnershipWhenFormattedIncorrectly() {
         Assessment sharedAssessment = AssessmentTest.createAssessment();

--- a/src/test/java/org/sagebionetworks/bridge/services/Schedule2ServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/Schedule2ServiceTest.java
@@ -931,4 +931,10 @@ public class Schedule2ServiceTest extends Mockito {
         
         verify(mockDao).updateSchedule(schedule);
     }
+    
+    @Test
+    public void deleteAllSchedules() { 
+        service.deleteAllSchedules(TEST_APP_ID);
+        verify(mockDao).deleteAllSchedules(TEST_APP_ID);
+    }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/TemplateServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/TemplateServiceTest.java
@@ -679,7 +679,7 @@ public class TemplateServiceTest extends Mockito {
     
     @Test
     public void deleteTemplatesForApp() {
-        service.deleteTemplatesForApp(TEST_APP_ID);
+        service.deleteAllTemplates(TEST_APP_ID);
         
         verify(mockTemplateDao).deleteTemplatesForApp(TEST_APP_ID);
     }

--- a/src/test/java/org/sagebionetworks/bridge/validators/AssessmentValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/AssessmentValidatorTest.java
@@ -13,6 +13,7 @@ import static org.sagebionetworks.bridge.validators.ValidatorUtils.INVALID_HEX_T
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
@@ -59,15 +60,15 @@ public class AssessmentValidatorTest extends Mockito {
     
     @Test
     public void validAssessment() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, assessment.getOwnerId()))
-            .thenReturn(Organization.create());
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, assessment.getOwnerId()))
+            .thenReturn(Optional.of(Organization.create()));
         
         Validate.entityThrowingException(validator, assessment);
     }
     @Test
     public void validAssessmentWithNoOptionalFields() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, assessment.getOwnerId()))
-            .thenReturn(Organization.create());
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, assessment.getOwnerId()))
+            .thenReturn(Optional.of(Organization.create()));
         assessment.setColorScheme(null);
         assessment.setLabels(null);
         assessment.setMinutesToComplete(null);
@@ -77,23 +78,27 @@ public class AssessmentValidatorTest extends Mockito {
     }
     @Test
     public void validAssessmentWithEmptyColorScheme() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, assessment.getOwnerId()))
-            .thenReturn(Organization.create());
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, assessment.getOwnerId()))
+            .thenReturn(Optional.of(Organization.create()));
         assessment.setColorScheme(new ColorScheme(null, null, null, null));
         
         Validate.entityThrowingException(validator, assessment);
     }
     @Test
     public void validSharedAssessment() {
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, TEST_OWNER_ID))
+            .thenReturn(Optional.of(Organization.create()));
+
         validator = new AssessmentValidator(SHARED_APP_ID, mockOrganizationService);
         assessment.setOwnerId(TEST_APP_ID + ":" + TEST_OWNER_ID);
-        
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, TEST_OWNER_ID)).thenReturn(Organization.create());
     
         Validate.entityThrowingException(validator, assessment);
     }
     @Test
     public void ownerIdInvalid() {
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, TEST_OWNER_ID))
+            .thenReturn(Optional.empty());
+        
         assertValidatorMessage(validator, assessment, "ownerId", "is not a valid organization ID");
     }
     @Test
@@ -138,8 +143,8 @@ public class AssessmentValidatorTest extends Mockito {
     }
     @Test
     public void osNameUniversalIsValid() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, assessment.getOwnerId()))
-            .thenReturn(Organization.create());
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, assessment.getOwnerId()))
+            .thenReturn(Optional.of(Organization.create()));
         
         assessment.setOsName("Universal");
         Validate.entityThrowingException(validator, assessment);
@@ -198,8 +203,8 @@ public class AssessmentValidatorTest extends Mockito {
     
     @Test
     public void labelsEmptyIsValid() {
-        when(mockOrganizationService.getOrganization(TEST_APP_ID, assessment.getOwnerId()))
-            .thenReturn(Organization.create());
+        when(mockOrganizationService.getOrganizationOpt(TEST_APP_ID, assessment.getOwnerId()))
+            .thenReturn(Optional.of(Organization.create()));
         
         assessment.setLabels(ImmutableList.of());
         Validate.entityThrowingException(validator, assessment);


### PR DESCRIPTION
BRIDGE-3065.

The first issue is that a number of models have been added that are not deleted when an app is deleted, and these need to be deleted in a certain order. Because app is in Dynamo and many of these objects are in MySQL, there is no transaction around these deletes. I moved the deletion of the app to last so I could retry until the delete was completely successfully.

I also fixed up /v1/apps to separate the "summary" and "includeDeleted" flags in order to support a reasonable UI for logically deleted apps.

AssessmentValidator did not return an invalid entity exception when the organization was wrong or missing (it threw an ENFE for the organization instead). This is now fixed.