### PR TITLE
Removed startEventId from SessionInfo

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionInfo.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/SessionInfo.java
@@ -12,14 +12,11 @@ import org.sagebionetworks.bridge.models.schedules2.PerformanceOrder;
 import org.sagebionetworks.bridge.models.schedules2.Session;
 import org.sagebionetworks.bridge.models.schedules2.TimeWindow;
 
-import com.google.common.collect.Iterables;
-
 public class SessionInfo {
 
     private String guid;
     private String label;
     private String symbol;
-    private String startEventId;
     private PerformanceOrder performanceOrder;
     private Integer minutesToComplete;
     private List<String> timeWindowGuids;
@@ -40,7 +37,6 @@ public class SessionInfo {
         info.guid = session.getGuid();
         info.label = label.getValue();
         info.symbol = session.getSymbol();
-        info.startEventId = Iterables.getFirst(session.getStartEventIds(), null);
         info.performanceOrder = session.getPerformanceOrder();
         info.timeWindowGuids = session.getTimeWindows().stream()
                 .map(TimeWindow::getGuid)
@@ -62,9 +58,6 @@ public class SessionInfo {
     }
     public String getSymbol() {
         return symbol;
-    }
-    public String getStartEventId() {
-        return startEventId;
     }
     public PerformanceOrder getPerformanceOrder() {
         return performanceOrder;


### PR DESCRIPTION
This has already been removed from the SDK and from the integration tests, so this is the only change that is necessary. This cannot be merged until the client libraries have been updated.