### PR TITLE
Split participant report APIs

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
@@ -135,6 +135,7 @@ public class AuthUtils {
      * Can the caller read study reports?
      */
     public static final AuthEvaluator CAN_READ_STUDY_REPORTS = new AuthEvaluator()
+            .isEnrolledInStudy().or()
             .canAccessStudy().or()
             .hasAnyRole(DEVELOPER, RESEARCHER, WORKER, ADMIN);
     

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoReportDataDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoReportDataDao.java
@@ -118,7 +118,7 @@ public class DynamoReportDataDao implements ReportDataDao {
         }
 
         int limit = Math.min(list.size(), pageSize);
-        return new ForwardCursorPagedResourceList<ReportData>(list.subList(0, limit), nextPageOffsetKey)
+        return new ForwardCursorPagedResourceList<ReportData>(list.subList(0, limit), nextPageOffsetKey, true)
                 .withRequestParam(PAGE_SIZE, pageSize)
                 .withRequestParam(OFFSET_KEY, offsetKey)
                 .withRequestParam(START_TIME, startTime)

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportController.java
@@ -7,8 +7,6 @@ import static org.sagebionetworks.bridge.BridgeUtils.getLocalDateOrDefault;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
-import static org.sagebionetworks.bridge.Roles.STUDY_COORDINATOR;
-import static org.sagebionetworks.bridge.Roles.STUDY_DESIGNER;
 import static org.sagebionetworks.bridge.Roles.WORKER;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -168,7 +166,7 @@ public class ParticipantReportController extends BaseController {
             @PathVariable String identifier, @RequestParam(required = false) String startTime,
             @RequestParam(required = false) String endTime, @RequestParam(required = false) String offsetKey,
             @RequestParam(required = false) String pageSize) {
-        UserSession session = getAdministrativeSession();
+        UserSession session = getAuthenticatedSession();
 
         AccountId accountId = BridgeUtils.parseAccountId(session.getAppId(), userIdToken);
         Account account = accountService.getAccount(accountId)
@@ -214,7 +212,7 @@ public class ParticipantReportController extends BaseController {
     @PostMapping({"/v4/participants/{userIdToken}/reports/{identifier}", "/v3/participants/{userIdToken}/reports/{identifier}"})
     @ResponseStatus(HttpStatus.CREATED)
     public StatusMessage saveParticipantReport(@PathVariable String userIdToken, @PathVariable String identifier) {
-        UserSession session = getAuthenticatedSession(DEVELOPER, RESEARCHER, STUDY_DESIGNER, STUDY_COORDINATOR);
+        UserSession session = getAuthenticatedSession(DEVELOPER, RESEARCHER);
 
         AccountId accountId = BridgeUtils.parseAccountId(session.getAppId(), userIdToken);
         Account account = accountService.getAccount(accountId)
@@ -295,7 +293,7 @@ public class ParticipantReportController extends BaseController {
     public StatusMessage deleteParticipantReportIndex(@PathVariable String identifier) {
         UserSession session = getAuthenticatedSession(ADMIN);
         
-        reportService.deleteParticipantReportIndex(session.getAppId(), null, identifier);
+        reportService.deleteParticipantReportIndex(session.getAppId(), session.getId(), identifier);
         
         return new StatusMessage("Report index deleted.");
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantController.java
@@ -599,7 +599,6 @@ public class StudyParticipantController extends BaseController {
                 .withAppId(session.getAppId()).build();
         
         ReportIndex index = reportService.getReportIndex(key);
-        System.out.println("################### " + index.getStudyIds());
         if (index == null || !index.getStudyIds().contains(studyId)) {
             throw new EntityNotFoundException(ReportIndex.class);
         }
@@ -619,7 +618,7 @@ public class StudyParticipantController extends BaseController {
         if (index == null || !index.getStudyIds().contains(studyId)) {
             throw new EntityNotFoundException(ReportIndex.class);
         }
-        reportService.deleteParticipantReportIndex(session.getAppId(), session.getId(), identifier);
+        reportService.deleteParticipantReportIndex(session.getAppId(), null, identifier);
         
         return REPORT_INDEX_DELETED_MSG;
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantController.java
@@ -565,10 +565,11 @@ public class StudyParticipantController extends BaseController {
         return EVENT_DELETED_MSG;
     }
     
-    /* -------------- Study-scoped participant reports -------------- */
-
-    // NOTE: We will want to add participant files and participant data APIs that are study-scoped
-    // as well, *if* these are ever accessible to administrators, which right now they are not.
+    /* --------------------------------------------------------------- */
+    /* STUDY-SCOPED PARTICIPANT REPORTS */
+    /* --------------------------------------------------------------- */
+    
+    // INDICES
     
     @GetMapping("/v5/studies/{studyId}/participants/reports")
     public ReportTypeResourceList<? extends ReportIndex> listParticipantReportIndices(@PathVariable String studyId) {
@@ -623,7 +624,12 @@ public class StudyParticipantController extends BaseController {
         return REPORT_INDEX_DELETED_MSG;
     }
 
-    // Did not port over the date-only API, which is not paginated.
+    // REPORTS
+
+    /**
+     * I did not port over the date-only API. The date-time API can be made to serve for dates only
+     * (just set the time portion to T00:00:00.000Z")
+     */
     @GetMapping("/v5/studies/{studyId}/participants/{userIdToken}/reports/{identifier}")
     public ForwardCursorPagedResourceList<ReportData> getParticipantReport(@PathVariable String studyId,
             @PathVariable String userIdToken, @PathVariable String identifier,
@@ -649,7 +655,10 @@ public class StudyParticipantController extends BaseController {
                 account.getHealthCode(), startTimeDate, endTimeDate, offsetKey, pageSizeInt);
     }
 
-    // Did not port over the date-only API, which is not paginated.
+    /**
+     * I did not port over the date-only API. The date-time API can be made to serve for dates only
+     * (just set the time portion to T00:00:00.000Z")
+     */
     @GetMapping("/v5/studies/{studyId}/participants/self/reports/{identifier}")
     public ForwardCursorPagedResourceList<ReportData> getParticipantReportForSelf(@PathVariable String studyId,
             @PathVariable String identifier, @RequestParam(required = false) String startTime,

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantController.java
@@ -5,13 +5,18 @@ import static org.apache.http.HttpHeaders.IF_MODIFIED_SINCE;
 import static org.sagebionetworks.bridge.AuthEvaluatorField.STUDY_ID;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_STUDY_PARTICIPANTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EXPORT_PARTICIPANTS;
+import static org.sagebionetworks.bridge.AuthUtils.CAN_READ_PARTICIPANT_REPORTS;
 import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
+import static org.sagebionetworks.bridge.BridgeUtils.addToSet;
 import static org.sagebionetworks.bridge.BridgeUtils.getDateTimeOrDefault;
 import static org.sagebionetworks.bridge.BridgeUtils.participantEligibleForDeletion;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
+import static org.sagebionetworks.bridge.Roles.STUDY_COORDINATOR;
+import static org.sagebionetworks.bridge.Roles.STUDY_DESIGNER;
 import static org.sagebionetworks.bridge.cache.CacheKey.scheduleModificationTimestamp;
 import static org.sagebionetworks.bridge.models.RequestInfo.REQUEST_INFO_WRITER;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.TIMELINE_RETRIEVED;
+import static org.sagebionetworks.bridge.models.reports.ReportType.PARTICIPANT;
 import static org.sagebionetworks.bridge.models.schedules2.timelines.Scheduler.INSTANCE;
 import static org.sagebionetworks.bridge.models.sms.SmsType.PROMOTIONAL;
 import static org.springframework.http.HttpStatus.NOT_MODIFIED;
@@ -20,9 +25,11 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
 
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.common.collect.ImmutableSet;
 
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,6 +50,7 @@ import org.sagebionetworks.bridge.models.AccountSummarySearch;
 import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.ParticipantRosterRequest;
+import org.sagebionetworks.bridge.models.ReportTypeResourceList;
 import org.sagebionetworks.bridge.models.RequestInfo;
 import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.StatusMessage;
@@ -59,6 +67,9 @@ import org.sagebionetworks.bridge.models.activities.StudyActivityEventRequest;
 import org.sagebionetworks.bridge.models.apps.App;
 import org.sagebionetworks.bridge.models.notifications.NotificationMessage;
 import org.sagebionetworks.bridge.models.notifications.NotificationRegistration;
+import org.sagebionetworks.bridge.models.reports.ReportData;
+import org.sagebionetworks.bridge.models.reports.ReportDataKey;
+import org.sagebionetworks.bridge.models.reports.ReportIndex;
 import org.sagebionetworks.bridge.models.schedules2.Schedule2;
 import org.sagebionetworks.bridge.models.schedules2.timelines.Timeline;
 import org.sagebionetworks.bridge.models.studies.Enrollment;
@@ -67,6 +78,7 @@ import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.models.upload.UploadView;
 import org.sagebionetworks.bridge.services.ParticipantService;
+import org.sagebionetworks.bridge.services.ReportService;
 import org.sagebionetworks.bridge.services.Schedule2Service;
 import org.sagebionetworks.bridge.services.StudyActivityEventService;
 import org.sagebionetworks.bridge.services.StudyService;
@@ -81,6 +93,7 @@ import org.sagebionetworks.bridge.services.EnrollmentService;
 @CrossOrigin
 @RestController
 public class StudyParticipantController extends BaseController {
+    static final StatusMessage REPORT_RECORD_DELETED_MSG = new StatusMessage("Report record deleted.");
     static final StatusMessage UPDATE_MSG = new StatusMessage("Participant updated.");
     static final StatusMessage SIGN_OUT_MSG = new StatusMessage("User signed out.");
     static final StatusMessage RESET_PWD_MSG = new StatusMessage("Request to reset password sent to user.");
@@ -92,7 +105,10 @@ public class StudyParticipantController extends BaseController {
     static final StatusMessage EVENT_RECORDED_MSG = new StatusMessage("Event recorded.");
     static final StatusMessage EVENT_DELETED_MSG = new StatusMessage("Event deleted.");
     static final StatusMessage PREPARING_ROSTER_MSG = new StatusMessage("Preparing participant roster.");
-    public static final StatusMessage INSTALL_LINK_SEND_MSG = new StatusMessage("Install instructions sent to participant.");
+    static final StatusMessage INSTALL_LINK_SEND_MSG = new StatusMessage("Install instructions sent to participant.");
+    static final StatusMessage REPORT_DELETED_MSG = new StatusMessage("Report deleted.");
+    static final StatusMessage REPORT_SAVED_MSG = new StatusMessage("Participant report saved.");
+    static final StatusMessage REPORT_INDEX_DELETED_MSG = new StatusMessage("Participant report index deleted.");
 
     private ParticipantService participantService;
     
@@ -105,6 +121,8 @@ public class StudyParticipantController extends BaseController {
     private StudyService studyService;
     
     private Schedule2Service scheduleService;
+
+    private ReportService reportService;
     
     @Autowired
     final void setParticipantService(ParticipantService participantService) {
@@ -134,6 +152,11 @@ public class StudyParticipantController extends BaseController {
     @Autowired
     final void setSchedule2Service(Schedule2Service scheduleService) {
         this.scheduleService = scheduleService;
+    }
+    
+    @Autowired
+    final void setReportService(ReportService reportService) {
+        this.reportService = reportService;
     }
     
     DateTime getDateTime() {
@@ -540,6 +563,198 @@ public class StudyParticipantController extends BaseController {
                 .withUserId(account.getId()).build());
         
         return EVENT_DELETED_MSG;
+    }
+    
+    /* -------------- Study-scoped participant reports -------------- */
+
+    // NOTE: We will want to add participant files and participant data APIs that are study-scoped
+    // as well, *if* these are ever accessible to administrators, which right now they are not.
+    
+    @GetMapping("/v5/studies/{studyId}/participants/reports")
+    public ReportTypeResourceList<? extends ReportIndex> listParticipantReportIndices(@PathVariable String studyId) {
+        UserSession session = getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR);
+
+        // this test is done in the service, but it will miss cases where there are no
+        // indices. Fail faster. 
+        CAN_READ_PARTICIPANT_REPORTS.checkAndThrow(STUDY_ID, studyId);
+        
+        List<ReportIndex> list = reportService
+                .getReportIndices(session.getAppId(), PARTICIPANT)
+                .getItems().stream()
+                .filter(index -> index.getStudyIds().contains(studyId))
+                .collect(Collectors.toList());
+        
+        return new ReportTypeResourceList<>(list, true)
+                .withRequestParam(ResourceList.STUDY_ID, studyId)
+                .withRequestParam(ResourceList.REPORT_TYPE, PARTICIPANT);
+    }
+
+    @GetMapping("/v5/studies/{studyId}/participants/reports/{identifier}")
+    public ReportIndex getParticipantReportIndex(@PathVariable String studyId, @PathVariable String identifier) {
+        UserSession session = getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR);
+        
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withIdentifier(identifier)
+                .withReportType(PARTICIPANT)
+                .withAppId(session.getAppId()).build();
+        
+        ReportIndex index = reportService.getReportIndex(key);
+        System.out.println("################### " + index.getStudyIds());
+        if (index == null || !index.getStudyIds().contains(studyId)) {
+            throw new EntityNotFoundException(ReportIndex.class);
+        }
+        return index;
+    }
+
+    @DeleteMapping("/v5/studies/{studyId}/participants/reports/{identifier}")
+    public StatusMessage deleteParticipantReportIndex(@PathVariable String studyId, @PathVariable String identifier) {
+        UserSession session = getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR);
+        
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withIdentifier(identifier)
+                .withReportType(PARTICIPANT)
+                .withAppId(session.getAppId()).build();
+        
+        ReportIndex index = reportService.getReportIndex(key);
+        if (index == null || !index.getStudyIds().contains(studyId)) {
+            throw new EntityNotFoundException(ReportIndex.class);
+        }
+        reportService.deleteParticipantReportIndex(session.getAppId(), session.getId(), identifier);
+        
+        return REPORT_INDEX_DELETED_MSG;
+    }
+
+    // Did not port over the date-only API, which is not paginated.
+    @GetMapping("/v5/studies/{studyId}/participants/{userIdToken}/reports/{identifier}")
+    public ForwardCursorPagedResourceList<ReportData> getParticipantReport(@PathVariable String studyId,
+            @PathVariable String userIdToken, @PathVariable String identifier,
+            @RequestParam(required = false) String startTime, @RequestParam(required = false) String endTime,
+            @RequestParam(required = false) String offsetKey, @RequestParam(required = false) String pageSize) {
+        UserSession session = getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR);
+        
+        DateTime startTimeDate = getDateTimeOrDefault(startTime, null);
+        DateTime endTimeDate = getDateTimeOrDefault(endTime, null);
+        Integer pageSizeInt = BridgeUtils.getIntegerOrDefault(pageSize, API_DEFAULT_PAGE_SIZE);
+
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withIdentifier(identifier)
+                .withReportType(PARTICIPANT)
+                .withAppId(session.getAppId()).build();
+        ReportIndex index = reportService.getReportIndex(key);
+        if (index == null || !index.getStudyIds().contains(studyId)) {
+            throw new EntityNotFoundException(ReportIndex.class);
+        }
+        Account account = getValidAccountInStudy(session.getAppId(), studyId, userIdToken);
+        
+        return reportService.getParticipantReportV4(session.getAppId(), account.getId(), identifier,
+                account.getHealthCode(), startTimeDate, endTimeDate, offsetKey, pageSizeInt);
+    }
+
+    // Did not port over the date-only API, which is not paginated.
+    @GetMapping("/v5/studies/{studyId}/participants/self/reports/{identifier}")
+    public ForwardCursorPagedResourceList<ReportData> getParticipantReportForSelf(@PathVariable String studyId,
+            @PathVariable String identifier, @RequestParam(required = false) String startTime,
+            @RequestParam(required = false) String endTime, @RequestParam(required = false) String offsetKey,
+            @RequestParam(required = false) String pageSize) {
+        UserSession session = getAuthenticatedAndConsentedSession();
+        
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withIdentifier(identifier)
+                .withReportType(PARTICIPANT)
+                .withAppId(session.getAppId()).build();
+        ReportIndex index = reportService.getReportIndex(key);
+        if (index == null || !index.getStudyIds().contains(studyId)) {
+            throw new EntityNotFoundException(ReportIndex.class);
+        }
+        Account account = getValidAccountInStudy(session.getAppId(), studyId, session.getId());
+
+        DateTime startTimeDate = getDateTimeOrDefault(startTime, null);
+        DateTime endTimeDate = getDateTimeOrDefault(endTime, null);
+        Integer pageSizeInt = BridgeUtils.getIntegerOrDefault(pageSize, API_DEFAULT_PAGE_SIZE);
+        
+        return reportService.getParticipantReportV4(session.getAppId(), account.getId(), identifier,
+                account.getHealthCode(), startTimeDate, endTimeDate, offsetKey, pageSizeInt);
+    }
+    
+    @PostMapping("/v5/studies/{studyId}/participants/{userIdToken}/reports/{identifier}")
+    @ResponseStatus(HttpStatus.CREATED)
+    public StatusMessage saveParticipantReport(@PathVariable String studyId, @PathVariable String userIdToken,
+            @PathVariable String identifier) {
+        UserSession session = getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR);
+        
+        Account account = getValidAccountInStudy(session.getAppId(), studyId, userIdToken);
+        
+        ReportData reportData = parseJson(ReportData.class);
+        reportData.setKey(null); // set in service, but just so no future use depends on it
+        if (reportData.getStudyIds() == null) {
+            reportData.setStudyIds(ImmutableSet.of());   
+        }
+        reportData.setStudyIds(addToSet(reportData.getStudyIds(), studyId));
+        
+        reportService.saveParticipantReport(session.getAppId(), account.getId(), 
+                identifier, account.getHealthCode(), reportData);
+        
+        return REPORT_SAVED_MSG;
+    }
+
+    @PostMapping("/v5/studies/{studyId}/participants/self/reports/{identifier}")
+    @ResponseStatus(HttpStatus.CREATED)
+    public StatusMessage saveParticipantReportForSelf(@PathVariable String studyId, @PathVariable String identifier) {
+        UserSession session = getAuthenticatedAndConsentedSession();
+        
+        Account account = getValidAccountInStudy(session.getAppId(), studyId, session.getId());
+        
+        ReportData reportData = parseJson(ReportData.class);
+        reportData.setKey(null); // set in service, but just so no future use depends on it
+        if (reportData.getStudyIds() == null) {
+            reportData.setStudyIds(ImmutableSet.of());   
+        }
+        reportData.setStudyIds(addToSet(reportData.getStudyIds(), studyId));
+        
+        reportService.saveParticipantReport(session.getAppId(), account.getId(), 
+                identifier, account.getHealthCode(), reportData);
+        
+        return REPORT_SAVED_MSG;
+    }
+
+    @DeleteMapping("/v5/studies/{studyId}/participants/{userIdToken}/reports/{identifier}/{date}")
+    public StatusMessage deleteParticipantReportRecord(@PathVariable String studyId, @PathVariable String userIdToken,
+            @PathVariable String identifier, @PathVariable String date) {
+        UserSession session = getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR);
+        
+        Account account = getValidAccountInStudy(session.getAppId(), studyId, userIdToken);
+        
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withIdentifier(identifier)
+                .withReportType(PARTICIPANT)
+                .withAppId(session.getAppId()).build();
+        ReportIndex index = reportService.getReportIndex(key);
+        if (index == null || !index.getStudyIds().contains(studyId)) {
+            throw new EntityNotFoundException(ReportIndex.class);
+        }
+        reportService.deleteParticipantReportRecord(session.getAppId(), account.getId(), identifier, date, account.getHealthCode());
+        
+        return REPORT_RECORD_DELETED_MSG;
+    }
+
+    @DeleteMapping("/v5/studies/{studyId}/participants/{userIdToken}/reports/{identifier}")
+    public StatusMessage deleteParticipantReport(@PathVariable String studyId, @PathVariable String userIdToken,
+            @PathVariable String identifier) {
+        UserSession session = getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR);
+        
+        Account account = getValidAccountInStudy(session.getAppId(), studyId, userIdToken);
+        
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withIdentifier(identifier)
+                .withReportType(PARTICIPANT)
+                .withAppId(session.getAppId()).build();
+        ReportIndex index = reportService.getReportIndex(key);
+        if (index == null || !index.getStudyIds().contains(studyId)) {
+            throw new EntityNotFoundException(ReportIndex.class);
+        }
+        reportService.deleteParticipantReport(session.getAppId(), account.getId(), identifier, account.getHealthCode());
+        
+        return REPORT_DELETED_MSG;
     }
     
     /**

--- a/src/test/java/org/sagebionetworks/bridge/services/ReportServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ReportServiceTest.java
@@ -153,20 +153,20 @@ public class ReportServiceTest {
     
     @Test
     public void canAccessIfNoIndex() {
-        assertTrue(service.canAccessParticipantReport(TEST_USER_ID, null));
+        service.checkParticipantReportAccess(TEST_USER_ID, null);
     }
     
     @Test
     public void canAccessIfReportHasNullStudies() {
         ReportIndex index = ReportIndex.create();
-        assertTrue(service.canAccessParticipantReport(TEST_USER_ID, index));
+        service.checkParticipantReportAccess(TEST_USER_ID, index);
     }
     
     @Test
     public void canAccessIfReportHasEmptyStudies() {
         ReportIndex index = ReportIndex.create();
         index.setStudyIds(ImmutableSet.of());
-        assertTrue(service.canAccessParticipantReport(TEST_USER_ID, index));        
+        service.checkParticipantReportAccess(TEST_USER_ID, index);        
     }
 
     @Test
@@ -174,7 +174,7 @@ public class ReportServiceTest {
         RequestContext.set(new RequestContext.Builder().withCallerUserId(TEST_USER_ID).build());
         ReportIndex index = ReportIndex.create();
         index.setStudyIds(USER_STUDY_IDS);
-        assertTrue(service.canAccessParticipantReport(TEST_USER_ID, index));
+        service.checkParticipantReportAccess(TEST_USER_ID, index);
     }
 
     @Test
@@ -184,21 +184,21 @@ public class ReportServiceTest {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId(TEST_USER_ID)
                 .withCallerEnrolledStudies(ImmutableSet.of("studyB", "studyC")).build());
-        assertTrue(service.canAccessParticipantReport(TEST_USER_ID, index));
+        service.checkParticipantReportAccess(TEST_USER_ID, index);
     }
 
     // If the index has studies, and the user doesn't have one of those studies, this fails
-    @Test
+    @Test(expectedExceptions = UnauthorizedException.class)
     public void canAccessFailsIfCallerDoesNotMatchStudies() {
         ReportIndex index = ReportIndex.create();
         index.setStudyIds(USER_STUDY_IDS);
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId("some-other-user-id")
                 .withCallerEnrolledStudies(ImmutableSet.of("studyC")).build());
-        assertFalse(service.canAccessParticipantReport(TEST_USER_ID, index));        
+        service.checkParticipantReportAccess(TEST_USER_ID, index);        
     }
     
-    @Test
+    @Test(expectedExceptions = UnauthorizedException.class)
     public void canAccessIfPublic() {
         // Create a situation where the user shares no studies in common with the index, but 
         // the index is public. In that case, access is allowed.
@@ -208,7 +208,7 @@ public class ReportServiceTest {
         
         RequestContext.set(
                 new RequestContext.Builder().withCallerEnrolledStudies(TestConstants.USER_STUDY_IDS).build());
-        assertTrue(service.canAccessParticipantReport(TEST_USER_ID, index));        
+        service.checkParticipantReportAccess(TEST_USER_ID, index);        
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportControllerTest.java
@@ -527,7 +527,7 @@ public class ParticipantReportControllerTest extends Mockito {
         StatusMessage result = controller.deleteParticipantReportIndex(REPORT_ID);
         assertEquals(result.getMessage(), "Report index deleted.");
         
-        verify(mockReportService).deleteParticipantReportIndex(TEST_APP_ID, null, REPORT_ID);
+        verify(mockReportService).deleteParticipantReportIndex(TEST_APP_ID, TEST_USER_ID, REPORT_ID);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantControllerTest.java
@@ -1646,7 +1646,7 @@ public class StudyParticipantControllerTest extends Mockito {
         StatusMessage retValue = controller.deleteParticipantReportIndex(TEST_STUDY_ID, IDENTIFIER);
         assertSame(retValue, REPORT_INDEX_DELETED_MSG);
         
-        verify(mockReportService).deleteParticipantReportIndex(TEST_APP_ID, TEST_STUDY_ID, IDENTIFIER);
+        verify(mockReportService).deleteParticipantReportIndex(TEST_APP_ID, null, IDENTIFIER);
     }
     
     @Test(expectedExceptions = EntityNotFoundException.class)
@@ -1682,12 +1682,19 @@ public class StudyParticipantControllerTest extends Mockito {
         ForwardCursorPagedResourceList<ReportData> page = new ForwardCursorPagedResourceList(ImmutableList.of(),
                 "offsetKey", true);
         when(mockReportService.getParticipantReportV4(any(), any(), any(),
-                any(), any(), any(), any(), anyInt())).thenReturn(page);        
+                any(), any(), any(), any(), anyInt())).thenReturn(page);
+        
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withIdentifier(IDENTIFIER)
+                .withReportType(PARTICIPANT)
+                .withAppId(TEST_APP_ID).build();
+        ReportIndex index = ReportIndex.create();
+        index.setStudyIds(ImmutableSet.of(TEST_STUDY_ID));
+        when(mockReportService.getReportIndex(key)).thenReturn(index);
         
         ForwardCursorPagedResourceList<ReportData> retValue = controller.getParticipantReport(TEST_STUDY_ID,
                 TEST_USER_ID, IDENTIFIER, CREATED_ON.toString(), MODIFIED_ON.toString(), "offsetKey", "150");
         assertSame(retValue, page);
-        
 
         verify(mockReportService).getParticipantReportV4(TEST_APP_ID, TEST_USER_ID, IDENTIFIER,
                 HEALTH_CODE, CREATED_ON, MODIFIED_ON, "offsetKey", 150);
@@ -1701,7 +1708,15 @@ public class StudyParticipantControllerTest extends Mockito {
         
         ForwardCursorPagedResourceList<ReportData> page = new ForwardCursorPagedResourceList(ImmutableList.of(), "offsetKey", true);
         when(mockReportService.getParticipantReportV4(any(), any(), any(),
-                any(), any(), any(), any(), anyInt())).thenReturn(page);        
+                any(), any(), any(), any(), anyInt())).thenReturn(page);
+        
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withIdentifier(IDENTIFIER)
+                .withReportType(PARTICIPANT)
+                .withAppId(TEST_APP_ID).build();
+        ReportIndex index = ReportIndex.create();
+        index.setStudyIds(ImmutableSet.of(TEST_STUDY_ID));
+        when(mockReportService.getReportIndex(key)).thenReturn(index);
         
         controller.getParticipantReport(TEST_STUDY_ID, TEST_USER_ID, IDENTIFIER, null, null, null, null);
 

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantControllerTest.java
@@ -1,15 +1,18 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
 import static java.lang.Boolean.TRUE;
+import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.TEST_USER_GROUP;
 import static org.sagebionetworks.bridge.RequestContext.NULL_INSTANCE;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.STUDY_COORDINATOR;
+import static org.sagebionetworks.bridge.Roles.STUDY_DESIGNER;
 import static org.sagebionetworks.bridge.Roles.WORKER;
 import static org.sagebionetworks.bridge.TestConstants.ACCOUNT_ID;
 import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
 import static org.sagebionetworks.bridge.TestConstants.EMAIL;
 import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
+import static org.sagebionetworks.bridge.TestConstants.IDENTIFIER;
 import static org.sagebionetworks.bridge.TestConstants.LANGUAGES;
 import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
 import static org.sagebionetworks.bridge.TestConstants.PASSWORD;
@@ -28,11 +31,16 @@ import static org.sagebionetworks.bridge.TestUtils.mockRequestBody;
 import static org.sagebionetworks.bridge.cache.CacheKey.scheduleModificationTimestamp;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventUpdateType.IMMUTABLE;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventUpdateType.MUTABLE;
+import static org.sagebionetworks.bridge.models.reports.ReportType.PARTICIPANT;
 import static org.sagebionetworks.bridge.models.sms.SmsType.PROMOTIONAL;
 import static org.sagebionetworks.bridge.spring.controllers.StudyParticipantController.EVENT_DELETED_MSG;
 import static org.sagebionetworks.bridge.spring.controllers.StudyParticipantController.INSTALL_LINK_SEND_MSG;
 import static org.sagebionetworks.bridge.spring.controllers.StudyParticipantController.NOTIFY_SUCCESS_MSG;
 import static org.sagebionetworks.bridge.spring.controllers.StudyParticipantController.PREPARING_ROSTER_MSG;
+import static org.sagebionetworks.bridge.spring.controllers.StudyParticipantController.REPORT_DELETED_MSG;
+import static org.sagebionetworks.bridge.spring.controllers.StudyParticipantController.REPORT_INDEX_DELETED_MSG;
+import static org.sagebionetworks.bridge.spring.controllers.StudyParticipantController.REPORT_RECORD_DELETED_MSG;
+import static org.sagebionetworks.bridge.spring.controllers.StudyParticipantController.REPORT_SAVED_MSG;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
@@ -60,7 +68,6 @@ import org.springframework.http.ResponseEntity;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.TestConstants;
@@ -75,6 +82,7 @@ import org.sagebionetworks.bridge.models.AccountSummarySearch;
 import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.ParticipantRosterRequest;
+import org.sagebionetworks.bridge.models.ReportTypeResourceList;
 import org.sagebionetworks.bridge.models.RequestInfo;
 import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.StatusMessage;
@@ -89,6 +97,9 @@ import org.sagebionetworks.bridge.models.activities.StudyActivityEventIdsMap;
 import org.sagebionetworks.bridge.models.apps.App;
 import org.sagebionetworks.bridge.models.notifications.NotificationMessage;
 import org.sagebionetworks.bridge.models.notifications.NotificationRegistration;
+import org.sagebionetworks.bridge.models.reports.ReportData;
+import org.sagebionetworks.bridge.models.reports.ReportDataKey;
+import org.sagebionetworks.bridge.models.reports.ReportIndex;
 import org.sagebionetworks.bridge.models.schedules2.Schedule2;
 import org.sagebionetworks.bridge.models.schedules2.timelines.Timeline;
 import org.sagebionetworks.bridge.models.studies.Enrollment;
@@ -102,6 +113,7 @@ import org.sagebionetworks.bridge.services.AppService;
 import org.sagebionetworks.bridge.services.AuthenticationService.ChannelType;
 import org.sagebionetworks.bridge.services.EnrollmentService;
 import org.sagebionetworks.bridge.services.ParticipantService;
+import org.sagebionetworks.bridge.services.ReportService;
 import org.sagebionetworks.bridge.services.RequestInfoService;
 import org.sagebionetworks.bridge.services.Schedule2Service;
 import org.sagebionetworks.bridge.services.StudyActivityEventService;
@@ -140,6 +152,9 @@ public class StudyParticipantControllerTest extends Mockito {
     CacheProvider mockCacheProvider;
     
     @Mock
+    ReportService mockReportService;
+    
+    @Mock
     HttpServletRequest mockRequest;
     
     @Mock
@@ -165,6 +180,12 @@ public class StudyParticipantControllerTest extends Mockito {
     
     @Captor
     ArgumentCaptor<ParticipantRosterRequest> requestCaptor;
+    
+    @Captor
+    ArgumentCaptor<ReportDataKey> keyCaptor;
+    
+    @Captor
+    ArgumentCaptor<ReportData> dataCaptor;
     
     @InjectMocks
     @Spy
@@ -226,6 +247,13 @@ public class StudyParticipantControllerTest extends Mockito {
         assertGet(StudyParticipantController.class, "getActivityEventHistory");
         assertPost(StudyParticipantController.class, "publishActivityEvent");
         assertDelete(StudyParticipantController.class, "deleteActivityEvent");
+        assertGet(StudyParticipantController.class, "listParticipantReportIndices");
+        assertGet(StudyParticipantController.class, "getParticipantReportIndex");
+        assertDelete(StudyParticipantController.class, "deleteParticipantReportIndex");
+        assertGet(StudyParticipantController.class, "getParticipantReport");
+        assertPost(StudyParticipantController.class, "saveParticipantReport");
+        assertDelete(StudyParticipantController.class, "deleteParticipantReportRecord");
+        assertDelete(StudyParticipantController.class, "deleteParticipantReport");
     }
     
     @Test
@@ -1542,6 +1570,259 @@ public class StudyParticipantControllerTest extends Mockito {
         
         verify(mockParticipantService).sendInstallLinkMessage(
                 app, PROMOTIONAL, HEALTH_CODE, null, null, null);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void listParticipantReportIndices() {
+        doReturn(session).when(controller).getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR);
+        
+        ReportIndex index1 = ReportIndex.create();
+        index1.setStudyIds(ImmutableSet.of(TEST_STUDY_ID));
+        ReportIndex index2 = ReportIndex.create();
+        index2.setStudyIds(ImmutableSet.of(TEST_STUDY_ID));
+        ReportIndex index3 = ReportIndex.create(); // this one will be filtred out
+        index3.setStudyIds(ImmutableSet.of());
+        
+        ReportTypeResourceList page = new ReportTypeResourceList(
+                ImmutableList.of(index1, index2, index3), false);
+        when(mockReportService.getReportIndices(TEST_APP_ID, PARTICIPANT)).thenReturn(page);
+        
+        ReportTypeResourceList<? extends ReportIndex> retValue = controller.listParticipantReportIndices(TEST_STUDY_ID);
+        assertEquals(retValue.getItems().size(), 2);
+        assertEquals(retValue.getRequestParams().get("studyId"), TEST_STUDY_ID);
+        assertEquals(retValue.getRequestParams().get("reportType"), PARTICIPANT);
+    }
+
+    @Test
+    public void getParticipantReportIndex() {
+        doReturn(session).when(controller).getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR);
+        
+        ReportIndex index = ReportIndex.create();
+        index.setStudyIds(ImmutableSet.of(TEST_STUDY_ID));
+        when(mockReportService.getReportIndex(any())).thenReturn(index);
+        
+        ReportIndex retValue = controller.getParticipantReportIndex(TEST_STUDY_ID, IDENTIFIER);
+        assertSame(retValue, index);
+        
+        verify(mockReportService).getReportIndex(keyCaptor.capture());
+        assertEquals(keyCaptor.getValue().getIdentifier(), IDENTIFIER);
+        assertEquals(keyCaptor.getValue().getReportType(), PARTICIPANT);
+        assertEquals(keyCaptor.getValue().getAppId(), TEST_APP_ID);
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void getParticipantReportIndex_indexNull() {
+        doReturn(session).when(controller).getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR);
+        
+        when(mockReportService.getReportIndex(any())).thenReturn(null);
+        
+        controller.getParticipantReportIndex(TEST_STUDY_ID, IDENTIFIER);
+    }
+
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void getParticipantReportIndex_indexWrongStudy() {
+        doReturn(session).when(controller).getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR);
+        
+        ReportIndex index = ReportIndex.create();
+        index.setStudyIds(ImmutableSet.of("some-other-study"));
+        when(mockReportService.getReportIndex(any())).thenReturn(index);
+        
+        controller.getParticipantReportIndex(TEST_STUDY_ID, IDENTIFIER);
+    }
+    
+    @Test
+    public void deleteParticipantReportIndex() {
+        doReturn(session).when(controller).getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR);
+
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withIdentifier(IDENTIFIER)
+                .withReportType(PARTICIPANT)
+                .withAppId(TEST_APP_ID).build();
+        ReportIndex index = ReportIndex.create();
+        index.setStudyIds(ImmutableSet.of(TEST_STUDY_ID));
+        when(mockReportService.getReportIndex(key)).thenReturn(index);
+        
+        StatusMessage retValue = controller.deleteParticipantReportIndex(TEST_STUDY_ID, IDENTIFIER);
+        assertSame(retValue, REPORT_INDEX_DELETED_MSG);
+        
+        verify(mockReportService).deleteParticipantReportIndex(TEST_APP_ID, TEST_STUDY_ID, IDENTIFIER);
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void deleteParticipantReportIndex_nullIndex() {
+        doReturn(session).when(controller).getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR);
+
+        when(mockReportService.getReportIndex(any())).thenReturn(null);
+        
+        controller.deleteParticipantReportIndex(TEST_STUDY_ID, IDENTIFIER);
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void deleteParticipantReportIndex_wrongStudy() {
+        doReturn(session).when(controller).getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR);
+
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withIdentifier(IDENTIFIER)
+                .withReportType(PARTICIPANT)
+                .withAppId(TEST_APP_ID).build();
+        ReportIndex index = ReportIndex.create();
+        index.setStudyIds(ImmutableSet.of("some-other-study"));
+        when(mockReportService.getReportIndex(key)).thenReturn(index);
+        
+        controller.deleteParticipantReportIndex(TEST_STUDY_ID, IDENTIFIER);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void getParticipantReport() {
+        doReturn(session).when(controller).getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR);
+        mockAccountInStudy(TEST_USER_ID);
+        
+        ForwardCursorPagedResourceList<ReportData> page = new ForwardCursorPagedResourceList(ImmutableList.of(),
+                "offsetKey", true);
+        when(mockReportService.getParticipantReportV4(any(), any(), any(),
+                any(), any(), any(), any(), anyInt())).thenReturn(page);        
+        
+        ForwardCursorPagedResourceList<ReportData> retValue = controller.getParticipantReport(TEST_STUDY_ID,
+                TEST_USER_ID, IDENTIFIER, CREATED_ON.toString(), MODIFIED_ON.toString(), "offsetKey", "150");
+        assertSame(retValue, page);
+        
+
+        verify(mockReportService).getParticipantReportV4(TEST_APP_ID, TEST_USER_ID, IDENTIFIER,
+                HEALTH_CODE, CREATED_ON, MODIFIED_ON, "offsetKey", 150);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void getParticipantReport_defaults() {
+        doReturn(session).when(controller).getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR);
+        mockAccountInStudy(TEST_USER_ID);
+        
+        ForwardCursorPagedResourceList<ReportData> page = new ForwardCursorPagedResourceList(ImmutableList.of(), "offsetKey", true);
+        when(mockReportService.getParticipantReportV4(any(), any(), any(),
+                any(), any(), any(), any(), anyInt())).thenReturn(page);        
+        
+        controller.getParticipantReport(TEST_STUDY_ID, TEST_USER_ID, IDENTIFIER, null, null, null, null);
+
+        verify(mockReportService).getParticipantReportV4(TEST_APP_ID, TEST_USER_ID, IDENTIFIER,
+                HEALTH_CODE, null, null, null, API_DEFAULT_PAGE_SIZE);
+    }
+    
+    @Test
+    public void saveParticipantReport() throws Exception {
+        doReturn(session).when(controller).getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR);        
+        mockAccountInStudy();
+        
+        ReportData data = ReportData.create();
+        data.setDate("2018-08-08T00:00:00.000Z");
+        data.setData(TestUtils.getClientData());
+        mockRequestBody(mockRequest, data);
+        
+        StatusMessage retValue = controller.saveParticipantReport(TEST_STUDY_ID, TEST_USER_ID, IDENTIFIER);
+        assertSame(retValue, REPORT_SAVED_MSG);
+        
+        verify(mockReportService).saveParticipantReport(eq(TEST_APP_ID), eq(TEST_USER_ID), 
+                eq(IDENTIFIER), eq(HEALTH_CODE), dataCaptor.capture());
+        
+        ReportData captured = dataCaptor.getValue();
+        assertNull(captured.getKey());
+        assertEquals(captured.getStudyIds(), ImmutableSet.of(TEST_STUDY_ID));
+        assertEquals(captured.getData().toString(), TestUtils.getClientData().toString());
+        assertNull(captured.getLocalDate());
+        assertEquals(captured.getDateTime(), DateTime.parse("2018-08-08T00:00:00.000Z"));
+    }
+
+    @Test
+    public void deleteParticipantReportRecord() {
+        doReturn(session).when(controller).getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR);
+        
+        mockAccountInStudy();
+        
+        ReportIndex index = ReportIndex.create();
+        index.setStudyIds(ImmutableSet.of(TEST_STUDY_ID));
+        
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withIdentifier(IDENTIFIER)
+                .withReportType(PARTICIPANT)
+                .withAppId(TEST_APP_ID).build();
+        when(mockReportService.getReportIndex(key)).thenReturn(index);
+        
+        StatusMessage retValue = controller.deleteParticipantReportRecord(TEST_STUDY_ID, TEST_USER_ID, IDENTIFIER, CREATED_ON.toString());
+        assertEquals(retValue, REPORT_RECORD_DELETED_MSG);
+        
+        verify(mockReportService).deleteParticipantReportRecord(TEST_APP_ID, TEST_USER_ID, IDENTIFIER, CREATED_ON.toString(), HEALTH_CODE);
+    }
+
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void deleteParticipantReportRecord_noIndex() {
+        doReturn(session).when(controller).getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR);
+        mockAccountInStudy();
+        when(mockReportService.getReportIndex(any())).thenReturn(null);
+        
+        controller.deleteParticipantReportRecord(TEST_STUDY_ID, TEST_USER_ID, IDENTIFIER, CREATED_ON.toString());
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void deleteParticipantReportRecord_wrongStudy() {
+        doReturn(session).when(controller).getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR);
+        mockAccountInStudy();
+        ReportIndex index = ReportIndex.create();
+        index.setStudyIds(ImmutableSet.of());
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withIdentifier(IDENTIFIER)
+                .withReportType(PARTICIPANT)
+                .withAppId(TEST_APP_ID).build();
+        when(mockReportService.getReportIndex(key)).thenReturn(index);
+        
+        controller.deleteParticipantReportRecord(TEST_STUDY_ID, TEST_USER_ID, IDENTIFIER, CREATED_ON.toString());
+    }
+    
+    @Test
+    public void deleteParticipantReport() {
+        doReturn(session).when(controller).getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR);
+        
+        mockAccountInStudy();
+        
+        ReportIndex index = ReportIndex.create();
+        index.setStudyIds(ImmutableSet.of(TEST_STUDY_ID));
+        
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withIdentifier(IDENTIFIER)
+                .withReportType(PARTICIPANT)
+                .withAppId(TEST_APP_ID).build();
+        when(mockReportService.getReportIndex(key)).thenReturn(index);
+        
+        StatusMessage retValue = controller.deleteParticipantReport(TEST_STUDY_ID, TEST_USER_ID, IDENTIFIER);
+        assertEquals(retValue, REPORT_DELETED_MSG);
+        
+        verify(mockReportService).deleteParticipantReport(TEST_APP_ID, TEST_USER_ID, IDENTIFIER, HEALTH_CODE);
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void deleteParticipantReport_noIndex() {
+        doReturn(session).when(controller).getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR);
+        mockAccountInStudy();
+        when(mockReportService.getReportIndex(any())).thenReturn(null);
+        
+        controller.deleteParticipantReport(TEST_STUDY_ID, TEST_USER_ID, IDENTIFIER);
+    }
+    
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void deleteParticipantReport_wrongStudy() {
+        doReturn(session).when(controller).getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR);
+        mockAccountInStudy();
+        
+        ReportIndex index = ReportIndex.create();
+        index.setStudyIds(ImmutableSet.of("wrong-study"));
+        
+        ReportDataKey key = new ReportDataKey.Builder()
+                .withIdentifier(IDENTIFIER)
+                .withReportType(PARTICIPANT)
+                .withAppId(TEST_APP_ID).build();
+        when(mockReportService.getReportIndex(key)).thenReturn(index);
+        
+        controller.deleteParticipantReport(TEST_STUDY_ID, TEST_USER_ID, IDENTIFIER);
     }
     
     private void mockAccountInStudy() {


### PR DESCRIPTION
Create a separate set of APIs for participant reports vis-a-vis study-scoped administrators. Participant data and files do not have Administrative APIs, but if they did, we could/should split them too.