### PR TITLE
Adding appId to app config assessment references

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/models/assessments/AssessmentReference.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/assessments/AssessmentReference.java
@@ -15,20 +15,20 @@ public final class AssessmentReference {
     private final ConfigResolver resolver;
     private final String guid;
     private final String id;
-    private final String sharedId;
+    private final String originSharedId;
     private final String appId;
     
     @JsonCreator
     public AssessmentReference(@JsonProperty("guid") String guid, @JsonProperty("id") String id,
-                               @JsonProperty("sharedId") String sharedId, @JsonProperty("appId") String appId) {
-        this(INSTANCE, guid, id, sharedId, appId);
+                               @JsonProperty("originSharedId") String originSharedId, @JsonProperty("appId") String appId) {
+        this(INSTANCE, guid, id, originSharedId, appId);
     }
 
-    public AssessmentReference(ConfigResolver resolver, String guid, String id, String sharedId, String appId) {
+    public AssessmentReference(ConfigResolver resolver, String guid, String id, String originSharedId, String appId) {
         this.resolver = resolver;
         this.guid = guid;
         this.id = id;
-        this.sharedId = sharedId;
+        this.originSharedId = originSharedId;
         this.appId = appId;
     }
     
@@ -51,8 +51,8 @@ public final class AssessmentReference {
      * because we don't anticipate clients will want to retrieve the original shared
      * assessment.
      */
-    public String getSharedId() {
-        return sharedId;
+    public String getOriginSharedId() {
+        return originSharedId;
     }
     public String getAppId() {
         return appId;
@@ -75,7 +75,7 @@ public final class AssessmentReference {
 
     @Override
     public String toString() {
-        return "AssessmentReference [id=" + id + ", sharedId=" + sharedId + ", guid=" + guid + ", appId=" + appId
+        return "AssessmentReference [id=" + id + ", originSharedId=" + originSharedId + ", guid=" + guid + ", appId=" + appId
                 + ", configHref=" + getConfigHref() + "]";
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/models/assessments/AssessmentReference.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/assessments/AssessmentReference.java
@@ -6,6 +6,7 @@ import static org.sagebionetworks.bridge.BridgeConstants.SHARED_APP_ID;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.sagebionetworks.bridge.models.appconfig.ConfigResolver;
@@ -14,10 +15,12 @@ public final class AssessmentReference {
     
     private final ConfigResolver resolver;
     private final String guid;
-    private final String id;
-    private final String originSharedId;
     private final String appId;
-    
+    @JsonIgnore
+    private final String id;
+    @JsonIgnore
+    private final String originSharedId;
+
     @JsonCreator
     public AssessmentReference(@JsonProperty("guid") String guid, @JsonProperty("id") String id,
                                @JsonProperty("originSharedId") String originSharedId, @JsonProperty("appId") String appId) {

--- a/src/main/java/org/sagebionetworks/bridge/models/assessments/AssessmentReference.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/assessments/AssessmentReference.java
@@ -6,7 +6,6 @@ import static org.sagebionetworks.bridge.BridgeConstants.SHARED_APP_ID;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.sagebionetworks.bridge.models.appconfig.ConfigResolver;
@@ -16,15 +15,15 @@ public final class AssessmentReference {
     private final ConfigResolver resolver;
     private final String guid;
     private final String appId;
-    @JsonIgnore
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private final String id;
-    @JsonIgnore
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private final String originSharedId;
 
     @JsonCreator
-    public AssessmentReference(@JsonProperty("guid") String guid, @JsonProperty("id") String id,
-                               @JsonProperty("originSharedId") String originSharedId, @JsonProperty("appId") String appId) {
-        this(INSTANCE, guid, id, originSharedId, appId);
+    public AssessmentReference(@JsonProperty("guid") String guid,
+                               @JsonProperty("appId") String appId) {
+        this(INSTANCE, guid, null, null, appId);
     }
 
     public AssessmentReference(ConfigResolver resolver, String guid, String id, String originSharedId, String appId) {

--- a/src/main/java/org/sagebionetworks/bridge/models/assessments/AssessmentReference.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/assessments/AssessmentReference.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.models.assessments;
 
 import static org.sagebionetworks.bridge.models.appconfig.ConfigResolver.INSTANCE;
+import static org.sagebionetworks.bridge.BridgeConstants.SHARED_APP_ID;
 
 import java.util.Objects;
 
@@ -18,15 +19,9 @@ public final class AssessmentReference {
     private final String appId;
     
     @JsonCreator
-    public AssessmentReference(@JsonProperty("guid") String guid,
-            @JsonProperty("id") String id, @JsonProperty("sharedId") String sharedId, @JsonProperty("appId") String appId) {
+    public AssessmentReference(@JsonProperty("guid") String guid, @JsonProperty("id") String id,
+                               @JsonProperty("sharedId") String sharedId, @JsonProperty("appId") String appId) {
         this(INSTANCE, guid, id, sharedId, appId);
-        System.out.println("--------In jsoncreator constructor-----------");
-        System.out.println("assessment guid: " + guid);
-        System.out.println("assessment id: " + id);
-        System.out.println("assessment sharedid: " + sharedId);
-        System.out.println("assessment appId: " + appId);
-        System.out.println("--------");
     }
 
     public AssessmentReference(ConfigResolver resolver, String guid, String id, String sharedId, String appId) {
@@ -47,7 +42,8 @@ public final class AssessmentReference {
         if (guid == null) {
             return null;
         }
-        return resolver.url("ws", "/v1/assessments/" + guid + "/config");
+        String path = (appId != null && appId.equals(SHARED_APP_ID)) ? "/v1/sharedassessments/" : "/v1/assessments/";
+        return resolver.url("ws", path + guid + "/config");
     }
     /**
      * If this assessment was derived from a shared assessment, the shared assessment's
@@ -79,7 +75,7 @@ public final class AssessmentReference {
 
     @Override
     public String toString() {
-        return "AssessmentReference [id=" + id + ", sharedId=" + sharedId + ", guid=" + guid + ", appId=" + appId + ", configHref="
-                + getConfigHref() + "]";
+        return "AssessmentReference [id=" + id + ", sharedId=" + sharedId + ", guid=" + guid + ", appId=" + appId
+                + ", configHref=" + getConfigHref() + "]";
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/models/assessments/AssessmentReference.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/assessments/AssessmentReference.java
@@ -13,27 +13,30 @@ import org.sagebionetworks.bridge.models.appconfig.ConfigResolver;
 public final class AssessmentReference {
     
     private final ConfigResolver resolver;
-    private final String guid;
     private final String appId;
+    private final String guid;
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private final String id;
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private final String originSharedId;
 
     @JsonCreator
-    public AssessmentReference(@JsonProperty("guid") String guid,
-                               @JsonProperty("appId") String appId) {
-        this(INSTANCE, guid, null, null, appId);
+    public AssessmentReference(@JsonProperty("appId") String appId,
+                               @JsonProperty("guid") String guid) {
+        this(INSTANCE, appId, guid, null, null);
     }
 
-    public AssessmentReference(ConfigResolver resolver, String guid, String id, String originSharedId, String appId) {
+    public AssessmentReference(ConfigResolver resolver, String appId, String guid, String id, String originSharedId) {
         this.resolver = resolver;
+        this.appId = appId;
         this.guid = guid;
         this.id = id;
         this.originSharedId = originSharedId;
-        this.appId = appId;
     }
     
+    public String getAppId() {
+        return appId;
+    }
     public String getGuid() {
         return guid;
     }
@@ -49,15 +52,12 @@ public final class AssessmentReference {
     }
     /**
      * If this assessment was derived from a shared assessment, the shared assessment's
-     * identifier may help to find it in config. We do not provide a GUID or revision 
+     * identifier may help to find it in config. We do not provide a GUID or revision
      * because we don't anticipate clients will want to retrieve the original shared
      * assessment.
      */
     public String getOriginSharedId() {
         return originSharedId;
-    }
-    public String getAppId() {
-        return appId;
     }
 
     @Override

--- a/src/main/java/org/sagebionetworks/bridge/models/assessments/AssessmentReference.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/assessments/AssessmentReference.java
@@ -15,18 +15,26 @@ public final class AssessmentReference {
     private final String guid;
     private final String id;
     private final String sharedId;
+    private final String appId;
     
     @JsonCreator
     public AssessmentReference(@JsonProperty("guid") String guid,
-            @JsonProperty("id") String id, @JsonProperty("sharedId") String sharedId) {
-        this(INSTANCE, guid, id, sharedId);
+            @JsonProperty("id") String id, @JsonProperty("sharedId") String sharedId, @JsonProperty("appId") String appId) {
+        this(INSTANCE, guid, id, sharedId, appId);
+        System.out.println("--------In jsoncreator constructor-----------");
+        System.out.println("assessment guid: " + guid);
+        System.out.println("assessment id: " + id);
+        System.out.println("assessment sharedid: " + sharedId);
+        System.out.println("assessment appId: " + appId);
+        System.out.println("--------");
     }
 
-    public AssessmentReference(ConfigResolver resolver, String guid, String id, String sharedId) {
+    public AssessmentReference(ConfigResolver resolver, String guid, String id, String sharedId, String appId) {
         this.resolver = resolver;
         this.guid = guid;
         this.id = id;
         this.sharedId = sharedId;
+        this.appId = appId;
     }
     
     public String getGuid() {
@@ -50,6 +58,9 @@ public final class AssessmentReference {
     public String getSharedId() {
         return sharedId;
     }
+    public String getAppId() {
+        return appId;
+    }
 
     @Override
     public int hashCode() {
@@ -68,7 +79,7 @@ public final class AssessmentReference {
 
     @Override
     public String toString() {
-        return "AssessmentReference [id=" + id + ", sharedId=" + sharedId + ", guid=" + guid + ", configHref="
+        return "AssessmentReference [id=" + id + ", sharedId=" + sharedId + ", guid=" + guid + ", appId=" + appId + ", configHref="
                 + getConfigHref() + "]";
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/services/AppConfigService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AppConfigService.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Comparator.comparingLong;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.sagebionetworks.bridge.BridgeConstants.SHARED_APP_ID;
+import static org.sagebionetworks.bridge.models.appconfig.ConfigResolver.INSTANCE;
 
 import java.util.List;
 import java.util.Set;
@@ -177,7 +178,7 @@ public class AppConfigService {
             return ref;
         }
         String originSharedId = getSharedAssessmentId(assessment);
-        return new AssessmentReference(ref.getGuid(), assessment.getIdentifier(), originSharedId, assessment.getAppId());
+        return new AssessmentReference(INSTANCE, ref.getGuid(), assessment.getIdentifier(), originSharedId, assessment.getAppId());
     }
     
     protected Assessment getAssessment(String appId, String guid) {
@@ -289,7 +290,7 @@ public class AppConfigService {
         AppConfig persistedConfig = appConfigDao.getAppConfig(appId, appConfig.getGuid());
         appConfig.setCreatedOn(persistedConfig.getCreatedOn());
         appConfig.setModifiedOn(getCurrentTimestamp());
-        
+
         return appConfigDao.updateAppConfig(appConfig);
     }
     

--- a/src/main/java/org/sagebionetworks/bridge/services/AppConfigService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AppConfigService.java
@@ -176,7 +176,7 @@ public class AppConfigService {
             return ref;
         }
         String sharedId = getSharedAssessmentId(assessment);
-        return new AssessmentReference(ref.getGuid(), assessment.getIdentifier(), sharedId);
+        return new AssessmentReference(ref.getGuid(), assessment.getIdentifier(), sharedId, appId);
     }
     
     protected Assessment getAssessment(String appId, String guid) {

--- a/src/main/java/org/sagebionetworks/bridge/services/AppConfigService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AppConfigService.java
@@ -111,7 +111,17 @@ public class AppConfigService {
     
     public List<AppConfig> getAppConfigs(String appId, boolean includeDeleted) {
         checkNotNull(appId);
-        
+
+        /*
+         TODO: Check if this is useful. It seems like the resolveReferences method
+            already fills out the assessment reference fields, and it just isn't used
+            in this path. But that could be intentional.
+        */
+//        List<AppConfig> appConfigs = appConfigDao.getAppConfigs(appId, includeDeleted);
+//        for (AppConfig appConfig : appConfigs) {
+//            resolveReferences(appId, appConfig);
+//        }
+//        return appConfigs;
         return appConfigDao.getAppConfigs(appId, includeDeleted);
     }
     
@@ -175,8 +185,8 @@ public class AppConfigService {
         if (assessment == null) {
             return ref;
         }
-        String sharedId = getSharedAssessmentId(assessment);
-        return new AssessmentReference(ref.getGuid(), assessment.getIdentifier(), sharedId, appId);
+        String originSharedId = getSharedAssessmentId(assessment);
+        return new AssessmentReference(ref.getGuid(), assessment.getIdentifier(), originSharedId, appId);
     }
     
     protected Assessment getAssessment(String appId, String guid) {
@@ -195,6 +205,7 @@ public class AppConfigService {
             try {
                 Assessment shared = assessmentService.getAssessmentByGuid(
                         SHARED_APP_ID, null, assessment.getOriginGuid());
+                System.out.println("--- " + shared.getIdentifier() + " ---");
                 return shared.getIdentifier();
             } catch(EntityNotFoundException e) {
                 return null;

--- a/src/main/java/org/sagebionetworks/bridge/services/AppConfigService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AppConfigService.java
@@ -178,7 +178,7 @@ public class AppConfigService {
             return ref;
         }
         String originSharedId = getSharedAssessmentId(assessment);
-        return new AssessmentReference(INSTANCE, ref.getGuid(), assessment.getIdentifier(), originSharedId, assessment.getAppId());
+        return new AssessmentReference(INSTANCE, assessment.getAppId(), ref.getGuid(), assessment.getIdentifier(), originSharedId);
     }
     
     protected Assessment getAssessment(String appId, String guid) {

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AppConfigController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AppConfigController.java
@@ -111,8 +111,19 @@ public class AppConfigController extends BaseController {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         
         AppConfig appConfig = parseJson(AppConfig.class);
+
+        System.out.println("GUID: " + guid);
+
+        System.out.println("------------------------------------");
+        System.out.println(appConfig);
+
         appConfig.setGuid(guid);
-        
+
+        System.out.println("------------------------------------");
+        System.out.println(appConfig);
+        System.out.println("------------------------------------");
+
+
         AppConfig updated = appConfigService.updateAppConfig(session.getAppId(), appConfig);
         cacheProvider.removeSetOfCacheKeys(CacheKey.appConfigList(session.getAppId()));
 

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AppConfigController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AppConfigController.java
@@ -111,18 +111,7 @@ public class AppConfigController extends BaseController {
         UserSession session = getAuthenticatedSession(DEVELOPER);
         
         AppConfig appConfig = parseJson(AppConfig.class);
-
-        System.out.println("GUID: " + guid);
-
-        System.out.println("------------------------------------");
-        System.out.println(appConfig);
-
         appConfig.setGuid(guid);
-
-        System.out.println("------------------------------------");
-        System.out.println(appConfig);
-        System.out.println("------------------------------------");
-
 
         AppConfig updated = appConfigService.updateAppConfig(session.getAppId(), appConfig);
         cacheProvider.removeSetOfCacheKeys(CacheKey.appConfigList(session.getAppId()));

--- a/src/main/java/org/sagebionetworks/bridge/validators/AppConfigValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/AppConfigValidator.java
@@ -212,7 +212,18 @@ public class AppConfigValidator implements Validator {
                         errors.rejectValue("guid", "refers to the same assessment as another reference");
                     } else {
                         try {
-                            assessmentService.getAssessmentByGuid(appConfig.getAppId(), null, ref.getGuid());
+                            /* TODO: This seems to validate only for local assessments because it is grabbing
+                            *   the appId from the appConfig. This will need to grab the appId from the
+                            *   assessmentReference to get "shared". Probably have it default to the local
+                            *   appId if not found. */
+                            String assessmentAppId = appConfig.getAppId();
+                            if (ref.getAppId().equals("shared")) {
+                                System.out.println("-----------VALIDATOR-----------");
+                                System.out.println("in shared block");
+                                System.out.println("-----------END VALIDATOR-------");
+                                assessmentAppId = "shared";
+                            }
+                            assessmentService.getAssessmentByGuid(assessmentAppId, null, ref.getGuid());
                         } catch(EntityNotFoundException e) {
                             errors.rejectValue("guid", "does not refer to an assessment");
                         }

--- a/src/main/java/org/sagebionetworks/bridge/validators/AppConfigValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/AppConfigValidator.java
@@ -213,35 +213,16 @@ public class AppConfigValidator implements Validator {
                     if (uniqueRefs.contains(ref)) {
                         errors.rejectValue("guid", "refers to the same assessment as another reference");
                     } else {
-try {
-    // Default's to the appId from the AppConfig if the AssessmentReference
-    // does not have one specified.
-    String assessmentAppId = (ref.getAppId() != null) ? ref.getAppId() : appConfig.getAppId();
-    Assessment retrievedAssessment = assessmentService.getAssessmentByGuid(assessmentAppId, null, ref.getGuid());
-
-    if (ref.getId() != null && !ref.getId().equals(retrievedAssessment.getIdentifier())) {
-        errors.rejectValue("id", "does not match assessment");
-    }
-    if (ref.getOriginSharedId() != null) {
-        if (retrievedAssessment.getOriginGuid() == null) {
-            // ref has origin, assessment does not
-            errors.rejectValue("originSharedId", "does not match assessment");
-        } else {
-            try {
-                Assessment originAssessment = assessmentService.getAssessmentByGuid(SHARED_APP_ID, null, retrievedAssessment.getOriginGuid());
-                if (!originAssessment.getIdentifier().equals(ref.getOriginSharedId())) {
-                    // ref origin does not match actual origin id
-                    errors.rejectValue("originSharedId", "does not match assessment");
-                }
-            } catch (EntityNotFoundException e) {
-                // assessment origin guid leads nowhere, can this even happen?
-                errors.rejectValue("originSharedId", "does not exist");
-            }
-        }
-    }
-} catch(EntityNotFoundException e) {
-    errors.rejectValue("guid", "does not refer to an assessment");
-}
+                        String assessmentAppId = (ref.getAppId() != null) ? ref.getAppId() : appConfig.getAppId();
+                        if (!assessmentAppId.equals(appConfig.getAppId()) && !assessmentAppId.equals(SHARED_APP_ID)) {
+                            errors.rejectValue("appId", "does not refer to a valid app");
+                        } else {
+                            try {
+                                assessmentService.getAssessmentByGuid(assessmentAppId, null, ref.getGuid());
+                            } catch(EntityNotFoundException e) {
+                                errors.rejectValue("guid", "does not refer to an assessment");
+                            }
+                        }
                     }
                     uniqueRefs.add(ref);
                 }

--- a/src/main/java/org/sagebionetworks/bridge/validators/AppConfigValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/AppConfigValidator.java
@@ -212,17 +212,9 @@ public class AppConfigValidator implements Validator {
                         errors.rejectValue("guid", "refers to the same assessment as another reference");
                     } else {
                         try {
-                            /* TODO: This seems to validate only for local assessments because it is grabbing
-                            *   the appId from the appConfig. This will need to grab the appId from the
-                            *   assessmentReference to get "shared". Probably have it default to the local
-                            *   appId if not found. */
-                            String assessmentAppId = appConfig.getAppId();
-                            if (ref.getAppId().equals("shared")) {
-                                System.out.println("-----------VALIDATOR-----------");
-                                System.out.println("in shared block");
-                                System.out.println("-----------END VALIDATOR-------");
-                                assessmentAppId = "shared";
-                            }
+                            // Default's to the appId from the AppConfig if the AssessmentReference
+                            // does not have one specified.
+                            String assessmentAppId = (ref.getAppId() != null) ? ref.getAppId() : appConfig.getAppId();
                             assessmentService.getAssessmentByGuid(assessmentAppId, null, ref.getGuid());
                         } catch(EntityNotFoundException e) {
                             errors.rejectValue("guid", "does not refer to an assessment");

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoAppConfigTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoAppConfigTest.java
@@ -6,6 +6,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+import static org.sagebionetworks.bridge.models.appconfig.ConfigResolver.INSTANCE;
 
 import java.util.HashSet;
 import java.util.List;
@@ -53,8 +54,8 @@ public class DynamoAppConfigTest {
             new FileReference(GUID, TIMESTAMP),
             new FileReference("twoGuid", TIMESTAMP));
     private static final List<AssessmentReference> ASSESSMENT_REFS = ImmutableList.of(
-            new AssessmentReference("guid1", "id1", "originSharedId1", "appId1"),
-            new AssessmentReference("guid2", "id2", "originSharedId2", "appId2"));
+            new AssessmentReference(INSTANCE, "guid1", "id1", "originSharedId1", "appId1"),
+            new AssessmentReference(INSTANCE, "guid2", "id2", "originSharedId2", "appId2"));
     
     private static final String APP_ID = TestUtils.randomName(DynamoAppConfigTest.class);
     

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoAppConfigTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoAppConfigTest.java
@@ -54,8 +54,8 @@ public class DynamoAppConfigTest {
             new FileReference(GUID, TIMESTAMP),
             new FileReference("twoGuid", TIMESTAMP));
     private static final List<AssessmentReference> ASSESSMENT_REFS = ImmutableList.of(
-            new AssessmentReference(INSTANCE, "guid1", "id1", "originSharedId1", "appId1"),
-            new AssessmentReference(INSTANCE, "guid2", "id2", "originSharedId2", "appId2"));
+            new AssessmentReference(INSTANCE, "appId1", "guid1", "id1", "originSharedId1"),
+            new AssessmentReference(INSTANCE, "appId2", "guid2", "id2", "originSharedId2"));
     
     private static final String APP_ID = TestUtils.randomName(DynamoAppConfigTest.class);
     
@@ -172,19 +172,19 @@ public class DynamoAppConfigTest {
         assertEquals(node.get("fileReferences").get(1).get("createdOn").textValue(), TIMESTAMP.toString());
         
         assertEquals(node.get("assessmentReferences").size(), 2);
+        assertEquals(node.get("assessmentReferences").get(0).get("appId").textValue(), "appId1");
+        assertEquals(node.get("assessmentReferences").get(0).get("guid").textValue(), "guid1");
         assertEquals(node.get("assessmentReferences").get(0).get("id").textValue(), "id1");
         assertEquals(node.get("assessmentReferences").get(0).get("originSharedId").textValue(), "originSharedId1");
-        assertEquals(node.get("assessmentReferences").get(0).get("guid").textValue(), "guid1");
         assertTrue(node.get("assessmentReferences").get(0).get("configHref").textValue()
                 .contains("/v1/assessments/guid1/config"));
-        assertEquals(node.get("assessmentReferences").get(0).get("appId").textValue(), "appId1");
 
+        assertEquals(node.get("assessmentReferences").get(1).get("appId").textValue(), "appId2");
+        assertEquals(node.get("assessmentReferences").get(1).get("guid").textValue(), "guid2");
         assertEquals(node.get("assessmentReferences").get(1).get("id").textValue(), "id2");
         assertEquals(node.get("assessmentReferences").get(1).get("originSharedId").textValue(), "originSharedId2");
-        assertEquals(node.get("assessmentReferences").get(1).get("guid").textValue(), "guid2");
         assertTrue(node.get("assessmentReferences").get(1).get("configHref").textValue()
                 .contains("/v1/assessments/guid2/config"));
-        assertEquals(node.get("assessmentReferences").get(1).get("appId").textValue(), "appId2");
 
         AppConfig deser = BridgeObjectMapper.get().treeToValue(node, AppConfig.class);
         assertNull(deser.getAppId());

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoAppConfigTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoAppConfigTest.java
@@ -53,8 +53,8 @@ public class DynamoAppConfigTest {
             new FileReference(GUID, TIMESTAMP),
             new FileReference("twoGuid", TIMESTAMP));
     private static final List<AssessmentReference> ASSESSMENT_REFS = ImmutableList.of(
-            new AssessmentReference("guid1", "id1", "sharedId1"),
-            new AssessmentReference("guid2", "id2", "sharedId2"));
+            new AssessmentReference("guid1", "id1", "sharedId1", "appId1"),
+            new AssessmentReference("guid2", "id2", "sharedId2", "appId2"));
     
     private static final String APP_ID = TestUtils.randomName(DynamoAppConfigTest.class);
     
@@ -173,12 +173,14 @@ public class DynamoAppConfigTest {
         assertEquals(node.get("assessmentReferences").get(0).get("guid").textValue(), "guid1");
         assertTrue(node.get("assessmentReferences").get(0).get("configHref").textValue()
                 .contains("/v1/assessments/guid1/config"));
+        assertEquals(node.get("assessmentReferences").get(0).get("appId").textValue(), "appId1");
 
         assertEquals(node.get("assessmentReferences").get(1).get("id").textValue(), "id2");
         assertEquals(node.get("assessmentReferences").get(1).get("sharedId").textValue(), "sharedId2");
         assertEquals(node.get("assessmentReferences").get(1).get("guid").textValue(), "guid2");
         assertTrue(node.get("assessmentReferences").get(1).get("configHref").textValue()
                 .contains("/v1/assessments/guid2/config"));
+        assertEquals(node.get("assessmentReferences").get(1).get("appId").textValue(), "appId2");
 
         AppConfig deser = BridgeObjectMapper.get().treeToValue(node, AppConfig.class);
         assertNull(deser.getAppId());

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoAppConfigTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoAppConfigTest.java
@@ -53,8 +53,8 @@ public class DynamoAppConfigTest {
             new FileReference(GUID, TIMESTAMP),
             new FileReference("twoGuid", TIMESTAMP));
     private static final List<AssessmentReference> ASSESSMENT_REFS = ImmutableList.of(
-            new AssessmentReference("guid1", "id1", "sharedId1", "appId1"),
-            new AssessmentReference("guid2", "id2", "sharedId2", "appId2"));
+            new AssessmentReference("guid1", "id1", "originSharedId1", "appId1"),
+            new AssessmentReference("guid2", "id2", "originSharedId2", "appId2"));
     
     private static final String APP_ID = TestUtils.randomName(DynamoAppConfigTest.class);
     
@@ -72,18 +72,21 @@ public class DynamoAppConfigTest {
         assertNotNull(config.getSchemaReferences());
         assertNotNull(config.getSurveyReferences());
         assertNotNull(config.getFileReferences());
+        assertNotNull(config.getAssessmentReferences());
         
         config.setConfigElements(null);
         config.setConfigReferences(null);
         config.setSchemaReferences(null);
         config.setSurveyReferences(null);
         config.setFileReferences(null);
+        config.setAssessmentReferences(null);
         
         assertNotNull(config.getConfigElements());
         assertNotNull(config.getConfigReferences());
         assertNotNull(config.getSchemaReferences());
         assertNotNull(config.getSurveyReferences());
         assertNotNull(config.getFileReferences());
+        assertNotNull(config.getAssessmentReferences());
     }
 
     @Test
@@ -169,14 +172,14 @@ public class DynamoAppConfigTest {
         
         assertEquals(node.get("assessmentReferences").size(), 2);
         assertEquals(node.get("assessmentReferences").get(0).get("id").textValue(), "id1");
-        assertEquals(node.get("assessmentReferences").get(0).get("sharedId").textValue(), "sharedId1");
+        assertEquals(node.get("assessmentReferences").get(0).get("originSharedId").textValue(), "originSharedId1");
         assertEquals(node.get("assessmentReferences").get(0).get("guid").textValue(), "guid1");
         assertTrue(node.get("assessmentReferences").get(0).get("configHref").textValue()
                 .contains("/v1/assessments/guid1/config"));
         assertEquals(node.get("assessmentReferences").get(0).get("appId").textValue(), "appId1");
 
         assertEquals(node.get("assessmentReferences").get(1).get("id").textValue(), "id2");
-        assertEquals(node.get("assessmentReferences").get(1).get("sharedId").textValue(), "sharedId2");
+        assertEquals(node.get("assessmentReferences").get(1).get("originSharedId").textValue(), "originSharedId2");
         assertEquals(node.get("assessmentReferences").get(1).get("guid").textValue(), "guid2");
         assertTrue(node.get("assessmentReferences").get(1).get("configHref").textValue()
                 .contains("/v1/assessments/guid2/config"));

--- a/src/test/java/org/sagebionetworks/bridge/models/assessments/AssessmentReferenceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/assessments/AssessmentReferenceTest.java
@@ -37,17 +37,17 @@ public class AssessmentReferenceTest extends Mockito {
         // should be globally unique for assessement references and is sufficient for 
         // equality. This makes detecting duplicates easier during validation.
         EqualsVerifier.forClass(AssessmentReference.class)
-            .allFieldsShouldBeUsedExcept("resolver", "id", "sharedId", "appId").verify();
+            .allFieldsShouldBeUsedExcept("resolver", "id", "originSharedId", "appId").verify();
     }
 
     @Test
     public void succeeds() throws Exception {
         ConfigResolver resolver = mockConfigResolver(UAT, "ws");
-        AssessmentReference ref = new AssessmentReference(resolver, "oneGuid", "id", "sharedId", "appId");
+        AssessmentReference ref = new AssessmentReference(resolver, "oneGuid", "id", "originSharedId", "appId");
         
         assertEquals(ref.getGuid(), "oneGuid");
         assertEquals(ref.getId(), "id");
-        assertEquals(ref.getSharedId(), "sharedId");
+        assertEquals(ref.getOriginSharedId(), "originSharedId");
         assertEquals(ref.getConfigHref(), 
                 "https://ws-uat.bridge.org/v1/assessments/oneGuid/config");
         assertEquals(ref.getAppId(), "appId");
@@ -60,7 +60,7 @@ public class AssessmentReferenceTest extends Mockito {
         
         assertEquals(ref.getGuid(), "oneGuid");
         assertNull(ref.getId());
-        assertNull(ref.getSharedId());
+        assertNull(ref.getOriginSharedId());
         assertEquals(ref.getConfigHref(), 
                 "http://ws-local.bridge.org/v1/assessments/oneGuid/config");
         assertNull(ref.getAppId());
@@ -75,12 +75,12 @@ public class AssessmentReferenceTest extends Mockito {
     @Test
     public void canSerialise() throws Exception {
         ConfigResolver resolver = mockConfigResolver(LOCAL, "ws");
-        AssessmentReference ref = new AssessmentReference(resolver, "oneGuid", "id", "sharedId", "appId");
+        AssessmentReference ref = new AssessmentReference(resolver, "oneGuid", "id", "originSharedId", "appId");
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(ref);
         assertEquals(node.get("guid").textValue(), "oneGuid");
         assertEquals(node.get("id").textValue(), "id");
-        assertEquals(node.get("sharedId").textValue(), "sharedId");
+        assertEquals(node.get("originSharedId").textValue(), "originSharedId");
         assertEquals(node.get("configHref").textValue(), 
             "http://ws-local.bridge.org/v1/assessments/oneGuid/config");
         assertEquals(node.get("appId").textValue(), "appId");

--- a/src/test/java/org/sagebionetworks/bridge/models/assessments/AssessmentReferenceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/assessments/AssessmentReferenceTest.java
@@ -68,7 +68,7 @@ public class AssessmentReferenceTest extends Mockito {
     
     @Test
     public void noGuid() {
-        AssessmentReference ref = new AssessmentReference(null, null, null, null);
+        AssessmentReference ref = new AssessmentReference(null, null);
         assertNull(ref.getConfigHref());
     }
     
@@ -89,6 +89,10 @@ public class AssessmentReferenceTest extends Mockito {
         AssessmentReference deser = BridgeObjectMapper.get().readValue(
                 node.toString(), AssessmentReference.class);
         assertEquals(deser, ref);
+        assertEquals(deser.getGuid(), "oneGuid");
+        assertEquals(deser.getAppId(), "appId");
+        assertNull(deser.getId());
+        assertNull(deser.getOriginSharedId());
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/models/assessments/AssessmentReferenceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/assessments/AssessmentReferenceTest.java
@@ -37,33 +37,33 @@ public class AssessmentReferenceTest extends Mockito {
         // should be globally unique for assessement references and is sufficient for 
         // equality. This makes detecting duplicates easier during validation.
         EqualsVerifier.forClass(AssessmentReference.class)
-            .allFieldsShouldBeUsedExcept("resolver", "id", "originSharedId", "appId").verify();
+            .allFieldsShouldBeUsedExcept("resolver", "appId", "id", "originSharedId").verify();
     }
 
     @Test
     public void succeeds() throws Exception {
         ConfigResolver resolver = mockConfigResolver(UAT, "ws");
-        AssessmentReference ref = new AssessmentReference(resolver, "oneGuid", "id", "originSharedId", "appId");
+        AssessmentReference ref = new AssessmentReference(resolver, "appId", "oneGuid", "id", "originSharedId");
         
+        assertEquals(ref.getAppId(), "appId");
         assertEquals(ref.getGuid(), "oneGuid");
         assertEquals(ref.getId(), "id");
         assertEquals(ref.getOriginSharedId(), "originSharedId");
-        assertEquals(ref.getConfigHref(), 
+        assertEquals(ref.getConfigHref(),
                 "https://ws-uat.bridge.org/v1/assessments/oneGuid/config");
-        assertEquals(ref.getAppId(), "appId");
     }
     
     @Test
     public void noIdentifiers() {
         ConfigResolver resolver = mockConfigResolver(LOCAL, "ws");
-        AssessmentReference ref = new AssessmentReference(resolver, "oneGuid", null, null, null);
+        AssessmentReference ref = new AssessmentReference(resolver, null, "oneGuid", null, null);
         
+        assertNull(ref.getAppId());
         assertEquals(ref.getGuid(), "oneGuid");
         assertNull(ref.getId());
         assertNull(ref.getOriginSharedId());
-        assertEquals(ref.getConfigHref(), 
+        assertEquals(ref.getConfigHref(),
                 "http://ws-local.bridge.org/v1/assessments/oneGuid/config");
-        assertNull(ref.getAppId());
     }
     
     @Test
@@ -75,22 +75,22 @@ public class AssessmentReferenceTest extends Mockito {
     @Test
     public void canSerialise() throws Exception {
         ConfigResolver resolver = mockConfigResolver(LOCAL, "ws");
-        AssessmentReference ref = new AssessmentReference(resolver, "oneGuid", "id", "originSharedId", "appId");
+        AssessmentReference ref = new AssessmentReference(resolver, "appId", "oneGuid", "id", "originSharedId");
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(ref);
+        assertEquals(node.get("appId").textValue(), "appId");
         assertEquals(node.get("guid").textValue(), "oneGuid");
         assertEquals(node.get("id").textValue(), "id");
         assertEquals(node.get("originSharedId").textValue(), "originSharedId");
-        assertEquals(node.get("configHref").textValue(), 
+        assertEquals(node.get("configHref").textValue(),
             "http://ws-local.bridge.org/v1/assessments/oneGuid/config");
-        assertEquals(node.get("appId").textValue(), "appId");
         assertEquals(node.get("type").textValue(), "AssessmentReference");
         
         AssessmentReference deser = BridgeObjectMapper.get().readValue(
                 node.toString(), AssessmentReference.class);
         assertEquals(deser, ref);
-        assertEquals(deser.getGuid(), "oneGuid");
         assertEquals(deser.getAppId(), "appId");
+        assertEquals(deser.getGuid(), "oneGuid");
         assertNull(deser.getId());
         assertNull(deser.getOriginSharedId());
     }
@@ -98,7 +98,7 @@ public class AssessmentReferenceTest extends Mockito {
     @Test
     public void configHrefChangesWithSharedAppId() {
         ConfigResolver resolver = mockConfigResolver(LOCAL, "ws");
-        AssessmentReference ref = new AssessmentReference(resolver, "oneGuid", null, null, SHARED_APP_ID);
+        AssessmentReference ref = new AssessmentReference(resolver, SHARED_APP_ID, "oneGuid", null, null);
 
         assertEquals(ref.getConfigHref(),
                 "http://ws-local.bridge.org/v1/sharedassessments/oneGuid/config");

--- a/src/test/java/org/sagebionetworks/bridge/services/AppConfigServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AppConfigServiceTest.java
@@ -69,7 +69,8 @@ public class AppConfigServiceTest {
     private static final List<SchemaReference> SCHEMA_REF_LIST = ImmutableList.of(new SchemaReference("id", 3));
     private static final List<ConfigReference> CONFIG_REF_LIST = ImmutableList.of(new ConfigReference("id", 1L));
     private static final List<FileReference> FILE_REF_LIST = ImmutableList.of(new FileReference(GUID, TIMESTAMP));
-    private static final List<AssessmentReference> ASSESSMENT_REF_LIST = ImmutableList.of(new AssessmentReference(GUID, null, null));
+    // TODO: check here
+    private static final List<AssessmentReference> ASSESSMENT_REF_LIST = ImmutableList.of(new AssessmentReference(GUID, null, null, null));
     private static final GuidCreatedOnVersionHolder SURVEY_KEY = new GuidCreatedOnVersionHolderImpl(SURVEY_REF_LIST.get(0));
     
     @Mock
@@ -520,6 +521,7 @@ public class AppConfigServiceTest {
         assertEquals(captured.getSchemaReferences(), SCHEMA_REF_LIST);
         assertEquals(captured.getConfigReferences(), CONFIG_REF_LIST);
         assertEquals(captured.getFileReferences(), FILE_REF_LIST);
+        assertEquals(captured.getAssessmentReferences(), ASSESSMENT_REF_LIST);
         
         verify(mockStudyService).getStudyIds(TEST_APP_ID);
     }

--- a/src/test/java/org/sagebionetworks/bridge/services/AppConfigServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AppConfigServiceTest.java
@@ -69,7 +69,6 @@ public class AppConfigServiceTest {
     private static final List<SchemaReference> SCHEMA_REF_LIST = ImmutableList.of(new SchemaReference("id", 3));
     private static final List<ConfigReference> CONFIG_REF_LIST = ImmutableList.of(new ConfigReference("id", 1L));
     private static final List<FileReference> FILE_REF_LIST = ImmutableList.of(new FileReference(GUID, TIMESTAMP));
-    // TODO: check here
     private static final List<AssessmentReference> ASSESSMENT_REF_LIST = ImmutableList.of(new AssessmentReference(GUID, null, null, null));
     private static final GuidCreatedOnVersionHolder SURVEY_KEY = new GuidCreatedOnVersionHolderImpl(SURVEY_REF_LIST.get(0));
     
@@ -254,7 +253,7 @@ public class AppConfigServiceTest {
         // Verify that we called the resolver on this as well
         assertEquals(retValue.getSurveyReferences().get(0).getIdentifier(), "theIdentifier");
         assertEquals(retValue.getAssessmentReferences().get(0).getId(), "assessmentId");
-        assertEquals(retValue.getAssessmentReferences().get(0).getSharedId(), "sharedAssessmentId");
+        assertEquals(retValue.getAssessmentReferences().get(0).getOriginSharedId(), "sharedAssessmentId");
         assertEquals(retValue.getConfigElements().get("clientData"), TestUtils.getClientData());  
         
         return retValue;
@@ -278,7 +277,7 @@ public class AppConfigServiceTest {
         
         // Verify that we called the resolver on this as well
         assertEquals(match.getAssessmentReferences().get(0).getId(), "assessmentId");
-        assertNull(match.getAssessmentReferences().get(0).getSharedId());
+        assertNull(match.getAssessmentReferences().get(0).getOriginSharedId());
     }
     
     @Test
@@ -302,7 +301,7 @@ public class AppConfigServiceTest {
         
         // Verify that we called the resolver on this as well
         assertEquals(match.getAssessmentReferences().get(0).getId(), "assessmentId");
-        assertNull(match.getAssessmentReferences().get(0).getSharedId());
+        assertNull(match.getAssessmentReferences().get(0).getOriginSharedId());
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/AppConfigServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AppConfigServiceTest.java
@@ -69,7 +69,7 @@ public class AppConfigServiceTest {
     private static final List<SchemaReference> SCHEMA_REF_LIST = ImmutableList.of(new SchemaReference("id", 3));
     private static final List<ConfigReference> CONFIG_REF_LIST = ImmutableList.of(new ConfigReference("id", 1L));
     private static final List<FileReference> FILE_REF_LIST = ImmutableList.of(new FileReference(GUID, TIMESTAMP));
-    private static final List<AssessmentReference> ASSESSMENT_REF_LIST = ImmutableList.of(new AssessmentReference(GUID, TEST_APP_ID));
+    private static final List<AssessmentReference> ASSESSMENT_REF_LIST = ImmutableList.of(new AssessmentReference(TEST_APP_ID, GUID));
     private static final GuidCreatedOnVersionHolder SURVEY_KEY = new GuidCreatedOnVersionHolderImpl(SURVEY_REF_LIST.get(0));
     
     @Mock
@@ -577,7 +577,7 @@ public class AppConfigServiceTest {
 
     @Test
     public void resolveAssessmentUsesAssessmentReferenceAppIdIfAvailable() {
-        AssessmentReference sharedAssessmentRef = new AssessmentReference(GUID, SHARED_APP_ID);
+        AssessmentReference sharedAssessmentRef = new AssessmentReference(SHARED_APP_ID, GUID);
 
         service.resolveAssessment(TEST_APP_ID, sharedAssessmentRef);
 
@@ -586,7 +586,7 @@ public class AppConfigServiceTest {
 
     @Test
     public void resolveAssessmentUsesAppConfigAppIdWhenMissingFromAssessmentReference() {
-        AssessmentReference sharedAssessmentRef = new AssessmentReference(GUID, null);
+        AssessmentReference sharedAssessmentRef = new AssessmentReference(null, GUID);
 
         service.resolveAssessment(TEST_APP_ID, sharedAssessmentRef);
 

--- a/src/test/java/org/sagebionetworks/bridge/services/AppConfigServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AppConfigServiceTest.java
@@ -69,7 +69,7 @@ public class AppConfigServiceTest {
     private static final List<SchemaReference> SCHEMA_REF_LIST = ImmutableList.of(new SchemaReference("id", 3));
     private static final List<ConfigReference> CONFIG_REF_LIST = ImmutableList.of(new ConfigReference("id", 1L));
     private static final List<FileReference> FILE_REF_LIST = ImmutableList.of(new FileReference(GUID, TIMESTAMP));
-    private static final List<AssessmentReference> ASSESSMENT_REF_LIST = ImmutableList.of(new AssessmentReference(GUID, null));
+    private static final List<AssessmentReference> ASSESSMENT_REF_LIST = ImmutableList.of(new AssessmentReference(GUID, TEST_APP_ID));
     private static final GuidCreatedOnVersionHolder SURVEY_KEY = new GuidCreatedOnVersionHolderImpl(SURVEY_REF_LIST.get(0));
     
     @Mock
@@ -573,5 +573,23 @@ public class AppConfigServiceTest {
         service.deleteAppConfigPermanently(TEST_APP_ID, GUID);
         
         verify(mockDao).deleteAppConfigPermanently(TEST_APP_ID, GUID);
+    }
+
+    @Test
+    public void resolveAssessmentUsesAssessmentReferenceAppIdIfAvailable() {
+        AssessmentReference sharedAssessmentRef = new AssessmentReference(GUID, SHARED_APP_ID);
+
+        service.resolveAssessment(TEST_APP_ID, sharedAssessmentRef);
+
+        verify(mockAssessmentService).getAssessmentByGuid(SHARED_APP_ID, null, GUID);
+    }
+
+    @Test
+    public void resolveAssessmentUsesAppConfigAppIdWhenMissingFromAssessmentReference() {
+        AssessmentReference sharedAssessmentRef = new AssessmentReference(GUID, null);
+
+        service.resolveAssessment(TEST_APP_ID, sharedAssessmentRef);
+
+        verify(mockAssessmentService).getAssessmentByGuid(TEST_APP_ID, null, GUID);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/AppConfigServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AppConfigServiceTest.java
@@ -69,7 +69,7 @@ public class AppConfigServiceTest {
     private static final List<SchemaReference> SCHEMA_REF_LIST = ImmutableList.of(new SchemaReference("id", 3));
     private static final List<ConfigReference> CONFIG_REF_LIST = ImmutableList.of(new ConfigReference("id", 1L));
     private static final List<FileReference> FILE_REF_LIST = ImmutableList.of(new FileReference(GUID, TIMESTAMP));
-    private static final List<AssessmentReference> ASSESSMENT_REF_LIST = ImmutableList.of(new AssessmentReference(GUID, null, null, null));
+    private static final List<AssessmentReference> ASSESSMENT_REF_LIST = ImmutableList.of(new AssessmentReference(GUID, null));
     private static final GuidCreatedOnVersionHolder SURVEY_KEY = new GuidCreatedOnVersionHolderImpl(SURVEY_REF_LIST.get(0));
     
     @Mock

--- a/src/test/java/org/sagebionetworks/bridge/validators/AppConfigValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/AppConfigValidatorTest.java
@@ -57,7 +57,7 @@ public class AppConfigValidatorTest extends Mockito {
     private static final SchemaReference VALID_SCHEMA_REF = new SchemaReference("guid", 3);
     private static final ConfigReference VALID_CONFIG_REF = new ConfigReference("id", 3L);
     private static final AssessmentReference INVALID_ASSESSMENT_REF = new AssessmentReference(null, null);
-    private static final AssessmentReference VALID_ASSESSMENT_REF = new AssessmentReference(GUID, TEST_APP_ID);
+    private static final AssessmentReference VALID_ASSESSMENT_REF = new AssessmentReference(TEST_APP_ID, GUID);
 
     @Mock
     private SurveyService mockSurveyService;
@@ -129,21 +129,21 @@ public class AppConfigValidatorTest extends Mockito {
 
     @Test
     public void assessmentReferenceMissingAppId() {
-        appConfig.setAssessmentReferences(ImmutableList.of(new AssessmentReference(GUID, null)));
+        appConfig.setAssessmentReferences(ImmutableList.of(new AssessmentReference(null, GUID)));
 
         assertValidatorMessage(newValidator, appConfig, "assessmentReferences[0].appId", "is required");
     }
 
     @Test
     public void assessmentReferenceInvalidAppId() {
-        appConfig.setAssessmentReferences(ImmutableList.of(new AssessmentReference(GUID, "fakeAppId")));
+        appConfig.setAssessmentReferences(ImmutableList.of(new AssessmentReference("fakeAppId", GUID)));
 
-        assertValidatorMessage(newValidator, appConfig, "assessmentReferences[0].appId", "does not refer to a valid app");
+        assertValidatorMessage(newValidator, appConfig, "assessmentReferences[0].appId", "is not a valid app");
     }
 
     @Test
     public void assessmentReferenceWithDifferentAppIdFromConfigValidates() {
-        AssessmentReference sharedAssessmentRef = new AssessmentReference(GUID, SHARED_APP_ID);
+        AssessmentReference sharedAssessmentRef = new AssessmentReference(SHARED_APP_ID, GUID);
         appConfig.setAssessmentReferences(ImmutableList.of(sharedAssessmentRef));
 
         try {

--- a/src/test/java/org/sagebionetworks/bridge/validators/AppConfigValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/AppConfigValidatorTest.java
@@ -55,7 +55,6 @@ public class AppConfigValidatorTest extends Mockito {
     private static final SchemaReference INVALID_SCHEMA_REF = new SchemaReference("guid", null);
     private static final SchemaReference VALID_SCHEMA_REF = new SchemaReference("guid", 3);
     private static final ConfigReference VALID_CONFIG_REF = new ConfigReference("id", 3L);
-    // TODO: check here
     private static final AssessmentReference INVALID_ASSESSMENT_REF = new AssessmentReference(null, null, null, null);
     private static final AssessmentReference VALID_ASSESSMENT_REF = new AssessmentReference(GUID, null, null, null);
 


### PR DESCRIPTION
For Bridge-2950.

- Adding ability to include shared assessments in app config's assessment references
- Adding appId field to assessment references
- Renaming sharedId field to originSharedId
- Converting assessment reference id and originSharedId fields to read only