### PR TITLE
Allowing physical delete of studies for other roles than admin.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
@@ -230,8 +230,6 @@ public class StudyService {
             throw new BadRequestException("Study cannot be deleted during phase " 
                     + existing.getPhase().label());
         }
-        
-        // Throws exception if the element does not exist.
         String scheduleGuid = existing.getScheduleGuid();
         
         studyDao.deleteStudyPermanently(appId, studyId);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyController.java
@@ -113,8 +113,8 @@ public class StudyController extends BaseController {
     public StatusMessage deleteStudy(@PathVariable String id,
             @RequestParam(defaultValue = "false") String physical) {
         UserSession session = getAuthenticatedSession(STUDY_DESIGNER, DEVELOPER, ADMIN);
-
-        if ("true".equals(physical) && session.isInRole(ADMIN)) {
+        
+        if ("true".equals(physical)) {
             service.deleteStudyPermanently(session.getAppId(), id);
         } else {
             service.deleteStudy(session.getAppId(), id);

--- a/src/main/resources/db/changelog/changelog.sql
+++ b/src/main/resources/db/changelog/changelog.sql
@@ -789,3 +789,12 @@ CREATE TABLE `SessionStartEvents` (
 
 ALTER TABLE `TimelineMetadata` 
 ADD INDEX `TimelineMetadata-ScheduleGuid` (scheduleGuid);
+
+-- changeset bridge:47
+
+ALTER TABLE `AccountsSubstudies` 
+DROP FOREIGN KEY `fk_substudy`;
+
+ALTER TABLE `AccountsSubstudies`
+ADD CONSTRAINT `fk_substudy` FOREIGN KEY (`substudyId`, `studyId`) REFERENCES `Substudies` (`id`, `studyId`) ON DELETE CASCADE;
+

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyControllerTest.java
@@ -294,17 +294,6 @@ public class StudyControllerTest extends Mockito {
     }
     
     @Test
-    public void deleteStudyPhysicalFallsbacktoLogical() throws Exception {
-        session.setParticipant(new StudyParticipant.Builder()
-                .withRoles(ImmutableSet.of(DEVELOPER)).build());
-        
-        StatusMessage result = controller.deleteStudy(TEST_STUDY_ID, "true");
-        assertEquals(result, StudyController.DELETED_MSG);
-
-        verify(mockStudyService).deleteStudy(TEST_APP_ID, TEST_STUDY_ID);
-    }
-    
-    @Test
     public void createStudyLogoNoExistingFile() throws Exception {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());


### PR DESCRIPTION
BRIDGE-3083. Logically deleted studies are accumulating in MTB, polluting the ID namespace. These can in many cases be physically deleted, so I have changed the logic to allow devs/study designers to do it, looking at the study phase to prevent the deletion of studies that are in use.