### PR TITLE
Add participant variables to consent email/sms template

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -34,6 +35,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.CaseUtils;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.joda.time.LocalDateTime;
@@ -260,6 +262,28 @@ public class BridgeUtils {
     
     public static Map<String,String> appTemplateVariables(App app) {
         return appTemplateVariables(app, null);
+    }
+    
+    public static Map<String,String> participantTemplateVariables(StudyParticipant participant) {
+        Map<String,String> map = Maps.newHashMap();
+        if (participant == null) {
+            return map;
+        }
+        map.put("participantFirstName", participant.getFirstName());
+        map.put("participantLastName", participant.getLastName());
+        map.put("participantEmail", participant.getEmail());
+        if (participant.getPhone() != null) {
+            map.put("participantPhone", participant.getPhone().getNumber());
+            map.put("participantPhoneRegion", participant.getPhone().getRegionCode());
+            map.put("participantPhoneNationalFormat", participant.getPhone().getNationalFormat());
+        }
+        for (Entry<String,String> entry : participant.getAttributes().entrySet()) {
+            String attName = entry.getKey();
+            attName = attName.replaceAll("[^a-zA-Z0-9]", " ");
+            String propName = "participant" + CaseUtils.toCamelCase(attName, true);
+            map.put(propName, entry.getValue());
+        }
+        return map;
     }
     
     /**

--- a/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
@@ -278,10 +278,7 @@ public class BridgeUtils {
             map.put("participantPhoneNationalFormat", participant.getPhone().getNationalFormat());
         }
         for (Entry<String,String> entry : participant.getAttributes().entrySet()) {
-            String attName = entry.getKey();
-            attName = attName.replaceAll("[^a-zA-Z0-9]", " ");
-            String propName = "participant" + CaseUtils.toCamelCase(attName, true);
-            map.put(propName, entry.getValue());
+            map.put("participant." + entry.getKey(), entry.getValue());
         }
         return map;
     }

--- a/src/main/java/org/sagebionetworks/bridge/models/HealthDataDocumentation.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/HealthDataDocumentation.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.models;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.joda.time.DateTime;
 import org.sagebionetworks.bridge.dynamodb.DynamoHealthDataDocumentation;
 import org.sagebionetworks.bridge.json.BridgeTypeName;
 

--- a/src/main/java/org/sagebionetworks/bridge/services/ConsentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ConsentService.java
@@ -234,6 +234,7 @@ public class ConsentService {
                 
                 BasicEmailProvider.Builder consentEmailBuilder = new BasicEmailProvider.Builder()
                         .withApp(app)
+                        .withParticipant(participant)
                         .withTemplateRevision(revision)
                         .withBinaryAttachment("consent.pdf", MimeType.PDF, consentPdf.getBytes())
                         .withType(EmailType.SIGN_CONSENT);
@@ -430,6 +431,7 @@ public class ConsentService {
             
             BasicEmailProvider provider = new BasicEmailProvider.Builder()
                     .withApp(app)
+                    .withParticipant(participant)
                     .withTemplateRevision(revision)
                     .withBinaryAttachment("consent.pdf", MimeType.PDF, consentPdf.getBytes())
                     .withRecipientEmail(participant.getEmail())

--- a/src/main/java/org/sagebionetworks/bridge/services/HealthDataDocumentationService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/HealthDataDocumentationService.java
@@ -14,7 +14,6 @@ import org.sagebionetworks.bridge.validators.Validate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
 

--- a/src/main/java/org/sagebionetworks/bridge/services/email/BasicEmailProvider.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/email/BasicEmailProvider.java
@@ -16,6 +16,7 @@ import javax.mail.internet.MimeBodyPart;
 import javax.mail.util.ByteArrayDataSource;
 
 import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.apps.App;
 import org.sagebionetworks.bridge.models.apps.MimeType;
 import org.sagebionetworks.bridge.models.templates.TemplateRevision;
@@ -103,6 +104,7 @@ public class BasicEmailProvider extends MimeTypeEmailProvider {
 
     public static class Builder {
         private App app;
+        private StudyParticipant participant;
         private String overrideSenderEmail;
         private Map<String,String> tokenMap = Maps.newHashMap();
         private Set<String> recipientEmails = Sets.newHashSet();
@@ -112,6 +114,11 @@ public class BasicEmailProvider extends MimeTypeEmailProvider {
 
         public Builder withApp(App app) {
             this.app = app;
+            return this;
+        }
+        
+        public Builder withParticipant(StudyParticipant participant) {
+            this.participant = participant;
             return this;
         }
 
@@ -170,6 +177,7 @@ public class BasicEmailProvider extends MimeTypeEmailProvider {
             checkNotNull(revision);
             
             tokenMap.putAll(BridgeUtils.appTemplateVariables(app));
+            tokenMap.putAll(BridgeUtils.participantTemplateVariables(participant));
             // Nulls will cause ImmutableMap.of to fail
             tokenMap.values().removeIf(Objects::isNull);
             

--- a/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -6,7 +6,9 @@ import static org.sagebionetworks.bridge.RequestContext.NULL_INSTANCE;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.Roles.STUDY_COORDINATOR;
 import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
+import static org.sagebionetworks.bridge.TestConstants.EMAIL;
 import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
+import static org.sagebionetworks.bridge.TestConstants.PHONE;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestConstants.USER_STUDY_IDS;
@@ -441,6 +443,26 @@ public class BridgeUtilsTest extends Mockito {
         assertEquals(map.get("consentEmail"), "consentNotificationEmail2");
         assertEquals(map.get("thisMap"), "isMutable");
         assertEquals(map.get("host"), host);
+    }
+    
+    @Test
+    public void participantTemplateVariblesWorks() {
+        StudyParticipant participant = new StudyParticipant.Builder()
+                .withFirstName("aFirstName")
+                .withLastName("aLastName")
+                .withEmail(EMAIL)
+                .withPhone(PHONE)
+                .withAttributes(ImmutableMap.of("first_prop", "A", "second prop", "B"))
+                .build();
+        Map<String,String> map = BridgeUtils.participantTemplateVariables(participant);
+        assertEquals(map.get("participantFirstName"), "aFirstName");
+        assertEquals(map.get("participantLastName"), "aLastName");
+        assertEquals(map.get("participantPhone"), "+19712486796");
+        assertEquals(map.get("participantPhoneRegion"), "US");
+        assertEquals(map.get("participantFirstProp"), "A");
+        assertEquals(map.get("participantSecondProp"), "B");
+        assertEquals(map.get("participantEmail"), "email@email.com");
+        assertEquals(map.get("participantPhoneNationalFormat"), "(971) 248-6796");
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -446,7 +446,7 @@ public class BridgeUtilsTest extends Mockito {
     }
     
     @Test
-    public void participantTemplateVariblesWorks() {
+    public void participantTemplateVariablesWorks() {
         StudyParticipant participant = new StudyParticipant.Builder()
                 .withFirstName("aFirstName")
                 .withLastName("aLastName")
@@ -459,8 +459,8 @@ public class BridgeUtilsTest extends Mockito {
         assertEquals(map.get("participantLastName"), "aLastName");
         assertEquals(map.get("participantPhone"), "+19712486796");
         assertEquals(map.get("participantPhoneRegion"), "US");
-        assertEquals(map.get("participantFirstProp"), "A");
-        assertEquals(map.get("participantSecondProp"), "B");
+        assertEquals(map.get("participant.first_prop"), "A");
+        assertEquals(map.get("participant.second prop"), "B");
         assertEquals(map.get("participantEmail"), "email@email.com");
         assertEquals(map.get("participantPhoneNationalFormat"), "(971) 248-6796");
     }

--- a/src/test/java/org/sagebionetworks/bridge/services/email/BasicEmailProviderTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/email/BasicEmailProviderTest.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.services.email;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static javax.mail.Part.ATTACHMENT;
+import static org.sagebionetworks.bridge.TestConstants.PHONE;
 import static org.sagebionetworks.bridge.models.apps.MimeType.HTML;
 import static org.sagebionetworks.bridge.models.apps.MimeType.PDF;
 import static org.sagebionetworks.bridge.models.apps.MimeType.TEXT;
@@ -10,17 +11,22 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.mail.internet.MimeBodyPart;
 
 import org.apache.commons.io.IOUtils;
 import org.testng.annotations.Test;
-
+import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.apps.App;
 import org.sagebionetworks.bridge.models.templates.TemplateRevision;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
+import com.newrelic.agent.deps.com.google.common.base.Joiner;
 
 public class BasicEmailProviderTest {
     @Test
@@ -34,17 +40,34 @@ public class BasicEmailProviderTest {
         app.setSupportEmail("support@email.com");
         app.setTechnicalEmail("tech@email.com");
         app.setConsentNotificationEmail("consent@email.com,consent2@email.com");
+        
+        StudyParticipant participant = new StudyParticipant.Builder()
+                .withFirstName("firstName")
+                .withLastName("lastName")
+                .withEmail("participant@email.com")
+                .withAttributes(ImmutableMap.of("prop_A", "A", "prop_B", "B"))
+                .withPhone(PHONE)
+                .build();
+
+        List<String> documentContentElements = Arrays.asList("studyName", "studyShortName", 
+                "studyId", "appName", "appShortName", "appId", "sponsorName", "supportEmail", 
+                "technicalEmail", "consentEmail", "url", "expirationPeriod", 
+                "participantFirstName", "participantLastName", "participantEmail", 
+                "participantPropA", "participantPropB", "participantPhone", "participantPhoneRegion",
+                "participantPhoneNationalFormat");
+        
+        String documentContent = Joiner.on("~").join(documentContentElements.stream()
+                .map(s -> ("${" + s + "}")).collect(Collectors.toList()));
 
         TemplateRevision revision = TemplateRevision.create();
         revision.setSubject("Subject ${url}");
-        revision.setDocumentContent("${studyName} ${studyShortName} ${studyId} "+
-            "${appName} ${appShortName} ${appId} ${sponsorName} ${supportEmail} "+
-            "${technicalEmail} ${consentEmail} ${url} ${expirationPeriod}");
+        revision.setDocumentContent(documentContent);
         revision.setMimeType(HTML); 
         
         // Create
         BasicEmailProvider provider = new BasicEmailProvider.Builder()
             .withApp(app)
+            .withParticipant(participant)
             .withRecipientEmail("recipient@recipient.com")
             .withRecipientEmail("recipient2@recipient.com")
             .withTemplateRevision(revision)
@@ -67,8 +90,28 @@ public class BasicEmailProviderTest {
 
         MimeBodyPart body = email.getMessageParts().get(0);
         String bodyString = (String)body.getContent();
-        assertEquals(bodyString,
-                "Name ShortName id Name ShortName id SponsorName support@email.com tech@email.com consent@email.com some-url 1 hour");
+        
+        String[] elements = bodyString.split("~");
+        assertEquals(elements[0], "Name");
+        assertEquals(elements[1], "ShortName");
+        assertEquals(elements[2], "id");
+        assertEquals(elements[3], "Name");
+        assertEquals(elements[4], "ShortName");
+        assertEquals(elements[5], "id");
+        assertEquals(elements[6], "SponsorName");
+        assertEquals(elements[7], "support@email.com");
+        assertEquals(elements[8], "tech@email.com");
+        assertEquals(elements[9], "consent@email.com");
+        assertEquals(elements[10], "some-url");
+        assertEquals(elements[11], "1 hour");
+        assertEquals(elements[12], "firstName");
+        assertEquals(elements[13], "lastName");
+        assertEquals(elements[14], "participant@email.com");
+        assertEquals(elements[15], "A");
+        assertEquals(elements[16], "B");
+        assertEquals(elements[17], PHONE.getNumber());
+        assertEquals(elements[18], PHONE.getRegionCode());
+        assertEquals(elements[19], PHONE.getNationalFormat());
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/email/BasicEmailProviderTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/email/BasicEmailProviderTest.java
@@ -53,8 +53,8 @@ public class BasicEmailProviderTest {
                 "studyId", "appName", "appShortName", "appId", "sponsorName", "supportEmail", 
                 "technicalEmail", "consentEmail", "url", "expirationPeriod", 
                 "participantFirstName", "participantLastName", "participantEmail", 
-                "participantPropA", "participantPropB", "participantPhone", "participantPhoneRegion",
-                "participantPhoneNationalFormat");
+                "participant.prop_A", "participant.prop_B", "participantPhone", 
+                "participantPhoneRegion", "participantPhoneNationalFormat");
         
         String documentContent = Joiner.on("~").join(documentContentElements.stream()
                 .map(s -> ("${" + s + "}")).collect(Collectors.toList()));


### PR DESCRIPTION
BRIDGE-3106. This will allow us to put something in the email itself that we can use to route emails sent to the consent administrator. This appears to be enough to do BRIDGE-3107 too, since we send the exact email to the consent coordinator that we send to end users (there is no other template that needs to be added to the template system).