### PR TITLE
PasswordGeneratorBugFix

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/PasswordGenerator.java
+++ b/src/main/java/org/sagebionetworks/bridge/PasswordGenerator.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge;
 
 import java.security.SecureRandom;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import com.google.common.base.Preconditions;
@@ -44,7 +45,7 @@ public class PasswordGenerator {
     }
     
     private Set<Integer> getFourUniqueIntegers(int max) {
-        Set<Integer> set = Sets.newHashSetWithExpectedSize(4);
+        LinkedHashSet<Integer> set = new LinkedHashSet<>(4);
         while (set.size() < 4) {
             set.add(RANDOM.nextInt(max));
         }

--- a/src/test/java/org/sagebionetworks/bridge/PasswordGeneratorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/PasswordGeneratorTest.java
@@ -3,6 +3,8 @@ package org.sagebionetworks.bridge;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import org.testng.annotations.Test;
@@ -22,5 +24,31 @@ public class PasswordGeneratorTest {
         assertTrue(password.matches(".*[A-Z].*"));
         assertTrue(password.matches(".*[a-z].*"));
         assertTrue(password.matches(".*[0-9].*"));
+    }
+
+    @Test
+    public void randomSymbolDistribution() {
+        // Test 10000 bridge passwords for validity
+        Map<Integer, Integer> counts = new HashMap<>();
+        for (int i = 0; i < 9; i++) {
+            counts.put(i, 0);
+        }
+
+        String symbols = "!#$%&'()*+,-./:;<=>?@[]^_`{|}~";
+        for (int i = 0; i < 10000; i++) {
+            String password = PasswordGenerator.INSTANCE.nextPassword(9);
+            // Add to the counts of where each symbol is
+            for (int j = 0; j < symbols.length(); j++) {
+                int symbolIdx =  password.indexOf(symbols.charAt(j));
+                if (symbolIdx >= 0) {
+                    counts.put(symbolIdx, counts.get(symbolIdx) + 1);
+                }
+            }
+        }
+
+        for (int i = 0; i < 9; i++) {
+            // Make sure each index has at least 1% of the distribution
+            assertTrue(counts.get(i) > 10);
+        }
     }
 }


### PR DESCRIPTION
I am using the PasswordGenerator class in the project https://github.com/Sage-Bionetworks/DianUserMigration-Java and came across a minor bug in its implementation.

I noticed that the passwords that were generated from the code heavily favored the symbol being in the 6th or 7th character location. I thought that was odd, so I investigated deeper using the code in the screenshot below, and found that the distribution never put the symbol at index 0 and 1, which made me realize there was definitely a bug somewhere.

<img width="774" alt="Screen Shot 2021-11-16 at 3 37 04 PM" src="https://user-images.githubusercontent.com/5590748/142087937-5dedd0be-e809-445d-8040-979ef9f115ea.png">

The root cause of the bug ended up being that the `getFourUniqueIntegers` function stores the random ints in a `HashSet` which orders the values from lowest to highest. So, when the `nextPassword` function converts it to an iterator, the symbols always gets the highest value of the set, which explains why 0 and 1 are not possible.

I switched to using a `LinkedHashSet` which stores the Ints based on the order you added them instead of what the value of them in the set is. This fixed the bug.

I added a conditional check in the unit tests that the symbol must be placed in each index at least 1% of the time for the tests to pass. The old algorithm failed the test, but the new one passes every time.