### PR TITLE
Move timeline metadata records into the transaction.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2Dao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2Dao.java
@@ -182,6 +182,10 @@ public class HibernateSchedule2Dao implements Schedule2Dao {
             LOG.info("Batch deleting timeline metadata records in " + 
                     deleteMetadataStopwatch.elapsed(MILLISECONDS) + " ms");
         }
+        
+        // This is necessary or the timeline records fail for lack of a session guid (hasn't been registered yet
+        // on creates).
+        session.flush();
 
         // Hibernate’s session.save() does an insert and then an update operation on each record, so 
         // switching to JDBC to do an insert only, halves the time it takes to do this operation

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2Dao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2Dao.java
@@ -131,9 +131,9 @@ public class HibernateSchedule2Dao implements Schedule2Dao {
 
         hibernateHelper.executeWithExceptionHandling(schedule, (session) -> {
             session.save(schedule);
+            deleteAndRecreateTimelineMetadataRecords(session, schedule, false);
             return schedule;
         });
-        deleteAndRecreateTimelineMetadataRecords(schedule, false);
         return schedule;
     }
 
@@ -158,47 +158,41 @@ public class HibernateSchedule2Dao implements Schedule2Dao {
                 query.setParameter(entry.getKey(), entry.getValue());
             }
             query.executeUpdate();
-
             session.update(schedule);
-
+            deleteAndRecreateTimelineMetadataRecords(session, schedule, true);
             return schedule;
         });
-        deleteAndRecreateTimelineMetadataRecords(schedule, true);
         return schedule;
     }
 
