### PR TITLE
Fixing two bugs with study activity events:

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudyActivityEventDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudyActivityEventDao.java
@@ -31,8 +31,8 @@ public class HibernateStudyActivityEventDao implements StudyActivityEventDao {
     static final String GET_RECENT_SQL = "SELECT *, (SELECT count(*) as total FROM " +
             "StudyActivityEvents WHERE eventId = sae.eventId AND studyId = :studyId " +
             "AND userId = :userId GROUP BY eventId) FROM StudyActivityEvents AS sae " +
-            "WHERE userId = :userId AND studyId = :studyId AND createdOn = (SELECT " +
-            "createdOn FROM StudyActivityEvents WHERE userId = :userId AND studyId = " +
+            "WHERE userId = :userId AND studyId = :studyId AND eventTimestamp = (SELECT " +
+            "eventTimestamp FROM StudyActivityEvents WHERE userId = :userId AND studyId = " +
             ":studyId AND eventId = sae.eventId ORDER BY createdOn DESC LIMIT 1) " +
             "ORDER BY eventId";
 

--- a/src/main/java/org/sagebionetworks/bridge/models/activities/StudyActivityEvent.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/activities/StudyActivityEvent.java
@@ -189,17 +189,29 @@ public class StudyActivityEvent implements HasTimestamp, BridgeEntity {
     public String getOriginEventId() { 
         return originEventId;
     }
+    public void setOriginEventId(String originEventId) {
+        this.originEventId = originEventId;
+    }
     public String getStudyBurstId() {
         return studyBurstId;
+    }
+    public void setStudyBurstId(String studyBurstId) {
+        this.studyBurstId = studyBurstId;
     }
     public Period getPeriodFromOrigin() {
         return periodFromOrigin;
     }
-    public Integer getRecordCount() {
-        return recordCount;
+    public void setPeriodFromOrigin(Period periodFromOrigin) {
+        this.periodFromOrigin = periodFromOrigin;
     }
     public ActivityEventUpdateType getUpdateType() {
         return updateType;
+    }
+    public void setUpdateType(ActivityEventUpdateType updateType) {
+        this.updateType = updateType;
+    }
+    public Integer getRecordCount() {
+        return recordCount;
     }
     
     public static final class Builder {
@@ -292,7 +304,6 @@ public class StudyActivityEvent implements HasTimestamp, BridgeEntity {
             this.eventId = eventId;
             return this;
         }
-        
         public StudyActivityEvent build() {
             // We’re constructing the event with a known (already validated) event ID
             if (eventId != null) {

--- a/src/main/java/org/sagebionetworks/bridge/services/StudyActivityEventService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyActivityEventService.java
@@ -16,6 +16,7 @@ import static org.sagebionetworks.bridge.validators.StudyActivityEventValidator.
 import static org.sagebionetworks.bridge.validators.StudyActivityEventValidator.CREATE_INSTANCE;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -165,9 +166,14 @@ public class StudyActivityEventService {
         StudyActivityEvent mostRecent = dao.getRecentStudyActivityEvent(
                 event.getUserId(), event.getStudyId(), event.getEventId());
         
-        // we will honor this, unless the origin event has never been published, then it *has* to
-        // trigger creating of the study bursts.
-        if (mostRecent == null) {
+        if (mostRecent != null) {
+            event.setOriginEventId(mostRecent.getOriginEventId());
+            event.setStudyBurstId(mostRecent.getStudyBurstId());
+            event.setPeriodFromOrigin(mostRecent.getPeriodFromOrigin());
+            event.setUpdateType(mostRecent.getUpdateType());
+        } else {
+            // we will honor this, unless the origin event has never been published, then it *has* to
+            // trigger creating of the study bursts.
             updateBursts = true;
         }
         // Throwing exceptions will prevent study burst updates from happening if 
@@ -228,6 +234,7 @@ public class StudyActivityEventService {
         for (String fieldName : GLOBAL_EVENTS_OF_INTEREST) {
             addIfPresent(events, map, fieldName, true);    
         }
+        events.sort(Comparator.comparing(StudyActivityEvent::getEventId));
         return new ResourceList<>(events); 
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/services/StudyActivityEventServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/StudyActivityEventServiceTest.java
@@ -71,7 +71,8 @@ public class StudyActivityEventServiceTest extends Mockito {
     private static final DateTime TIMELINE_RETRIEVED_TS = DateTime.parse("2019-03-05T01:34:53.395Z");
     private static final DateTime ENROLLMENT_TS = DateTime.parse("2019-10-14T01:34:53.395Z");
     private static final DateTime INSTALL_LINK_SENT_TS = DateTime.parse("2018-10-11T03:34:53.395Z");
-    private static final StudyActivityEvent PERSISTED_EVENT = new StudyActivityEvent.Builder().build();
+    private static final StudyActivityEvent PERSISTED_EVENT = new StudyActivityEvent.Builder()
+            .withUpdateType(IMMUTABLE).build();
 
     @Mock
     StudyActivityEventDao mockDao;
@@ -865,16 +866,16 @@ public class StudyActivityEventServiceTest extends Mockito {
         assertEquals(retValue.getItems().size(), 2);
         
         StudyActivityEvent event = retValue.getItems().get(0);
+        assertEquals(event.getEventId(), CREATED_ON_FIELD);
+        assertEquals(event.getTimestamp(), CREATED_ON);
+        
+        event = retValue.getItems().get(1);
         assertEquals(event.getEventId(), "enrollment");
         assertEquals(event.getTimestamp(), MODIFIED_ON);
         assertNull(event.getOriginEventId());
         assertNull(event.getStudyBurstId());
         assertEquals(event.getRecordCount(), Integer.valueOf(1));
         assertEquals(event.getUpdateType(), IMMUTABLE);
-        
-        event = retValue.getItems().get(1);
-        assertEquals(event.getEventId(), CREATED_ON_FIELD);
-        assertEquals(event.getTimestamp(), CREATED_ON);
     }
 
     @Test


### PR DESCRIPTION
- updates to study bursts were not carrying over the new study burst metadata;
- the query for most recent events was not using eventTimestamp for the key query portion;
- sorting the events by event ID after we add some stuff in the service;