### PR TITLE
Make it a little easier to delete an unused account.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
@@ -734,16 +734,13 @@ public class BridgeUtils {
         if (testAccount) {
             return true;
         }
-        // Accounts enrolled in multiple studies cannot be deleted, too risky.
-        if (account.getEnrollments().size() > 1) {
-            return false;
+        // Must have rights to delete participant in all studies using this account.
+        for (Enrollment en : account.getEnrollments()) {
+            if (!CAN_DELETE_PARTICIPANTS.check(STUDY_ID, en.getStudyId())) {
+                return false;
+            }
         }
-        // Get a studyId if there is one. If it's null, that part of the security rule will just fail to match.
-        String studyId = Iterables.getFirst(collectStudyIds(account), null);
-        boolean unused = participantHasNeverSignedIn(requestInfoService, account.getId());
-        
-        // If the account is unused, *and* the caller has access to the participant, allow the delete 
-        return (unused && CAN_DELETE_PARTICIPANTS.check(STUDY_ID, studyId));
+        return participantHasNeverSignedIn(requestInfoService, account.getId());
     }
     
     private static boolean participantHasNeverSignedIn(RequestInfoService requestInfoService, String userId) {

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
@@ -90,7 +90,8 @@ import org.sagebionetworks.bridge.services.EnrollmentService;
 @RestController
 public class ParticipantController extends BaseController {
     
-    private static final String NOTIFY_SUCCESS_MESSAGE = "Message has been sent to external notification service.";
+    static final String CANNOT_DELETE_ACCOUNT_ERROR = "Account is not a test account, it is already in use, or it is enrolled in a study that is not managed by the caller’s organization.";
+    static final String NOTIFY_SUCCESS_MESSAGE = "Message has been sent to external notification service.";
 
     private ParticipantService participantService;
     
@@ -210,7 +211,7 @@ public class ParticipantController extends BaseController {
                 .orElseThrow(() -> new EntityNotFoundException(Account.class));
         
         if (!participantEligibleForDeletion(requestInfoService, account)) {
-            throw new UnauthorizedException("Account is not a test account or it is already in use.");
+            throw new UnauthorizedException(CANNOT_DELETE_ACCOUNT_ERROR);
         }
         App app = appService.getApp(session.getAppId());
         userAdminService.deleteUser(app, account.getId());

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
@@ -1493,7 +1493,7 @@ public class ParticipantControllerTest extends Mockito {
     }
 
     @Test
-    public void deleteTestUserWorks() {
+    public void deleteUserWorks() {
         Account account = Account.create();
         account.setDataGroups(ImmutableSet.of(TEST_USER_GROUP));
         account.setId(TEST_USER_ID);
@@ -1506,7 +1506,7 @@ public class ParticipantControllerTest extends Mockito {
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void deleteTestUserNotAResearcher() {
+    public void deleteUserNotAResearcher() {
         participant = new StudyParticipant.Builder().copyOf(participant)
                 .withRoles(ImmutableSet.of(WORKER))
                 .withId("notUserId").build();
@@ -1519,7 +1519,7 @@ public class ParticipantControllerTest extends Mockito {
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void deleteTestUserNotATestAccount() {
+    public void deleteUserNotATestAccount() {
         Account account = Account.create();
         when(mockAccountService.getAccount(any())).thenReturn(Optional.of(account));
         


### PR DESCRIPTION
You can now delete an account enrolled in multiple studies as long as you have access to all the studies (and it hasn't been used). Also clarified this rule in the error message if you are not allowed to delete the account. Test accounts continue to be deletable no matter what.