### PR TITLE
Switching health code admin exception to superadmin

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantController.java
@@ -9,6 +9,7 @@ import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeUtils.getDateTimeOrDefault;
 import static org.sagebionetworks.bridge.BridgeUtils.participantEligibleForDeletion;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
+import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
 import static org.sagebionetworks.bridge.cache.CacheKey.scheduleModificationTimestamp;
 import static org.sagebionetworks.bridge.models.RequestInfo.REQUEST_INFO_WRITER;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.TIMELINE_RETRIEVED;
@@ -37,6 +38,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.AccountSummarySearch;
@@ -280,14 +282,14 @@ public class StudyParticipantController extends BaseController {
 
         // Do not allow lookup by health code if health code access is disabled. Allow it however
         // if the user is an administrator.
-        if (!session.isInRole(ADMIN) && !app.isHealthCodeExportEnabled()
+        if (!app.isHealthCodeExportEnabled() && !session.isInRole(SUPERADMIN) 
                 && userId.toLowerCase().startsWith("healthcode:")) {
             throw new EntityNotFoundException(Account.class);
         }
         
         StudyParticipant participant = participantService.getParticipant(app, account, consents);
         
-        ObjectWriter writer = (app.isHealthCodeExportEnabled() || session.isInRole(ADMIN)) ?
+        ObjectWriter writer = (app.isHealthCodeExportEnabled() || session.isInRole(SUPERADMIN)) ?
                 StudyParticipant.API_WITH_HEALTH_CODE_WRITER :
                 StudyParticipant.API_NO_HEALTH_CODE_WRITER;
         return writer.writeValueAsString(participant);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantControllerTest.java
@@ -5,6 +5,7 @@ import static org.sagebionetworks.bridge.BridgeConstants.TEST_USER_GROUP;
 import static org.sagebionetworks.bridge.RequestContext.NULL_INSTANCE;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.STUDY_COORDINATOR;
+import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
 import static org.sagebionetworks.bridge.Roles.WORKER;
 import static org.sagebionetworks.bridge.TestConstants.ACCOUNT_ID;
 import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
@@ -63,6 +64,7 @@ import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.RequestContext;
+import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.cache.CacheProvider;
@@ -582,14 +584,14 @@ public class StudyParticipantControllerTest extends Mockito {
     }
     
     @Test
-    public void getParticipantIncludesHealthCodeForAdmin() throws Exception {
+    public void getParticipantIncludesHealthCodeForSuperadmin() throws Exception {
         app.setHealthCodeExportEnabled(false);
         
         RequestContext.set(new RequestContext.Builder()
-                .withCallerRoles(ImmutableSet.of(ADMIN))
+                .withCallerRoles(ImmutableSet.of(SUPERADMIN))
                 .build());
         session.setParticipant(new StudyParticipant.Builder()
-                .withRoles(ImmutableSet.of(ADMIN))
+                .withRoles(ImmutableSet.of(SUPERADMIN))
                 .build());
         
         StudyParticipant participant = new StudyParticipant.Builder()
@@ -674,15 +676,15 @@ public class StudyParticipantControllerTest extends Mockito {
     }
     
     @Test
-    public void getParticipantPreventsNoHealthCodeExportOverrriddenByAdmin() throws Exception {
+    public void getParticipantPreventsNoHealthCodeExportOverrriddenBySuperadmin() throws Exception {
         app.setHealthCodeExportEnabled(false);
         
         RequestContext.set(new RequestContext.Builder()
-                .withCallerRoles(ImmutableSet.of(ADMIN))
+                .withCallerRoles(ImmutableSet.of(SUPERADMIN))
                 .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
                 .build());
         session.setParticipant(new StudyParticipant.Builder()
-                .withRoles(ImmutableSet.of(ADMIN)).build());
+                .withRoles(ImmutableSet.of(SUPERADMIN)).build());
         
         StudyParticipant participant = new StudyParticipant.Builder()
                 .withHealthCode("healthCode").build();


### PR DESCRIPTION
BRIDGE-3108. This is working, but the code was making an exception for an admin. Which got me to thinking that this is now an application role we are giving to other people, so I changed this to SUPERADMIN. I also changed the self route to return healthCode for any test account, rather than just returning it for admin users, as this seemed more directly what we want for testing (we actually don't care what the health code is for admin users). Otherwise, this is good SFAICT.