### PR TITLE
Bridge 3101

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
@@ -36,9 +36,6 @@ public class AuthUtils {
     public static final AuthEvaluator IS_ONLY_DEVELOPER = new AuthEvaluator()
             .isNotSelf().hasOnlyRoles(DEVELOPER, STUDY_DESIGNER);
 
-    public static final AuthEvaluator CANNOT_SEE_PROD_PARTICIPANTS = new AuthEvaluator()
-            .isNotSelf().hasOnlyRoles(DEVELOPER, STUDY_DESIGNER, ORG_ADMIN);
-    
     public static final AuthEvaluator CAN_TRANSITION_STUDY = new AuthEvaluator()
             .canAccessStudy().hasAnyRole(STUDY_COORDINATOR).or()
             .hasAnyRole(RESEARCHER, ADMIN);
@@ -115,7 +112,7 @@ public class AuthUtils {
     public static final AuthEvaluator CAN_READ_PARTICIPANTS = new AuthEvaluator().isSelf().or()
             // This allows an org admin to see study participants, but we block this in the relevant API calls.
             .isInOrg().hasAnyRole(ORG_ADMIN).or()
-            .canAccessStudy().hasAnyRole(STUDY_DESIGNER, STUDY_COORDINATOR, ORG_ADMIN).or()
+            .canAccessStudy().hasAnyRole(STUDY_DESIGNER, STUDY_COORDINATOR).or()
             .hasAnyRole(DEVELOPER, RESEARCHER, WORKER, ADMIN);
     
     /**
@@ -274,7 +271,7 @@ public class AuthUtils {
         if (account != null) {
             if (account.getOrgMembership() == null) {
                 Set<String> userDataGroups = account.getDataGroups();
-                if (CANNOT_SEE_PROD_PARTICIPANTS.check(USER_ID, account.getId()) && !userDataGroups.contains(TEST_USER_GROUP)) {
+                if (IS_ONLY_DEVELOPER.check(USER_ID, account.getId()) && !userDataGroups.contains(TEST_USER_GROUP)) {
                     return false;
                 }
             }

--- a/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
@@ -46,7 +46,8 @@ public class AuthUtils {
      * when using the APIs.
      */
     public static final AuthEvaluator CAN_READ_ORG_SPONSORED_STUDIES = new AuthEvaluator()
-            .hasAnyRole(ORG_ADMIN, STUDY_DESIGNER, STUDY_COORDINATOR).hasNoRole(DEVELOPER, RESEARCHER, ADMIN, WORKER);
+            .hasAnyRole(ORG_ADMIN, STUDY_DESIGNER, STUDY_COORDINATOR)
+            .hasNoRole(DEVELOPER, RESEARCHER, ADMIN, WORKER);
 
     /**
      * Can the caller edit assessments? Must be a study designer in the organization that 
@@ -164,7 +165,7 @@ public class AuthUtils {
     public static final AuthEvaluator CAN_READ_STUDIES = new AuthEvaluator()
             .isEnrolledInStudy().or()
             .canAccessStudy().hasAnyRole(STUDY_DESIGNER, STUDY_COORDINATOR, ORG_ADMIN).or()
-            .hasAnyRole(DEVELOPER, ADMIN);
+            .hasAnyRole(DEVELOPER, RESEARCHER, ADMIN);
     
     /**
      * Can the caller edit studies? Caller must be a study coordinator, or a developer.

--- a/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
@@ -33,7 +33,7 @@ public class AuthUtils {
      * Calling account is only a developer, and thus should only have access to test
      * accounts, not production accounts.
      */
-    public static final AuthEvaluator IS_ONLY_DEVELOPER = new AuthEvaluator()
+    public static final AuthEvaluator CANNOT_ACCESS_PARTICIPANTS = new AuthEvaluator()
             .isNotSelf().hasNoRole(RESEARCHER, STUDY_COORDINATOR, WORKER, ADMIN);
 
     public static final AuthEvaluator CAN_TRANSITION_STUDY = new AuthEvaluator()
@@ -275,7 +275,7 @@ public class AuthUtils {
             // participant accounts).
             boolean prodParticipant = account.getRoles().isEmpty() 
                     && !account.getDataGroups().contains(TEST_USER_GROUP);
-            if (prodParticipant && IS_ONLY_DEVELOPER.check(USER_ID, account.getId())) {
+            if (prodParticipant && CANNOT_ACCESS_PARTICIPANTS.check(USER_ID, account.getId())) {
                 return false;
             }
             // If the account is in a study that the caller can access with the correct role, 

--- a/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
@@ -6,11 +6,12 @@ import static java.util.stream.Collectors.toSet;
 import static org.sagebionetworks.bridge.AuthEvaluatorField.ORG_ID;
 import static org.sagebionetworks.bridge.AuthEvaluatorField.USER_ID;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_READ_PARTICIPANTS;
-import static org.sagebionetworks.bridge.AuthUtils.IS_ONLY_DEVELOPER;
+import static org.sagebionetworks.bridge.AuthUtils.CANNOT_ACCESS_PARTICIPANTS;
 import static org.sagebionetworks.bridge.AuthUtils.canAccessAccount;
 import static org.sagebionetworks.bridge.BridgeConstants.TEST_USER_GROUP;
 import static org.sagebionetworks.bridge.BridgeUtils.addToSet;
 import static org.sagebionetworks.bridge.BridgeUtils.collectStudyIds;
+import static org.sagebionetworks.bridge.Roles.ORG_ADMIN;
 import static org.sagebionetworks.bridge.dao.AccountDao.MIGRATION_VERSION;
 import static org.sagebionetworks.bridge.models.accounts.AccountSecretType.REAUTH;
 import static org.sagebionetworks.bridge.models.accounts.AccountStatus.DISABLED;
@@ -228,7 +229,7 @@ public class AccountService {
         account.setModifiedOn(timestamp);
         account.setPasswordModifiedOn(timestamp);
         account.setMigrationVersion(MIGRATION_VERSION);
-        if (IS_ONLY_DEVELOPER.check()) {
+        if (CANNOT_ACCESS_PARTICIPANTS.check()) {
             Set<String> newDataGroups = addToSet(account.getDataGroups(), TEST_USER_GROUP);
             account.setDataGroups(newDataGroups);
         }
@@ -260,20 +261,24 @@ public class AccountService {
 
         Account persistedAccount = accountDao.getAccount(accountId)
                 .orElseThrow(() -> new EntityNotFoundException(Account.class));
-
-        // The test_user flag taints an account; once set it cannot be unset. 
+        
+        // The test_user flag taints an account; once set it cannot be unset.
         boolean testUser = persistedAccount.getDataGroups().contains(TEST_USER_GROUP);
         if (testUser) {
             Set<String> newDataGroups = addToSet(account.getDataGroups(), TEST_USER_GROUP);
             account.setDataGroups(newDataGroups);
         }
-        // If the account is a production account, check the caller and don’t allow the update if 
-        // it is a developer account not operating on itself.
-        boolean prodParticipant = persistedAccount.getRoles().isEmpty() && !testUser;
-        if (prodParticipant && IS_ONLY_DEVELOPER.check(USER_ID, persistedAccount.getId())) {
-            throw new UnauthorizedException();
+        // Participant accounts shouldn't be submitted to this endpoint; but if they are we check
+        // access, and throw if the caller is an org admin or a developer trying to operate on a 
+        // production account. These checks cannot currently be represented in the AuthEvaluator 
+        // checks.
+        boolean isParticipant = persistedAccount.getRoles().isEmpty();
+        if (isParticipant && CANNOT_ACCESS_PARTICIPANTS.check(USER_ID, persistedAccount.getId())) {
+            if (RequestContext.get().isInRole(ORG_ADMIN) || !testUser) {
+                throw new UnauthorizedException();    
+            }
         }
-
+        
         // None of these values should be changeable by the user.
         account.setAppId(persistedAccount.getAppId());
         account.setCreatedOn(persistedAccount.getCreatedOn());
@@ -329,7 +334,7 @@ public class AccountService {
         Account account = accountDao.getAccount(accountId)
                 .orElseThrow(() -> new EntityNotFoundException(Account.class));
  
-        if (IS_ONLY_DEVELOPER.check(USER_ID, account.getId()) && !account.getDataGroups().contains(TEST_USER_GROUP)) {
+        if (CANNOT_ACCESS_PARTICIPANTS.check(USER_ID, account.getId()) && !account.getDataGroups().contains(TEST_USER_GROUP)) {
             throw new UnauthorizedException();
         }
         accountEdits.accept(account);

--- a/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
@@ -265,10 +265,13 @@ public class AccountService {
         // The test_user flag taints an account; once set it cannot be unset. If the account is a production
         // account, however, check the caller and don’t allow the update if it is a developer account not
         // operating on itself.
-        if (persistedAccount.getDataGroups().contains(TEST_USER_GROUP)) {
+        boolean testUser = persistedAccount.getDataGroups().contains(TEST_USER_GROUP);
+        if (testUser) {
             Set<String> newDataGroups = addToSet(account.getDataGroups(), TEST_USER_GROUP);
             account.setDataGroups(newDataGroups);
-        } else if (IS_ONLY_DEVELOPER.check(USER_ID, persistedAccount.getId())) {
+        }
+        boolean prodParticipant = persistedAccount.getRoles().isEmpty() && !testUser;
+        if (prodParticipant && IS_ONLY_DEVELOPER.check(USER_ID, persistedAccount.getId())) {
             throw new UnauthorizedException();
         }
 

--- a/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
@@ -258,18 +258,17 @@ public class AccountService {
         
         AccountId accountId = AccountId.forId(account.getAppId(),  account.getId());
 
-        // Can't change app, email, phone, emailVerified, phoneVerified, createdOn, or passwordModifiedOn.
         Account persistedAccount = accountDao.getAccount(accountId)
                 .orElseThrow(() -> new EntityNotFoundException(Account.class));
 
-        // The test_user flag taints an account; once set it cannot be unset. If the account is a production
-        // account, however, check the caller and don’t allow the update if it is a developer account not
-        // operating on itself.
+        // The test_user flag taints an account; once set it cannot be unset. 
         boolean testUser = persistedAccount.getDataGroups().contains(TEST_USER_GROUP);
         if (testUser) {
             Set<String> newDataGroups = addToSet(account.getDataGroups(), TEST_USER_GROUP);
             account.setDataGroups(newDataGroups);
         }
+        // If the account is a production account, check the caller and don’t allow the update if 
+        // it is a developer account not operating on itself.
         boolean prodParticipant = persistedAccount.getRoles().isEmpty() && !testUser;
         if (prodParticipant && IS_ONLY_DEVELOPER.check(USER_ID, persistedAccount.getId())) {
             throw new UnauthorizedException();

--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -9,9 +9,9 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.sagebionetworks.bridge.AuthEvaluatorField.ORG_ID;
 import static org.sagebionetworks.bridge.AuthEvaluatorField.STUDY_ID;
 import static org.sagebionetworks.bridge.AuthEvaluatorField.USER_ID;
+import static org.sagebionetworks.bridge.AuthUtils.CANNOT_SEE_PROD_PARTICIPANTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_MEMBERS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_PARTICIPANTS;
-import static org.sagebionetworks.bridge.AuthUtils.IS_ONLY_DEVELOPER;
 import static org.sagebionetworks.bridge.BridgeConstants.TEST_USER_GROUP;
 import static org.sagebionetworks.bridge.BridgeUtils.addToSet;
 import static org.sagebionetworks.bridge.BridgeUtils.studyAssociationsVisibleToCaller;
@@ -54,7 +54,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
 import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.BridgeUtils.StudyAssociations;
@@ -432,7 +431,7 @@ public class ParticipantService {
         
         Validate.entityThrowingException(new AccountSummarySearchValidator(app.getDataGroups()), search);
         
-        if (IS_ONLY_DEVELOPER.check()) {
+        if (CANNOT_SEE_PROD_PARTICIPANTS.check()) {
             Set<String> newDataGroups = addToSet(search.getAllOfGroups(), TEST_USER_GROUP);
             search = search.toBuilder().withAllOfGroups(newDataGroups).build();
         }

--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -9,9 +9,9 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.sagebionetworks.bridge.AuthEvaluatorField.ORG_ID;
 import static org.sagebionetworks.bridge.AuthEvaluatorField.STUDY_ID;
 import static org.sagebionetworks.bridge.AuthEvaluatorField.USER_ID;
-import static org.sagebionetworks.bridge.AuthUtils.CANNOT_SEE_PROD_PARTICIPANTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_MEMBERS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_PARTICIPANTS;
+import static org.sagebionetworks.bridge.AuthUtils.IS_ONLY_DEVELOPER;
 import static org.sagebionetworks.bridge.BridgeConstants.TEST_USER_GROUP;
 import static org.sagebionetworks.bridge.BridgeUtils.addToSet;
 import static org.sagebionetworks.bridge.BridgeUtils.studyAssociationsVisibleToCaller;
@@ -431,7 +431,7 @@ public class ParticipantService {
         
         Validate.entityThrowingException(new AccountSummarySearchValidator(app.getDataGroups()), search);
         
-        if (CANNOT_SEE_PROD_PARTICIPANTS.check()) {
+        if (IS_ONLY_DEVELOPER.check()) {
             Set<String> newDataGroups = addToSet(search.getAllOfGroups(), TEST_USER_GROUP);
             search = search.toBuilder().withAllOfGroups(newDataGroups).build();
         }

--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -11,7 +11,7 @@ import static org.sagebionetworks.bridge.AuthEvaluatorField.STUDY_ID;
 import static org.sagebionetworks.bridge.AuthEvaluatorField.USER_ID;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_MEMBERS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_PARTICIPANTS;
-import static org.sagebionetworks.bridge.AuthUtils.IS_ONLY_DEVELOPER;
+import static org.sagebionetworks.bridge.AuthUtils.CANNOT_ACCESS_PARTICIPANTS;
 import static org.sagebionetworks.bridge.BridgeConstants.TEST_USER_GROUP;
 import static org.sagebionetworks.bridge.BridgeUtils.addToSet;
 import static org.sagebionetworks.bridge.BridgeUtils.studyAssociationsVisibleToCaller;
@@ -431,7 +431,7 @@ public class ParticipantService {
         
         Validate.entityThrowingException(new AccountSummarySearchValidator(app.getDataGroups()), search);
         
-        if (IS_ONLY_DEVELOPER.check()) {
+        if (CANNOT_ACCESS_PARTICIPANTS.check()) {
             Set<String> newDataGroups = addToSet(search.getAllOfGroups(), TEST_USER_GROUP);
             search = search.toBuilder().withAllOfGroups(newDataGroups).build();
         }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AccountsController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AccountsController.java
@@ -6,7 +6,6 @@ import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_ACCOUNTS;
 import static org.sagebionetworks.bridge.BridgeUtils.parseAccountId;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.ORG_ADMIN;
-import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
 import static org.sagebionetworks.bridge.models.RequestInfo.REQUEST_INFO_WRITER;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -29,7 +28,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.CriteriaContext;

--- a/src/main/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandler.java
@@ -47,7 +47,6 @@ public class BridgeExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<String> handleException(HttpServletRequest request, Exception ex) throws JsonProcessingException {
-        ex.printStackTrace();
         logException(request, ex);
 
         return getResult(ex);

--- a/src/main/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandler.java
@@ -47,6 +47,7 @@ public class BridgeExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<String> handleException(HttpServletRequest request, Exception ex) throws JsonProcessingException {
+        ex.printStackTrace();
         logException(request, ex);
 
         return getResult(ex);

--- a/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
@@ -796,7 +796,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canAccessAccount_orgAdminSucceedsOnTestParticipant() {
+    public void canAccessAccount_orgAdminFailsOnTestParticipant() {
         Account account = Account.create();
         account.setDataGroups(ImmutableSet.of(TEST_USER_GROUP));
         account.setEnrollments(ImmutableSet.of(Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID)));
@@ -806,7 +806,7 @@ public class AuthUtilsTest extends Mockito {
                 .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
 
-        assertTrue(AuthUtils.canAccessAccount(account));
+        assertFalse(AuthUtils.canAccessAccount(account));
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
@@ -731,7 +731,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canAccessAccount_orgAdminSucceedsInOrg() {
+    public void canAccessAccount_orgAdminSucceedsOnProductionAccountInOrg() {
         Account account = Account.create();
         account.setOrgMembership(TEST_ORG_ID);
         
@@ -743,7 +743,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canAccessAccount_orgAdminFailsFromOtherOrg() {
+    public void canAccessAccount_orgAdminFailsOnProductionAccountOtherOrg() {
         Account account = Account.create();
         account.setOrgMembership("other-organization");
         
@@ -753,6 +753,60 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerOrgMembership(TEST_ORG_ID).build());
 
         assertFalse(AuthUtils.canAccessAccount(account));
+    }
+    
+    @Test
+    public void canAccessAccount_orgAdminSucceedsOnTextAccountInOrg() {
+        Account account = Account.create();
+        account.setDataGroups(ImmutableSet.of(TEST_USER_GROUP));
+        account.setOrgMembership(TEST_ORG_ID);
+        
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
+                .withCallerOrgMembership(TEST_ORG_ID).build());
+
+        assertTrue(AuthUtils.canAccessAccount(account));
+    }
+    
+    @Test
+    public void canAccessAccount_orgAdminFailsOnTestAccountOtherOrg() {
+        Account account = Account.create();
+        account.setDataGroups(ImmutableSet.of(TEST_USER_GROUP));
+        account.setOrgMembership("other-organization");
+        
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("id")
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
+                .withCallerOrgMembership(TEST_ORG_ID).build());
+
+        assertFalse(AuthUtils.canAccessAccount(account));
+    }
+    
+    @Test
+    public void canAccessAccount_orgAdminFailsOnProdParticipant() {
+        Account account = Account.create();
+        account.setEnrollments(ImmutableSet.of(Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID)));
+        
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("id")
+                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
+
+        assertFalse(AuthUtils.canAccessAccount(account));
+    }
+    
+    @Test
+    public void canAccessAccount_orgAdminSucceedsOnTestParticipant() {
+        Account account = Account.create();
+        account.setDataGroups(ImmutableSet.of(TEST_USER_GROUP));
+        account.setEnrollments(ImmutableSet.of(Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID)));
+        
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("id")
+                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
+
+        assertTrue(AuthUtils.canAccessAccount(account));
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
@@ -57,14 +57,14 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canEditEnrollmentsSucceedsForSelf() {
+    public void canEditEnrollments_succeedsForSelf() {
         RequestContext.set(new RequestContext.Builder().withCallerUserId(TEST_USER_ID).build());
         
         CAN_EDIT_ENROLLMENTS.checkAndThrow(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID);
     }
     
     @Test
-    public void canEditEnrollmentsSucceedsForStudyResearcher() {
+    public void canEditEnrollments_succeedsForStudyResearcher() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(RESEARCHER))
                 .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
@@ -74,7 +74,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test
-    public void canEditEnrollmentsSucceedsForAdmin() {
+    public void canEditEnrollments_succeedsForAdmin() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(ADMIN))
                 .build());
@@ -83,7 +83,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void canEditEnrollmentsFailsForNonStudyCoordinator() {
+    public void canEditEnrollments_failsForNonStudyCoordinator() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId(OTHER_USER_ID)
                 .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR))
@@ -99,7 +99,7 @@ public class AuthUtilsTest extends Mockito {
     // canEditEnrollmentsFailsForDev
 
     @Test
-    public void canEditEnrollmentsSucceedsForMatchingOrgId() {
+    public void canEditEnrollments_succeedsForMatchingOrgId() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID).build());
         
@@ -107,7 +107,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void canEditEnrollmentsFailsWrongOrganization() {
+    public void canEditEnrollments_failsWrongOrganization() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId(TEST_USER_ID)
                 .withCallerOrgMembership("another-organization").build());
@@ -116,7 +116,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void canEditEnrollmentsFailsOnNullOrg() {
+    public void canEditEnrollments_failsOnNullOrg() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId(TEST_USER_ID)
                 .build());
@@ -125,7 +125,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canEditEnrollmentsSucceeds() {
+    public void canEditEnrollments_succeeds() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID).build());
         
@@ -133,7 +133,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void canEditEnrollmentsFails() {
+    public void canEditEnrollments_fails() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId(TEST_USER_ID)
                 .build());
@@ -142,20 +142,20 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canEditSharedAssessmentsSucceedsForAdmin() {
+    public void canEditSharedAssessments_succeedsForAdmin() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());
         CAN_EDIT_SHARED_ASSESSMENTS.checkAndThrow(OWNER_ID, SHARED_OWNER_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void canEditSharedAssessmentsFailsForGlobalOwnerId() {
+    public void canEditSharedAssessments_failsForGlobalOwnerId() {
         RequestContext.set(NULL_INSTANCE);
         CAN_EDIT_SHARED_ASSESSMENTS.checkAndThrow(OWNER_ID, TEST_OWNER_ID);
     }
     
     @Test
-    public void canEditSharedAssessmentsSucceedsForStudyDesignerOwner() {
+    public void canEditSharedAssessments_succeedsForStudyDesignerOwner() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerAppId(TEST_APP_ID)
                 .withCallerOrgMembership(TEST_OWNER_ID)
@@ -164,7 +164,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test
-    public void canEditSharedAssessmentsSucceedsForDeveloperOwner() {
+    public void canEditSharedAssessments_succeedsForDeveloperOwner() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerAppId(TEST_APP_ID)
                 .withCallerOrgMembership(TEST_OWNER_ID)
@@ -173,7 +173,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void canEditSharedAssessmentsFailsForDeveloper() {
+    public void canEditSharedAssessments_failsForDeveloper() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerAppId("some-other-app")
                 .withCallerOrgMembership("some-other-org")
@@ -182,21 +182,21 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void canEditSharedAssessmentsFailsWrongOrgId() {
+    public void canEditSharedAssessments_failsWrongOrgId() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership("notValidOwner").build());
         CAN_EDIT_SHARED_ASSESSMENTS.checkAndThrow(OWNER_ID, SHARED_OWNER_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void canEditSharedAssessmentsFailsWrongAppId() { 
+    public void canEditSharedAssessments_failsWrongAppId() { 
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_APP_ID).build());
         CAN_EDIT_SHARED_ASSESSMENTS.checkAndThrow(OWNER_ID, SHARED_OWNER_ID);        
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void canEditSharedAssessmentsFailsUserWrongAppId() { 
+    public void canEditSharedAssessments_failsUserWrongAppId() { 
         RequestContext.set(NULL_INSTANCE);
         // still doesn't pass because the appId must always match (global users must call 
         // this API after associating to the right app context):
@@ -204,7 +204,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void canEditParticipantsFailsOnStudyAccess() { 
+    public void canEditParticipants_failsOnStudyAccess() { 
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId("callerUserId")
                 .withOrgSponsoredStudies(ImmutableSet.of("studyA", "studyB")).build());
@@ -213,7 +213,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canEditParticipantsFails() {
+    public void canEditParticipants_fails() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId("callerUserId")
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
@@ -222,7 +222,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canEditParticipantsFailsOnNullStudy() {
+    public void canEditParticipants_failsOnNullStudy() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId("callerUserId")
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
@@ -231,7 +231,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canEditParticipantsSucceedsForWorker() {
+    public void canEditParticipants_succeedsForWorker() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(WORKER))
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
@@ -240,7 +240,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test
-    public void canEditParticipantsSucceedsForAdmin() {
+    public void canEditParticipants_succeedsForAdmin() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(ADMIN))
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
@@ -249,7 +249,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canEditStudyParticipantsSucceedsForOrgSponsoredStudy() {
+    public void canEditStudyParticipants_succeedsForOrgSponsoredStudy() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR))
                 .withOrgSponsoredStudies(ImmutableSet.of("study1", "study2")).build());
@@ -258,7 +258,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test
-    public void canEditStudyParticipantsSucceedsForEnrolledParticipant() {
+    public void canEditStudyParticipants_succeedsForEnrolledParticipant() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerEnrolledStudies(ImmutableSet.of("study1", "study2")).build());
         
@@ -303,7 +303,7 @@ public class AuthUtilsTest extends Mockito {
     }
  
     @Test
-    public void canEditAssessmentsSucceedsForAdmin() {
+    public void canEditAssessments_succeedsForAdmin() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());
 
@@ -311,7 +311,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canEditParticipantsSucceedsForResearcher() {
+    public void canEditParticipants_succeedsForResearcher() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(RESEARCHER))
                 .build());
@@ -330,7 +330,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test
-    public void canEditMembersSucceedsForAdmin() {
+    public void canEditMembers_succeedsForAdmin() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(ADMIN))
                 .build());
@@ -339,7 +339,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void canEditMembersWrongOrgId() {
+    public void canEditMembers_wrongOrgId() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership("wrong-org-id")
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
@@ -349,7 +349,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void canEditMembersWrongRole() {
+    public void canEditMembers_wrongRole() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(DEVELOPER))
@@ -359,7 +359,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canEditAssessmentsSucceedsForStudyDesignerOrgMember() {
+    public void canEditAssessments_succeedsForStudyDesignerOrgMember() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(STUDY_DESIGNER))
                 .withCallerOrgMembership(TEST_ORG_ID).build());
@@ -368,7 +368,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canEditAssessmentsSucceedsForDeveloper() {
+    public void canEditAssessments_succeedsForDeveloper() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
         
@@ -376,7 +376,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canEditAssessmentsSucceedsForStudyCoordinatorOrgMember() {
+    public void canEditAssessments_failsForStudyCoordinatorOrgMember() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR))
                 .withCallerOrgMembership(TEST_ORG_ID).build());
@@ -385,7 +385,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canEditAssessmentsWrongOrg() {
+    public void canEditAssessments_wrongOrg() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerAppId(TEST_APP_ID)
                 .withCallerOrgMembership("wrong-org")
@@ -395,7 +395,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canEditMembersSucceedsForOrgAdmin() {
+    public void canEditMembers_succeedsForOrgAdmin() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
@@ -405,7 +405,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test
-    public void canEditMembersFailsOnWrongOrgMembership() {
+    public void canEditMembers_failsOnWrongOrgMembership() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
                 .build());
@@ -414,7 +414,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test
-    public void canEditMembersFailsOnNotOrgAdmin() {
+    public void canEditMembers_failsOnNotOrgAdmin() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .build());
@@ -423,7 +423,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canReadStudyAssociationsSucceedsForSelf() {
+    public void canReadStudyAssociations_succeedsForSelf() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId(TEST_USER_ID).build());
         
@@ -431,7 +431,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test
-    public void canReadStudyAssociationsSucceedsForStudyTeamMember() {
+    public void canReadStudyAssociations_succeedsForStudyTeamMember() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR))
                 .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID)).build());
@@ -440,7 +440,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test
-    public void canReadStudyAssociationsSucceedsForWorker() {
+    public void canReadStudyAssociations_succeedsForWorker() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(WORKER)).build());
         
@@ -448,7 +448,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test
-    public void canReadStudyAssociationsFails() {
+    public void canReadStudyAssociations_fails() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId(OTHER_USER_ID)
                 .build());
@@ -457,7 +457,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canReadParticipantsFails() {
+    public void canReadParticipants_fails() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId(OTHER_USER_ID)
                 .build());
@@ -466,7 +466,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test
-    public void canReadParticipantsSucceedsForSelf() {
+    public void canReadParticipants_succeedsForSelf() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId(TEST_USER_ID)
                 .build());
@@ -475,7 +475,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test
-    public void canReadParticipantsSucceedsForWorker() {
+    public void canReadParticipants_succeedsForWorker() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(WORKER))
                 .build());
@@ -484,7 +484,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test
-    public void canReadParticipantsSucceedsForOrgAdmin() {
+    public void canReadParticipants_succeedsForOrgAdmin() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
@@ -494,7 +494,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canReadExternalIdsSucceedsForStudyCoordinator() {
+    public void canReadExternalIds_succeedsForStudyCoordinator() {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
                 .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR))
@@ -504,7 +504,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test
-    public void canReadExternalIdsSucceedsForDeveloper() {
+    public void canReadExternalIds_succeedsForDeveloper() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(DEVELOPER))
                 .build());
@@ -513,7 +513,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test
-    public void canReadExternalIdsSucceedsForResearcher() {
+    public void canReadExternalIds_succeedsForResearcher() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(RESEARCHER))
                 .build());
@@ -522,7 +522,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void canReadExternalIdsFails() {
+    public void canReadExternalIds_fails() {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of("some-other-study"))
                 .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR))
@@ -532,7 +532,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canEditStudyParticipantsSucceedsForResearcher() {
+    public void canEditStudyParticipants_succeedsForResearcher() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(RESEARCHER))
                 .build());
@@ -541,7 +541,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void canEditStudyParticipantsFailsForWrongStudyCoordinator() {
+    public void canEditStudyParticipants_failsForWrongStudyCoordinator() {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of("some-study-id"))
                 .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR))
@@ -551,7 +551,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canReadSchedulesFailsForStudyCoordinator() { // for example
+    public void canReadSchedules_failsForStudyCoordinator() { // for example
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR)).build());
         
@@ -559,7 +559,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canReadSchedulesSucceedsForDeveloper() {
+    public void canReadSchedules_succeedsForDeveloper() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
         
@@ -567,7 +567,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test
-    public void canReadSchedulesSucceedsForStudyDesigner() {
+    public void canReadSchedules_succeedsForStudyDesigner() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(STUDY_DESIGNER)).build());
@@ -576,7 +576,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test
-    public void canReadSchedulesSucceedsForEnrollee() {
+    public void canReadSchedules_succeedsForEnrollee() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerEnrolledStudies(ImmutableSet.of(TEST_STUDY_ID)).build());
         
@@ -584,7 +584,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test
-    public void canReadSchedulesFailsForNonEnrollee() {
+    public void canReadSchedules_failsForNonEnrollee() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerEnrolledStudies(ImmutableSet.of("someOtherStudy")).build());
         
@@ -592,7 +592,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canReadSchedulesFailsForStudyDesignerInOtherOrg() {
+    public void canReadSchedules_failsForStudyDesignerInOtherOrg() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership("other-organization")
                 .withCallerRoles(ImmutableSet.of(STUDY_DESIGNER)).build());
@@ -601,7 +601,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canEditSchedulesSucceedsForStudyDesigner() {
+    public void canEditSchedules_succeedsForStudyDesigner() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(STUDY_DESIGNER)).build());
@@ -610,7 +610,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test
-    public void canEditSchedulesSucceedsForDeveloper() {
+    public void canEditSchedules_succeedsForDeveloper() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
                 
@@ -618,14 +618,14 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void canEditSchedulesFailsForAnon() {
+    public void canEditSchedules_failsForAnon() {
         RequestContext.set(NULL_INSTANCE);
                 
         CAN_EDIT_SCHEDULES.checkAndThrow(ORG_ID, TEST_ORG_ID);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void canEditSchedulesFailsForStudyCoordinatorNotInOrg() {
+    public void canEditSchedules_failsForStudyCoordinatorNotInOrg() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership("wrongOrganization")
                 .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR)).build());
@@ -634,7 +634,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void canEditSchedulesFailsForNonDeveloper() {
+    public void canEditSchedules_failsForNonDeveloper() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
                 
@@ -642,7 +642,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canTransitionStudiesForResearcher() { 
+    public void canTransitionStudies_succeedsForResearcher() { 
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
                 
@@ -650,7 +650,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canTransitionStudiesForStudyCoordinator() { 
+    public void canTransitionStudies_succeedsForStudyCoordinator() { 
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
                 .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR)).build());
@@ -659,7 +659,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void canEditSchedulesFails() {
+    public void canEditSchedules_fails() {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of("some-other-study"))
                 .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR)).build());
@@ -674,7 +674,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void canReadOrgFails() { 
+    public void canReadOrg_fails() { 
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership("some-other-org").build());
         AuthUtils.CAN_READ_ORG.checkAndThrow(ORG_ID, TEST_ORG_ID);
@@ -689,7 +689,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void canEditOrgFailes() {
+    public void canEditOrg_fails() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of(STUDY_DESIGNER))
                 .withCallerOrgMembership(TEST_ORG_ID).build());
@@ -703,7 +703,7 @@ public class AuthUtilsTest extends Mockito {
     }
 
     @Test
-    public void canAccessAccount_selfSucceeds() {
+    public void canAccessAccount_succeedsForSelf() {
         Account account = Account.create();
         account.setId(TEST_USER_ID);
         
@@ -713,7 +713,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canAccessAccount_adminSucceeds() {
+    public void canAccessAccount_succeedsForAdmin() {
         Account account = Account.create();
         
         RequestContext.set(new RequestContext.Builder().withCallerRoles(ImmutableSet.of(ADMIN)).build());
@@ -722,7 +722,7 @@ public class AuthUtilsTest extends Mockito {
     }
     
     @Test
-    public void canAccessAccount_workerSucceeds() {
+    public void canAccessAccount_succeedsForWorker() {
         Account account = Account.create();
         
         RequestContext.set(new RequestContext.Builder().withCallerRoles(ImmutableSet.of(WORKER)).build());
@@ -901,7 +901,82 @@ public class AuthUtilsTest extends Mockito {
 
         assertFalse(AuthUtils.canAccessAccount(account));
     }
+    
+    @Test
+    public void canReadStudies_enrolleeSucceeds() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("id")
+                .withCallerEnrolledStudies(ImmutableSet.of("studyA")).build());
+        
+        assertTrue(AuthUtils.CAN_READ_STUDIES.check(STUDY_ID, "studyA"));
+    }
+    
+    @Test
+    public void canReadStudies_studyDesignerSucceeds() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("id")
+                .withCallerRoles(ImmutableSet.of(STUDY_DESIGNER))
+                .withOrgSponsoredStudies(ImmutableSet.of("studyA")).build());
+        
+        assertTrue(AuthUtils.CAN_READ_STUDIES.check(STUDY_ID, "studyA"));
+    }
+    
+    @Test
+    public void canReadStudies_studyCoordinatorSucceeds() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("id")
+                .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR))
+                .withOrgSponsoredStudies(ImmutableSet.of("studyA")).build());
+        
+        assertTrue(AuthUtils.CAN_READ_STUDIES.check(STUDY_ID, "studyA"));
+    }
+    
+    @Test
+    public void canReadStudies_studyOrgAdminSucceeds() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("id")
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
+                .withOrgSponsoredStudies(ImmutableSet.of("studyA")).build());
+        
+        assertTrue(AuthUtils.CAN_READ_STUDIES.check(STUDY_ID, "studyA"));
+    }
 
+    @Test
+    public void canReadStudies_nonMemberAdminFails() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("id")
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN))
+                .withOrgSponsoredStudies(ImmutableSet.of("studyB")).build());
+        
+        assertFalse(AuthUtils.CAN_READ_STUDIES.check(STUDY_ID, "studyA"));
+    }
+
+    @Test
+    public void canReadStudies_developerSucceeds() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("id")
+                .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
+        
+        assertTrue(AuthUtils.CAN_READ_STUDIES.check(STUDY_ID, "studyA"));
+    }
+    
+    @Test
+    public void canReadStudies_researcherSucceeds() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("id")
+                .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
+        
+        assertTrue(AuthUtils.CAN_READ_STUDIES.check(STUDY_ID, "studyA"));
+    }
+
+    @Test
+    public void canReadStudies_fails() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("id").build());
+        
+        assertFalse(AuthUtils.CAN_READ_STUDIES.check(STUDY_ID, "studyA"));
+    }
+    
     private Account getAccountEnrolledIn(String... studyIds) {
         Account account = Account.create();
         account.setId(TEST_USER_ID);

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
@@ -436,20 +436,17 @@ public class AccountServiceTest extends Mockito {
     public void updateAccountSucceedsForOrgAdminUpdatingAdminAccount() throws Exception {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId("id")
-                // .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         
         Account account = mockGetAccountById(ACCOUNT_ID, false);
         account.setRoles(ImmutableSet.of(STUDY_DESIGNER));
-        // account.setDataGroups(ImmutableSet.of(TEST_USER_GROUP));
-        // account.setEnrollments(ImmutableSet.of(Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID)));
 
         service.updateAccount(account);
         
         verify(mockAccountDao).updateAccount(account);
     }
     
-    @Test
+    @Test(expectedExceptions = UnauthorizedException.class)
     public void updateAccountFailsForOrgAdminUpdatingParticipantAccount() throws Exception {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId("id")
@@ -457,13 +454,10 @@ public class AccountServiceTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         
         Account account = mockGetAccountById(ACCOUNT_ID, false);
-        // account.setRoles(ImmutableSet.of(STUDY_DESIGNER));
         account.setDataGroups(ImmutableSet.of(TEST_USER_GROUP));
         account.setEnrollments(ImmutableSet.of(Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID)));
 
         service.updateAccount(account);
-        
-        verify(mockAccountDao).updateAccount(account);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
@@ -7,6 +7,7 @@ import static org.sagebionetworks.bridge.BridgeConstants.TEST_USER_GROUP;
 import static org.sagebionetworks.bridge.RequestContext.NULL_INSTANCE;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
+import static org.sagebionetworks.bridge.Roles.ORG_ADMIN;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.STUDY_COORDINATOR;
 import static org.sagebionetworks.bridge.Roles.STUDY_DESIGNER;
@@ -432,7 +433,41 @@ public class AccountServiceTest extends Mockito {
     }
     
     @Test
-    public void updateAccountNotFound() {
+    public void updateAccountSucceedsForOrgAdminUpdatingAdminAccount() throws Exception {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("id")
+                // .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
+        
+        Account account = mockGetAccountById(ACCOUNT_ID, false);
+        account.setRoles(ImmutableSet.of(STUDY_DESIGNER));
+        // account.setDataGroups(ImmutableSet.of(TEST_USER_GROUP));
+        // account.setEnrollments(ImmutableSet.of(Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID)));
+
+        service.updateAccount(account);
+        
+        verify(mockAccountDao).updateAccount(account);
+    }
+    
+    @Test
+    public void updateAccountFailsForOrgAdminUpdatingParticipantAccount() throws Exception {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("id")
+                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
+        
+        Account account = mockGetAccountById(ACCOUNT_ID, false);
+        // account.setRoles(ImmutableSet.of(STUDY_DESIGNER));
+        account.setDataGroups(ImmutableSet.of(TEST_USER_GROUP));
+        account.setEnrollments(ImmutableSet.of(Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID)));
+
+        service.updateAccount(account);
+        
+        verify(mockAccountDao).updateAccount(account);
+    }
+    
+    @Test
+    public void updateAccountNotFound() throws Exception {
         // mock hibernate
         Account account = Account.create();
         account.setAppId(TEST_APP_ID);

--- a/src/test/java/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -10,6 +10,7 @@ import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.ORG_ADMIN;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.STUDY_COORDINATOR;
+import static org.sagebionetworks.bridge.Roles.STUDY_DESIGNER;
 import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
 import static org.sagebionetworks.bridge.Roles.WORKER;
 import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
@@ -887,6 +888,36 @@ public class ParticipantServiceTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId("some-id")
                 .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
+        
+        AccountSummarySearch search = new AccountSummarySearch.Builder().build();
+        
+        participantService.getPagedAccountSummaries(APP, search);
+        
+        verify(accountService).getPagedAccountSummaries(
+                eq(TEST_APP_ID), searchCaptor.capture());
+        assertEquals(searchCaptor.getValue().getAllOfGroups(), ImmutableSet.of(TEST_USER_GROUP));
+    }
+    
+    @Test
+    public void getPagedAccountSummariesAddsTestFlagForStudyDesigners() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("some-id")
+                .withCallerRoles(ImmutableSet.of(STUDY_DESIGNER)).build());
+        
+        AccountSummarySearch search = new AccountSummarySearch.Builder().build();
+        
+        participantService.getPagedAccountSummaries(APP, search);
+        
+        verify(accountService).getPagedAccountSummaries(
+                eq(TEST_APP_ID), searchCaptor.capture());
+        assertEquals(searchCaptor.getValue().getAllOfGroups(), ImmutableSet.of(TEST_USER_GROUP));
+    }
+    
+    @Test
+    public void getPagedAccountSummariesAddsTestFlagForOrgAdmins() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("some-id")
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         
         AccountSummarySearch search = new AccountSummarySearch.Builder().build();
         

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AccountsControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AccountsControllerTest.java
@@ -424,8 +424,7 @@ public class AccountsControllerTest extends Mockito {
         controller.verifyOrgAdminIsActingOnOrgMember(session, TEST_USER_ID);
     }
 
-    @Test(expectedExceptions = EntityNotFoundException.class, 
-            expectedExceptionsMessageRegExp = "Account not found.")
+    @Test(expectedExceptions = UnauthorizedException.class)
     public void verifyOrgAdminIsActingOnOrgMemberFailsNotOrgAdmin() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId("callerUserId")
@@ -467,9 +466,8 @@ public class AccountsControllerTest extends Mockito {
     @Test
     public void verifySuperadminCanAccessAccount() {
         // Not part of the target organization, but it doesn't matter
-        session.setParticipant(new StudyParticipant.Builder()
-                .withRoles(ImmutableSet.of(SUPERADMIN))
-                .withOrgMembership(null).build());
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(SUPERADMIN)).build());
         
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(Optional.of(account));
         
@@ -480,9 +478,8 @@ public class AccountsControllerTest extends Mockito {
     @Test
     public void verifyAdminCanAccessAccount() {
         // Not part of the target organization, but it doesn't matter
-        session.setParticipant(new StudyParticipant.Builder()
-                .withRoles(ImmutableSet.of(ADMIN))
-                .withOrgMembership(null).build());
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(ADMIN)).build());
         
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(Optional.of(account));
         


### PR DESCRIPTION
IS_ONLY_DEVELOPER was listing developer roles rather than listing roles with production participant access, which is brittle and was allowing org admin's access to accounts. Changed this, which picks up org admins, but then that role needs some help to still be able to access and edit administrative accounts. Tests in AuthUtils.canAccessAccount and AccountService need heuristics to determine an admin account (at least one role). Finally, the AccountController's verifyOrgAdminIsActingOnOrgMember method is almost entirely redundant with the more standard CAN_EDIT_ACCOUNTS check, so it was largely removed. Tests added or changed as appropriate.