-    private void deleteAndRecreateTimelineMetadataRecords(Schedule2 schedule, boolean deleteFirst) {
+    private void deleteAndRecreateTimelineMetadataRecords(org.hibernate.Session session, Schedule2 schedule, boolean deleteFirst) {
         Timeline timeline = Scheduler.INSTANCE.calculateTimeline(schedule);
         List<TimelineMetadata> metadata = timeline.getMetadata();
 
-        hibernateHelper.executeWithExceptionHandling(schedule, (session) -> {
-            // batch these operations. Improves network performance
-            session.setJdbcBatchSize(batchSize);
+        // batch these operations. Improves network performance
+        session.setJdbcBatchSize(batchSize);
 
-            if (deleteFirst) {
-                Stopwatch deleteMetadataStopwatch = Stopwatch.createStarted();
-                NativeQuery<?> query = session.createNativeQuery(DELETE_TIMELINE_RECORDS);
-                query.setParameter(SCHEDULE_GUID, schedule.getGuid());
-                query.executeUpdate();
-                deleteMetadataStopwatch.stop();
+        if (deleteFirst) {
+            Stopwatch deleteMetadataStopwatch = Stopwatch.createStarted();
+            NativeQuery<?> query = session.createNativeQuery(DELETE_TIMELINE_RECORDS);
+            query.setParameter(SCHEDULE_GUID, schedule.getGuid());
+            query.executeUpdate();
+            deleteMetadataStopwatch.stop();
 
-                LOG.info("Batch deleting timeline metadata records in " + deleteMetadataStopwatch.elapsed(MILLISECONDS)
-                        + " ms");
-            }
+            LOG.info("Batch deleting timeline metadata records in " + 
+                    deleteMetadataStopwatch.elapsed(MILLISECONDS) + " ms");
+        }
 
-            // Hibernate’s session.save() does an insert and then an update operation on each record, so 
-            // switching to JDBC to do an insert only, halves the time it takes to do this operation
-            // even without further batch optimizations. I was not able to determine why Hibernate is doing 
-            // this (it’s not the most frequently cited culprit, an @Id generator, because we don’t use one).
-            Stopwatch createMetadataStopwatch = Stopwatch.createStarted();
-            session.doWork(persistRecordsInBatches(metadata));
-            createMetadataStopwatch.stop();
+        // Hibernate’s session.save() does an insert and then an update operation on each record, so 
+        // switching to JDBC to do an insert only, halves the time it takes to do this operation
+        // even without further batch optimizations. I was not able to determine why Hibernate is doing 
+        // this (it’s not the most frequently cited culprit, an @Id generator, because we don’t use one).
+        Stopwatch createMetadataStopwatch = Stopwatch.createStarted();
+        session.doWork(persistRecordsInBatches(metadata));
+        createMetadataStopwatch.stop();
 
-            LOG.info("Persisting " + metadata.size() + " timeline metadata records in "
-                    + createMetadataStopwatch.elapsed(MILLISECONDS) + " ms (batchSize = " + batchSize + ")");
-
-            return null;
-        });
+        LOG.info("Persisting " + metadata.size() + " timeline metadata records in "
+                + createMetadataStopwatch.elapsed(MILLISECONDS) + " ms (batchSize = " + batchSize + ")");
     }
 
     /**

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Scheduler.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Scheduler.java
@@ -48,12 +48,12 @@ public class Scheduler {
 
         for (Session session : schedule.getSessions()) {
             if (!session.getAssessments().isEmpty()) {
+                List<String> startEventIds = session.getStartEventIds();
                 for (String studyBurstId : session.getStudyBurstIds()) {
-                    List<String> combinedSet = addUniqueItemsToList(session.getStartEventIds(), studyBurstEventsMap.get(studyBurstId));
-                    session.setStartEventIds(combinedSet);
+                    startEventIds = addUniqueItemsToList(startEventIds, studyBurstEventsMap.get(studyBurstId));
                 }
                 for (TimeWindow window : session.getTimeWindows()) {
-                    scheduleTimeWindowSequence(builder, schedule, session, window);
+                    scheduleTimeWindowSequence(builder, schedule, session, startEventIds, window);
                 }
             }
         }
@@ -106,7 +106,8 @@ public class Scheduler {
         return endDay;
     }
 
-    void scheduleTimeWindowSequence(Timeline.Builder builder, Schedule2 schedule, Session session, TimeWindow window) {
+    void scheduleTimeWindowSequence(Timeline.Builder builder, Schedule2 schedule, Session session,
+            List<String> startEventIds, TimeWindow window) {
         // Can be in days or weeks. Note that this means no individual session time stream can be longer than the
         // duration of the study, *not* that the study will last the duration on the calendar, since events that 
         // trigger a session series can start at any time. Those sessions will *also* run for the duration. It’s up 
@@ -162,7 +163,7 @@ public class Scheduler {
             // Add a scheduled session with a different GUID for each event, and one SessionInfo object for
             // all of them.
             
-            for (String oneEventId : session.getStartEventIds()) {
+            for (String oneEventId : startEventIds) {
                 // Clear the assessments that are calculated in each iteration. Other fields calculated 
                 // in this loop will be reset.
                 scheduledSession = scheduledSession.copyWithoutAssessments();

--- a/src/main/java/org/sagebionetworks/bridge/services/Schedule2Service.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/Schedule2Service.java
@@ -262,7 +262,7 @@ public class Schedule2Service {
 
         Validate.entityThrowingException(INSTANCE, schedule);
         
-        return dao.updateSchedule(schedule);        
+        return dao.updateSchedule(schedule);
     }
     
     /**

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/SchedulerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/SchedulerTest.java
@@ -1117,6 +1117,11 @@ public class SchedulerTest extends Mockito {
                 .collect(toSet());
         assertEquals(triggerEventIds, ImmutableSet.of("enrollment", "study_burst:burst1:01", "study_burst:burst1:02",
                 "study_burst:burst1:03", "study_burst:burst2:01"));
+        
+        // Let's verify that the original schedule does not contain alterations to its
+        // start event IDs or study burst IDs
+        assertEquals(schedule.getSessions().get(0).getStartEventIds(), ImmutableList.of("enrollment"));
+        assertEquals(schedule.getSessions().get(0).getStudyBurstIds(), ImmutableList.of("burst1", "burst2"));
     }
     
     /* ============================================================ */

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/SchedulerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/SchedulerTest.java
@@ -1120,8 +1120,9 @@ public class SchedulerTest extends Mockito {
         
         // Let's verify that the original schedule does not contain alterations to its
         // start event IDs or study burst IDs
-        assertEquals(schedule.getSessions().get(0).getStartEventIds(), ImmutableList.of("enrollment"));
-        assertEquals(schedule.getSessions().get(0).getStudyBurstIds(), ImmutableList.of("burst1", "burst2"));
+        Session updatedSession = schedule.getSessions().get(0);
+        assertEquals(updatedSession.getStartEventIds(), ImmutableList.of("enrollment"));
+        assertEquals(updatedSession.getStudyBurstIds(), ImmutableList.of("burst1", "burst2"));
     }
     
     /* ============================================================ */


### PR DESCRIPTION
Moving these into the transactions appears pretty straightforward (I did have to add one flush statement during the transaction). In the process though, in manual testing, I noticed that study burst IDs were appearing transferred into the startEventIds of the session. I'm not sure if this was an existing bug or a by-product of this change, but I have fixed it.