### PR TITLE
Removing unneeded auth check that prevents org admin from updating test accounts.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
@@ -11,7 +11,6 @@ import static org.sagebionetworks.bridge.AuthUtils.canAccessAccount;
 import static org.sagebionetworks.bridge.BridgeConstants.TEST_USER_GROUP;
 import static org.sagebionetworks.bridge.BridgeUtils.addToSet;
 import static org.sagebionetworks.bridge.BridgeUtils.collectStudyIds;
-import static org.sagebionetworks.bridge.Roles.ORG_ADMIN;
 import static org.sagebionetworks.bridge.dao.AccountDao.MIGRATION_VERSION;
 import static org.sagebionetworks.bridge.models.accounts.AccountSecretType.REAUTH;
 import static org.sagebionetworks.bridge.models.accounts.AccountStatus.DISABLED;
@@ -268,17 +267,6 @@ public class AccountService {
             Set<String> newDataGroups = addToSet(account.getDataGroups(), TEST_USER_GROUP);
             account.setDataGroups(newDataGroups);
         }
-        // Participant accounts shouldn't be submitted to this endpoint; but if they are we check
-        // access, and throw if the caller is an org admin or a developer trying to operate on a 
-        // production account. These checks cannot currently be represented in the AuthEvaluator 
-        // checks.
-        boolean isParticipant = persistedAccount.getRoles().isEmpty();
-        if (isParticipant && CANNOT_ACCESS_PARTICIPANTS.check(USER_ID, persistedAccount.getId())) {
-            if (RequestContext.get().isInRole(ORG_ADMIN) || !testUser) {
-                throw new UnauthorizedException();    
-            }
-        }
-        
         // None of these values should be changeable by the user.
         account.setAppId(persistedAccount.getAppId());
         account.setCreatedOn(persistedAccount.getCreatedOn());

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
@@ -321,17 +321,6 @@ public class AccountServiceTest extends Mockito {
         verify(mockAccountDao).updateAccount(account);
     }
     
-    @Test(expectedExceptions = UnauthorizedException.class)
-    public void updateAccountFailsForDevUpdatingProdAccount() throws Exception {
-        RequestContext.set(new RequestContext.Builder()
-                .withCallerUserId("id")
-                .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
-        
-        Account account = mockGetAccountById(ACCOUNT_ID, false);
-
-        service.updateAccount(account);
-    }
-    
     @Test
     public void updateAccountDevCannotRemoveTestFlag() throws Exception {
         RequestContext.set(new RequestContext.Builder()
@@ -405,19 +394,6 @@ public class AccountServiceTest extends Mockito {
         assertEquals(account.getDataGroups(), ImmutableSet.of(TEST_USER_GROUP));
     }
     
-    @Test(expectedExceptions = UnauthorizedException.class)
-    public void updateAccountFailsForStudyDesignerUpdatingProdAccount() throws Exception {
-        RequestContext.set(new RequestContext.Builder()
-                .withCallerUserId("id")
-                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
-                .withCallerRoles(ImmutableSet.of(STUDY_DESIGNER)).build());
-        
-        Account account = mockGetAccountById(ACCOUNT_ID, false);
-        account.setEnrollments(ImmutableSet.of(Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID)));
-
-        service.updateAccount(account);
-    }
-    
     @Test
     public void updateAccountSucceedsForStudyDesignerUpdatingTestAccount() throws Exception {
         RequestContext.set(new RequestContext.Builder()
@@ -446,20 +422,6 @@ public class AccountServiceTest extends Mockito {
         service.updateAccount(account);
         
         verify(mockAccountDao).updateAccount(account);
-    }
-    
-    @Test(expectedExceptions = UnauthorizedException.class)
-    public void updateAccountFailsForOrgAdminUpdatingParticipantAccount() throws Exception {
-        RequestContext.set(new RequestContext.Builder()
-                .withCallerUserId("id")
-                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
-                .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
-        
-        Account account = mockGetAccountById(ACCOUNT_ID, false);
-        account.setDataGroups(ImmutableSet.of(TEST_USER_GROUP));
-        account.setEnrollments(ImmutableSet.of(Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID)));
-
-        service.updateAccount(account);
     }
     
     @Test


### PR DESCRIPTION
We have many layers of security checks going on right now and some of the older ones are no longer necessary. I removed some code that is no longer needed to prevent org admins from updating production participant accounts (they just can't see these accounts at all anymore). This allows accounts that have org admin + something like study designer to see and edit test participant accounts, which was being prevented by this code. We need it to be possible for study designers to work on test accounts without having access to production accounts.

All integration tests pass as is.