### PR TITLE
BRIDGE-3131 Truncate UserAgent and ClientInfo to fit in our database

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/src/main/java/org/sagebionetworks/bridge/BridgeConstants.java
@@ -12,6 +12,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 
 public class BridgeConstants {
+    // Excessively long User-Agent strings break the database and generally aren't parseable anyway.
+    public static final int MAX_USER_AGENT_LENGTH = 255;
+
     // see https://owasp.org/www-community/OWASP_Validation_Regex_Repository
     public static final String OWASP_REGEXP_VALID_EMAIL = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$";
     

--- a/src/main/java/org/sagebionetworks/bridge/models/ClientInfo.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/ClientInfo.java
@@ -16,6 +16,8 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 
+import org.sagebionetworks.bridge.BridgeConstants;
+
 /**
  * <p>
  * Parsed representation of the User-Agent header provided by the client, when it is in one of our prescribed formats:
@@ -259,7 +261,8 @@ public final class ClientInfo {
     }
     
     static ClientInfo parseUserAgentString(String userAgent) {
-        if (StringUtils.isBlank(userAgent) || 
+        if (StringUtils.isBlank(userAgent) ||
+            userAgent.length() > BridgeConstants.MAX_USER_AGENT_LENGTH ||
             MULTI_PARENS.matcher(userAgent).matches() ||
             SEMICOLON_IN_APP_STANZA.matcher(userAgent).matches()) {
             return UNKNOWN_CLIENT;

--- a/src/main/java/org/sagebionetworks/bridge/models/RequestInfo.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/RequestInfo.java
@@ -13,6 +13,7 @@ import javax.persistence.Table;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.hibernate.ClientInfoConverter;
 import org.sagebionetworks.bridge.hibernate.DateTimeToLongAttributeConverter;
 import org.sagebionetworks.bridge.hibernate.DateTimeZoneAttributeConverter;
@@ -206,6 +207,9 @@ public final class RequestInfo {
         }
         public Builder withUserAgent(String userAgent) {
             if (userAgent != null) {
+                if (userAgent.length() > BridgeConstants.MAX_USER_AGENT_LENGTH) {
+                    userAgent = userAgent.substring(0, BridgeConstants.MAX_USER_AGENT_LENGTH);
+                }
                 this.userAgent = userAgent;
             }
             return this;

--- a/src/test/java/org/sagebionetworks/bridge/models/ClientInfoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/ClientInfoTest.java
@@ -6,9 +6,12 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
+import org.apache.commons.lang3.StringUtils;
 import org.testng.annotations.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
+
+import org.sagebionetworks.bridge.BridgeConstants;
 
 public class ClientInfoTest {
 
@@ -82,7 +85,11 @@ public class ClientInfoTest {
         assertClientInfo("(test) (tones)", null, null, null, null, null, null, null);
         assertClientInfo("foo/bar d/e (c; a/b)", null, null, null, null, null, null, null);
         assertClientInfo("(c/d; a/b)", null, null, null, null, null, null, null);
-        
+
+        // Excessively long strings are rejected.
+        String aaaTooBig = StringUtils.repeat('A', 2*BridgeConstants.MAX_USER_AGENT_LENGTH);
+        assertClientInfo(aaaTooBig, null, null, null, null, null, null, null);
+
         // All the original test strings pass
         assertClientInfo("Unknown Client/14", "Unknown Client", 14, null, null, null, null, null);
         assertClientInfo("App Name: Here/14", "App Name: Here", 14, null, null, null, null, null);

--- a/src/test/java/org/sagebionetworks/bridge/models/RequestInfoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/RequestInfoTest.java
@@ -4,14 +4,17 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.USER_DATA_GROUPS;
 import static org.sagebionetworks.bridge.TestConstants.USER_STUDY_IDS;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.testng.annotations.Test;
 
+import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.time.DateUtils;
@@ -112,7 +115,17 @@ public class RequestInfoTest {
         assertEquals(copy.getUploadedOn(), UPLOADED_ON.withZone(copy.getTimeZone()));
         assertEquals(copy.getSignedInOn(), SIGNED_IN_ON.withZone(copy.getTimeZone()));
     }
-    
+
+    @Test
+    public void truncatesLongUserAgent() {
+        String aaaTooBig = StringUtils.repeat('A', 2*BridgeConstants.MAX_USER_AGENT_LENGTH);
+        String aaaJustRight = StringUtils.repeat('A', BridgeConstants.MAX_USER_AGENT_LENGTH);
+
+        RequestInfo requestInfo = new RequestInfo.Builder().withUserAgent(aaaTooBig).build();
+        assertNotEquals(requestInfo.getUserAgent(), aaaTooBig);
+        assertEquals(requestInfo.getUserAgent(), aaaJustRight);
+    }
+
     @Test
     public void deserializesSubstudyIdsCorrectly() throws Exception {
         String json = TestUtils.createJson("{'userSubstudyIds': ['A','B']}");


### PR DESCRIPTION
See https://sagebionetworks.jira.com/browse/BRIDGE-3131

MindKind (appId wellness) users in India are sending excessively long User-Agent strings. When we try to shove this in our RequestInfo, our database vomits because it's expecting a varchar(255). These User-Agent strings aren't in any format ClientInfo recognizes, so I'm okay with just truncating them.

While testing this, I also discovered that if you specify a User-Agent string that's just a long string of the same repeating character ("AAAAAAAAAAAAAAAAAAAAAAAA..."), ClientInfo will parse the whole thing as the app name. This is even less realistic than the above, but I figured while I'm in here, I'll have ClientInfo throw out any excessively long strings as well.

Note that the real fix is that MindKind app should send sensible User-Agent strings, but given that this is preventing users from signing in, and this is causing us to throw HTTP 500s, I figured we ought to fix it.