### PR TITLE
Study bursts in timeline metadata

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2Dao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2Dao.java
@@ -48,8 +48,8 @@ public class HibernateSchedule2Dao implements Schedule2Dao {
     static final String AND_NOT_IN_GUIDS = "AND guid NOT IN (:guids)";
     static final String INSERT = "INSERT INTO TimelineMetadata (appId, assessmentGuid, assessmentId, assessmentInstanceGuid, "
             + "assessmentRevision, scheduleGuid, scheduleModifiedOn, schedulePublished, sessionGuid, sessionInstanceEndDay, "
-            + "sessionInstanceGuid, sessionInstanceStartDay, sessionStartEventId, timeWindowGuid, timeWindowPersistent, guid) "
-            + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+            + "sessionInstanceGuid, sessionInstanceStartDay, sessionStartEventId, timeWindowGuid, timeWindowPersistent, guid, "
+            + "studyBurstId, studyBurstNum) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
     static final String DELETE_TIMELINE_RECORDS = "DELETE FROM TimelineMetadata WHERE scheduleGuid = :scheduleGuid";
     static final String SELECT_ASSESSMENTS_FOR_SESSION_INSTANCE = "SELECT * FROM TimelineMetadata WHERE sessionInstanceGuid = :instanceGuid AND assessmentInstanceGuid IS NOT NULL";
     static final String DELETE_ALL_SCHEDULES = "DELETE FROM Schedules WHERE appId = :appId";
@@ -245,6 +245,14 @@ public class HibernateSchedule2Dao implements Schedule2Dao {
         ps.setString(14, meta.getTimeWindowGuid());
         ps.setBoolean(15, meta.isTimeWindowPersistent());
         ps.setString(16, meta.getGuid());
+        System.out.println(meta.getStudyBurstId());
+        ps.setString(17, meta.getStudyBurstId());
+        System.out.println(meta.getStudyBurstNum());
+        if (meta.getStudyBurstNum() == null) {
+            ps.setInt(18, Types.NULL);
+        } else {
+            ps.setInt(18, meta.getStudyBurstNum());    
+        }
         ps.addBatch();
     }
 

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2Dao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2Dao.java
@@ -245,9 +245,7 @@ public class HibernateSchedule2Dao implements Schedule2Dao {
         ps.setString(14, meta.getTimeWindowGuid());
         ps.setBoolean(15, meta.isTimeWindowPersistent());
         ps.setString(16, meta.getGuid());
-        System.out.println(meta.getStudyBurstId());
         ps.setString(17, meta.getStudyBurstId());
-        System.out.println(meta.getStudyBurstNum());
         if (meta.getStudyBurstNum() == null) {
             ps.setInt(18, Types.NULL);
         } else {

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudyActivityEventDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudyActivityEventDao.java
@@ -31,8 +31,8 @@ public class HibernateStudyActivityEventDao implements StudyActivityEventDao {
     static final String GET_RECENT_SQL = "SELECT *, (SELECT count(*) as total FROM " +
             "StudyActivityEvents WHERE eventId = sae.eventId AND studyId = :studyId " +
             "AND userId = :userId GROUP BY eventId) FROM StudyActivityEvents AS sae " +
-            "WHERE userId = :userId AND studyId = :studyId AND createdOn = (SELECT " +
-            "createdOn FROM StudyActivityEvents WHERE userId = :userId AND studyId = " +
+            "WHERE userId = :userId AND studyId = :studyId AND eventTimestamp = (SELECT " +
+            "eventTimestamp FROM StudyActivityEvents WHERE userId = :userId AND studyId = " +
             ":studyId AND eventId = sae.eventId ORDER BY createdOn DESC LIMIT 1) " +
             "ORDER BY eventId";
 

--- a/src/main/java/org/sagebionetworks/bridge/models/activities/StudyActivityEvent.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/activities/StudyActivityEvent.java
@@ -189,17 +189,29 @@ public class StudyActivityEvent implements HasTimestamp, BridgeEntity {
     public String getOriginEventId() { 
         return originEventId;
     }
+    public void setOriginEventId(String originEventId) {
+        this.originEventId = originEventId;
+    }
     public String getStudyBurstId() {
         return studyBurstId;
+    }
+    public void setStudyBurstId(String studyBurstId) {
+        this.studyBurstId = studyBurstId;
     }
     public Period getPeriodFromOrigin() {
         return periodFromOrigin;
     }
-    public Integer getRecordCount() {
-        return recordCount;
+    public void setPeriodFromOrigin(Period periodFromOrigin) {
+        this.periodFromOrigin = periodFromOrigin;
     }
     public ActivityEventUpdateType getUpdateType() {
         return updateType;
+    }
+    public void setUpdateType(ActivityEventUpdateType updateType) {
+        this.updateType = updateType;
+    }
+    public Integer getRecordCount() {
+        return recordCount;
     }
     
     public static final class Builder {
@@ -292,7 +304,6 @@ public class StudyActivityEvent implements HasTimestamp, BridgeEntity {
             this.eventId = eventId;
             return this;
         }
-        
         public StudyActivityEvent build() {
             // We’re constructing the event with a known (already validated) event ID
             if (eventId != null) {

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Timeline.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Timeline.java
@@ -123,6 +123,8 @@ public class Timeline {
             sessionMeta.setSessionInstanceEndDay(schSession.getEndDay());
             sessionMeta.setTimeWindowGuid(schSession.getTimeWindow().getGuid());
             sessionMeta.setTimeWindowPersistent(schSession.getTimeWindow().isPersistent());
+            sessionMeta.setStudyBurstId(schSession.getStudyBurstId());
+            sessionMeta.setStudyBurstNum(schSession.getStudyBurstNum());
             metadata.add(sessionMeta);
             
             for (ScheduledAssessment schAsmt : schSession.getAssessments()) {

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineMetadata.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineMetadata.java
@@ -41,6 +41,8 @@ public class TimelineMetadata implements BridgeEntity {
         copy.setScheduleModifiedOn(meta.getScheduleModifiedOn());
         copy.setSchedulePublished(meta.isSchedulePublished());
         copy.setAppId(meta.getAppId());
+        copy.setStudyBurstId(meta.getStudyBurstId());
+        copy.setStudyBurstNum(meta.getStudyBurstNum());
         return copy;
     }
     
@@ -50,18 +52,20 @@ public class TimelineMetadata implements BridgeEntity {
         map.put("assessmentInstanceGuid", assessmentInstanceGuid);
         map.put("assessmentGuid", assessmentGuid);
         map.put("assessmentId", assessmentId);
-        map.put("assessmentRevision", Integer.toString(assessmentRevision));
+        map.put("assessmentRevision", assessmentRevision == null ? null : Integer.toString(assessmentRevision));
         map.put("sessionInstanceGuid", sessionInstanceGuid);
         map.put("sessionGuid", sessionGuid);
-        map.put("sessionInstanceStartDay", Integer.toString(sessionInstanceStartDay));
-        map.put("sessionInstanceEndDay", Integer.toString(sessionInstanceEndDay));
+        map.put("sessionInstanceStartDay", sessionInstanceStartDay == null ? null : Integer.toString(sessionInstanceStartDay));
+        map.put("sessionInstanceEndDay", sessionInstanceEndDay == null ? null : Integer.toString(sessionInstanceEndDay));
         map.put("sessionStartEventId", sessionStartEventId);
         map.put("timeWindowGuid", timeWindowGuid);
         map.put("timeWindowPersistent", Boolean.toString(timeWindowPersistent));
         map.put("scheduleGuid", scheduleGuid);
-        map.put("scheduleModifiedOn", scheduleModifiedOn.toString());
+        map.put("scheduleModifiedOn", scheduleModifiedOn == null ? null : scheduleModifiedOn.toString());
         map.put("schedulePublished", Boolean.toString(schedulePublished));
         map.put("appId", appId);
+        map.put("studyBurstId", studyBurstId);
+        map.put("studyBurstNum", studyBurstNum == null ? null : studyBurstNum.toString());
         return map;
     }
     
@@ -82,6 +86,8 @@ public class TimelineMetadata implements BridgeEntity {
     @Convert(converter = DateTimeToLongAttributeConverter.class)
     private DateTime scheduleModifiedOn;
     private boolean schedulePublished;
+    private String studyBurstId;
+    private Integer studyBurstNum;
     private String appId;
     
     public String getGuid() {
@@ -179,5 +185,17 @@ public class TimelineMetadata implements BridgeEntity {
     }
     public void setAppId(String appId) {
         this.appId = appId;
+    }
+    public String getStudyBurstId() {
+        return studyBurstId;
+    }
+    public void setStudyBurstId(String studyBurstId) {
+        this.studyBurstId = studyBurstId;
+    }
+    public Integer getStudyBurstNum() {
+        return studyBurstNum;
+    }
+    public void setStudyBurstNum(Integer studyBurstNum) {
+        this.studyBurstNum = studyBurstNum;
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/services/StudyActivityEventService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyActivityEventService.java
@@ -16,6 +16,7 @@ import static org.sagebionetworks.bridge.validators.StudyActivityEventValidator.
 import static org.sagebionetworks.bridge.validators.StudyActivityEventValidator.CREATE_INSTANCE;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -165,9 +166,14 @@ public class StudyActivityEventService {
         StudyActivityEvent mostRecent = dao.getRecentStudyActivityEvent(
                 event.getUserId(), event.getStudyId(), event.getEventId());
         
-        // we will honor this, unless the origin event has never been published, then it *has* to
-        // trigger creating of the study bursts.
-        if (mostRecent == null) {
+        if (mostRecent != null) {
+            event.setOriginEventId(mostRecent.getOriginEventId());
+            event.setStudyBurstId(mostRecent.getStudyBurstId());
+            event.setPeriodFromOrigin(mostRecent.getPeriodFromOrigin());
+            event.setUpdateType(mostRecent.getUpdateType());
+        } else {
+            // we will honor this, unless the origin event has never been published, then it *has* to
+            // trigger creating of the study bursts.
             updateBursts = true;
         }
         // Throwing exceptions will prevent study burst updates from happening if 
@@ -228,6 +234,7 @@ public class StudyActivityEventService {
         for (String fieldName : GLOBAL_EVENTS_OF_INTEREST) {
             addIfPresent(events, map, fieldName, true);    
         }
+        events.sort(Comparator.comparing(StudyActivityEvent::getEventId));
         return new ResourceList<>(events); 
     }
     

--- a/src/main/resources/db/changelog/changelog.sql
+++ b/src/main/resources/db/changelog/changelog.sql
@@ -841,3 +841,9 @@ ADD COLUMN `updateType` enum('MUTABLE', 'IMMUTABLE', 'FUTURE_ONLY') DEFAULT 'IMM
 
 ALTER TABLE `ScheduleStudyBursts`
 ADD COLUMN `delayPeriod` varchar(60);
+
+-- changeset bridge:55
+
+ALTER TABLE `TimelineMetadata`
+ADD COLUMN `studyBurstId` varchar(255),
+ADD COLUMN `studyBurstNum` int(10) unsigned;

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2DaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2DaoTest.java
@@ -318,13 +318,19 @@ public class HibernateSchedule2DaoTest extends Mockito {
         verify(mockStatement).setString(14, meta.getTimeWindowGuid());
         verify(mockStatement).setBoolean(15, meta.isTimeWindowPersistent());
         verify(mockStatement).setString(16, meta.getGuid());
+        verify(mockStatement).setString(17, meta.getStudyBurstId());
+        verify(mockStatement).setInt(18, Types.NULL);
         verify(mockStatement).addBatch();
 
-        reset(mockStatement);
-        meta = timeline.getMetadata().get(1);
-
+        mockStatement = mock(PreparedStatement.class);
+        meta = timeline.getMetadata().get(7);
         dao.updatePreparedStatement(mockStatement, meta);
-
+        verify(mockStatement).setString(17, "burst1");
+        verify(mockStatement).setInt(18, 2);
+        
+        mockStatement = mock(PreparedStatement.class);
+        meta = timeline.getMetadata().get(1);
+        dao.updatePreparedStatement(mockStatement, meta);
         // this also works
         verify(mockStatement).setInt(5, meta.getAssessmentRevision());
     }

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineMetadataTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineMetadataTest.java
@@ -5,6 +5,7 @@ import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
 import static org.sagebionetworks.bridge.TestConstants.SESSION_GUID_1;
 import static org.sagebionetworks.bridge.TestConstants.SESSION_WINDOW_GUID_1;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import java.util.Map;
@@ -32,6 +33,8 @@ public class TimelineMetadataTest extends Mockito {
         assertEquals(meta.getScheduleModifiedOn(), MODIFIED_ON);
         assertTrue(meta.isSchedulePublished());
         assertTrue(meta.isTimeWindowPersistent());
+        assertEquals(meta.getStudyBurstId(), "studyBurstId");
+        assertEquals(meta.getStudyBurstNum(), Integer.valueOf(4));
         assertEquals(meta.getAppId(), "appId");
     }
 
@@ -54,6 +57,8 @@ public class TimelineMetadataTest extends Mockito {
         assertEquals(copy.getScheduleModifiedOn(), MODIFIED_ON);
         assertTrue(copy.isSchedulePublished());
         assertTrue(copy.isTimeWindowPersistent());
+        assertEquals(copy.getStudyBurstId(), "studyBurstId");
+        assertEquals(copy.getStudyBurstNum(), Integer.valueOf(4));
         assertEquals(copy.getAppId(), "appId");
     }
     
@@ -79,6 +84,29 @@ public class TimelineMetadataTest extends Mockito {
         assertEquals(map.get("scheduleModifiedOn"), MODIFIED_ON.toString());
         assertEquals(map.get("schedulePublished"), "true");
     }
+    
+    @Test
+    public void asMap_nullValues() {
+        TimelineMetadata meta = new TimelineMetadata();;
+        
+        Map<String,String> map = meta.asMap();
+        assertNull(map.get("appId"));
+        assertNull(map.get("guid"));
+        assertNull(map.get("assessmentInstanceGuid"));
+        assertNull(map.get("assessmentGuid"));
+        assertNull(map.get("assessmentId"));
+        assertNull(map.get("assessmentRevision"));
+        assertNull(map.get("sessionInstanceGuid"));
+        assertNull(map.get("sessionGuid"));
+        assertNull(map.get("sessionStartEventId"));
+        assertNull(map.get("sessionInstanceStartDay"));
+        assertNull(map.get("sessionInstanceEndDay"));
+        assertNull(map.get("timeWindowGuid"));
+        assertEquals(map.get("timeWindowPersistent"), "false");
+        assertNull(map.get("scheduleGuid"));
+        assertNull(map.get("scheduleModifiedOn"));
+        assertEquals(map.get("schedulePublished"), "false");
+    }
 
     private TimelineMetadata createTimelineMetadata() {
         TimelineMetadata meta = new TimelineMetadata();
@@ -98,6 +126,8 @@ public class TimelineMetadataTest extends Mockito {
         meta.setScheduleModifiedOn(MODIFIED_ON);
         meta.setSchedulePublished(true);
         meta.setAppId("appId");
+        meta.setStudyBurstId("studyBurstId");
+        meta.setStudyBurstNum(Integer.valueOf(4));
         return meta;
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineMetadataTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineMetadataTest.java
@@ -14,7 +14,7 @@ import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 public class TimelineMetadataTest extends Mockito {
-    
+
     @Test
     public void test() {
         TimelineMetadata meta = createTimelineMetadata();
@@ -83,11 +83,13 @@ public class TimelineMetadataTest extends Mockito {
         assertEquals(map.get("scheduleGuid"), "scheduleGuid");
         assertEquals(map.get("scheduleModifiedOn"), MODIFIED_ON.toString());
         assertEquals(map.get("schedulePublished"), "true");
+        assertEquals(map.get("studyBurstId"), "studyBurstId");
+        assertEquals(map.get("studyBurstNum"), "4");
     }
     
     @Test
     public void asMap_nullValues() {
-        TimelineMetadata meta = new TimelineMetadata();;
+        TimelineMetadata meta = new TimelineMetadata();
         
         Map<String,String> map = meta.asMap();
         assertNull(map.get("appId"));
@@ -106,6 +108,8 @@ public class TimelineMetadataTest extends Mockito {
         assertNull(map.get("scheduleGuid"));
         assertNull(map.get("scheduleModifiedOn"));
         assertEquals(map.get("schedulePublished"), "false");
+        assertNull(map.get("studyBurstId"));
+        assertNull(map.get("studyBurstNum"));
     }
 
     private TimelineMetadata createTimelineMetadata() {

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/timelines/TimelineTest.java
@@ -101,34 +101,22 @@ public class TimelineTest extends Mockito {
     }
     
     @Test
-    public void generatesTimelineMetadataRecord() {
+    public void generatesTimelineMetadataRecord() throws Exception {
         Schedule2 schedule = Schedule2Test.createValidSchedule();
         schedule.setDuration(Period.parse("P2W"));
         
         Timeline timeline = Scheduler.INSTANCE.calculateTimeline(schedule);
         List<TimelineMetadata> metadata = timeline.getMetadata();
         
-        // This is the session record
-        TimelineMetadata meta1 = metadata.get(0);
-        String sessionInstanceGuid = "faQS0dRjAt9xNFTfOd5XqA";
-        assertEquals(meta1.getGuid(), sessionInstanceGuid);
-        assertNull(meta1.getAssessmentInstanceGuid());
-        assertNull(meta1.getAssessmentGuid());
-        assertNull(meta1.getAssessmentId());
-        assertNull(meta1.getAssessmentRevision());
-        assertEquals(meta1.getSessionInstanceGuid(), sessionInstanceGuid);
-        assertEquals(meta1.getSessionGuid(), SESSION_GUID_1);
-        assertEquals(meta1.getSessionStartEventId(), "activities_retrieved");
-        assertEquals(meta1.getSessionInstanceStartDay(), Integer.valueOf(7));
-        assertEquals(meta1.getSessionInstanceEndDay(), Integer.valueOf(7));
-        assertEquals(meta1.getTimeWindowGuid(), SESSION_WINDOW_GUID_1);
-        assertEquals(meta1.getScheduleGuid(), SCHEDULE_GUID);
-        assertEquals(meta1.getScheduleModifiedOn(), MODIFIED_ON);
-        assertTrue(meta1.isSchedulePublished());
-        assertEquals(meta1.getAppId(), TEST_APP_ID);
+        // This is a metadata record for a burst
+        TimelineMetadata meta1 = metadata.get(6);
+        
+        assertEquals(meta1.getStudyBurstId(), "burst1");
+        assertEquals(meta1.getStudyBurstNum(), Integer.valueOf(2));
 
         // This is the assessment #1 record
         TimelineMetadata meta2 = metadata.get(1);
+        String sessionInstanceGuid = "faQS0dRjAt9xNFTfOd5XqA";
         String asmtInstanceGuid = "5NzDH5Q4V2VkSBFQF2HntA";
         assertEquals(meta2.getGuid(), asmtInstanceGuid);
         assertEquals(meta2.getAssessmentInstanceGuid(), asmtInstanceGuid);

--- a/src/test/java/org/sagebionetworks/bridge/services/StudyActivityEventServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/StudyActivityEventServiceTest.java
@@ -71,7 +71,8 @@ public class StudyActivityEventServiceTest extends Mockito {
     private static final DateTime TIMELINE_RETRIEVED_TS = DateTime.parse("2019-03-05T01:34:53.395Z");
     private static final DateTime ENROLLMENT_TS = DateTime.parse("2019-10-14T01:34:53.395Z");
     private static final DateTime INSTALL_LINK_SENT_TS = DateTime.parse("2018-10-11T03:34:53.395Z");
-    private static final StudyActivityEvent PERSISTED_EVENT = new StudyActivityEvent.Builder().build();
+    private static final StudyActivityEvent PERSISTED_EVENT = new StudyActivityEvent.Builder()
+            .withUpdateType(IMMUTABLE).build();
 
     @Mock
     StudyActivityEventDao mockDao;
@@ -865,16 +866,16 @@ public class StudyActivityEventServiceTest extends Mockito {
         assertEquals(retValue.getItems().size(), 2);
         
         StudyActivityEvent event = retValue.getItems().get(0);
+        assertEquals(event.getEventId(), CREATED_ON_FIELD);
+        assertEquals(event.getTimestamp(), CREATED_ON);
+        
+        event = retValue.getItems().get(1);
         assertEquals(event.getEventId(), "enrollment");
         assertEquals(event.getTimestamp(), MODIFIED_ON);
         assertNull(event.getOriginEventId());
         assertNull(event.getStudyBurstId());
         assertEquals(event.getRecordCount(), Integer.valueOf(1));
         assertEquals(event.getUpdateType(), IMMUTABLE);
-        
-        event = retValue.getItems().get(1);
-        assertEquals(event.getEventId(), CREATED_ON_FIELD);
-        assertEquals(event.getTimestamp(), CREATED_ON);
     }
 
     @Test


### PR DESCRIPTION
This information is useful to export and useful for adherence reports, so it needs to go into the timeline metadata table (our main way of processing timeline information efficiently).

This incorporates bug fixes in related code and will be a smaller PR once that's reviewed and merged. Then we can review this.