### PR TITLE
Events mutability enhancements

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/dao/StudyActivityEventDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dao/StudyActivityEventDao.java
@@ -10,7 +10,7 @@ public interface StudyActivityEventDao {
      * Remove all timestamp records for a specific custom event. A timestamp value 
      * need not be supplied as part of this event (if it is supplied, it is ignored).
      */
-    void deleteCustomEvent(StudyActivityEvent event);
+    void deleteEvent(StudyActivityEvent event);
 
     /**
      * Publish an event into this user’s event stream. This event becomes available 
@@ -20,8 +20,8 @@ public interface StudyActivityEventDao {
     
     /**
      * Return the most recently persisted study event record (the record with the most 
-     * recent `createdOn` timestamp, not necessarily the recordwith the most recent 
-     * `eventTimestamp` field). Returns null if this event has not been persisted for 
+     * recent `createdOn` timestamp, not necessarily the record with the most recent 
+     * `timestamp` field). Returns null if this event has not been persisted for 
      * this user in this study. 
      */
     StudyActivityEvent getRecentStudyActivityEvent(String userId, String studyId, String eventId);
@@ -41,7 +41,7 @@ public interface StudyActivityEventDao {
      * for immutable events there should only ever be one timestamp. Returns an 
      * empty PagedResourceList if the event has not yet been recorded for this 
      * participant. “Synthetic” or calculated events (study_start_date and 
-     * created_on) are returned by this method.
+     * created_on) are not returned by this method and must be added by the service.
      */
     PagedResourceList<StudyActivityEvent> getStudyActivityEventHistory(
             String userId, String studyId, String eventId, Integer offsetBy, Integer pageSize);

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudyActivityEventDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudyActivityEventDao.java
@@ -48,7 +48,7 @@ public class HibernateStudyActivityEventDao implements StudyActivityEventDao {
     }
 
     @Override
-    public void deleteCustomEvent(StudyActivityEvent event) {
+    public void deleteEvent(StudyActivityEvent event) {
         checkNotNull(event);
         
         QueryBuilder query = new QueryBuilder();

--- a/src/main/java/org/sagebionetworks/bridge/models/activities/StudyActivityEvent.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/activities/StudyActivityEvent.java
@@ -58,7 +58,9 @@ public class StudyActivityEvent implements HasTimestamp, BridgeEntity {
         if (event.getPeriodFromOrigin() != null) {
             array[10] = event.getPeriodFromOrigin().toString();    
         }
-        array[11] = event.getUpdateType().name();
+        if (event.getUpdateType() != null) {
+            array[11] = event.getUpdateType().name();    
+        }
         // Not in table, this is retrieved from the query itself
         array[12] = BigInteger.valueOf(event.getRecordCount());
         return array;
@@ -91,7 +93,7 @@ public class StudyActivityEvent implements HasTimestamp, BridgeEntity {
         return builder.build();
     }
     private static int toInt(Object obj) {
-        return (obj == null) ? -1 : ((BigInteger)obj).intValue();
+        return (obj == null) ? 0 : ((BigInteger)obj).intValue();
     }
     private static String toString(Object obj) {
         return (obj == null) ? null : (String)obj;

--- a/src/main/java/org/sagebionetworks/bridge/models/activities/StudyActivityEvent.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/activities/StudyActivityEvent.java
@@ -7,6 +7,8 @@ import java.math.BigInteger;
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
 import javax.persistence.Table;
@@ -38,7 +40,7 @@ public class StudyActivityEvent implements HasTimestamp, BridgeEntity {
      * This method is only used to test the results of a SQL query. 
      */
     public static Object[] recordify(StudyActivityEvent event) {
-        Object[] array = new Object[12];
+        Object[] array = new Object[13];
         array[0] = event.getAppId();
         array[1] = event.getUserId();
         array[2] = event.getStudyId();
@@ -56,8 +58,9 @@ public class StudyActivityEvent implements HasTimestamp, BridgeEntity {
         if (event.getPeriodFromOrigin() != null) {
             array[10] = event.getPeriodFromOrigin().toString();    
         }
+        array[11] = event.getUpdateType().name();
         // Not in table, this is retrieved from the query itself
-        array[11] = BigInteger.valueOf(event.getRecordCount());
+        array[12] = BigInteger.valueOf(event.getRecordCount());
         return array;
     }
     
@@ -79,8 +82,11 @@ public class StudyActivityEvent implements HasTimestamp, BridgeEntity {
         builder.withStudyBurstId(toString(record[8]));
         builder.withOriginEventId(toString(record[9]));
         builder.withPeriodFromOrigin(toPeriod(record[10]));
-        if (record.length > 11) {
-            builder.withRecordCount(toInt(record[11]));    
+        if (record[11] != null) {
+            builder.withUpdateType(ActivityEventUpdateType.valueOf((String)record[11]));
+        }
+        if (record.length > 12) {
+            builder.withRecordCount(toInt(record[12]));    
         }
         return builder.build();
     }
@@ -127,7 +133,7 @@ public class StudyActivityEvent implements HasTimestamp, BridgeEntity {
     private Period periodFromOrigin;
     @Transient
     private int recordCount;
-    @Transient
+    @Enumerated(EnumType.STRING)
     private ActivityEventUpdateType updateType;
     
     public StudyActivityEvent() {} // for hibernate

--- a/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
@@ -246,7 +246,7 @@ public class AccountService {
                 .withObjectType(ENROLLMENT)
                 .withTimestamp(account.getCreatedOn());
         for (Enrollment en : account.getEnrollments()) {
-            studyActivityEventService.publishEvent(builder.withStudyId(en.getStudyId()).build(), false);
+            studyActivityEventService.publishEvent(builder.withStudyId(en.getStudyId()).build(), false, true);
         }
     }
     
@@ -303,7 +303,7 @@ public class AccountService {
                     .withTimestamp(account.getModifiedOn());
                     
             for (String studyId : newStudies) {
-                studyActivityEventService.publishEvent(builder.withStudyId(studyId).build(), false);
+                studyActivityEventService.publishEvent(builder.withStudyId(studyId).build(), false, true);
             }
         }
     }

--- a/src/main/java/org/sagebionetworks/bridge/services/AdherenceService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AdherenceService.java
@@ -186,7 +186,7 @@ public class AdherenceService {
                 builder.withObjectType(ASSESSMENT);
                 builder.withObjectId(meta.getAssessmentId());
             }
-            studyActivityEventService.publishEvent(builder.build(), false);
+            studyActivityEventService.publishEvent(builder.build(), false, true);
         }
     }
 
@@ -240,7 +240,7 @@ public class AdherenceService {
             if (TRUE.equals(search.getCurrentTimestampsOnly())) {
                 // This adds current server timestamps to the search filters
                 Map<String, DateTime> events = studyActivityEventService
-                        .getRecentStudyActivityEvents(appId, search.getUserId(), search.getStudyId())
+                        .getRecentStudyActivityEvents(appId, search.getStudyId(), search.getUserId())
                         .getItems().stream()
                         .collect(toMap(StudyActivityEvent::getEventId, StudyActivityEvent::getTimestamp));
                 addToMap(events, eventMap, fixedMap);

--- a/src/main/java/org/sagebionetworks/bridge/services/StudyActivityEventService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyActivityEventService.java
@@ -47,15 +47,16 @@ import org.slf4j.LoggerFactory;
  * Activity events that are scoped to a person participating in a specific study. 
  * Unlike v1 of activity events, these events maintain a history of their changes 
  * (if they are mutable). They also include some metadata that the earlier event 
- * system could not maintain, including a client time zone. This API will replace 
- * the v1 API, so some events that span all studies (like the creation of an 
- * account) are also in the events returned by this system. 
+ * system could not maintain, including a client time zone and their relationship 
+ * to study bursts. This API will replace the v1 API, so some events that span 
+ * all studies (like the creation of an account) are also in the events returned 
+ * by this service. 
  * 
  * The code in this class to insert an enrollment event, when there is no enrollment
  * event in the tables, is backfill code for accounts that were created and enrolled 
- * in a study before the deployment of study-specific events. There is no apparent 
- * reason to actually save them in the table at this point since the records should
- * only be accessed through this service.
+ * in a study before the deployment of study-specific events. There is no reason to 
+ * save them in the table at this point since the records should only be accessed 
+ * through this service.
  */
 @Component
 public class StudyActivityEventService {

--- a/src/main/java/org/sagebionetworks/bridge/services/StudyActivityEventService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyActivityEventService.java
@@ -99,8 +99,14 @@ public class StudyActivityEventService {
     }
 
     /**
-     * Only custom events can be deleted (if they are mutable). Other requests 
-     * are silently ignored. 
+     * Delete an event if it is mutable (basically only custom events). If the event was the originating
+     * (triggering) event for a set of study burst events, those events will be deleted as well.
+     * 
+     * @param event
+     *      the event to be deleted 
+     * @param showError
+     *      if false (the default), this method returns quietly regardless of the outcome of publishing 
+     *      the event. If true, it will throw a BadRequestException if any event cannot be deleted.
      */
     public void deleteEvent(StudyActivityEvent event, boolean showError) {
         checkNotNull(event);
@@ -111,7 +117,12 @@ public class StudyActivityEventService {
                 event.getUserId(), event.getStudyId(), event.getEventId());
 
         if (event.getUpdateType().canDelete(mostRecent, event)) {
-            dao.deleteCustomEvent(event);
+            dao.deleteEvent(event);
+            Study study = studyService.getStudy(event.getAppId(), event.getStudyId(), true);
+            Schedule2 schedule = scheduleService.getScheduleForStudy(study.getAppId(), study).orElse(null);
+            if (schedule != null) {
+                deleteStudyBurstEvents(schedule, event);
+            }
         } else {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("User " + event.getUserId() + " failed to delete study event: " + event.getEventId());
@@ -122,7 +133,25 @@ public class StudyActivityEventService {
         }
     }
     
-    public void publishEvent(StudyActivityEvent event, boolean showError) {
+    /**
+     * Publish an event. If the event is being created for the first time and it is the originating (triggering)
+     * event for a study burst, the set of study burst events will be created. Editing of both the event
+     * and any study burst events is thereafter governed by the update type of the event and study bursts. If 
+     * both are mutable or future_only, then updating the originating event will update all the study burst 
+     * events, unless the <code>updateBursts</code> flag is set to false.
+     *  
+     * @param event
+     *      the event to publish
+     * @param showError
+     *      if false (the default), this method returns quietly regardless of the outcome of publishing the event.
+     *      If true, it will throw a BadRequestException if any event cannot be published.
+     * @param updateBursts
+     *      if true (the default), this method will update study burst events based on their update type. If false, 
+     *      study burst events will not be updated if the update would be an edit of existing events (if the origin 
+     *      event is being published for the first time, then this flag has to be ignored so the study bursts are 
+     *      published).
+     */
+    public void publishEvent(StudyActivityEvent event, boolean showError, boolean updateBursts) {
         checkNotNull(event);
 
         event.setCreatedOn(getCreatedOn());
@@ -132,6 +161,11 @@ public class StudyActivityEventService {
         StudyActivityEvent mostRecent = dao.getRecentStudyActivityEvent(
                 event.getUserId(), event.getStudyId(), event.getEventId());
         
+        // we will honor this, unless the origin event has never been published, then it *has* to
+        // trigger creating of the study bursts.
+        if (mostRecent == null) {
+            updateBursts = true;
+        }
         // Throwing exceptions will prevent study burst updates from happening if 
         // an error occurs in earlier order...so we collect errors and only show 
         // them at the end if we want to throw an exception.
@@ -141,10 +175,12 @@ public class StudyActivityEventService {
         } else {
             failedEventIds.add(event.getEventId());
         }
-        Study study = studyService.getStudy(event.getAppId(), event.getStudyId(), true);
-        Schedule2 schedule = scheduleService.getScheduleForStudy(study.getAppId(), study).orElse(null);
-        if (schedule != null) {
-            createStudyBurstEvents(schedule, event, failedEventIds);
+        if (updateBursts) {
+            Study study = studyService.getStudy(event.getAppId(), event.getStudyId(), true);
+            Schedule2 schedule = scheduleService.getScheduleForStudy(study.getAppId(), study).orElse(null);
+            if (schedule != null) {
+                createStudyBurstEvents(schedule, event, failedEventIds);
+            }
         }
         if (!failedEventIds.isEmpty()) {
             String eventNames = COMMA_SPACE_JOINER.join(failedEventIds);
@@ -157,7 +193,21 @@ public class StudyActivityEventService {
         }
     }
     
-    public ResourceList<StudyActivityEvent> getRecentStudyActivityEvents(String appId, String userId, String studyId) {
+    /**
+     * Get a complete set of all events for this user, where the timestamp of each entry is the most recent timestamp
+     * as determined by the <code>createdOn</code> value of the record (in other words, the time of creation as measured
+     * by the server, and not the client or the time of the event).
+     * 
+     * @param appId
+     *      the appId of the study
+     * @param studyId
+     *      the study in which these events have occurred
+     * @param userId
+     *      the ID of the participant account
+     * @return
+     *      a complete set of event records for this user, including the most recent record for each event     
+     */
+    public ResourceList<StudyActivityEvent> getRecentStudyActivityEvents(String appId, String studyId, String userId) {
         checkNotNull(userId);
         checkNotNull(studyId);
 
@@ -177,6 +227,12 @@ public class StudyActivityEventService {
         return new ResourceList<>(events); 
     }
     
+    /**
+     * Get a paginated list of all timestamp values for a specific event ID. This method should return a 
+     * value for any event that can be found in the map of recent events, including immutable and app-scoped
+     * events of interest to the study-scoped APIs (created_on, enrollment, and install_link_sent), though 
+     * these will only be one record.
+     */
     public PagedResourceList<StudyActivityEvent> getStudyActivityEventHistory(
             AccountId accountId, String studyId, String eventId, Integer offsetBy, Integer pageSize) {
         
@@ -289,6 +345,34 @@ public class StudyActivityEventService {
                     }  else {
                         failedEventIds.add(burstEvent.getEventId());
                     } 
+                }
+            }
+        }
+    }
+    
+    private void deleteStudyBurstEvents(Schedule2 schedule, StudyActivityEvent event) {
+        String eventId = event.getEventId();
+        
+        StudyActivityEvent.Builder builder = new StudyActivityEvent.Builder()
+            .withAppId(event.getAppId())
+            .withUserId(event.getUserId())
+            .withStudyId(event.getStudyId())
+            .withObjectType(STUDY_BURST);
+        
+        for(StudyBurst burst : schedule.getStudyBursts()) {
+            if (burst.getOriginEventId().equals(eventId)) {
+                int len =  burst.getOccurrences().intValue();
+                
+                for (int i=0; i < len; i++) {
+                    String iteration = Strings.padStart(Integer.toString(i+1), 2, '0');
+
+                    StudyActivityEvent burstEvent = builder
+                            .withEventId(null)
+                            .withObjectId(burst.getIdentifier())
+                            .withAnswerValue(iteration)
+                            .build();
+                    
+                    dao.deleteEvent(burstEvent);
                 }
             }
         }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ActivityEventController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ActivityEventController.java
@@ -122,9 +122,9 @@ public class ActivityEventController extends BaseController {
                 .withStudyId(studyId)
                 .withUserId(session.getId())
                 .withObjectType(TIMELINE_RETRIEVED)
-                .withTimestamp(timelineRequestedOn).build(), false);
+                .withTimestamp(timelineRequestedOn).build(), false, true);
 
-        return studyActivityEventService.getRecentStudyActivityEvents(session.getAppId(), session.getId(), studyId);
+        return studyActivityEventService.getRecentStudyActivityEvents(session.getAppId(), studyId, session.getId());
     }
 
     @GetMapping("/v5/studies/{studyId}/participants/self/activityevents/{eventId}")
@@ -150,7 +150,8 @@ public class ActivityEventController extends BaseController {
     @PostMapping("/v5/studies/{studyId}/participants/self/activityevents")
     @ResponseStatus(HttpStatus.CREATED)
     public StatusMessage publishActivityEventForSelf(@PathVariable String studyId,
-            @RequestParam(required = false) String showError) {
+            @RequestParam(required = false) String showError, 
+            @RequestParam(required = false) String updateBursts) {
         UserSession session = getAuthenticatedAndConsentedSession();
 
         if (!session.getParticipant().getStudyIds().contains(studyId)) {
@@ -160,12 +161,13 @@ public class ActivityEventController extends BaseController {
         StudyActivityEventRequest request = parseJson(StudyActivityEventRequest.class);
         StudyActivityEventIdsMap eventMap = studyService.getStudyActivityEventIdsMap(session.getAppId(), studyId);
         boolean showErrorBool = "true".equals(showError);
-
+        boolean updateBurstsBool = !"false".equals(updateBursts);
+        
         studyActivityEventService.publishEvent(request.parse(eventMap)
                 .withAppId(session.getAppId())
                 .withStudyId(studyId)
                 .withUserId(session.getId())
-                .build(), showErrorBool);
+                .build(), showErrorBool, updateBurstsBool);
         
         return EVENT_RECORDED_MSG;
     }   

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantController.java
@@ -193,7 +193,7 @@ public class StudyParticipantController extends BaseController {
                 .withStudyId(studyId)
                 .withUserId(session.getId())
                 .withObjectType(TIMELINE_RETRIEVED)
-                .withTimestamp(timelineRequestedOn).build(), false);
+                .withTimestamp(timelineRequestedOn).build(), false, true);
         
         return new ResponseEntity<>(INSTANCE.calculateTimeline(schedule), OK);
     }
@@ -507,7 +507,7 @@ public class StudyParticipantController extends BaseController {
         
         Account account = getValidAccountInStudy(session.getAppId(), studyId, userId);
         
-        return studyActivityEventService.getRecentStudyActivityEvents(session.getAppId(), account.getId(), studyId);
+        return studyActivityEventService.getRecentStudyActivityEvents(session.getAppId(), studyId, account.getId());
     }
     
     @GetMapping("/v5/studies/{studyId}/participants/{userId}/activityevents/{eventId}")
@@ -532,7 +532,7 @@ public class StudyParticipantController extends BaseController {
     @PostMapping("/v5/studies/{studyId}/participants/{userId}/activityevents")
     @ResponseStatus(HttpStatus.CREATED)
     public StatusMessage publishActivityEvent(@PathVariable String studyId, @PathVariable String userId,
-            @RequestParam(required = false) String showError) {
+            @RequestParam(required = false) String showError, @RequestParam(required = false) String updateBursts) {
         UserSession session = getAdministrativeSession();
         
         Account account = getValidAccountInStudy(session.getAppId(), studyId, userId);
@@ -540,11 +540,12 @@ public class StudyParticipantController extends BaseController {
         StudyActivityEventRequest request = parseJson(StudyActivityEventRequest.class);
         StudyActivityEventIdsMap eventMap = studyService.getStudyActivityEventIdsMap(session.getAppId(), studyId);
         boolean showErrorBool = "true".equals(showError);
+        boolean updateBurstsBool = !"false".equals(updateBursts);
         
         studyActivityEventService.publishEvent(request.parse(eventMap)
                 .withAppId(session.getAppId())
                 .withStudyId(studyId)
-                .withUserId(account.getId()).build(), showErrorBool);
+                .withUserId(account.getId()).build(), showErrorBool, updateBurstsBool);
         
         return EVENT_RECORDED_MSG;
     }

--- a/src/main/resources/db/changelog/changelog.sql
+++ b/src/main/resources/db/changelog/changelog.sql
@@ -831,3 +831,8 @@ ALTER TABLE `StudyActivityEvents`
 ADD COLUMN `studyBurstId` varchar(255),
 ADD COLUMN `originEventId` varchar(255),
 ADD COLUMN `periodFromOrigin` varchar(60);
+
+-- changeset bridge:53
+
+ALTER TABLE `StudyActivityEvents`
+ADD COLUMN `updateType` enum('MUTABLE', 'IMMUTABLE', 'FUTURE_ONLY') DEFAULT 'IMMUTABLE';

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateStudyActivityEventDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateStudyActivityEventDaoTest.java
@@ -58,7 +58,7 @@ public class HibernateStudyActivityEventDaoTest extends Mockito {
             .withObjectType(CUSTOM)
             .withObjectId("event1").build();
         
-        dao.deleteCustomEvent(event);
+        dao.deleteEvent(event);
         
         verify(mockHelper).nativeQueryUpdate(eq(DELETE_SQL), paramsCaptor.capture());
         Map<String,Object> params = paramsCaptor.getValue();
@@ -78,7 +78,7 @@ public class HibernateStudyActivityEventDaoTest extends Mockito {
     
     @Test
     public void getRecentStudyActivityEvents() { 
-        List<Object[]> list = ImmutableList.of(new Object[11], new Object[11]);
+        List<Object[]> list = ImmutableList.of(new Object[12], new Object[12]);
         when(mockHelper.nativeQuery(any(), any())).thenReturn(list);
         
         List<StudyActivityEvent> retValue = dao.getRecentStudyActivityEvents(

--- a/src/test/java/org/sagebionetworks/bridge/models/activities/StudyActivityEventTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/activities/StudyActivityEventTest.java
@@ -161,12 +161,13 @@ public class StudyActivityEventTest {
         assertEquals(record[8], "foo");
         assertEquals(record[9], "enrollment");
         assertEquals(record[10], "P2D");
-        assertEquals(record[11], BigInteger.valueOf(7));
+        assertEquals(record[11], "MUTABLE");
+        assertEquals(record[12], BigInteger.valueOf(7));
     }
     
     @Test
     public void create() {
-        Object[] record = new Object[12];
+        Object[] record = new Object[13];
         record[0] = TEST_APP_ID;
         record[1] = TEST_USER_ID;
         record[2] = TEST_STUDY_ID;
@@ -178,7 +179,8 @@ public class StudyActivityEventTest {
         record[8] = "foo";
         record[9] = "enrollment";
         record[10] = "P2D";
-        record[11] = BigInteger.valueOf(7);
+        record[11] = "MUTABLE";
+        record[12] = BigInteger.valueOf(7);
         
         StudyActivityEvent event = StudyActivityEvent.create(record);
         assertEquals(event.getAppId(), TEST_APP_ID);
@@ -192,6 +194,7 @@ public class StudyActivityEventTest {
         assertEquals(event.getStudyBurstId(), "foo");
         assertEquals(event.getOriginEventId(), "enrollment");
         assertEquals(event.getPeriodFromOrigin(), Period.parse("P2D"));
+        assertEquals(event.getUpdateType(), MUTABLE);
         assertEquals(event.getRecordCount(), 7);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/activities/StudyActivityEventTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/activities/StudyActivityEventTest.java
@@ -166,6 +166,17 @@ public class StudyActivityEventTest {
     }
     
     @Test
+    public void recordify_nullValues() {
+        StudyActivityEvent event = new StudyActivityEvent();
+        Object[] record = StudyActivityEvent.recordify(event);
+        assertEquals(record.length, 13);
+        for (int i=0; i < 12; i++) {
+            assertNull(record[i]);
+        }
+        assertEquals(record[12], BigInteger.valueOf(0)); // recordCount
+    }
+    
+    @Test
     public void create() {
         Object[] record = new Object[13];
         record[0] = TEST_APP_ID;
@@ -197,4 +208,25 @@ public class StudyActivityEventTest {
         assertEquals(event.getUpdateType(), MUTABLE);
         assertEquals(event.getRecordCount(), 7);
     }
+    
+    @Test
+    public void create_nullValues() {
+        Object[] record = new Object[13];
+        
+        StudyActivityEvent event = StudyActivityEvent.create(record);
+        assertNull(event.getAppId());
+        assertNull(event.getUserId());
+        assertNull(event.getStudyId());
+        assertNull(event.getEventId());
+        assertNull(event.getTimestamp());
+        assertNull(event.getAnswerValue());
+        assertNull(event.getClientTimeZone());
+        assertNull(event.getCreatedOn());
+        assertNull(event.getStudyBurstId());
+        assertNull(event.getOriginEventId());
+        assertNull(event.getPeriodFromOrigin());
+        assertNull(event.getUpdateType());
+        assertEquals(event.getRecordCount(), 0);
+    }
+
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
@@ -995,7 +995,7 @@ public class AccountServiceTest extends Mockito {
         assertEquals(createdAccount.getMigrationVersion(), MIGRATION_VERSION);
         
         verify(activityEventService, never()).publishEnrollmentEvent(any(), any(), any());
-        verify(studyActivityEventService, never()).publishEvent(any(), anyBoolean());
+        verify(studyActivityEventService, never()).publishEvent(any(), anyBoolean(), anyBoolean());
     }
     
     @Test
@@ -1016,7 +1016,7 @@ public class AccountServiceTest extends Mockito {
 
         verify(mockAccountDao).createAccount(app, account);
         verify(activityEventService).publishEnrollmentEvent(any(), any(), any());
-        verify(studyActivityEventService, times(2)).publishEvent(eventCaptor.capture(), eq(false));
+        verify(studyActivityEventService, times(2)).publishEvent(eventCaptor.capture(), eq(false), eq(true));
 
         StudyActivityEvent event1 = getElement(
                 eventCaptor.getAllValues(), StudyActivityEvent::getStudyId, STUDY_A).orElse(null);
@@ -1096,7 +1096,7 @@ public class AccountServiceTest extends Mockito {
         assertEquals(updatedAccount.getClientTimeZone(), OTHER_CLIENT_TIME_ZONE);
         
         verify(activityEventService, never()).publishEnrollmentEvent(any(), any(), any());
-        verify(studyActivityEventService, never()).publishEvent(any(), anyBoolean());
+        verify(studyActivityEventService, never()).publishEvent(any(), anyBoolean(), anyBoolean());
     }
 
     @Test
@@ -1131,7 +1131,7 @@ public class AccountServiceTest extends Mockito {
         
         verify(activityEventService).publishEnrollmentEvent(
                 eq(app), eq(HEALTH_CODE), any(DateTime.class));
-        verify(studyActivityEventService).publishEvent(eventCaptor.capture(), eq(false));
+        verify(studyActivityEventService).publishEvent(eventCaptor.capture(), eq(false), eq(true));
         StudyActivityEvent event = eventCaptor.getValue();
         assertEquals(event.getAppId(), TEST_APP_ID);
         assertEquals(event.getStudyId(), STUDY_B);

--- a/src/test/java/org/sagebionetworks/bridge/services/AdherenceServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AdherenceServiceTest.java
@@ -132,7 +132,7 @@ public class AdherenceServiceTest extends Mockito {
         assertEquals(recordCaptor.getAllValues().get(2).getInstanceGuid(), "sessionInstanceGuid");
         
         // Nothing is finished, nothing is published.
-        verify(mockStudyActivityEventService, never()).publishEvent(any(), eq(false));
+        verify(mockStudyActivityEventService, never()).publishEvent(any(), eq(false), eq(true));
     }
     
     @Test(expectedExceptions = BadRequestException.class)
@@ -172,7 +172,7 @@ public class AdherenceServiceTest extends Mockito {
         
         verify(mockDao).updateAdherenceRecord(list.getRecords().get(0));
         verify(mockDao).updateAdherenceRecord(list.getRecords().get(1));
-        verify(mockStudyActivityEventService, times(3)).publishEvent(eventCaptor.capture(), eq(false));
+        verify(mockStudyActivityEventService, times(3)).publishEvent(eventCaptor.capture(), eq(false), eq(true));
         
         StudyActivityEvent event = eventCaptor.getAllValues().get(2);
         assertEquals(event.getAppId(), TEST_APP_ID);
@@ -197,7 +197,7 @@ public class AdherenceServiceTest extends Mockito {
         
         verify(mockDao).updateAdherenceRecord(list.getRecords().get(0));
         verify(mockDao).updateAdherenceRecord(list.getRecords().get(1));
-        verify(mockStudyActivityEventService, times(1)).publishEvent(eventCaptor.capture(), eq(false));
+        verify(mockStudyActivityEventService, times(1)).publishEvent(eventCaptor.capture(), eq(false), eq(true));
         
         StudyActivityEvent event = eventCaptor.getValue();
         assertEquals(event.getAppId(), TEST_APP_ID);
@@ -220,7 +220,7 @@ public class AdherenceServiceTest extends Mockito {
         
         service.updateAdherenceRecords(TEST_APP_ID, list);
         
-        verify(mockStudyActivityEventService, never()).publishEvent(any(), eq(false));
+        verify(mockStudyActivityEventService, never()).publishEvent(any(), eq(false), eq(true));
     }
     
     private AdherenceRecord mockAssessmentRecord(String id) {
@@ -266,7 +266,7 @@ public class AdherenceServiceTest extends Mockito {
         service.updateSessionState(TEST_APP_ID, container, list.getRecords().get(0));
         
         verify(mockDao, never()).updateAdherenceRecord(any());
-        verify(mockStudyActivityEventService, never()).publishEvent(any(), eq(false));
+        verify(mockStudyActivityEventService, never()).publishEvent(any(), eq(false), eq(true));
     }
     
     @Test
@@ -433,7 +433,7 @@ public class AdherenceServiceTest extends Mockito {
         assertNull(captured.getFinishedOn());
         assertFalse(captured.isDeclined());
         
-        verify(mockStudyActivityEventService, never()).publishEvent(any(), eq(false));
+        verify(mockStudyActivityEventService, never()).publishEvent(any(), eq(false), eq(true));
     }
     
     @Test
@@ -627,13 +627,13 @@ public class AdherenceServiceTest extends Mockito {
         
         StudyActivityEvent event1 = createEvent("custom:event1", MODIFIED_ON);
         StudyActivityEvent event2 = createEvent("custom:event2", MODIFIED_ON);
-        when(mockStudyActivityEventService.getRecentStudyActivityEvents(TEST_APP_ID, TEST_USER_ID, TEST_STUDY_ID))
+        when(mockStudyActivityEventService.getRecentStudyActivityEvents(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID))
             .thenReturn(new ResourceList<StudyActivityEvent>(ImmutableList.of(event1, event2)));
         
         AdherenceRecordsSearch retValue = service.cleanupSearch(TEST_APP_ID, search);
         
         verify(mockStudyActivityEventService)
-            .getRecentStudyActivityEvents(TEST_APP_ID, TEST_USER_ID, TEST_STUDY_ID);
+            .getRecentStudyActivityEvents(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         
         // this first one is overridden by the values submitted by the client
         assertEquals(retValue.getEventTimestamps().get("custom:event1"), CREATED_ON);

--- a/src/test/java/org/sagebionetworks/bridge/services/StudyActivityEventServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/StudyActivityEventServiceTest.java
@@ -462,6 +462,7 @@ public class StudyActivityEventServiceTest extends Mockito {
         service.publishEvent(event, false, false);
         
         verify(mockDao, times(1)).publishEvent(eventCaptor.capture());
+        assertEquals(eventCaptor.getValue().getEventId(), "assessment:foo:finished");
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/StudyActivityEventServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/StudyActivityEventServiceTest.java
@@ -9,10 +9,12 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestUtils.createEvent;
+import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.ASSESSMENT;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.CUSTOM;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.ENROLLMENT;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.INSTALL_LINK_SENT;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.TIMELINE_RETRIEVED;
+import static org.sagebionetworks.bridge.models.activities.ActivityEventType.FINISHED;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventUpdateType.IMMUTABLE;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventUpdateType.MUTABLE;
 import static org.sagebionetworks.bridge.services.StudyActivityEventService.CREATED_ON_FIELD;
@@ -124,7 +126,7 @@ public class StudyActivityEventServiceTest extends Mockito {
 
         service.deleteEvent(originEvent, false);
         
-        verify(mockDao).deleteCustomEvent(eventCaptor.capture());
+        verify(mockDao).deleteEvent(eventCaptor.capture());
         StudyActivityEvent event = eventCaptor.getValue();
         assertEquals(event.getAppId(), TEST_APP_ID);
         assertEquals(event.getStudyId(), TEST_STUDY_ID);
@@ -140,7 +142,7 @@ public class StudyActivityEventServiceTest extends Mockito {
 
         service.deleteEvent(originEvent, false);
         
-        verify(mockDao, never()).deleteCustomEvent(any());
+        verify(mockDao, never()).deleteEvent(any());
     }
 
     @Test
@@ -151,7 +153,7 @@ public class StudyActivityEventServiceTest extends Mockito {
 
         service.deleteEvent(originEvent, false);
         
-        verify(mockDao, never()).deleteCustomEvent(any());
+        verify(mockDao, never()).deleteEvent(any());
     }
     
     @Test
@@ -185,13 +187,61 @@ public class StudyActivityEventServiceTest extends Mockito {
     }
     
     @Test
+    public void deleteEvent_deletesStudyBurstEvents() {
+        // Publish a deletable event. 
+        StudyActivityEvent event = makeBuilder().withObjectId("foo")
+                .withTimestamp(ENROLLMENT_TS).withObjectType(CUSTOM)
+                .withUpdateType(MUTABLE).build();        
+        
+        Study study = Study.create();
+        study.setAppId(TEST_APP_ID);
+        when(mockStudyService.getStudy(TEST_APP_ID, TEST_STUDY_ID, true)).thenReturn(study);
+
+        StudyBurst burst = new StudyBurst();
+        burst.setOriginEventId("custom:foo");
+        burst.setIdentifier("foo");
+        burst.setInterval(Period.parse("P1W"));
+        burst.setOccurrences(3);
+        burst.setUpdateType(MUTABLE);
+
+        Schedule2 schedule = new Schedule2();
+        schedule.setStudyBursts(ImmutableList.of(burst));
+        
+        when(mockScheduleService.getScheduleForStudy(TEST_APP_ID, study))
+                .thenReturn(Optional.of(schedule));
+        
+        StudyActivityEvent persistedEvent = new StudyActivityEvent();
+        when(mockDao.getRecentStudyActivityEvent(TEST_USER_ID, TEST_STUDY_ID, "custom:foo"))
+            .thenReturn(persistedEvent);
+        
+        service.deleteEvent(event, false);
+        
+        verify(mockDao, times(4)).deleteEvent(eventCaptor.capture());
+        
+        StudyActivityEvent origin = eventCaptor.getAllValues().get(0);
+        assertEquals(origin.getEventId(), "custom:foo");
+        
+        StudyActivityEvent sb1 = eventCaptor.getAllValues().get(1);
+        assertEquals(sb1.getEventId(), "study_burst:foo:01");
+        assertEquals(sb1.getAppId(), TEST_APP_ID);
+        assertEquals(sb1.getStudyId(), TEST_STUDY_ID);
+        assertEquals(sb1.getUserId(), TEST_USER_ID);
+        
+        StudyActivityEvent sb2 = eventCaptor.getAllValues().get(2);
+        assertEquals(sb2.getEventId(), "study_burst:foo:02");
+        
+        StudyActivityEvent sb3 = eventCaptor.getAllValues().get(3);
+        assertEquals(sb3.getEventId(), "study_burst:foo:03");
+    }
+    
+    @Test
     public void publishEvent_eventIsImmutable() {
         StudyActivityEvent originEvent = makeBuilder()
                 .withObjectType(CUSTOM).withObjectId("event2").withTimestamp(MODIFIED_ON).build();
         
         when(mockDao.getRecentStudyActivityEvent(any(), any(), any())).thenReturn(PERSISTED_EVENT);
 
-        service.publishEvent(originEvent, false);
+        service.publishEvent(originEvent, false, true);
         
         verify(mockDao, never()).publishEvent(any());
     }
@@ -202,7 +252,7 @@ public class StudyActivityEventServiceTest extends Mockito {
                 .withObjectId("event1").withTimestamp(MODIFIED_ON)
                 .withClientTimeZone("America/Los_Angeles").build();
         
-        service.publishEvent(originEvent, false);
+        service.publishEvent(originEvent, false, true);
         
         verify(mockDao).publishEvent(eventCaptor.capture());
         StudyActivityEvent event = eventCaptor.getValue();
@@ -221,7 +271,7 @@ public class StudyActivityEventServiceTest extends Mockito {
         StudyActivityEvent event = makeBuilder().withObjectId("timeline_retrieved")
                 .withTimestamp(TIMELINE_RETRIEVED_TS).withObjectType(TIMELINE_RETRIEVED).build();
         
-        service.publishEvent(event, false);
+        service.publishEvent(event, false, true);
         
         verify(mockDao).publishEvent(any());
     }
@@ -235,7 +285,7 @@ public class StudyActivityEventServiceTest extends Mockito {
         
         when(mockDao.getRecentStudyActivityEvent(any(), any(), any())).thenReturn(PERSISTED_EVENT);
 
-        service.publishEvent(event, false);
+        service.publishEvent(event, false, true);
         
         verify(mockDao, never()).publishEvent(any());
     }
@@ -244,7 +294,7 @@ public class StudyActivityEventServiceTest extends Mockito {
     public void publishEvent_eventInvalid() {
         StudyActivityEvent event = makeBuilder().build();
         
-        service.publishEvent(event, false);
+        service.publishEvent(event, false, true);
     }
     
     @Test(expectedExceptions = BadRequestException.class)
@@ -256,7 +306,7 @@ public class StudyActivityEventServiceTest extends Mockito {
         
         when(mockDao.getRecentStudyActivityEvent(any(), any(), any())).thenReturn(PERSISTED_EVENT);
 
-        service.publishEvent(event, true);
+        service.publishEvent(event, true, true);
     }
     
     @Test
@@ -284,7 +334,7 @@ public class StudyActivityEventServiceTest extends Mockito {
         when(mockScheduleService.getScheduleForStudy(TEST_APP_ID, study))
                 .thenReturn(Optional.of(schedule));
         try {
-            service.publishEvent(event, true);
+            service.publishEvent(event, true, true);
             fail("Should have thrown exception");
         } catch(BadRequestException e) {
             assertTrue(e.getMessage().contains("Study event(s) failed to publish: enrollment, study_burst:foo:01."));
@@ -319,7 +369,7 @@ public class StudyActivityEventServiceTest extends Mockito {
         when(mockDao.getRecentStudyActivityEvent(any(), any(), eq("study_burst:foo:01"))).thenReturn(PERSISTED_EVENT);
         
         try {
-            service.publishEvent(event, true);
+            service.publishEvent(event, true, true);
             fail("Should have thrown exception");
         } catch(BadRequestException e) {
             assertEquals(e.getMessage(), "Study event(s) failed to publish: study_burst:foo:01.");
@@ -351,7 +401,7 @@ public class StudyActivityEventServiceTest extends Mockito {
         when(mockScheduleService.getScheduleForStudy(TEST_APP_ID, study))
                 .thenReturn(Optional.of(schedule));
         
-        service.publishEvent(event, false);
+        service.publishEvent(event, false, true);
         
         verify(mockDao, times(4)).publishEvent(eventCaptor.capture());
         
@@ -382,6 +432,68 @@ public class StudyActivityEventServiceTest extends Mockito {
     }
     
     @Test
+    public void publishEvent_studyBurstsSuppressed() {
+        StudyActivityEvent persistedEvent = makeBuilder().withObjectType(ASSESSMENT).withObjectId("foo").withEventType(FINISHED)
+                .withTimestamp(ENROLLMENT_TS).build();
+
+        StudyActivityEvent event = makeBuilder().withObjectType(ASSESSMENT).withObjectId("foo").withEventType(FINISHED)
+                .withTimestamp(ENROLLMENT_TS.plusDays(1)).build();
+
+        Study study = Study.create();
+        study.setAppId(TEST_APP_ID);
+        when(mockStudyService.getStudy(TEST_APP_ID, TEST_STUDY_ID, true)).thenReturn(study);
+
+        StudyBurst burst = new StudyBurst();
+        burst.setOriginEventId("assessment:foo:finished");
+        burst.setIdentifier("foo");
+        burst.setInterval(Period.parse("P1W"));
+        burst.setOccurrences(3);
+        burst.setUpdateType(MUTABLE);
+
+        Schedule2 schedule = new Schedule2();
+        schedule.setStudyBursts(ImmutableList.of(burst));
+        
+        when(mockScheduleService.getScheduleForStudy(TEST_APP_ID, study))
+                .thenReturn(Optional.of(schedule));
+        
+        when(mockDao.getRecentStudyActivityEvent(TEST_USER_ID, TEST_STUDY_ID, "assessment:foo:finished"))
+            .thenReturn(persistedEvent);
+        
+        service.publishEvent(event, false, false);
+        
+        verify(mockDao, times(1)).publishEvent(eventCaptor.capture());
+    }
+    
+    @Test
+    public void publishEvent_studyBurstsSuppressedButIgnored() {
+        // There is no existing assessment finished event, which means that despite the call setting study burst
+        // updates to false, it's still going to create the study bursts.
+        StudyActivityEvent event = makeBuilder().withObjectType(ASSESSMENT).withObjectId("foo").withEventType(FINISHED)
+                .withTimestamp(ENROLLMENT_TS.plusDays(1)).build();
+
+        Study study = Study.create();
+        study.setAppId(TEST_APP_ID);
+        when(mockStudyService.getStudy(TEST_APP_ID, TEST_STUDY_ID, true)).thenReturn(study);
+
+        StudyBurst burst = new StudyBurst();
+        burst.setOriginEventId("assessment:foo:finished");
+        burst.setIdentifier("foo");
+        burst.setInterval(Period.parse("P1W"));
+        burst.setOccurrences(3);
+        burst.setUpdateType(MUTABLE);
+
+        Schedule2 schedule = new Schedule2();
+        schedule.setStudyBursts(ImmutableList.of(burst));
+        
+        when(mockScheduleService.getScheduleForStudy(TEST_APP_ID, study))
+                .thenReturn(Optional.of(schedule));
+        
+        service.publishEvent(event, false, false);
+        
+        verify(mockDao, times(4)).publishEvent(eventCaptor.capture());
+    }
+    
+    @Test
     public void publishEvent_doesNotPublishStudyBursts() { 
         // Study bursts are specified, but this is not the origin event, so nothing happens.
         // We can just count calls to the DAO for this.
@@ -403,7 +515,7 @@ public class StudyActivityEventServiceTest extends Mockito {
         when(mockScheduleService.getScheduleForStudy(TEST_APP_ID, study))
                 .thenReturn(Optional.of(schedule));
         
-        service.publishEvent(event, false);
+        service.publishEvent(event, false, true);
         
         verify(mockDao, times(1)).publishEvent(eventCaptor.capture());
         
@@ -439,7 +551,7 @@ public class StudyActivityEventServiceTest extends Mockito {
         when(mockScheduleService.getScheduleForStudy(TEST_APP_ID, study))
                 .thenReturn(Optional.of(schedule));
         
-        service.publishEvent(event, false);
+        service.publishEvent(event, false, true);
         
         verify(mockDao, times(3)).publishEvent(eventCaptor.capture());
         
@@ -488,7 +600,7 @@ public class StudyActivityEventServiceTest extends Mockito {
         when(mockDao.getRecentStudyActivityEvent(any(), any(), eq("study_burst:foo:03")))
             .thenReturn(PERSISTED_EVENT);
         
-        service.publishEvent(event, false);
+        service.publishEvent(event, false, true);
         
         verify(mockDao, times(1)).publishEvent(eventCaptor.capture());
         
@@ -519,7 +631,7 @@ public class StudyActivityEventServiceTest extends Mockito {
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(Optional.of(account));
         
         ResourceList<StudyActivityEvent> retValue = service
-                .getRecentStudyActivityEvents(TEST_APP_ID, TEST_USER_ID, TEST_STUDY_ID);
+                .getRecentStudyActivityEvents(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         assertEquals(retValue.getItems().size(), 4);
         
         StudyActivityEvent createdOn = TestUtils.findByEventId(
@@ -533,7 +645,7 @@ public class StudyActivityEventServiceTest extends Mockito {
     
     @Test(expectedExceptions = EntityNotFoundException.class)
     public void getRecentStudyActivityEvents_noAccount() {
-        service.getRecentStudyActivityEvents(TEST_APP_ID, TEST_USER_ID, TEST_STUDY_ID);
+        service.getRecentStudyActivityEvents(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
     }
     
     @Test
@@ -688,7 +800,7 @@ public class StudyActivityEventServiceTest extends Mockito {
         Map<String, DateTime> map = ImmutableMap.of(CREATED_ON_FIELD, CREATED_ON);
         when(mockActivityEventService.getActivityEventMap(TEST_APP_ID, HEALTH_CODE)).thenReturn(map);
         
-        ResourceList<StudyActivityEvent> retValue = service.getRecentStudyActivityEvents(TEST_APP_ID, TEST_USER_ID, TEST_STUDY_ID);
+        ResourceList<StudyActivityEvent> retValue = service.getRecentStudyActivityEvents(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         assertEquals(retValue.getItems().size(), 2);
         
         StudyActivityEvent event = retValue.getItems().get(0);
@@ -717,7 +829,7 @@ public class StudyActivityEventServiceTest extends Mockito {
         when(mockDao.getRecentStudyActivityEvents(TEST_USER_ID, TEST_STUDY_ID))
             .thenReturn(list);
         
-        ResourceList<StudyActivityEvent> retValue = service.getRecentStudyActivityEvents(TEST_APP_ID, TEST_USER_ID, TEST_STUDY_ID);
+        ResourceList<StudyActivityEvent> retValue = service.getRecentStudyActivityEvents(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         assertEquals(retValue.getItems().get(0).getEventId(), ENROLLMENT_FIELD);
         assertEquals(retValue.getItems().get(0).getTimestamp(), CREATED_ON); // not modifiedOn
     }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantControllerTest.java
@@ -303,7 +303,7 @@ public class StudyParticipantControllerTest extends Mockito {
         List<StudyActivityEvent> list = ImmutableList.of(new StudyActivityEvent.Builder().build());
         ResourceList<StudyActivityEvent> page = new ResourceList<>(list);
         when(mockStudyActivityEventService.getRecentStudyActivityEvents(
-                TEST_APP_ID, TEST_USER_ID, TEST_STUDY_ID)).thenReturn(page);
+                TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID)).thenReturn(page);
         
         mockAccountInStudy();
         
@@ -349,10 +349,10 @@ public class StudyParticipantControllerTest extends Mockito {
         
         mockAccountInStudy();
         
-        StatusMessage retValue = controller.publishActivityEvent(TEST_STUDY_ID, TEST_USER_ID, null);
+        StatusMessage retValue = controller.publishActivityEvent(TEST_STUDY_ID, TEST_USER_ID, null, null);
         assertEquals(retValue, StudyParticipantController.EVENT_RECORDED_MSG);
         
-        verify(mockStudyActivityEventService).publishEvent(eventCaptor.capture(), eq(false));
+        verify(mockStudyActivityEventService).publishEvent(eventCaptor.capture(), eq(false), eq(true));
         StudyActivityEvent event = eventCaptor.getValue();
         assertEquals(event.getAppId(), TEST_APP_ID);
         assertEquals(event.getStudyId(), TEST_STUDY_ID);
@@ -383,9 +383,63 @@ public class StudyParticipantControllerTest extends Mockito {
         
         mockAccountInStudy();
         
-        controller.publishActivityEvent(TEST_STUDY_ID, TEST_USER_ID, "true");
+        controller.publishActivityEvent(TEST_STUDY_ID, TEST_USER_ID, "true", null);
         
-        verify(mockStudyActivityEventService).publishEvent(eventCaptor.capture(), eq(true));
+        verify(mockStudyActivityEventService).publishEvent(eventCaptor.capture(), eq(true), eq(true));
+    }
+    
+    @Test
+    public void publishActivityEvent_updateBursts() throws Exception {
+        RequestContext.set(new RequestContext.Builder()
+                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
+                .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR))
+                .build());
+        session.setParticipant(new StudyParticipant.Builder().withId(TEST_USER_ID).build());
+        
+        App app = App.create();
+        when(mockAppService.getApp(TEST_APP_ID)).thenReturn(app);
+        
+        StudyActivityEventIdsMap eventMap = new StudyActivityEventIdsMap();
+        eventMap.addCustomEvents(ImmutableList.of(new StudyCustomEvent("eventKey", IMMUTABLE)));
+        when(mockStudyService.getStudyActivityEventIdsMap(TEST_APP_ID, TEST_STUDY_ID)).thenReturn(eventMap);
+        
+        doReturn(session).when(controller).getAdministrativeSession();
+
+        TestUtils.mockRequestBody(mockRequest, createJson(
+                "{'eventId':'eventKey','timestamp':'"+CREATED_ON+"'}"));
+        
+        mockAccountInStudy();
+        
+        controller.publishActivityEvent(TEST_STUDY_ID, TEST_USER_ID, "true", "true");
+        
+        verify(mockStudyActivityEventService).publishEvent(eventCaptor.capture(), eq(true), eq(true));
+    }
+    
+    @Test
+    public void publishActivityEvent_doNotUpdateBursts() throws Exception {
+        RequestContext.set(new RequestContext.Builder()
+                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID))
+                .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR))
+                .build());
+        session.setParticipant(new StudyParticipant.Builder().withId(TEST_USER_ID).build());
+        
+        App app = App.create();
+        when(mockAppService.getApp(TEST_APP_ID)).thenReturn(app);
+        
+        StudyActivityEventIdsMap eventMap = new StudyActivityEventIdsMap();
+        eventMap.addCustomEvents(ImmutableList.of(new StudyCustomEvent("eventKey", IMMUTABLE)));
+        when(mockStudyService.getStudyActivityEventIdsMap(TEST_APP_ID, TEST_STUDY_ID)).thenReturn(eventMap);
+        
+        doReturn(session).when(controller).getAdministrativeSession();
+
+        TestUtils.mockRequestBody(mockRequest, createJson(
+                "{'eventId':'eventKey','timestamp':'"+CREATED_ON+"'}"));
+        
+        mockAccountInStudy();
+        
+        controller.publishActivityEvent(TEST_STUDY_ID, TEST_USER_ID, "true", "false");
+        
+        verify(mockStudyActivityEventService).publishEvent(eventCaptor.capture(), eq(true), eq(false));
     }
     
     @Test
@@ -1434,7 +1488,7 @@ public class StudyParticipantControllerTest extends Mockito {
         verify(mockStudyService).getStudy(TEST_APP_ID, TEST_STUDY_ID, true);
         verify(mockScheduleService).getScheduleForStudy(TEST_APP_ID, study);
         verify(mockCacheProvider).getObject(scheduleModificationTimestamp(TEST_STUDY_ID), String.class);
-        verify(mockStudyActivityEventService).publishEvent(eventCaptor.capture(), eq(false));
+        verify(mockStudyActivityEventService).publishEvent(eventCaptor.capture(), eq(false), eq(true));
         StudyActivityEvent event = eventCaptor.getValue();
         assertEquals(event.getAppId(), TEST_APP_ID);
         assertEquals(event.getStudyId(), TEST_STUDY_ID);


### PR DESCRIPTION
1. Deleting an event that triggers a study burst now also deletes the study burst events;
2. New query parameter introduced, `updateBursts` (default is true). If set to false, an update to a trigger event will not update the study burst events (a creation of the event will still create the study burst events however);
3. persisting `updateType` (once an event is created, its event type cannot be changed by redefining the event).