### PR TITLE
Enrollment note

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
@@ -145,6 +145,14 @@ public class AuthUtils {
             .canAccessStudy().hasAnyRole(STUDY_DESIGNER, STUDY_COORDINATOR).or()
             .hasAnyRole(DEVELOPER, RESEARCHER, ADMIN);
 
+    /**
+     * Can the caller edit an existing enrollment to create a study-scoped note? Must be a
+     * study designer for test accounts or a study coordinator for any account.
+     */
+    public static final AuthEvaluator CAN_EDIT_EXISTING_ENROLLMENT = new AuthEvaluator()
+            .canAccessStudy().hasAnyRole(STUDY_DESIGNER, STUDY_COORDINATOR).or()
+            .hasAnyRole(DEVELOPER, RESEARCHER, ADMIN);
+
     public static final AuthEvaluator CAN_DELETE_PARTICIPANTS = new AuthEvaluator()
             .canAccessStudy().hasAnyRole(STUDY_COORDINATOR).or()
             .hasAnyRole(RESEARCHER, ADMIN); 

--- a/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
@@ -149,7 +149,7 @@ public class AuthUtils {
      * Can the caller edit an existing enrollment to create a study-scoped note? Must be a
      * study designer for test accounts or a study coordinator for any account.
      */
-    public static final AuthEvaluator CAN_EDIT_EXISTING_ENROLLMENT = new AuthEvaluator()
+    public static final AuthEvaluator CAN_EDIT_OTHER_ENROLLMENTS = new AuthEvaluator()
             .canAccessStudy().hasAnyRole(STUDY_DESIGNER, STUDY_COORDINATOR).or()
             .hasAnyRole(DEVELOPER, RESEARCHER, ADMIN);
 

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateEnrollment.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateEnrollment.java
@@ -44,6 +44,7 @@ public final class HibernateEnrollment implements Enrollment {
     private String withdrawnBy;
     private String withdrawalNote;
     private boolean consentRequired;
+    private String note;
     
     // Needed for Hibernate, or else you have to create an instantiation helper class
     public HibernateEnrollment() {
@@ -109,11 +110,17 @@ public final class HibernateEnrollment implements Enrollment {
     public void setConsentRequired(boolean consentRequired) {
         this.consentRequired = consentRequired;
     }
+    public String getNote() {
+        return note;
+    }
+    public void setNote(String note) {
+        this.note = note;
+    }
 
     @Override
     public int hashCode() {
         return Objects.hash(accountId, externalId, appId, studyId, enrolledOn, 
-                withdrawnOn, enrolledBy, withdrawnBy, withdrawalNote, consentRequired);
+                withdrawnOn, enrolledBy, withdrawnBy, withdrawalNote, consentRequired, note);
     }
 
     @Override
@@ -132,7 +139,8 @@ public final class HibernateEnrollment implements Enrollment {
                Objects.equals(enrolledBy, other.enrolledBy) &&
                Objects.equals(withdrawnBy, other.withdrawnBy) &&
                Objects.equals(withdrawalNote, other.withdrawalNote) &&
-               Objects.equals(consentRequired, other.consentRequired);
+               Objects.equals(consentRequired, other.consentRequired) &&
+               Objects.equals(note, other.note);
     }
 
     @Override
@@ -141,6 +149,6 @@ public final class HibernateEnrollment implements Enrollment {
                 + accountId + ", externalId=" + externalId + ", enrolledOn=" + enrolledOn 
                 + ", withdrawnOn=" + withdrawnOn + ", enrolledBy=" + enrolledBy 
                 + ", withdrawnBy=" + withdrawnBy + ", withdrawalNote=" + withdrawalNote 
-                + ", consentRequired=" + consentRequired + "]";
+                + ", consentRequired=" + consentRequired + ", note=" + note + "]";
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/models/studies/Enrollment.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/studies/Enrollment.java
@@ -93,4 +93,11 @@ public interface Enrollment extends BridgeEntity {
      */
     String getWithdrawalNote();
     void setWithdrawalNote(String note);
+
+    // TODO: add description of note field's use
+    /**
+     *
+     */
+    String getNote();
+    void setNote(String note);
 }

--- a/src/main/java/org/sagebionetworks/bridge/models/studies/Enrollment.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/studies/Enrollment.java
@@ -94,9 +94,8 @@ public interface Enrollment extends BridgeEntity {
     String getWithdrawalNote();
     void setWithdrawalNote(String note);
 
-    // TODO: add description of note field's use
-    /**
-     *
+    /** Note field is accessible only by users with administrative roles. The enrolled participant
+     * can not get or set the note.
      */
     String getNote();
     void setNote(String note);

--- a/src/main/java/org/sagebionetworks/bridge/models/studies/EnrollmentDetail.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/studies/EnrollmentDetail.java
@@ -16,7 +16,7 @@ public class EnrollmentDetail {
     private final AccountRef participant;
     private final AccountRef enrolledBy;
     private final AccountRef withdrawnBy;
-
+    
     public EnrollmentDetail(Enrollment enrollment, AccountRef participant, AccountRef enrolledBy,
             AccountRef withdrawnBy) {
         this.enrollment = enrollment;

--- a/src/main/java/org/sagebionetworks/bridge/models/studies/EnrollmentDetail.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/studies/EnrollmentDetail.java
@@ -16,7 +16,7 @@ public class EnrollmentDetail {
     private final AccountRef participant;
     private final AccountRef enrolledBy;
     private final AccountRef withdrawnBy;
-    
+
     public EnrollmentDetail(Enrollment enrollment, AccountRef participant, AccountRef enrolledBy,
             AccountRef withdrawnBy) {
         this.enrollment = enrollment;
@@ -42,6 +42,9 @@ public class EnrollmentDetail {
     }
     public String getWithdrawalNote() {
         return enrollment.getWithdrawalNote();
+    }
+    public String getNote() {
+        return enrollment.getNote();
     }
     public AccountRef getParticipant() {
         return participant;

--- a/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
@@ -238,35 +238,24 @@ public class EnrollmentService {
         throw new EntityNotFoundException(Enrollment.class);
     }
 
-    // TODO: Add an update method that updates editable fields of an enrollment record
-    //       specifically in order to update the note field. (Could just make it specifically only
-    //       retrieve the previous record, update the note field, and save)
-    //       - Also note the method name could change to updateEnrollment but would conflict
-    //         with existing method above.
     public void editEnrollment(Enrollment enrollment) {
         checkNotNull(enrollment);
 
         Validate.entityThrowingException(INSTANCE, enrollment);
 
+        AccountId accountId = AccountId.forId(enrollment.getAppId(), enrollment.getAccountId());
+        Account account = accountService.getAccount(accountId)
+                .orElseThrow(() -> new EntityNotFoundException(Account.class));
+
         CAN_EDIT_OTHER_ENROLLMENTS.checkAndThrow(STUDY_ID, enrollment.getStudyId(), USER_ID, enrollment.getAccountId());
 
-        AccountId accountId = AccountId.forId(enrollment.getAppId(), enrollment.getAccountId());
-        Optional<Account> optionalAccount = accountService.getAccount(accountId);
-
-        if (optionalAccount.isPresent()) {
-            Account account = optionalAccount.get();
-
-            if (!account.getDataGroups().contains(TEST_USER_GROUP)) {
-                IS_ONLY_DEVELOPER.checkAndThrow();
+        for (Enrollment accountEnrollment : account.getEnrollments()) {
+            if (accountEnrollment.getStudyId().equals(enrollment.getStudyId())) {
+                accountEnrollment.setNote(enrollment.getNote());
+                break;
             }
-            for (Enrollment accountEnrollment : account.getEnrollments()) {
-                if (accountEnrollment.getStudyId().equals(enrollment.getStudyId())) {
-                    accountEnrollment.setNote(enrollment.getNote());
-                    break;
-                }
-            }
-
-            accountService.updateAccount(account);
         }
+
+        accountService.updateAccount(account);
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
@@ -238,8 +238,15 @@ public class EnrollmentService {
     // TODO: Add an update method that updates editable fields of an enrollment record
     //       specifically in order to update the note field. (Could just make it specifically only
     //       retrieve the previous record, update the note field, and save)
-    public void updateEnrollmentNote(Enrollment enrollment) {
+    //       - Also note the method name could change to updateEnrollment but would conflict
+    //         with existing method above.
+    public void editEnrollment(Enrollment enrollment) {
         checkNotNull(enrollment);
+
+        Validate.entityThrowingException(INSTANCE, enrollment);
+
+        // TODO: Check on these permissions, is isSelf() applicable
+        CAN_EDIT_ENROLLMENTS.checkAndThrow(STUDY_ID, enrollment.getStudyId(), USER_ID, enrollment.getAccountId());
 
         AccountId accountId = AccountId.forId(enrollment.getAppId(), enrollment.getAccountId());
         Optional<Account> optionalAccount = accountService.getAccount(accountId);
@@ -249,6 +256,7 @@ public class EnrollmentService {
             for (Enrollment accountEnrollment : account.getEnrollments()) {
                 if (accountEnrollment.getStudyId().equals(enrollment.getStudyId())) {
                     accountEnrollment.setNote(enrollment.getNote());
+                    break;
                 }
             }
 

--- a/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
@@ -210,6 +210,8 @@ public class EnrollmentService {
         if (!account.getId().equals(callerUserId)) {
             existingEnrollment.setEnrolledBy(callerUserId);
             existingEnrollment.setNote(newEnrollment.getNote());
+        } else {
+            newEnrollment.setNote(null);
         }
     }
     

--- a/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
@@ -193,6 +193,7 @@ public class EnrollmentService {
         existingEnrollment.setWithdrawnOn(null);
         existingEnrollment.setWithdrawnBy(null);
         existingEnrollment.setWithdrawalNote(null);
+        existingEnrollment.setNote(newEnrollment.getNote());
         existingEnrollment.setConsentRequired(newEnrollment.isConsentRequired());
         // We might want eventually to allow this to be nullified, but right now with two 
         // systems for enrolling the user, ParticipantService and ConsentService can easily
@@ -209,9 +210,6 @@ public class EnrollmentService {
         String callerUserId = RequestContext.get().getCallerUserId();
         if (!account.getId().equals(callerUserId)) {
             existingEnrollment.setEnrolledBy(callerUserId);
-            existingEnrollment.setNote(newEnrollment.getNote());
-        } else {
-            newEnrollment.setNote(null);
         }
     }
     
@@ -265,22 +263,23 @@ public class EnrollmentService {
 
     public void updateEnrollment(Enrollment enrollment) {
         checkNotNull(enrollment);
-
+        
         Validate.entityThrowingException(INSTANCE, enrollment);
-
+        
         AccountId accountId = AccountId.forId(enrollment.getAppId(), enrollment.getAccountId());
         Account account = accountService.getAccount(accountId)
                 .orElseThrow(() -> new EntityNotFoundException(Account.class));
-
+        
         CAN_EDIT_OTHER_ENROLLMENTS.checkAndThrow(STUDY_ID, enrollment.getStudyId(), USER_ID, enrollment.getAccountId());
-
+        
         for (Enrollment accountEnrollment : account.getEnrollments()) {
             if (accountEnrollment.getStudyId().equals(enrollment.getStudyId())) {
                 accountEnrollment.setNote(enrollment.getNote());
+                accountEnrollment.setWithdrawalNote(enrollment.getWithdrawalNote());
                 break;
             }
         }
-
+        
         accountService.updateAccount(account);
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
@@ -15,6 +15,7 @@ import static org.sagebionetworks.bridge.models.ResourceList.PAGE_SIZE;
 import static org.sagebionetworks.bridge.validators.EnrollmentValidator.INSTANCE;
 
 import java.util.List;
+import java.util.Optional;
 
 import javax.annotation.Nullable;
 
@@ -232,5 +233,26 @@ public class EnrollmentService {
             }
         }
         throw new EntityNotFoundException(Enrollment.class);
+    }
+
+    // TODO: Add an update method that updates editable fields of an enrollment record
+    //       specifically in order to update the note field. (Could just make it specifically only
+    //       retrieve the previous record, update the note field, and save)
+    public void updateEnrollmentNote(Enrollment enrollment) {
+        checkNotNull(enrollment);
+
+        AccountId accountId = AccountId.forId(enrollment.getAppId(), enrollment.getAccountId());
+        Optional<Account> optionalAccount = accountService.getAccount(accountId);
+
+        if (optionalAccount.isPresent()) {
+            Account account = optionalAccount.get();
+            for (Enrollment accountEnrollment : account.getEnrollments()) {
+                if (accountEnrollment.getStudyId().equals(enrollment.getStudyId())) {
+                    accountEnrollment.setNote(enrollment.getNote());
+                }
+            }
+
+            accountService.updateAccount(account);
+        }
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
@@ -5,10 +5,12 @@ import static org.sagebionetworks.bridge.AuthEvaluatorField.STUDY_ID;
 import static org.sagebionetworks.bridge.AuthEvaluatorField.USER_ID;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_STUDY_PARTICIPANTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_ENROLLMENTS;
+import static org.sagebionetworks.bridge.AuthUtils.IS_ONLY_DEVELOPER;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.NEGATIVE_OFFSET_ERROR;
 import static org.sagebionetworks.bridge.BridgeConstants.PAGE_SIZE_ERROR;
+import static org.sagebionetworks.bridge.BridgeConstants.TEST_USER_GROUP;
 import static org.sagebionetworks.bridge.models.ResourceList.ENROLLMENT_FILTER;
 import static org.sagebionetworks.bridge.models.ResourceList.OFFSET_BY;
 import static org.sagebionetworks.bridge.models.ResourceList.PAGE_SIZE;
@@ -245,7 +247,6 @@ public class EnrollmentService {
 
         Validate.entityThrowingException(INSTANCE, enrollment);
 
-        // TODO: Check on these permissions, is isSelf() applicable
         CAN_EDIT_ENROLLMENTS.checkAndThrow(STUDY_ID, enrollment.getStudyId(), USER_ID, enrollment.getAccountId());
 
         AccountId accountId = AccountId.forId(enrollment.getAppId(), enrollment.getAccountId());
@@ -253,6 +254,10 @@ public class EnrollmentService {
 
         if (optionalAccount.isPresent()) {
             Account account = optionalAccount.get();
+
+            if (!account.getDataGroups().contains(TEST_USER_GROUP)) {
+                IS_ONLY_DEVELOPER.checkAndThrow();
+            }
             for (Enrollment accountEnrollment : account.getEnrollments()) {
                 if (accountEnrollment.getStudyId().equals(enrollment.getStudyId())) {
                     accountEnrollment.setNote(enrollment.getNote());

--- a/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
@@ -5,6 +5,7 @@ import static org.sagebionetworks.bridge.AuthEvaluatorField.STUDY_ID;
 import static org.sagebionetworks.bridge.AuthEvaluatorField.USER_ID;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_STUDY_PARTICIPANTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_ENROLLMENTS;
+import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_OTHER_ENROLLMENTS;
 import static org.sagebionetworks.bridge.AuthUtils.IS_ONLY_DEVELOPER;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
@@ -247,7 +248,7 @@ public class EnrollmentService {
 
         Validate.entityThrowingException(INSTANCE, enrollment);
 
-        CAN_EDIT_ENROLLMENTS.checkAndThrow(STUDY_ID, enrollment.getStudyId(), USER_ID, enrollment.getAccountId());
+        CAN_EDIT_OTHER_ENROLLMENTS.checkAndThrow(STUDY_ID, enrollment.getStudyId(), USER_ID, enrollment.getAccountId());
 
         AccountId accountId = AccountId.forId(enrollment.getAppId(), enrollment.getAccountId());
         Optional<Account> optionalAccount = accountService.getAccount(accountId);

--- a/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
@@ -6,19 +6,16 @@ import static org.sagebionetworks.bridge.AuthEvaluatorField.USER_ID;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_STUDY_PARTICIPANTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_ENROLLMENTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_OTHER_ENROLLMENTS;
-import static org.sagebionetworks.bridge.AuthUtils.IS_ONLY_DEVELOPER;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.NEGATIVE_OFFSET_ERROR;
 import static org.sagebionetworks.bridge.BridgeConstants.PAGE_SIZE_ERROR;
-import static org.sagebionetworks.bridge.BridgeConstants.TEST_USER_GROUP;
 import static org.sagebionetworks.bridge.models.ResourceList.ENROLLMENT_FILTER;
 import static org.sagebionetworks.bridge.models.ResourceList.OFFSET_BY;
 import static org.sagebionetworks.bridge.models.ResourceList.PAGE_SIZE;
 import static org.sagebionetworks.bridge.validators.EnrollmentValidator.INSTANCE;
 
 import java.util.List;
-import java.util.Optional;
 
 import javax.annotation.Nullable;
 
@@ -187,6 +184,7 @@ public class EnrollmentService {
         String callerUserId = RequestContext.get().getCallerUserId();
         if (!account.getId().equals(callerUserId)) {
             existingEnrollment.setEnrolledBy(callerUserId);
+            existingEnrollment.setNote(newEnrollment.getNote());
         }
     }
     

--- a/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
@@ -180,16 +180,16 @@ public class EnrollmentService {
         }
         for (Enrollment existingEnrollment : account.getEnrollments()) {
             if (existingEnrollment.getStudyId().equals(newEnrollment.getStudyId())) {
-                updateEnrollment(account, newEnrollment, existingEnrollment);
+                editEnrollment(account, newEnrollment, existingEnrollment);
                 return existingEnrollment;
             }
         }
-        updateEnrollment(account, newEnrollment, newEnrollment);
+        editEnrollment(account, newEnrollment, newEnrollment);
         account.getEnrollments().add(newEnrollment);
         return newEnrollment;
     }
     
-    private void updateEnrollment(Account account, Enrollment newEnrollment, Enrollment existingEnrollment) {
+    private void editEnrollment(Account account, Enrollment newEnrollment, Enrollment existingEnrollment) {
         existingEnrollment.setWithdrawnOn(null);
         existingEnrollment.setWithdrawnBy(null);
         existingEnrollment.setWithdrawalNote(null);
@@ -263,7 +263,7 @@ public class EnrollmentService {
         throw new EntityNotFoundException(Enrollment.class);
     }
 
-    public void editEnrollment(Enrollment enrollment) {
+    public void updateEnrollment(Enrollment enrollment) {
         checkNotNull(enrollment);
 
         Validate.entityThrowingException(INSTANCE, enrollment);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentController.java
@@ -2,7 +2,10 @@ package org.sagebionetworks.bridge.spring.controllers;
 
 import static java.util.stream.Collectors.toSet;
 import static org.sagebionetworks.bridge.AuthEvaluatorField.STUDY_ID;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.USER_ID;
+import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_ENROLLMENTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_STUDY_PARTICIPANTS;
+import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_EXISTING_ENROLLMENT;
 import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
 
@@ -89,20 +92,24 @@ public class EnrollmentController extends BaseController {
         return service.unenroll(enrollment);
     }
 
-    // TODO: Make an update route that is study specific for a user
-    //       to allow for note updates.
     @PostMapping("/v5/studies/{studyId}/enrollments/{userId}")
     public StatusMessage updateEnrollment(@PathVariable String studyId, @PathVariable String userId) {
         UserSession session = getAdministrativeSession();
 
-        CAN_EDIT_STUDY_PARTICIPANTS.checkAndThrow(STUDY_ID, studyId);
+        // TODO: Check on the permission here:
+        //       - study designers for test accounts
+        //       - study coordinators for all accounts
+        //       Should "isSelf" be allowed as well? If not, need to customize the Auth
+//        CAN_EDIT_ENROLLMENTS.checkAndThrow(STUDY_ID, studyId, USER_ID, userId);
+//        CAN_EDIT_STUDY_PARTICIPANTS.checkAndThrow(STUDY_ID, studyId);
+        CAN_EDIT_EXISTING_ENROLLMENT.checkAndThrow(STUDY_ID, studyId, USER_ID, userId);
 
         Enrollment enrollment = parseJson(Enrollment.class);
         enrollment.setAppId(session.getAppId());
         enrollment.setStudyId(studyId);
         enrollment.setAccountId(userId);
 
-        service.updateEnrollmentNote(enrollment);
+        service.editEnrollment(enrollment);
 
         return new StatusMessage("Enrollment updated.");
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentController.java
@@ -3,9 +3,8 @@ package org.sagebionetworks.bridge.spring.controllers;
 import static java.util.stream.Collectors.toSet;
 import static org.sagebionetworks.bridge.AuthEvaluatorField.STUDY_ID;
 import static org.sagebionetworks.bridge.AuthEvaluatorField.USER_ID;
-import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_ENROLLMENTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_STUDY_PARTICIPANTS;
-import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_EXISTING_ENROLLMENT;
+import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_OTHER_ENROLLMENTS;
 import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
 
@@ -98,11 +97,7 @@ public class EnrollmentController extends BaseController {
 
         // TODO: Check on the permission here:
         //       - study designers for test accounts
-        //       - study coordinators for all accounts
-        //       Should "isSelf" be allowed as well? If not, need to customize the Auth
-//        CAN_EDIT_ENROLLMENTS.checkAndThrow(STUDY_ID, studyId, USER_ID, userId);
-//        CAN_EDIT_STUDY_PARTICIPANTS.checkAndThrow(STUDY_ID, studyId);
-        CAN_EDIT_EXISTING_ENROLLMENT.checkAndThrow(STUDY_ID, studyId, USER_ID, userId);
+        CAN_EDIT_OTHER_ENROLLMENTS.checkAndThrow(STUDY_ID, studyId, USER_ID, userId);
 
         Enrollment enrollment = parseJson(Enrollment.class);
         enrollment.setAppId(session.getAppId());

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentController.java
@@ -88,6 +88,24 @@ public class EnrollmentController extends BaseController {
         
         return service.unenroll(enrollment);
     }
+
+    // TODO: Make an update route that is study specific for a user
+    //       to allow for note updates.
+    @PostMapping("/v5/studies/{studyId}/enrollments/{userId}")
+    public StatusMessage updateEnrollment(@PathVariable String studyId, @PathVariable String userId) {
+        UserSession session = getAdministrativeSession();
+
+        CAN_EDIT_STUDY_PARTICIPANTS.checkAndThrow(STUDY_ID, studyId);
+
+        Enrollment enrollment = parseJson(Enrollment.class);
+        enrollment.setAppId(session.getAppId());
+        enrollment.setStudyId(studyId);
+        enrollment.setAccountId(userId);
+
+        service.updateEnrollmentNote(enrollment);
+
+        return new StatusMessage("Enrollment updated.");
+    }
     
     @PostMapping("/v3/participants/{userId}/enrollments")
     public StatusMessage updateUserEnrollments(@PathVariable String userId) {

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentController.java
@@ -90,13 +90,13 @@ public class EnrollmentController extends BaseController {
         
         return service.unenroll(enrollment);
     }
-
+    
     @PostMapping("/v3/participants/{userId}/enrollments")
     public StatusMessage updateUserEnrollments(@PathVariable String userId) {
         UserSession session = getAuthenticatedSession(SUPERADMIN);
-
+        
         List<EnrollmentMigration> migrations = parseJson(new TypeReference<List<EnrollmentMigration>>() {});
-
+        
         AccountId accountId = BridgeUtils.parseAccountId(session.getAppId(), userId);
         accountService.editAccount(accountId, (acct) -> {
             acct.getEnrollments().clear();
@@ -116,7 +116,7 @@ public class EnrollmentController extends BaseController {
         enrollment.setStudyId(studyId);
         enrollment.setAccountId(userId);
 
-        service.editEnrollment(enrollment);
+        service.updateEnrollment(enrollment);
 
         return new StatusMessage("Enrollment updated.");
     }

--- a/src/main/resources/db/changelog/changelog.sql
+++ b/src/main/resources/db/changelog/changelog.sql
@@ -814,3 +814,8 @@ CREATE TABLE `ScheduleStudyBursts` (
 
 ALTER TABLE `Sessions`
 ADD COLUMN `studyBurstIds` varchar(512);
+
+-- changeset bridge:49
+
+ALTER TABLE `AccountsSubstudies`
+ADD COLUMN `note` text DEFAULT NULL;

--- a/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
@@ -9,6 +9,7 @@ import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_MEMBERS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_ASSESSMENTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_SHARED_ASSESSMENTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_ENROLLMENTS;
+import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_OTHER_ENROLLMENTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_READ_STUDY_ASSOCIATIONS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_TRANSITION_STUDY;
 import static org.sagebionetworks.bridge.BridgeConstants.TEST_USER_GROUP;
@@ -857,5 +858,85 @@ public class AuthUtilsTest extends Mockito {
                 .collect(toSet());
         account.setEnrollments(enrollments);
         return account;
+    }
+
+    @Test
+    public void canEditOtherEnrollments_baseCaseFails() {
+        RequestContext.set(new RequestContext.Builder().build());
+
+        assertFalse(CAN_EDIT_OTHER_ENROLLMENTS.check(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID));
+    }
+
+    @Test
+    public void canEditOtherEnrollments_selfFails() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId(TEST_USER_ID).build());
+
+        assertFalse(CAN_EDIT_OTHER_ENROLLMENTS.check(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID));
+    }
+
+    @Test
+    public void canEditOtherEnrollments_studyDesignerWithStudyAccessSucceeds() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(STUDY_DESIGNER))
+                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
+                .build());
+
+        assertTrue(CAN_EDIT_OTHER_ENROLLMENTS.check(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID));
+    }
+
+    @Test
+    public void canEditOtherEnrollments_studyDesignerWithoutStudyAccessFails() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(STUDY_DESIGNER))
+                .build());
+
+        assertFalse(CAN_EDIT_OTHER_ENROLLMENTS.check(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID));
+    }
+
+    @Test
+    public void canEditOtherEnrollments_studyCoordinatorWithStudyAccessSucceeds() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR))
+                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
+                .build());
+
+        assertTrue(CAN_EDIT_OTHER_ENROLLMENTS.check(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID));
+    }
+
+    @Test
+    public void canEditOtherEnrollments_studyCoordinatorWithoutStudyAccessFails() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR))
+                .build());
+
+        assertFalse(CAN_EDIT_OTHER_ENROLLMENTS.check(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID));
+    }
+
+    @Test
+    public void canEditOtherEnrollments_adminSucceeds() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(ADMIN))
+                .build());
+
+        assertTrue(CAN_EDIT_OTHER_ENROLLMENTS.check(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID));
+    }
+
+    @Test
+    public void canEditOtherEnrollments_researcherSucceeds() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(RESEARCHER))
+                .build());
+
+        assertTrue(CAN_EDIT_OTHER_ENROLLMENTS.check(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID));
+    }
+
+    @Test
+    public void canEditOtherEnrollments_developerSucceeds() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerRoles(ImmutableSet.of(DEVELOPER))
+                .build());
+
+        assertTrue(CAN_EDIT_OTHER_ENROLLMENTS.check(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID));
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateEnrollmentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateEnrollmentTest.java
@@ -54,7 +54,7 @@ public class HibernateEnrollmentTest {
         assertTrue(node.get("consentRequired").booleanValue());
         assertEquals(node.get("note").textValue(), TEST_NOTE);
         assertEquals(node.get("type").textValue(), "Enrollment");
-
+        
         Enrollment deser = BridgeObjectMapper.get().readValue(node.toString(), Enrollment.class);
         assertNull(deser.getAppId());
         assertNull(deser.getStudyId());

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateEnrollmentTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateEnrollmentTest.java
@@ -4,6 +4,7 @@ import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
 import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_NOTE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -39,6 +40,7 @@ public class HibernateEnrollmentTest {
         enrollment.setWithdrawnBy("withdrawnBy");
         enrollment.setWithdrawalNote("note");
         enrollment.setConsentRequired(true);
+        enrollment.setNote(TEST_NOTE);
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(enrollment);
         
@@ -50,8 +52,9 @@ public class HibernateEnrollmentTest {
         assertEquals(node.get("withdrawnBy").textValue(), "withdrawnBy");
         assertEquals(node.get("withdrawalNote").textValue(), "note");
         assertTrue(node.get("consentRequired").booleanValue());
+        assertEquals(node.get("note").textValue(), TEST_NOTE);
         assertEquals(node.get("type").textValue(), "Enrollment");
-        
+
         Enrollment deser = BridgeObjectMapper.get().readValue(node.toString(), Enrollment.class);
         assertNull(deser.getAppId());
         assertNull(deser.getStudyId());
@@ -63,6 +66,7 @@ public class HibernateEnrollmentTest {
         assertEquals(deser.getWithdrawnBy(), "withdrawnBy");
         assertEquals(deser.getWithdrawalNote(), "note");
         assertTrue(deser.isConsentRequired());
+        assertEquals(deser.getNote(), TEST_NOTE);
     }
     
     @Test
@@ -78,6 +82,7 @@ public class HibernateEnrollmentTest {
         enrollment.setWithdrawnBy("withdrawnBy");
         enrollment.setWithdrawalNote("note");
         enrollment.setConsentRequired(true);
+        enrollment.setNote(TEST_NOTE);
         
         assertEquals(enrollment.getAppId(), TEST_APP_ID);
         assertEquals(enrollment.getStudyId(), TEST_STUDY_ID);
@@ -88,5 +93,6 @@ public class HibernateEnrollmentTest {
         assertEquals(enrollment.getEnrolledBy(), "enrolledBy");
         assertEquals(enrollment.getWithdrawnBy(), "withdrawnBy");
         assertEquals(enrollment.getWithdrawalNote(), "note");
+        assertEquals(enrollment.getNote(), TEST_NOTE);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/studies/EnrollmentDetailTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/studies/EnrollmentDetailTest.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.models.studies;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_NOTE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -33,6 +34,7 @@ public class EnrollmentDetailTest {
         Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         enrollment.setExternalId("anExternalId");
         enrollment.setConsentRequired(true);
+        enrollment.setNote(TEST_NOTE);
 
         EnrollmentDetail detail = new EnrollmentDetail(enrollment, ref1, ref2, ref3);
         
@@ -40,21 +42,23 @@ public class EnrollmentDetailTest {
         assertEquals(detail.getParticipant().getEmail(), "email1@email.com");
         assertEquals(detail.getEnrolledBy().getEmail(), "email2@email.com");
         assertEquals(detail.getWithdrawnBy().getEmail(), "email3@email.com");
+        assertEquals(detail.getNote(), TEST_NOTE);
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(detail);
-        assertEquals(node.size(), 7);
+        assertEquals(node.size(), 8);
         
         // Note that other than email and type properties, there's nothing else exposed about account
         assertEquals(node.get("studyId").textValue(), TEST_STUDY_ID);
         assertEquals(node.get("participant").size(), 2);
         assertEquals(node.get("enrolledBy").size(), 2);
         assertEquals(node.get("withdrawnBy").size(), 2);
-        
+
         assertEquals(node.get("participant").get("email").textValue(), "email1@email.com");
         assertEquals(node.get("enrolledBy").get("email").textValue(), "email2@email.com");
         assertEquals(node.get("withdrawnBy").get("email").textValue(), "email3@email.com");
         assertEquals(node.get("externalId").textValue(), "anExternalId");
         assertTrue(node.get("consentRequired").booleanValue());
+        assertEquals(node.get("note").textValue(), TEST_NOTE);
         assertEquals(node.get("type").textValue(), "EnrollmentDetail");
         
         // This object is not deserialized on the server.

--- a/src/test/java/org/sagebionetworks/bridge/models/studies/EnrollmentDetailTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/studies/EnrollmentDetailTest.java
@@ -52,7 +52,7 @@ public class EnrollmentDetailTest {
         assertEquals(node.get("participant").size(), 2);
         assertEquals(node.get("enrolledBy").size(), 2);
         assertEquals(node.get("withdrawnBy").size(), 2);
-
+        
         assertEquals(node.get("participant").get("email").textValue(), "email1@email.com");
         assertEquals(node.get("enrolledBy").get("email").textValue(), "email2@email.com");
         assertEquals(node.get("withdrawnBy").get("email").textValue(), "email3@email.com");

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
@@ -33,6 +33,7 @@ import static org.sagebionetworks.bridge.services.AccountService.ROTATIONS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -1053,15 +1054,19 @@ public class AccountServiceTest extends Mockito {
         verify(mockAccountDao).createAccount(app, account);
         verify(activityEventService).publishEnrollmentEvent(any(), any(), any());
         verify(studyActivityEventService, times(2)).publishEvent(eventCaptor.capture());
-        
-        StudyActivityEvent event1 = eventCaptor.getAllValues().get(0);
+
+        StudyActivityEvent event1 = eventCaptor.getAllValues().stream()
+                .filter(event -> event.getStudyId().equals(STUDY_A)).findFirst().orElse(null);
+        assertNotNull(event1);
         assertEquals(event1.getAppId(), TEST_APP_ID);
         assertEquals(event1.getStudyId(), STUDY_A);
         assertEquals(event1.getUserId(), TEST_USER_ID);
         assertEquals(event1.getEventId(), "enrollment");
         assertEquals(event1.getTimestamp(), account.getCreatedOn());
-        
-        StudyActivityEvent event2 = eventCaptor.getAllValues().get(1);
+
+        StudyActivityEvent event2 = eventCaptor.getAllValues().stream()
+                .filter(event -> event.getStudyId().equals(STUDY_B)).findFirst().orElse(null);
+        assertNotNull(event2);
         assertEquals(event2.getAppId(), TEST_APP_ID);
         assertEquals(event2.getStudyId(), STUDY_B);
         assertEquals(event2.getUserId(), TEST_USER_ID);

--- a/src/test/java/org/sagebionetworks/bridge/services/EnrollmentServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/EnrollmentServiceTest.java
@@ -400,15 +400,18 @@ public class EnrollmentServiceTest extends Mockito {
         enrollment.setWithdrawalNote("Withdrawal reason");
         
         Enrollment retValue = service.unenroll(enrollment);
+        System.out.println(retValue);
         assertEquals(retValue.getWithdrawnOn(), MODIFIED_ON.minusHours(1));
         assertNull(retValue.getWithdrawnBy());
         assertEquals(retValue.getWithdrawalNote(), "Withdrawal reason");
 
         verify(mockAccountService).editAccount(any(), any());
         Enrollment captured = Iterables.getLast(account.getEnrollments(), null);
+        System.out.println(captured);
+        System.out.println(account.getEnrollments());
         assertEquals(captured.getWithdrawnOn(), MODIFIED_ON.minusHours(1));
         assertNull(captured.getWithdrawnBy());
-        assertEquals(captured.getWithdrawalNote(), "Withdrawal reason");        
+        assertEquals(captured.getWithdrawalNote(), "Withdrawal reason");
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/EnrollmentServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/EnrollmentServiceTest.java
@@ -217,8 +217,7 @@ public class EnrollmentServiceTest extends Mockito {
         assertNull(retValue.getWithdrawnBy());
         assertNull(retValue.getWithdrawalNote());
         assertFalse(retValue.isConsentRequired());
-        // The note does not set because the caller is self.
-        assertNull(retValue.getNote());
+        assertEquals(retValue.getNote(), TEST_NOTE);
         
         assertTrue(account.getEnrollments().contains(retValue));
     }
@@ -708,7 +707,7 @@ public class EnrollmentServiceTest extends Mockito {
     }
 
     @Test
-    public void updateEnrollment_canUpdateOnlyNoteField() {
+    public void updateEnrollment_canUpdateOnlyNoteFields() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId("otherId")
                 .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
@@ -737,7 +736,7 @@ public class EnrollmentServiceTest extends Mockito {
         assertNull(targetEnrollment.getEnrolledOn());
         assertNull(targetEnrollment.getWithdrawnBy());
         assertNull(targetEnrollment.getWithdrawnOn());
-        assertNull(targetEnrollment.getWithdrawalNote());
+        assertEquals(targetEnrollment.getWithdrawalNote(), TEST_NOTE);
     }
 
     @Test(expectedExceptions = InvalidEntityException.class)
@@ -787,15 +786,9 @@ public class EnrollmentServiceTest extends Mockito {
         verify(mockAccountService).updateAccount(accountCaptor.capture());
 
         Set<Enrollment> capturedEnrollments = accountCaptor.getValue().getEnrollments();
-        assertEquals(capturedEnrollments.size(), 2);
-        assertTrue(capturedEnrollments.contains(targetEnrollment));
-        assertTrue(capturedEnrollments.contains(otherEnrollment));
-        for (Enrollment captureEnrollment : capturedEnrollments) {
-            if (captureEnrollment.getStudyId().equals(TEST_STUDY_ID)) {
-                assertEquals(captureEnrollment.getNote(), TEST_NOTE);
-            } else {
-                assertNull(captureEnrollment.getNote());
-            }
-        }
+        Enrollment captured = capturedEnrollments.stream().filter(e -> e.getStudyId().equals(TEST_STUDY_ID))
+                .findFirst().orElse(null);
+        assertNotNull(captured);
+        assertEquals(captured.getNote(), TEST_NOTE);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/EnrollmentServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/EnrollmentServiceTest.java
@@ -395,31 +395,31 @@ public class EnrollmentServiceTest extends Mockito {
 
         service.enroll(enrollment);
     }
-
+    
     @Test
     public void unenrollBySelf() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId(TEST_USER_ID).build());
-
+        
         Enrollment existing = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         Enrollment otherStudy = Enrollment.create(TEST_APP_ID, "otherStudy", TEST_USER_ID);
-
+        
         Account account = Account.create();
         account.setId(TEST_USER_ID);
         account.setEnrollments(Sets.newHashSet(otherStudy, existing));
         TestUtils.mockEditAccount(mockAccountService, account);
-
+        
         Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         enrollment.setWithdrawnOn(MODIFIED_ON.minusHours(1));
         enrollment.setWithdrawalNote("Withdrawal reason");
-
+        
         Enrollment retValue = service.unenroll(enrollment);
         assertEquals(retValue.getWithdrawnOn(), MODIFIED_ON.minusHours(1));
         assertNull(retValue.getWithdrawnBy());
         assertEquals(retValue.getWithdrawalNote(), "Withdrawal reason");
-
+        
         verify(mockAccountService).editAccount(any(), any());
-
+        
         Enrollment captured = account.getEnrollments().stream().filter(e -> e.getStudyId().equals(TEST_STUDY_ID)).findAny().orElse(null);
         assertNotNull(captured);
         assertEquals(captured.getWithdrawnOn(), MODIFIED_ON.minusHours(1));
@@ -708,7 +708,7 @@ public class EnrollmentServiceTest extends Mockito {
     }
 
     @Test
-    public void editEnrollment_canUpdateOnlyNoteField() {
+    public void updateEnrollment_canUpdateOnlyNoteField() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId("otherId")
                 .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
@@ -728,7 +728,7 @@ public class EnrollmentServiceTest extends Mockito {
 
         when(mockAccountService.getAccount(accountId)).thenReturn(Optional.of(account));
 
-        service.editEnrollment(incomingEnrollment);
+        service.updateEnrollment(incomingEnrollment);
 
         verify(mockAccountService).updateAccount(account);
 
@@ -741,15 +741,15 @@ public class EnrollmentServiceTest extends Mockito {
     }
 
     @Test(expectedExceptions = InvalidEntityException.class)
-    public void editEnrollment_incomingEnrollmentIsValidated() {
+    public void updateEnrollment_incomingEnrollmentIsValidated() {
         Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         enrollment.setAccountId(null);
 
-        service.editEnrollment(enrollment);
+        service.updateEnrollment(enrollment);
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void editEnrollment_verifiesAdministrativeAccessToEdit() {
+    public void updateEnrollment_verifiesAdministrativeAccessToEdit() {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerRoles(ImmutableSet.of()).build());
         Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
@@ -759,11 +759,11 @@ public class EnrollmentServiceTest extends Mockito {
 
         when(mockAccountService.getAccount(accountId)).thenReturn(Optional.of(account));
 
-        service.editEnrollment(enrollment);
+        service.updateEnrollment(enrollment);
     }
 
     @Test
-    public void editEnrollment_onlyUpdatesTargetedEnrollment() {
+    public void updateEnrollment_onlyUpdatesTargetedEnrollment() {
         RequestContext.set(new RequestContext.Builder()
                 .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
                 .withCallerRoles(ImmutableSet.of(STUDY_DESIGNER)).build());
@@ -782,7 +782,7 @@ public class EnrollmentServiceTest extends Mockito {
 
         when(mockAccountService.getAccount(accountId)).thenReturn(Optional.of(account));
 
-        service.editEnrollment(incomingEnrollment);
+        service.updateEnrollment(incomingEnrollment);
 
         verify(mockAccountService).updateAccount(accountCaptor.capture());
 

--- a/src/test/java/org/sagebionetworks/bridge/services/EnrollmentServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/EnrollmentServiceTest.java
@@ -202,6 +202,7 @@ public class EnrollmentServiceTest extends Mockito {
         Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         enrollment.setExternalId("extId");
         enrollment.setEnrolledOn(timestamp);
+        enrollment.setNote("test enr note");
 
         Enrollment retValue = service.enroll(enrollment);
         assertEquals(retValue.getAppId(), TEST_APP_ID);
@@ -214,6 +215,7 @@ public class EnrollmentServiceTest extends Mockito {
         assertNull(retValue.getWithdrawnBy());
         assertNull(retValue.getWithdrawalNote());
         assertFalse(retValue.isConsentRequired());
+        assertNull(enrollment.getNote());
         
         assertTrue(account.getEnrollments().contains(retValue));
     }
@@ -643,7 +645,7 @@ public class EnrollmentServiceTest extends Mockito {
     @Test
     public void editEnrollment_canUpdateOnlyNoteField() {
         RequestContext.set(new RequestContext.Builder()
-//                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
+                .withCallerUserId("otherId")
                 .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
 
         Enrollment targetEnrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
@@ -657,10 +659,6 @@ public class EnrollmentServiceTest extends Mockito {
 
         AccountId accountId = AccountId.forId(TEST_APP_ID, TEST_USER_ID);
         Account account = Account.create();
-        account.setAppId(TEST_APP_ID);
-        account.setId(TEST_USER_ID);
-        // TODO: This line shouldn't be required for a researcher, something is wrong here
-        account.setDataGroups(ImmutableSet.of(TEST_USER_GROUP));
         account.setEnrollments(ImmutableSet.of(targetEnrollment));
 
         when(mockAccountService.getAccount(accountId)).thenReturn(Optional.of(account));
@@ -691,39 +689,8 @@ public class EnrollmentServiceTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of()).build());
         Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
 
-        service.editEnrollment(enrollment);
-    }
-
-    @Test
-    public void editEnrollment_allowsStudyDesignerAccessToTestAccounts() {
-        RequestContext.set(new RequestContext.Builder()
-                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
-                .withCallerRoles(ImmutableSet.of(STUDY_DESIGNER)).build());
-        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
-
         AccountId accountId = AccountId.forId(TEST_APP_ID, TEST_USER_ID);
         Account account = Account.create();
-        account.setAppId(TEST_APP_ID);
-        account.setId(TEST_USER_ID);
-        account.setDataGroups(ImmutableSet.of(TEST_USER_GROUP));
-
-        when(mockAccountService.getAccount(accountId)).thenReturn(Optional.of(account));
-
-        service.editEnrollment(enrollment);
-    }
-
-    @Test(expectedExceptions = UnauthorizedException.class)
-    public void editEnrollment_preventsStudyDesignerAccessToNonTestAccounts() {
-        RequestContext.set(new RequestContext.Builder()
-                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
-                .withCallerRoles(ImmutableSet.of(STUDY_DESIGNER)).build());
-
-        Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
-
-        AccountId accountId = AccountId.forId(TEST_APP_ID, TEST_USER_ID);
-        Account account = Account.create();
-        account.setAppId(TEST_APP_ID);
-        account.setId(TEST_USER_ID);
 
         when(mockAccountService.getAccount(accountId)).thenReturn(Optional.of(account));
 

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentControllerTest.java
@@ -249,7 +249,7 @@ public class EnrollmentControllerTest extends Mockito {
 
         controller.updateEnrollment(TEST_STUDY_ID, TEST_USER_ID);
 
-        verify(mockService).editEnrollment(enrollmentCaptor.capture());
+        verify(mockService).updateEnrollment(enrollmentCaptor.capture());
 
         Enrollment captured = enrollmentCaptor.getValue();
         assertEquals(captured.getAppId(), TEST_APP_ID);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentControllerTest.java
@@ -227,5 +227,14 @@ public class EnrollmentControllerTest extends Mockito {
         
         verify(mockAccount, times(2)).getEnrollments();
         assertTrue(enrollments.isEmpty());
-    }    
+    }
+
+    @Test
+    public void updateEnrollmentNote() {
+        UserSession session = new UserSession();
+        session.setAppId(TEST_APP_ID);
+        doReturn(session).when(controller).getAuthenticatedSession();
+
+
+    }
 }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/EnrollmentControllerTest.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.bridge.spring.controllers;
 import static org.sagebionetworks.bridge.RequestContext.NULL_INSTANCE;
 import static org.sagebionetworks.bridge.Roles.STUDY_COORDINATOR;
 import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
-import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;


### PR DESCRIPTION
For BRIDGE-3095

- Add note field to enrollment records for a study-scoped participant note
- Create route to update existing enrollments
- Allow note to be set on enrollment
- Prevent users from setting notes on own enrollments