### PR TITLE
BRIDGE-3152 (integration tests in production)

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
@@ -253,19 +253,35 @@ public class AuthUtils {
             .hasAnyRole(DEVELOPER, RESEARCHER, ADMIN);
     
     /**
-     * Is the caller in the provided role? Superadmins always pass this test.
+     * Is the caller in the provided role? Superadmins always pass this test, and admins
+     * always pass this test unless it requires a superadmin.
      */
     public static boolean isInRole(Set<Roles> callerRoles, Roles requiredRole) {
-        return callerRoles != null && requiredRole != null && 
-                (callerRoles.contains(SUPERADMIN) || callerRoles.contains(requiredRole));
+        if (callerRoles == null || requiredRole == null) {
+            return false;
+        }
+        // User is a superadmin, or an admin for a call requiring any role other than superadmin,
+        // and therefore can access.
+        if (callerRoles.contains(SUPERADMIN) || (callerRoles.contains(ADMIN) && requiredRole != SUPERADMIN)) {
+            return true;
+        }
+        return callerRoles.contains(requiredRole);
     }
     
     /**
-     * Is the caller in any of the provided roles? Superadmins always pass this test.
+     * Is the caller in any of the provided roles? Superadmins always pass this test. Admins
+     * always pass this test unless it requires a superadmin.
      */
     public static boolean isInRole(Set<Roles> callerRoles, Set<Roles> requiredRoles) {
-        return callerRoles != null && requiredRoles != null && 
-                requiredRoles.stream().anyMatch(role -> isInRole(callerRoles, role));
+        if (callerRoles == null || requiredRoles == null || requiredRoles.isEmpty()) {
+            return false;
+        }
+        // User is a superadmin, or an admin for a call requiring any role other than superadmin,
+        // and therefore can access.
+        if (callerRoles.contains(SUPERADMIN) || (!requiredRoles.contains(SUPERADMIN) && callerRoles.contains(ADMIN))) {
+            return true;
+        }
+        return requiredRoles.stream().anyMatch(role -> callerRoles.contains(role));
     }
     
     

--- a/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
@@ -18,8 +18,6 @@ import java.util.Set;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.studies.Enrollment;
 
-import com.google.common.collect.ImmutableSet;
-
 /**
  * Utility methods to check caller authorization in service methods. Given the way the code and the 
  * authorization rules are written, ADMIN and SUPERADMIN roles will currently always pass. They

--- a/src/main/java/org/sagebionetworks/bridge/Roles.java
+++ b/src/main/java/org/sagebionetworks/bridge/Roles.java
@@ -41,4 +41,15 @@ public enum Roles {
         .put(STUDY_COORDINATOR, EnumSet.of(SUPERADMIN, ADMIN, ORG_ADMIN))
         .put(STUDY_DESIGNER, EnumSet.of(SUPERADMIN, ADMIN, ORG_ADMIN))
         .build();
+
+    public static final Map<Roles,EnumSet<Roles>> PASSES_AS_ROLE = new ImmutableMap.Builder<Roles, EnumSet<Roles>>()
+            .put(SUPERADMIN, EnumSet.of(SUPERADMIN, ADMIN, RESEARCHER, DEVELOPER, ORG_ADMIN, STUDY_COORDINATOR, STUDY_DESIGNER))
+            .put(ADMIN, EnumSet.of(ADMIN, RESEARCHER, DEVELOPER, ORG_ADMIN, STUDY_COORDINATOR, STUDY_DESIGNER))
+            .put(RESEARCHER, EnumSet.of(RESEARCHER))
+            .put(DEVELOPER, EnumSet.of(DEVELOPER))
+            .put(ORG_ADMIN, EnumSet.of(ORG_ADMIN))
+            .put(STUDY_COORDINATOR, EnumSet.of(STUDY_COORDINATOR))
+            .put(STUDY_DESIGNER, EnumSet.of(STUDY_DESIGNER))
+            .put(WORKER, EnumSet.of(WORKER))
+            .build();
 }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AccountsController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AccountsController.java
@@ -80,7 +80,7 @@ public class AccountsController extends BaseController  {
     @PostMapping("/v1/accounts")
     @ResponseStatus(code = CREATED)
     public IdentifierHolder createAccount() {
-        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(ORG_ADMIN);
         String orgId = session.getParticipant().getOrgMembership();
         
         // We can deserialize this as a participant record, because StudyParticipant
@@ -99,14 +99,14 @@ public class AccountsController extends BaseController  {
     
     @GetMapping("/v1/accounts/{userId}")
     public Account getAccount(@PathVariable String userId) {
-        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(ORG_ADMIN);
         
         return verifyOrgAdminIsActingOnOrgMember(session, userId);
     }
     
     @PostMapping("/v1/accounts/{userId}")
     public StatusMessage updateAccount(@PathVariable String userId) {
-        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(ORG_ADMIN);
         
         Account account = verifyOrgAdminIsActingOnOrgMember(session, userId);
         App app = appService.getApp(session.getAppId());
@@ -128,7 +128,7 @@ public class AccountsController extends BaseController  {
     
     @DeleteMapping("/v1/accounts/{userId}")
     public StatusMessage deleteAccount(@PathVariable String userId) {
-        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(ORG_ADMIN);
         
         verifyOrgAdminIsActingOnOrgMember(session, userId);
         
@@ -143,7 +143,7 @@ public class AccountsController extends BaseController  {
             produces = { APPLICATION_JSON_UTF8_VALUE })
     public String getRequestInfo(@PathVariable String userId) 
             throws JsonProcessingException {
-        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(ORG_ADMIN);
         
         verifyOrgAdminIsActingOnOrgMember(session, userId);
         
@@ -159,7 +159,7 @@ public class AccountsController extends BaseController  {
     @PostMapping("/v1/accounts/{userId}/requestResetPassword")
     @ResponseStatus(code = ACCEPTED)
     public StatusMessage requestResetPassword(@PathVariable String userId) {
-        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(ORG_ADMIN);
         
         verifyOrgAdminIsActingOnOrgMember(session, userId);
 
@@ -172,7 +172,7 @@ public class AccountsController extends BaseController  {
     @PostMapping("/v1/accounts/{userId}/resendEmailVerification")
     @ResponseStatus(code = ACCEPTED)
     public StatusMessage resendEmailVerification(@PathVariable String userId) {
-        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(ORG_ADMIN);
         
         verifyOrgAdminIsActingOnOrgMember(session, userId);
 
@@ -185,7 +185,7 @@ public class AccountsController extends BaseController  {
     @PostMapping("/v1/accounts/{userId}/resendPhoneVerification")
     @ResponseStatus(code = ACCEPTED)
     public StatusMessage resendPhoneVerification(@PathVariable String userId) {
-        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(ORG_ADMIN);
         
         verifyOrgAdminIsActingOnOrgMember(session, userId);
 
@@ -213,7 +213,7 @@ public class AccountsController extends BaseController  {
     @PostMapping("/v1/accounts/{userId}/signOut")
     public StatusMessage signOut(@PathVariable String userId,
             @RequestParam(required = false) boolean deleteReauthToken) {
-        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(ORG_ADMIN);
         
         verifyOrgAdminIsActingOnOrgMember(session, userId);
 

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AppConfigController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AppConfigController.java
@@ -121,7 +121,7 @@ public class AppConfigController extends BaseController {
     
     @DeleteMapping("/v3/appconfigs/{guid}")
     public StatusMessage deleteAppConfig(@PathVariable String guid, @RequestParam String physical) {
-        UserSession session = getAuthenticatedSession(DEVELOPER, ADMIN);
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         
         if ("true".equals(physical) && session.isInRole(ADMIN)) {
             appConfigService.deleteAppConfigPermanently(session.getAppId(), guid);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AppConfigElementsController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AppConfigElementsController.java
@@ -113,7 +113,7 @@ public class AppConfigElementsController extends BaseController {
 
     @DeleteMapping("/v3/appconfigs/elements/{id}")
     public StatusMessage deleteElementAllRevisions(@PathVariable String id, @RequestParam String physical) {
-        UserSession session = getAuthenticatedSession(DEVELOPER, ADMIN);
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         
         if ("true".equals(physical) && session.isInRole(ADMIN)) {
             service.deleteElementAllRevisionsPermanently(session.getAppId(), id);
@@ -128,7 +128,7 @@ public class AppConfigElementsController extends BaseController {
     @DeleteMapping("/v3/appconfigs/elements/{id}/revisions/{revision}")
     public StatusMessage deleteElementRevision(@PathVariable String id, @PathVariable String revision,
             @RequestParam String physical) {
-        UserSession session = getAuthenticatedSession(DEVELOPER, ADMIN);
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         
         Long revisionLong = BridgeUtils.getLongOrDefault(revision, null);
         if (revisionLong == null) {

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AppController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AppController.java
@@ -109,7 +109,7 @@ public class AppController extends BaseController {
     
     @PostMapping(path = {"/v1/apps/self", "/v3/studies/self"})
     public VersionHolder updateAppForDeveloperOrAdmin() {
-        UserSession session = getAuthenticatedSession(DEVELOPER, ADMIN  );
+        UserSession session = getAuthenticatedSession(DEVELOPER);
 
         App appUpdate = parseJson(App.class);
         appUpdate.setIdentifier(session.getAppId());

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AssessmentConfigController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AssessmentConfigController.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.bridge.spring.controllers;
 import static org.sagebionetworks.bridge.BridgeConstants.SHARED_ASSESSMENTS_ERROR;
 import static org.sagebionetworks.bridge.BridgeConstants.SHARED_APP_ID;
 import static org.sagebionetworks.bridge.BridgeConstants.UPDATES_TYPEREF;
-import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.STUDY_DESIGNER;
 
@@ -36,7 +35,7 @@ public class AssessmentConfigController extends BaseController {
     }
     
     private String getOwnerId(UserSession session) {
-        if (session.isInRole(ImmutableSet.of(DEVELOPER, ADMIN))) {
+        if (session.isInRole(ImmutableSet.of(DEVELOPER))) {
             return null;
         }
         return session.getParticipant().getOrgMembership();

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AssessmentController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AssessmentController.java
@@ -44,7 +44,7 @@ public class AssessmentController extends BaseController {
     }
     
     private String getOwnerId(UserSession session) {
-        if (session.isInRole(ImmutableSet.of(DEVELOPER, ADMIN))) {
+        if (session.isInRole(ImmutableSet.of(DEVELOPER))) {
             return null;
         }
         return session.getParticipant().getOrgMembership();
@@ -169,7 +169,7 @@ public class AssessmentController extends BaseController {
         
     @DeleteMapping("/v1/assessments/{guid}")
     public StatusMessage deleteAssessment(@PathVariable String guid, @RequestParam(required = false) String physical) {
-        UserSession session = getAuthenticatedSession(DEVELOPER, STUDY_DESIGNER, ADMIN);
+        UserSession session = getAuthenticatedSession(DEVELOPER, STUDY_DESIGNER);
 
         String appId = session.getAppId();
         String ownerId = getOwnerId(session);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AssessmentResourceController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AssessmentResourceController.java
@@ -48,7 +48,7 @@ public class AssessmentResourceController extends BaseController {
     }
     
     private String getOwnerId(UserSession session) {
-        if (session.isInRole(ImmutableSet.of(DEVELOPER, ADMIN))) {
+        if (session.isInRole(ImmutableSet.of(DEVELOPER))) {
             return null;
         }
         return session.getParticipant().getOrgMembership();
@@ -130,7 +130,7 @@ public class AssessmentResourceController extends BaseController {
     @DeleteMapping("/v1/assessments/identifier:{assessmentId}/resources/{guid}")
     public StatusMessage deleteAssessmentResource(@PathVariable String assessmentId, @PathVariable String guid,
             @RequestParam(required = false) String physical) {
-        UserSession session = getAuthenticatedSession(DEVELOPER, STUDY_DESIGNER, ADMIN);
+        UserSession session = getAuthenticatedSession(DEVELOPER, STUDY_DESIGNER);
         String appId = session.getAppId();
         String ownerId = session.getParticipant().getOrgMembership();
         

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/Exporter3Controller.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/Exporter3Controller.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
-import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 
 import java.io.IOException;
@@ -32,7 +31,7 @@ public class Exporter3Controller extends BaseController {
     @PostMapping(path = "/v1/apps/self/exporter3")
     @ResponseStatus(HttpStatus.CREATED)
     public Exporter3Configuration initExporter3() throws IOException, SynapseException {
-        UserSession session = getAuthenticatedSession(ADMIN, DEVELOPER);
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         return exporter3Service.initExporter3(session.getAppId());
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/FileController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/FileController.java
@@ -85,7 +85,7 @@ public class FileController extends BaseController {
     @DeleteMapping("/v3/files/{guid}")
     public StatusMessage deleteFile(@PathVariable String guid,
             @RequestParam(defaultValue = "false") String physical) {
-        UserSession session = getAuthenticatedSession(DEVELOPER, ADMIN);
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         
         if ("true".equals(physical) && session.isInRole(ADMIN)) {
             fileService.deleteFilePermanently(session.getAppId(), guid);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/HealthDataDocumentationController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/HealthDataDocumentationController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
+import static org.sagebionetworks.bridge.Roles.ADMIN;
 
 @CrossOrigin
 @RestController
@@ -65,7 +66,7 @@ public class HealthDataDocumentationController extends BaseController {
     /** Delete a health data documentation with the given identifier. */
     @DeleteMapping(path="v3/healthdatadocumentation/{identifier}")
     public StatusMessage deleteHealthDataDocumentationForIdentifier(@PathVariable String identifier) {
-        UserSession session = getAuthenticatedSession(Roles.ADMIN);
+        UserSession session = getAuthenticatedSession(ADMIN);
 
         String parentId = session.getAppId(); // placeholder
         healthDataDocumentationService.deleteHealthDataDocumentation(parentId, identifier);
@@ -76,7 +77,7 @@ public class HealthDataDocumentationController extends BaseController {
     /** Delete all health data documentation with the given parentId. */
     @DeleteMapping(path="/v3/healthdatadocumentation")
     public StatusMessage deleteAllHealthDataDocumentationForParentId() {
-        UserSession session = getAuthenticatedSession(Roles.ADMIN);
+        UserSession session = getAuthenticatedSession(ADMIN);
 
         healthDataDocumentationService.deleteAllHealthDataDocumentation(session.getAppId());
         return new StatusMessage("Health data documentation has been deleted.");

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/MembershipController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/MembershipController.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.bridge.spring.controllers;
 import static org.sagebionetworks.bridge.AuthEvaluatorField.ORG_ID;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_MEMBERS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_READ_MEMBERS;
-import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.ORG_ADMIN;
 import static org.springframework.http.HttpStatus.CREATED;
 
@@ -46,7 +45,7 @@ public class MembershipController extends BaseController {
     @PostMapping("/v1/organizations/{orgId}/members/{userId}")
     @ResponseStatus(code = CREATED)
     public StatusMessage addMember(@PathVariable String orgId, @PathVariable String userId) {
-        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(ORG_ADMIN);
         
         CAN_EDIT_MEMBERS.checkAndThrow(ORG_ID, orgId);
         
@@ -57,7 +56,7 @@ public class MembershipController extends BaseController {
 
     @DeleteMapping("/v1/organizations/{orgId}/members/{userId}")
     public StatusMessage removeMember(@PathVariable String orgId, @PathVariable String userId) {
-        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(ORG_ADMIN);
 
         CAN_EDIT_MEMBERS.checkAndThrow(ORG_ID, orgId);
         

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/NotificationTopicController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/NotificationTopicController.java
@@ -82,7 +82,7 @@ public class NotificationTopicController extends BaseController {
     @DeleteMapping("/v3/topics/{guid}")
     public StatusMessage deleteTopic(@PathVariable String guid,
             @RequestParam(defaultValue = "false") boolean physical) {
-        UserSession session = getAuthenticatedSession(DEVELOPER, ADMIN);
+        UserSession session = getAuthenticatedSession(DEVELOPER);
 
         if (physical && session.isInRole(ADMIN)) {
             topicService.deleteTopicPermanently(session.getAppId(), guid);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/OrganizationController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/OrganizationController.java
@@ -63,7 +63,7 @@ public class OrganizationController extends BaseController {
     public Organization updateOrganization(@PathVariable String orgId) {
         // A study admin caller will also be able to edit some fields of their own organization.
         // The association of accounts to organizations has to be completed first.
-        UserSession session = getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(ORG_ADMIN);
 
         CAN_EDIT_ORG.checkAndThrow(ORG_ID, orgId);
 

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantDataController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantDataController.java
@@ -97,7 +97,7 @@ public class ParticipantDataController extends BaseController {
     @GetMapping("/v1/apps/{appId}/participants/{userId}/data")
     public ForwardCursorPagedResourceList<String> getAllDataForAdminWorker(@PathVariable String appId, @PathVariable String userId,
                                                                            String offsetKey, String pageSize) {
-        UserSession session = getAuthenticatedSession(ADMIN, WORKER);
+        UserSession session = getAuthenticatedSession(WORKER);
 
         checkAccountExists(appId, userId);
         checkAdminSessionAppId(session, appId);
@@ -131,7 +131,7 @@ public class ParticipantDataController extends BaseController {
     @GetMapping("/v1/apps/{appId}/participants/{userId}/data/{identifier}")
     public ParticipantData getDataByIdentifierForAdminWorker(@PathVariable String appId, @PathVariable String userId,
                                                              @PathVariable String identifier) {
-        UserSession session = getAuthenticatedSession(ADMIN, WORKER);
+        UserSession session = getAuthenticatedSession(WORKER);
 
         checkAccountExists(appId, userId);
         checkAdminSessionAppId(session, userId);
@@ -145,7 +145,7 @@ public class ParticipantDataController extends BaseController {
     @PostMapping("/v1/apps/{appId}/participants/{userId}/data/{identifier}")
     @ResponseStatus(HttpStatus.CREATED)
     public StatusMessage saveDataForAdminWorker(@PathVariable String appId, @PathVariable String userId, @PathVariable String identifier) {
-        UserSession session = getAuthenticatedSession(ADMIN, WORKER);
+        UserSession session = getAuthenticatedSession(WORKER);
 
         checkAccountExists(appId, userId);
         checkAdminSessionAppId(session, appId);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/SchedulePlanController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/SchedulePlanController.java
@@ -98,7 +98,7 @@ public class SchedulePlanController extends BaseController {
     @DeleteMapping("/v3/scheduleplans/{guid}")
     public StatusMessage deleteSchedulePlan(@PathVariable String guid,
             @RequestParam(defaultValue = "false") boolean physical) {
-        UserSession session = getAuthenticatedSession(DEVELOPER, ADMIN);
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         String appId = session.getAppId();
         
         if (physical && session.isInRole(ADMIN)) {

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/SharedModuleMetadataController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/SharedModuleMetadataController.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.spring.controllers;
 
 import static org.sagebionetworks.bridge.BridgeConstants.SHARED_APP_ID;
+import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -179,7 +180,7 @@ public class SharedModuleMetadataController extends BaseController {
     }
     
     private UserSession verifySharedDeveloperOrAdminAccess() {
-        UserSession session = getAuthenticatedSession(Roles.DEVELOPER, Roles.ADMIN);
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         String appId = session.getAppId();
         if (!SHARED_APP_ID.equals(appId)) {
             throw new UnauthorizedException();

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyController.java
@@ -5,7 +5,6 @@ import static org.sagebionetworks.bridge.AuthUtils.CAN_UPDATE_STUDIES;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_READ_STUDIES;
 import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.ONE_DAY_IN_SECONDS;
-import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.ORG_ADMIN;
 import static org.sagebionetworks.bridge.Roles.STUDY_COORDINATOR;
@@ -77,7 +76,7 @@ public class StudyController extends BaseController {
     @PostMapping(path = {"/v5/studies", "/v3/substudies"})
     @ResponseStatus(HttpStatus.CREATED)
     public VersionHolder createStudy() {
-        UserSession session = getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR, ORG_ADMIN, ADMIN);
+        UserSession session = getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR, ORG_ADMIN);
 
         // we don't check if the study coordinator is member of the study because it doesn't
         // exist yet. If the caller is in an organization, that organization will sponsor the
@@ -112,7 +111,7 @@ public class StudyController extends BaseController {
     @DeleteMapping(path = {"/v5/studies/{id}", "/v3/substudies/{id}"})
     public StatusMessage deleteStudy(@PathVariable String id,
             @RequestParam(defaultValue = "false") String physical) {
-        UserSession session = getAuthenticatedSession(STUDY_DESIGNER, DEVELOPER, ADMIN);
+        UserSession session = getAuthenticatedSession(STUDY_DESIGNER, DEVELOPER);
         
         if ("true".equals(physical)) {
             service.deleteStudyPermanently(session.getAppId(), id);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/SubpopulationController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/SubpopulationController.java
@@ -90,7 +90,7 @@ public class SubpopulationController extends BaseController {
     @DeleteMapping("/v3/subpopulations/{guid}")
     public StatusMessage deleteSubpopulation(@PathVariable String guid,
             @RequestParam(defaultValue = "false") boolean physical) {
-        UserSession session = getAuthenticatedSession(ADMIN, DEVELOPER);
+        UserSession session = getAuthenticatedSession(DEVELOPER);
 
         SubpopulationGuid subpopGuid = SubpopulationGuid.create(guid);
         if (physical && session.isInRole(ADMIN)) {

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/SurveyController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/SurveyController.java
@@ -177,7 +177,7 @@ public class SurveyController extends BaseController {
     @DeleteMapping("/v3/surveys/{surveyGuid}/revisions/{createdOn}")
     public StatusMessage deleteSurvey(@PathVariable String surveyGuid, @PathVariable String createdOn,
             @RequestParam(defaultValue = "false") boolean physical) {
-        UserSession session = getAuthenticatedSession(DEVELOPER, ADMIN);
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         String appId = session.getAppId();
 
         long createdOnLong = DateUtils.convertToMillisFromEpoch(createdOn);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/TemplateController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/TemplateController.java
@@ -91,7 +91,7 @@ public class TemplateController extends BaseController {
     
     @DeleteMapping("/v3/templates/{guid}")
     public StatusMessage deleteTemplate(@PathVariable String guid, @RequestParam String physical) {
-        UserSession session = getAuthenticatedSession(DEVELOPER, ADMIN);
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         
         if ("true".equals(physical) && session.isInRole(ADMIN)) {
             templateService.deleteTemplatePermanently(session.getAppId(), guid);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/UploadController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/UploadController.java
@@ -168,7 +168,7 @@ public class UploadController extends BaseController {
     
     @GetMapping("/v3/uploads/{uploadId}")
     public UploadView getUpload(@PathVariable String uploadId) {
-        UserSession session = getAuthenticatedSession(DEVELOPER, ADMIN, WORKER);
+        UserSession session = getAuthenticatedSession(DEVELOPER, WORKER);
 
         if (uploadId.startsWith("recordId:")) {
             String recordId = uploadId.split(":")[1];

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/UploadSchemaController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/UploadSchemaController.java
@@ -79,7 +79,7 @@ public class UploadSchemaController extends BaseController {
     @DeleteMapping("/v3/uploadschemas/{schemaId}")
     public StatusMessage deleteAllRevisionsOfUploadSchema(@PathVariable String schemaId,
             @RequestParam(defaultValue = "false") boolean physical) {
-        UserSession session = getAuthenticatedSession(DEVELOPER, ADMIN);
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         
         if (physical && session.isInRole(ADMIN)) {
             uploadSchemaService.deleteUploadSchemaByIdPermanently(session.getAppId(), schemaId);
@@ -92,7 +92,7 @@ public class UploadSchemaController extends BaseController {
     @DeleteMapping("/v3/uploadschemas/{schemaId}/revisions/{revision}")
     public StatusMessage deleteSchemaRevision(@PathVariable String schemaId, @PathVariable int revision,
             @RequestParam(defaultValue = "false") boolean physical) {
-        UserSession session = getAuthenticatedSession(DEVELOPER, ADMIN);
+        UserSession session = getAuthenticatedSession(DEVELOPER);
         
         if (physical && session.isInRole(ADMIN)) {
             uploadSchemaService.deleteUploadSchemaByIdAndRevisionPermanently(session.getAppId(), schemaId, revision);

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/UserManagementController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/UserManagementController.java
@@ -68,28 +68,6 @@ public class UserManagementController extends BaseController {
         return UserSessionInfo.toJSON(session);
     }
     
-    /**
-     * This turned out to be useful... so useful we're opening it up to all administrative
-     * users.
-     * 
-     * @see org.sagebionetworks.bridge.spring.controllers.AuthenticationController#changeStudy 
-     */
-    @Deprecated
-    @PostMapping(path = {"/v3/auth/admin/app", "/v3/auth/admin/study"})
-    public JsonNode changeAppForAdmin() {
-        UserSession session = getAuthenticatedSession(SUPERADMIN);
-
-        // The only part of this payload we care about is the app property
-        SignIn signIn = parseJson(SignIn.class);
-        String appId = signIn.getAppId();
-
-        // Verify it's correct
-        App app = appService.getApp(appId);
-        sessionUpdateService.updateApp(session, app.getIdentifier());
-        
-        return UserSessionInfo.toJSON(session);
-    }
-    
     @PostMapping("/v3/users")
     @ResponseStatus(HttpStatus.CREATED)
     public JsonNode createUser() {
@@ -104,28 +82,6 @@ public class UserManagementController extends BaseController {
         UserSession userSession = userAdminService.createUser(app, participant, null, false, consent);
 
         return UserSessionInfo.toJSON(userSession);
-    }
-
-    /**
-     * Admin api used to create consent/not-consent user for given app
-     * nearly identical to createUser() one
-     * @param appId
-     * @return
-     */
-    @PostMapping(path = {"/v1/apps/{appId}/users", "/v3/studies/{appId}/users"})
-    @ResponseStatus(HttpStatus.CREATED)
-    public StatusMessage createUserWithAppId(@PathVariable String appId) {
-        getAuthenticatedSession(SUPERADMIN);
-        App app = appService.getApp(appId);
-        
-        JsonNode node = parseJson(JsonNode.class);
-        StudyParticipant participant = parseJson(node, StudyParticipant.class);
-
-        boolean consent = JsonUtils.asBoolean(node, CONSENT_FIELD);
-
-        userAdminService.createUser(app, participant, null, false, consent);
-
-        return CREATED_MSG;
     }
 
     @DeleteMapping("/v3/users/{userId}")

--- a/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
@@ -273,36 +273,63 @@ public class AuthUtilsTest extends Mockito {
     
     @Test
     public void isInRoleMethodsAreNullSafe() {
-        assertFalse(AuthUtils.isInRole(null, (Roles)null));
-        assertFalse(AuthUtils.isInRole(null, (Set<Roles>)null));
+        assertFalse(AuthUtils.isInRole(ImmutableSet.of(DEVELOPER), (Roles)null));
+        assertFalse(AuthUtils.isInRole(null, DEVELOPER));
+        assertFalse(AuthUtils.isInRole(ImmutableSet.of(DEVELOPER), (Set<Roles>)null));
+        assertFalse(AuthUtils.isInRole(null, ImmutableSet.of(DEVELOPER)));        
+        assertFalse(AuthUtils.isInRole(null, ImmutableSet.of()));
+        assertFalse(AuthUtils.isInRole(ImmutableSet.of(DEVELOPER), ImmutableSet.of()));
     }
     
     @Test
-    public void isInRoleForSuperadminMatchesEverything() {
+    public void isInRole_superadmin() {
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), DEVELOPER));
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), RESEARCHER));
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), ADMIN));
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), WORKER));
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), ADMIN));
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), SUPERADMIN));
+        
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), ImmutableSet.of(DEVELOPER)));
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), ImmutableSet.of(RESEARCHER)));
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), ImmutableSet.of(ADMIN)));
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), ImmutableSet.of(WORKER)));
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), ImmutableSet.of(DEVELOPER, ADMIN)));
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), ImmutableSet.of(SUPERADMIN)));
     }
     
     @Test
-    public void isInRole() {
-        assertFalse(AuthUtils.isInRole(ImmutableSet.of(ADMIN), DEVELOPER));
-        assertFalse(AuthUtils.isInRole(ImmutableSet.of(ADMIN), RESEARCHER));
+    public void isInRole_admin() {
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(ADMIN), DEVELOPER));
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(ADMIN), RESEARCHER));
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ADMIN));
-        assertFalse(AuthUtils.isInRole(ImmutableSet.of(ADMIN), WORKER));
-        assertFalse(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(DEVELOPER)));
-        assertFalse(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(RESEARCHER)));
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(ADMIN), WORKER));
+        assertFalse(AuthUtils.isInRole(ImmutableSet.of(ADMIN), SUPERADMIN));
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(DEVELOPER)));
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(RESEARCHER)));
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(ADMIN)));
-        assertFalse(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(WORKER)));
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(WORKER)));
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(DEVELOPER, ADMIN)));
+        assertFalse(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(SUPERADMIN)));
+        assertFalse(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(DEVELOPER, SUPERADMIN)));
     }
  
+    @Test
+    public void isInRole_developer() {
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(DEVELOPER), DEVELOPER));
+        assertFalse(AuthUtils.isInRole(ImmutableSet.of(DEVELOPER), RESEARCHER));
+        assertFalse(AuthUtils.isInRole(ImmutableSet.of(DEVELOPER), ADMIN));
+        assertFalse(AuthUtils.isInRole(ImmutableSet.of(DEVELOPER), WORKER));
+        assertFalse(AuthUtils.isInRole(ImmutableSet.of(DEVELOPER), SUPERADMIN));
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(DEVELOPER), ImmutableSet.of(DEVELOPER)));
+        assertFalse(AuthUtils.isInRole(ImmutableSet.of(DEVELOPER), ImmutableSet.of(RESEARCHER)));
+        assertFalse(AuthUtils.isInRole(ImmutableSet.of(DEVELOPER), ImmutableSet.of(ADMIN)));
+        assertFalse(AuthUtils.isInRole(ImmutableSet.of(DEVELOPER), ImmutableSet.of(WORKER)));
+        assertFalse(AuthUtils.isInRole(ImmutableSet.of(DEVELOPER), ImmutableSet.of(SUPERADMIN)));
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(DEVELOPER), ImmutableSet.of(DEVELOPER, ADMIN)));
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(DEVELOPER), ImmutableSet.of(DEVELOPER, SUPERADMIN)));
+    }
+    
     @Test
     public void canEditAssessments_succeedsForAdmin() {
         RequestContext.set(new RequestContext.Builder()

--- a/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
@@ -286,14 +286,14 @@ public class AuthUtilsTest extends Mockito {
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), DEVELOPER));
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), RESEARCHER));
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), ADMIN));
-        assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), WORKER));
+        assertFalse(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), WORKER));
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), ADMIN));
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), SUPERADMIN));
         
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), ImmutableSet.of(DEVELOPER)));
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), ImmutableSet.of(RESEARCHER)));
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), ImmutableSet.of(ADMIN)));
-        assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), ImmutableSet.of(WORKER)));
+        assertFalse(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), ImmutableSet.of(WORKER)));
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), ImmutableSet.of(DEVELOPER, ADMIN)));
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(SUPERADMIN), ImmutableSet.of(SUPERADMIN)));
     }
@@ -303,15 +303,15 @@ public class AuthUtilsTest extends Mockito {
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(ADMIN), DEVELOPER));
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(ADMIN), RESEARCHER));
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ADMIN));
-        assertTrue(AuthUtils.isInRole(ImmutableSet.of(ADMIN), WORKER));
+        assertFalse(AuthUtils.isInRole(ImmutableSet.of(ADMIN), WORKER));
         assertFalse(AuthUtils.isInRole(ImmutableSet.of(ADMIN), SUPERADMIN));
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(DEVELOPER)));
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(RESEARCHER)));
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(ADMIN)));
-        assertTrue(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(WORKER)));
+        assertFalse(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(WORKER)));
         assertTrue(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(DEVELOPER, ADMIN)));
         assertFalse(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(SUPERADMIN)));
-        assertFalse(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(DEVELOPER, SUPERADMIN)));
+        assertTrue(AuthUtils.isInRole(ImmutableSet.of(ADMIN), ImmutableSet.of(DEVELOPER, WORKER)));
     }
  
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/RequestContextTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/RequestContextTest.java
@@ -187,15 +187,15 @@ public class RequestContextTest extends Mockito {
     
     @Test
     public void isInRole() {
-        RequestContext context = new RequestContext.Builder().withCallerRoles(ImmutableSet.of(ADMIN)).build();
+        RequestContext context = new RequestContext.Builder().withCallerRoles(ImmutableSet.of(DEVELOPER)).build();
 
-        assertFalse(context.isInRole(DEVELOPER));
+        assertTrue(context.isInRole(DEVELOPER));
         assertFalse(context.isInRole(RESEARCHER));
-        assertTrue(context.isInRole(ADMIN));
+        assertFalse(context.isInRole(ADMIN));
         assertFalse(context.isInRole(WORKER));
-        assertFalse(context.isInRole(ImmutableSet.of(DEVELOPER)));
+        assertTrue(context.isInRole(ImmutableSet.of(DEVELOPER)));
         assertFalse(context.isInRole(ImmutableSet.of(RESEARCHER)));
-        assertTrue(context.isInRole(ImmutableSet.of(ADMIN)));
+        assertFalse(context.isInRole(ImmutableSet.of(ADMIN)));
         assertFalse(context.isInRole(ImmutableSet.of(WORKER)));
         assertTrue(context.isInRole(ImmutableSet.of(DEVELOPER, ADMIN)));
     }

--- a/src/test/java/org/sagebionetworks/bridge/RequestContextTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/RequestContextTest.java
@@ -177,12 +177,12 @@ public class RequestContextTest extends Mockito {
         assertTrue(context.isInRole(DEVELOPER));
         assertTrue(context.isInRole(RESEARCHER));
         assertTrue(context.isInRole(ADMIN));
-        assertTrue(context.isInRole(WORKER));
         assertTrue(context.isInRole(ImmutableSet.of(DEVELOPER)));
         assertTrue(context.isInRole(ImmutableSet.of(RESEARCHER)));
         assertTrue(context.isInRole(ImmutableSet.of(ADMIN)));
-        assertTrue(context.isInRole(ImmutableSet.of(WORKER)));
         assertTrue(context.isInRole(ImmutableSet.of(DEVELOPER, ADMIN)));
+        assertFalse(context.isInRole(ImmutableSet.of(WORKER)));  // except worker!
+        assertFalse(context.isInRole(WORKER));
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/UserSessionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/UserSessionTest.java
@@ -119,24 +119,24 @@ public class UserSessionTest {
     @Test
     public void userIsInRole() {
         UserSession session = new UserSession(new StudyParticipant.Builder()
-                .withRoles(ImmutableSet.of(ADMIN, DEVELOPER)).build());
+                .withRoles(ImmutableSet.of(DEVELOPER)).build());
 
         assertTrue(session.isInRole(DEVELOPER));
         assertFalse(session.isInRole(RESEARCHER));
         assertFalse(session.isInRole(WORKER));
-        assertTrue(session.isInRole(ADMIN));
+        assertFalse(session.isInRole(ADMIN));
         assertFalse(session.isInRole((Roles)null));
     }
     
     @Test
     public void userIsInRoleSet() {
         UserSession session = new UserSession(new StudyParticipant.Builder()
-                .withRoles(ImmutableSet.of(ADMIN, DEVELOPER)).build());
+                .withRoles(ImmutableSet.of(RESEARCHER, DEVELOPER)).build());
                 
         assertTrue(session.isInRole(ImmutableSet.of(DEVELOPER)));
-        assertFalse(session.isInRole(ImmutableSet.of(RESEARCHER)));
+        assertTrue(session.isInRole(ImmutableSet.of(RESEARCHER)));
         assertFalse(session.isInRole(ImmutableSet.of(WORKER)));
-        assertTrue(session.isInRole(ImmutableSet.of(ADMIN)));
+        assertFalse(session.isInRole(ImmutableSet.of(ADMIN)));
         assertFalse(session.isInRole((Set<Roles>)null));
     }
     

--- a/src/test/java/org/sagebionetworks/bridge/models/accounts/UserSessionTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/accounts/UserSessionTest.java
@@ -147,8 +147,8 @@ public class UserSessionTest {
         
         assertTrue(session.isInRole(DEVELOPER));
         assertTrue(session.isInRole(RESEARCHER));
-        assertTrue(session.isInRole(WORKER));
         assertTrue(session.isInRole(ADMIN));
+        assertFalse(session.isInRole(WORKER));
     }
     
     @Test
@@ -158,9 +158,9 @@ public class UserSessionTest {
         
         assertTrue(session.isInRole(ImmutableSet.of(DEVELOPER)));
         assertTrue(session.isInRole(ImmutableSet.of(RESEARCHER)));
-        assertTrue(session.isInRole(ImmutableSet.of(WORKER)));
         assertTrue(session.isInRole(ImmutableSet.of(ADMIN)));
         assertTrue(session.isInRole(ImmutableSet.of(RESEARCHER, ADMIN)));
+        assertFalse(session.isInRole(ImmutableSet.of(WORKER)));
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AccountsControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AccountsControllerTest.java
@@ -186,7 +186,7 @@ public class AccountsControllerTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
-        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN);
         when(mockParticipantService.createParticipant(any(), any(), anyBoolean())).thenReturn(ID);
         
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(Optional.of(account));
@@ -212,7 +212,7 @@ public class AccountsControllerTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID).build());
         session.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(ADMIN)).build());
-        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN);
         when(mockParticipantService.createParticipant(any(), any(), anyBoolean())).thenReturn(ID);
         
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(Optional.of(account));
@@ -238,7 +238,7 @@ public class AccountsControllerTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
-        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN);
         
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(Optional.of(account));
@@ -252,7 +252,7 @@ public class AccountsControllerTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
-        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN);
         
         session.setParticipant(new StudyParticipant.Builder().withOrgMembership(TEST_ORG_ID).build());
         
@@ -282,7 +282,7 @@ public class AccountsControllerTest extends Mockito {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
-        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN);
         
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(Optional.of(account));
@@ -304,7 +304,7 @@ public class AccountsControllerTest extends Mockito {
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         
-        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN);
         
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(Optional.of(account));
@@ -322,7 +322,7 @@ public class AccountsControllerTest extends Mockito {
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         
-        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN);
         
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(Optional.of(account));
@@ -340,7 +340,7 @@ public class AccountsControllerTest extends Mockito {
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         
-        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN);
         
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(Optional.of(account));
@@ -357,7 +357,7 @@ public class AccountsControllerTest extends Mockito {
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         
-        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN);
         
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(Optional.of(account));
@@ -373,7 +373,7 @@ public class AccountsControllerTest extends Mockito {
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         
-        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN);
         
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(Optional.of(account));
@@ -389,7 +389,7 @@ public class AccountsControllerTest extends Mockito {
                 .withCallerOrgMembership(TEST_ORG_ID)
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
         
-        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN);
         
         account.setOrgMembership(TEST_ORG_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(Optional.of(account));

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AppConfigControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AppConfigControllerTest.java
@@ -210,7 +210,7 @@ public class AppConfigControllerTest extends Mockito {
     
     @Test
     public void deleteAppConfigDefault() throws Exception {
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
 
         StatusMessage message = controller.deleteAppConfig(GUID, null);
         assertEquals(message.getMessage(), "App config deleted.");
@@ -220,7 +220,7 @@ public class AppConfigControllerTest extends Mockito {
 
     @Test
     public void deleteAppConfig() throws Exception {
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         
         StatusMessage message = controller.deleteAppConfig(GUID, "false");
         assertEquals(message.getMessage(), "App config deleted.");
@@ -230,7 +230,7 @@ public class AppConfigControllerTest extends Mockito {
 
     @Test
     public void developerCannotPermanentlyDelete() throws Exception {
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         
         StatusMessage message = controller.deleteAppConfig(GUID, "true");
         assertEquals(message.getMessage(), "App config deleted.");
@@ -244,7 +244,7 @@ public class AppConfigControllerTest extends Mockito {
                 .copyOf(session.getParticipant())
                 .withRoles(ImmutableSet.of(DEVELOPER, ADMIN))
                 .build());
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         
         StatusMessage message = controller.deleteAppConfig(GUID, "true");
         assertEquals(message.getMessage(), "App config deleted.");
@@ -290,7 +290,7 @@ public class AppConfigControllerTest extends Mockito {
 
     @Test
     public void deleteAppConfigDeletesCache() throws Exception {
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         
         controller.deleteAppConfig("guid", null);
         

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AppControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AppControllerTest.java
@@ -905,7 +905,7 @@ public class AppControllerTest extends Mockito {
     
     @Test
     public void updateAppForDeveloperOrAdmin() throws Exception {
-        doReturn(mockSession).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        doReturn(mockSession).when(controller).getAuthenticatedSession(DEVELOPER);
         
         App app = App.create();
         app.setName("My new app");

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AssessmentControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AssessmentControllerTest.java
@@ -483,7 +483,7 @@ public class AssessmentControllerTest extends Mockito {
                 .withOrgMembership(TEST_ORG_ID)
                 .withRoles(ImmutableSet.of(DEVELOPER)).build());
         
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, STUDY_DESIGNER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, STUDY_DESIGNER);
         controller.deleteAssessment(GUID, "false");
         verify(mockService).deleteAssessment(TEST_APP_ID, null, GUID);
     }
@@ -494,7 +494,7 @@ public class AssessmentControllerTest extends Mockito {
                 .withOrgMembership(TEST_ORG_ID)
                 .withRoles(ImmutableSet.of(ADMIN)).build());
         
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, STUDY_DESIGNER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, STUDY_DESIGNER);
         controller.deleteAssessment(GUID, "false");
         verify(mockService).deleteAssessment(TEST_APP_ID, null, GUID);
     }
@@ -505,7 +505,7 @@ public class AssessmentControllerTest extends Mockito {
                 .withOrgMembership(TEST_ORG_ID)
                 .withRoles(ImmutableSet.of(DEVELOPER)).build());
         
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, STUDY_DESIGNER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, STUDY_DESIGNER);
         controller.deleteAssessment(GUID, "true");
         verify(mockService).deleteAssessment(TEST_APP_ID, null, GUID);        
     }
@@ -516,7 +516,7 @@ public class AssessmentControllerTest extends Mockito {
                 .withOrgMembership(TEST_ORG_ID)
                 .withRoles(ImmutableSet.of(ADMIN)).build());
         
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, STUDY_DESIGNER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, STUDY_DESIGNER);
         controller.deleteAssessment(GUID, "true");
         verify(mockService).deleteAssessmentPermanently(TEST_APP_ID, null, GUID);        
     }
@@ -525,7 +525,7 @@ public class AssessmentControllerTest extends Mockito {
             expectedExceptionsMessageRegExp = SHARED_ASSESSMENTS_ERROR)
     public void deleteAssessmentRejectsSharedAppContext() {
         session.setAppId(SHARED_APP_ID);
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, STUDY_DESIGNER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, STUDY_DESIGNER);
         
         controller.deleteAssessment(GUID, null);
     }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AssessmentResourceControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AssessmentResourceControllerTest.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.bridge.spring.controllers;
 import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.SHARED_APP_ID;
 import static org.sagebionetworks.bridge.BridgeConstants.SHARED_ASSESSMENTS_ERROR;
-import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.STUDY_DESIGNER;
 import static org.sagebionetworks.bridge.TestConstants.ASSESSMENT_ID;
@@ -178,14 +177,14 @@ public class AssessmentResourceControllerTest extends Mockito {
 
     @Test
     public void deleteAssessmentResourceDefaultsToLogical() {
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, STUDY_DESIGNER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, STUDY_DESIGNER);
         controller.deleteAssessmentResource(ASSESSMENT_ID, GUID, null);
         verify(mockService).deleteResource(TEST_APP_ID, TEST_ORG_ID, ASSESSMENT_ID, GUID);
     }
 
     @Test
     public void deleteAssessmentResourceDeveloperMustBeLogical() {
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, STUDY_DESIGNER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, STUDY_DESIGNER);
         controller.deleteAssessmentResource(ASSESSMENT_ID, GUID, "true");
         verify(mockService).deleteResource(TEST_APP_ID, TEST_ORG_ID, ASSESSMENT_ID, GUID);
     }
@@ -195,7 +194,7 @@ public class AssessmentResourceControllerTest extends Mockito {
         session.setParticipant(new StudyParticipant.Builder()
                 .withRoles(ImmutableSet.of(Roles.ADMIN)).build());
         
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, STUDY_DESIGNER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, STUDY_DESIGNER);
         controller.deleteAssessmentResource(ASSESSMENT_ID, GUID, "true");
         verify(mockService).deleteResourcePermanently(TEST_APP_ID, ASSESSMENT_ID, GUID);
     }
@@ -205,7 +204,7 @@ public class AssessmentResourceControllerTest extends Mockito {
         session.setParticipant(new StudyParticipant.Builder()
                 .withRoles(ImmutableSet.of(Roles.ADMIN)).build());
         
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, STUDY_DESIGNER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, STUDY_DESIGNER);
         controller.deleteAssessmentResource(ASSESSMENT_ID, GUID, "false");
         verify(mockService).deleteResource(TEST_APP_ID, null, ASSESSMENT_ID, GUID);
     }
@@ -250,7 +249,7 @@ public class AssessmentResourceControllerTest extends Mockito {
             expectedExceptionsMessageRegExp = SHARED_ASSESSMENTS_ERROR)
     public void deleteAssessmentResourceRejectsSharedAppContext() {
         session.setAppId(SHARED_APP_ID);
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, STUDY_DESIGNER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, STUDY_DESIGNER);
         
         controller.deleteAssessmentResource(ASSESSMENT_ID, GUID, null);
     }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/BaseControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/BaseControllerTest.java
@@ -240,7 +240,7 @@ public class BaseControllerTest extends Mockito {
         session.setAuthenticated(true);
         session.setAppId(TEST_APP_ID);
         session.setConsentStatuses(CONSENTED_STATUS_MAP);
-        session.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.ADMIN))
+        session.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(Roles.RESEARCHER))
                 .withHealthCode(HEALTH_CODE).build());
         when(mockRequest.getHeader(SESSION_TOKEN_HEADER)).thenReturn(SESSION_TOKEN);
         when(mockRequest.getHeader(X_REQUEST_ID_HEADER)).thenReturn(REQUEST_ID);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/Exporter3ControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/Exporter3ControllerTest.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.spring.controllers;
 
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.TestUtils.assertCrossOrigin;
 import static org.sagebionetworks.bridge.TestUtils.assertPost;
 import static org.testng.Assert.assertSame;
@@ -13,7 +14,6 @@ import org.mockito.Spy;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.apps.Exporter3Configuration;
@@ -43,7 +43,7 @@ public class Exporter3ControllerTest {
         // Mock session.
         UserSession mockSession = new UserSession();
         mockSession.setAppId(TestConstants.TEST_APP_ID);
-        doReturn(mockSession).when(controller).getAuthenticatedSession(Roles.ADMIN, Roles.DEVELOPER);
+        doReturn(mockSession).when(controller).getAuthenticatedSession(DEVELOPER);
 
         // Mock service.
         Exporter3Configuration ex3Config = new Exporter3Configuration();

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/FileControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/FileControllerTest.java
@@ -178,7 +178,7 @@ public class FileControllerTest extends Mockito {
     
     @Test
     public void deleteFileDefault() throws Exception {
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         
         StatusMessage message = controller.deleteFile(GUID, null);
         assertEquals(message.getMessage(), DELETE_MSG.getMessage());
@@ -188,7 +188,7 @@ public class FileControllerTest extends Mockito {
 
     @Test
     public void deleteTemplate() throws Exception {
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         
         StatusMessage message = controller.deleteFile(GUID, "false");
         assertEquals(message.getMessage(), DELETE_MSG.getMessage());
@@ -198,7 +198,7 @@ public class FileControllerTest extends Mockito {
 
     @Test
     public void developerCannotPermanentlyDelete() throws Exception {
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         
         StatusMessage message = controller.deleteFile(GUID, "true");
         assertEquals(message.getMessage(), DELETE_MSG.getMessage());
@@ -208,7 +208,7 @@ public class FileControllerTest extends Mockito {
     
     @Test
     public void adminCanPermanentlyDelete() throws Exception {
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         
         session.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(ADMIN)).build());
         StatusMessage message = controller.deleteFile(GUID, "true");

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/MembershipControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/MembershipControllerTest.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.bridge.spring.controllers;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertSame;
 import static org.sagebionetworks.bridge.RequestContext.NULL_INSTANCE;
-import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.ORG_ADMIN;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
@@ -32,7 +31,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.RequestContext;
-import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.AccountSummarySearch;
 import org.sagebionetworks.bridge.models.PagedResourceList;
@@ -141,8 +139,8 @@ public class MembershipControllerTest extends Mockito {
     @Test
     public void addMember() {
         setContext(b -> b.withCallerOrgMembership(TEST_ORG_ID)
-                .withCallerRoles(ImmutableSet.of(Roles.ORG_ADMIN)));
-        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN)));
+        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN);
         
         controller.addMember(TEST_ORG_ID, TEST_USER_ID);
         
@@ -152,8 +150,8 @@ public class MembershipControllerTest extends Mockito {
     @Test
     public void removeMember() {
         setContext(b -> b.withCallerOrgMembership(TEST_ORG_ID)
-                .withCallerRoles(ImmutableSet.of(Roles.ORG_ADMIN)));
-        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN)));
+        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN);
         
         controller.removeMember(TEST_ORG_ID, TEST_USER_ID);
         

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/NotificationTopicControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/NotificationTopicControllerTest.java
@@ -173,7 +173,7 @@ public class NotificationTopicControllerTest extends Mockito {
     
     @Test
     public void deleteTopic() throws Exception {
-        doReturn(mockUserSession).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);        
+        doReturn(mockUserSession).when(controller).getAuthenticatedSession(DEVELOPER);        
         StatusMessage result = controller.deleteTopic(GUID, false);
         assertEquals(result, NotificationTopicController.DELETE_STATUS_MSG);
 
@@ -182,7 +182,7 @@ public class NotificationTopicControllerTest extends Mockito {
     
     @Test
     public void deleteTopicPermanently() throws Exception {
-        doReturn(mockUserSession).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);        
+        doReturn(mockUserSession).when(controller).getAuthenticatedSession(DEVELOPER);        
         when(mockUserSession.isInRole(ADMIN)).thenReturn(true);
         
         StatusMessage result = controller.deleteTopic(GUID, true);
@@ -194,7 +194,7 @@ public class NotificationTopicControllerTest extends Mockito {
 
     @Test
     public void deleteTopicPermanentlyForDeveloper() throws Exception {
-        doReturn(mockUserSession).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        doReturn(mockUserSession).when(controller).getAuthenticatedSession(DEVELOPER);
         StatusMessage result = controller.deleteTopic(GUID, true);
         assertEquals(result, NotificationTopicController.DELETE_STATUS_MSG);
 

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/OrganizationControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/OrganizationControllerTest.java
@@ -136,7 +136,7 @@ public class OrganizationControllerTest extends Mockito {
     public void updateOrganization() throws Exception {
         RequestContext.set(RequestContext.get().toBuilder()
                 .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
-        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN);
         
         Organization org = Organization.create();
         org.setName("This is my organization");

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantDataControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantDataControllerTest.java
@@ -120,7 +120,7 @@ public class ParticipantDataControllerTest extends Mockito {
         doReturn(app).when(mockAppService).getApp(TEST_APP_ID);
         doReturn(TEST_USER_ID).when(mockAccount).getId();
         doReturn(session).when(controller).getSessionIfItExists();
-        doReturn(session).when(controller).getAuthenticatedSession(ADMIN, WORKER);
+        doReturn(session).when(controller).getAuthenticatedSession(WORKER);
         doReturn(session).when(controller).getAuthenticatedAndConsentedSession();
 
         doReturn(mockRequest).when(controller).request();
@@ -236,7 +236,7 @@ public class ParticipantDataControllerTest extends Mockito {
     @Test(expectedExceptions = EntityNotFoundException.class,
             expectedExceptionsMessageRegExp=".*Account not found.*")
     public void testGetAllDataForAdminWorkerEntityNotFound() {
-        doReturn(mockSession).when(controller).getAuthenticatedSession(ADMIN, WORKER);
+        doReturn(mockSession).when(controller).getAuthenticatedSession(WORKER);
         doReturn(true).when(mockSession).isInRole(ADMIN);
         doReturn("notSameAppId").when(mockSession).getAppId();
 
@@ -256,7 +256,7 @@ public class ParticipantDataControllerTest extends Mockito {
     @Test(expectedExceptions = EntityNotFoundException.class,
             expectedExceptionsMessageRegExp=".*Account not found.*")
     public void testGetDataByIdentifierForAdminWorkerEntityNotFound() {
-        doReturn(mockSession).when(controller).getAuthenticatedSession(ADMIN, WORKER);
+        doReturn(mockSession).when(controller).getAuthenticatedSession(WORKER);
         doReturn(true).when(mockSession).isInRole(ADMIN);
         doReturn("notSameAppId").when(mockSession).getAppId();
 
@@ -266,7 +266,7 @@ public class ParticipantDataControllerTest extends Mockito {
     @Test(expectedExceptions = EntityNotFoundException.class,
             expectedExceptionsMessageRegExp=".*Account not found.*")
     public void testSaveDataForAdminWorkerEntityNotFound() {
-        doReturn(mockSession).when(controller).getAuthenticatedSession(ADMIN, WORKER);
+        doReturn(mockSession).when(controller).getAuthenticatedSession(WORKER);
         doReturn(true).when(mockSession).isInRole(ADMIN);
         doReturn("notSameAppId").when(mockSession).getAppId();
 

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportControllerTest.java
@@ -4,6 +4,7 @@ import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.DEVELOPER;
+import static org.sagebionetworks.bridge.Roles.ORG_ADMIN;
 import static org.sagebionetworks.bridge.Roles.WORKER;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
@@ -45,6 +46,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.RequestContext;
+import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoApp;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
@@ -512,7 +514,7 @@ public class ParticipantReportControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class)
     public void deleteParticipantRecordDataRecordDeveloper() {
         StudyParticipant regularUser = new StudyParticipant.Builder().copyOf(session.getParticipant())
-            .withRoles(Sets.newHashSet(ADMIN)).build();
+            .withRoles(Sets.newHashSet(ORG_ADMIN)).build();
         session.setParticipant(regularUser);
         
         controller.deleteParticipantReportRecord(REPORT_ID, "bar", "2014-05-10");

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantReportControllerTest.java
@@ -46,7 +46,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.RequestContext;
-import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoApp;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/SharedModuleMetadataControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/SharedModuleMetadataControllerTest.java
@@ -113,31 +113,31 @@ public class SharedModuleMetadataControllerTest extends Mockito {
     @Test
     public void deleteMetadataByIdAllVersionsOK() throws Exception {
         mockSession.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(DEVELOPER)).build());
-        doReturn(mockSession).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        doReturn(mockSession).when(controller).getAuthenticatedSession(DEVELOPER);
         
         StatusMessage result = controller.deleteMetadataByIdAllVersions(MODULE_ID, false);
         assertEquals(result, DELETED_MSG);
 
         verify(mockSvc).deleteMetadataByIdAllVersions(MODULE_ID);
-        verify(controller).getAuthenticatedSession(Roles.DEVELOPER, Roles.ADMIN);
+        verify(controller).getAuthenticatedSession(DEVELOPER);
     }
     
     @Test
     public void deleteMetadataByIdAllVersionsDevDefaultsToLogical() throws Exception {
         mockSession.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(DEVELOPER)).build());
-        doReturn(mockSession).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        doReturn(mockSession).when(controller).getAuthenticatedSession(DEVELOPER);
         
         StatusMessage result = controller.deleteMetadataByIdAllVersions(MODULE_ID, true);
         assertEquals(result, DELETED_MSG);
 
         verify(mockSvc).deleteMetadataByIdAllVersions(MODULE_ID);
-        verify(controller).getAuthenticatedSession(Roles.DEVELOPER, Roles.ADMIN);
+        verify(controller).getAuthenticatedSession(DEVELOPER);
     }
     
     @Test
     public void deleteMetadataByIdAllVersionsAdminPhysical() throws Exception {
         mockSession.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(ADMIN)).build());
-        doReturn(mockSession).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        doReturn(mockSession).when(controller).getAuthenticatedSession(DEVELOPER);
         
         // setup, execute, and validate
         StatusMessage result = controller.deleteMetadataByIdAllVersions(MODULE_ID, true);
@@ -147,39 +147,39 @@ public class SharedModuleMetadataControllerTest extends Mockito {
         verify(mockSvc).deleteMetadataByIdAllVersionsPermanently(MODULE_ID);
 
         // validate permissions
-        verify(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        verify(controller).getAuthenticatedSession(DEVELOPER);
     }
     
     @Test
     public void deleteMetadataByIdAndVersionOK() throws Exception {
-        mockSession.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(ADMIN)).build());
-        doReturn(mockSession).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        mockSession.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(DEVELOPER)).build());
+        doReturn(mockSession).when(controller).getAuthenticatedSession(DEVELOPER);
         
         // setup, execute, and validate
         StatusMessage result = controller.deleteMetadataByIdAndVersion(MODULE_ID, 3, false);
         assertEquals(result, DELETED_MSG);
 
         verify(mockSvc).deleteMetadataByIdAndVersion(MODULE_ID, 3);
-        verify(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        verify(controller).getAuthenticatedSession(DEVELOPER);
     }
     
     @Test
     public void deleteMetadataByIdAndVersionDevDefaultsToLogical() throws Exception {
         mockSession.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(DEVELOPER)).build());
-        doReturn(mockSession).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        doReturn(mockSession).when(controller).getAuthenticatedSession(DEVELOPER);
         
         // setup, execute, and validate
         StatusMessage result = controller.deleteMetadataByIdAndVersion(MODULE_ID, 3, true);
         assertEquals(result, DELETED_MSG);
 
         verify(mockSvc).deleteMetadataByIdAndVersion(MODULE_ID, 3);
-        verify(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        verify(controller).getAuthenticatedSession(DEVELOPER);
     }
     
     @Test
     public void deleteMetadataByIdAndVersionAdminPhysical() throws Exception {
         mockSession.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(ADMIN)).build());
-        doReturn(mockSession).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        doReturn(mockSession).when(controller).getAuthenticatedSession(DEVELOPER);
         
         // setup, execute, and validate
         StatusMessage result = controller.deleteMetadataByIdAndVersion(MODULE_ID, 3, true);
@@ -187,13 +187,13 @@ public class SharedModuleMetadataControllerTest extends Mockito {
 
         // verify backend
         verify(mockSvc).deleteMetadataByIdAndVersionPermanently(MODULE_ID, 3);
-        verify(controller).getAuthenticatedSession(Roles.DEVELOPER, Roles.ADMIN);
+        verify(controller).getAuthenticatedSession(DEVELOPER);
     }
     
     @Test
     public void deleteByIdAllVersionsPermanently() throws Exception {
         mockSession.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(ADMIN)).build());
-        doReturn(mockSession).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        doReturn(mockSession).when(controller).getAuthenticatedSession(DEVELOPER);
         
         // setup, execute, and validate
         StatusMessage result = controller.deleteMetadataByIdAllVersions(MODULE_ID, true);
@@ -203,13 +203,13 @@ public class SharedModuleMetadataControllerTest extends Mockito {
         verify(mockSvc).deleteMetadataByIdAllVersionsPermanently(MODULE_ID);
 
         // validate permissions
-        verify(controller).getAuthenticatedSession(Roles.DEVELOPER, Roles.ADMIN);
+        verify(controller).getAuthenticatedSession(DEVELOPER);
     }
     
     @Test
     public void deleteByIdAndVersionPermanently() throws Exception {
         mockSession.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(ADMIN)).build());
-        doReturn(mockSession).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        doReturn(mockSession).when(controller).getAuthenticatedSession(DEVELOPER);
         
         // setup, execute, and validate
         StatusMessage result = controller.deleteMetadataByIdAndVersion(MODULE_ID, MODULE_VERSION, true);
@@ -219,7 +219,7 @@ public class SharedModuleMetadataControllerTest extends Mockito {
         verify(mockSvc).deleteMetadataByIdAndVersionPermanently(MODULE_ID, MODULE_VERSION);
 
         // validate permissions
-        verify(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        verify(controller).getAuthenticatedSession(DEVELOPER);
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyControllerTest.java
@@ -121,9 +121,9 @@ public class StudyControllerTest extends Mockito {
 
         controller.setStudyService(mockStudyService);
 
-        doReturn(session).when(controller).getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR, ORG_ADMIN, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(STUDY_DESIGNER, STUDY_COORDINATOR, ORG_ADMIN);
         doReturn(session).when(controller).getAuthenticatedSession(ADMIN);
-        doReturn(session).when(controller).getAuthenticatedSession(STUDY_DESIGNER, DEVELOPER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(STUDY_DESIGNER, DEVELOPER);
         doReturn(session).when(controller).getAdministrativeSession();
         
         doReturn(mockRequest).when(controller).request();

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/SubpopulationControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/SubpopulationControllerTest.java
@@ -264,7 +264,7 @@ public class SubpopulationControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class)
     public void createSubpopulationRequiresDeveloper() throws Exception {
         session.setParticipant(
-                new StudyParticipant.Builder().copyOf(participant).withRoles(ImmutableSet.of(ADMIN)).build());
+                new StudyParticipant.Builder().copyOf(participant).withRoles(ImmutableSet.of(RESEARCHER)).build());
 
         controller.createSubpopulation();
     }
@@ -272,7 +272,7 @@ public class SubpopulationControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class)
     public void updateSubpopulationRequiresDeveloper() throws Exception {
         session.setParticipant(
-                new StudyParticipant.Builder().copyOf(participant).withRoles(ImmutableSet.of(ADMIN)).build());
+                new StudyParticipant.Builder().copyOf(participant).withRoles(ImmutableSet.of(RESEARCHER)).build());
 
         controller.updateSubpopulation(TEST_APP_ID);
     }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/SurveyControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/SurveyControllerTest.java
@@ -343,7 +343,7 @@ public class SurveyControllerTest extends Mockito {
     @Test
     public void developerCanLogicallyDelete() throws Exception {
         setupContext(TEST_APP_ID, UNCONSENTED, DEVELOPER);
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         Survey survey = getSurvey(false);
         when(mockSurveyService.getSurvey(TEST_APP_ID, KEYS, false, false)).thenReturn(survey);
         
@@ -358,7 +358,7 @@ public class SurveyControllerTest extends Mockito {
     @Test
     public void adminCanLogicallyDelete() throws Exception {
         setupContext(TEST_APP_ID, UNCONSENTED, ADMIN);
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         Survey survey = getSurvey(false);
         when(mockSurveyService.getSurvey(TEST_APP_ID, KEYS, false, false)).thenReturn(survey);
         
@@ -380,7 +380,7 @@ public class SurveyControllerTest extends Mockito {
     @Test
     public void deleteSurveyAllowedForDeveloper() throws Exception {
         setupContext(TEST_APP_ID, UNCONSENTED, DEVELOPER);
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         Survey survey = getSurvey(false);
         when(mockSurveyService.getSurvey(TEST_APP_ID, KEYS, false, false))
                 .thenReturn(survey);
@@ -396,7 +396,7 @@ public class SurveyControllerTest extends Mockito {
     @Test
     public void physicalDeleteOfSurveyNotAllowedForDeveloper() throws Exception {
         setupContext(TEST_APP_ID, UNCONSENTED, DEVELOPER);
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         Survey survey = getSurvey(false);
         when(mockSurveyService.getSurvey(TEST_APP_ID, KEYS, false, false)).thenReturn(survey);
         
@@ -411,7 +411,7 @@ public class SurveyControllerTest extends Mockito {
     @Test
     public void physicalDeleteAllowedForAdmin() throws Exception {
         setupContext(TEST_APP_ID, UNCONSENTED, ADMIN);
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         Survey survey = getSurvey(false);
         when(mockSurveyService.getSurvey(TEST_APP_ID, KEYS, false, false)).thenReturn(survey);
         
@@ -426,7 +426,7 @@ public class SurveyControllerTest extends Mockito {
     @Test(expectedExceptions = EntityNotFoundException.class)
     public void deleteSurveyThrowsGoodExceptionIfSurveyDoesntExist() throws Exception {
         setupContext(TEST_APP_ID, UNCONSENTED, DEVELOPER);
-        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+        doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
         when(mockSurveyService.getSurvey(TEST_APP_ID, KEYS, false, false)).thenReturn(null);
         
         controller.deleteSurvey(SURVEY_GUID, CREATED_ON.toString(), false);
@@ -525,8 +525,8 @@ public class SurveyControllerTest extends Mockito {
     }
 
     @Test
-    public void adminRejectedAsUnauthorized() throws Exception {
-        setupContext(TEST_APP_ID, UNCONSENTED, ADMIN);
+    public void resercherRejectedAsUnauthorized() throws Exception {
+        setupContext(TEST_APP_ID, UNCONSENTED, RESEARCHER);
         doReturn(session).when(controller).getSessionIfItExists();
         Survey survey = getSurvey(false);
         when(mockSurveyService.getSurvey(TEST_APP_ID, KEYS, true, true)).thenReturn(survey);
@@ -557,7 +557,7 @@ public class SurveyControllerTest extends Mockito {
     @Test
     public void deleteSurveyInvalidatesCache() throws Exception {
         assertCacheIsCleared((guid, dateString) -> {
-            doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN);
+            doReturn(session).when(controller).getAuthenticatedSession(DEVELOPER);
             controller.deleteSurvey(guid, dateString, false);
         }, 2);
     }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/UploadControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/UploadControllerTest.java
@@ -312,7 +312,7 @@ public class UploadControllerTest extends Mockito {
     
     @Test
     public void getUploadById() {
-        doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN, WORKER);
+        doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(DEVELOPER, WORKER);
         when(mockResearcherSession.getAppId()).thenReturn(TEST_APP_ID);
         when(mockResearcherSession.isInRole(EnumSet.of(SUPERADMIN, WORKER))).thenReturn(true);
 
@@ -337,7 +337,7 @@ public class UploadControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class,
             expectedExceptionsMessageRegExp=".*Caller does not have permission to access upload.*")
     public void getUploadByIdRejectsAppAdmin() {
-        doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN, WORKER);
+        doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(DEVELOPER, WORKER);
         when(mockResearcherSession.getAppId()).thenReturn(TEST_APP_ID);
         when(mockResearcherSession.isInRole(ADMIN)).thenReturn(true);
 
@@ -356,7 +356,7 @@ public class UploadControllerTest extends Mockito {
 
     @Test
     public void getUploadByIdWorksForFullAdmin() {
-        doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN, WORKER);
+        doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(DEVELOPER, WORKER);
         when(mockResearcherSession.getAppId()).thenReturn(TEST_APP_ID);
         when(mockResearcherSession.isInRole(EnumSet.of(Roles.SUPERADMIN, Roles.WORKER))).thenReturn(true);
 
@@ -376,7 +376,7 @@ public class UploadControllerTest extends Mockito {
 
     @Test
     public void getUploadByIdWorksForDevelopersOwnAccount() {
-        doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN, WORKER);
+        doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(DEVELOPER, WORKER);
         when(mockResearcherSession.getAppId()).thenReturn(TEST_APP_ID);
         when(mockResearcherSession.getHealthCode()).thenReturn(HEALTH_CODE);
         when(mockResearcherSession.isInRole(DEVELOPER)).thenReturn(true);
@@ -401,7 +401,7 @@ public class UploadControllerTest extends Mockito {
         doReturn(TEST_USER_ID).when(mockResearcherSession).getId();
         doReturn(TEST_APP_ID).when(mockResearcherSession).getAppId();
         doReturn(true).when(mockResearcherSession).isInRole(EnumSet.of(SUPERADMIN, WORKER));
-        doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN, WORKER);
+        doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(DEVELOPER, WORKER);
         
         HealthDataRecord record = HealthDataRecord.create();
         record.setAppId(TEST_APP_ID);
@@ -427,7 +427,7 @@ public class UploadControllerTest extends Mockito {
     @Test(expectedExceptions = UnauthorizedException.class,
             expectedExceptionsMessageRegExp=".*Caller does not have permission to access upload.*")
     public void getUploadByRecordIdRejectsAppAdmin() throws Exception {
-        doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN, WORKER);
+        doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(DEVELOPER, WORKER);
         doReturn(true).when(mockResearcherSession).isInRole(ADMIN);
         doReturn(TEST_USER_ID).when(mockResearcherSession).getId();
         when(mockResearcherSession.getAppId()).thenReturn(TEST_APP_ID);
@@ -450,7 +450,7 @@ public class UploadControllerTest extends Mockito {
 
     @Test
     public void getUploadByRecordIdWorksForFullAdmin() throws Exception {
-        doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN, WORKER);
+        doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(DEVELOPER, WORKER);
         doReturn(true).when(mockResearcherSession).isInRole(EnumSet.of(Roles.SUPERADMIN, Roles.WORKER));
         
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(Optional.of(Account.create()));
@@ -474,7 +474,7 @@ public class UploadControllerTest extends Mockito {
     
     @Test(expectedExceptions = EntityNotFoundException.class)
     public void getUploadByRecordIdRecordMissing() throws Exception {
-        doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(DEVELOPER, ADMIN, WORKER);
+        doReturn(mockResearcherSession).when(controller).getAuthenticatedSession(DEVELOPER, WORKER);
         
         when(mockHealthDataService.getRecordById("record-id")).thenReturn(null);
 


### PR DESCRIPTION
BRIDGE-3152

Clean-up of integration tests to ensure they can run in production without a SUPERADMIN boostrap account.

1) Changed permissions so ADMIN behaves like SUPERADMIN within the scope of one app (however ADMIN cannot emulate WORKER or SUPERUSER roles). Removed ADMIN from many controllers where it is now redundant.

2) Removed two APIs, one superseded by a general API to change between apps, and other that was not being used and could be emulated with two calls to the server. Both required SUPERADMIN permissions.

3) Cleaned up the SDK, integration test utilities package, and integration tests to remove all the references to unused properties that were there for our integration tests, and to move the ones that are being used to the right packages (SDK no longer references integration test properties, the Config in the Java SDK can load multiple property files, the Config defined in the integration test utils loads both bridge-sdk.properties and bridge-sdk-test.properties). Updated the integration test README file to document the needed properties.

4) Reconfigured the bootstrap user so it only has access to 'api' and 'shared', joined by a bogus Synapse user ID of “0000” (note that it can’t be five zeroes, our integration tests use that as well). In production, this boostrap account should be an ADMIN with no access to production apps. NOTE: the shared app is actually in use in production! The next step will be to introduce a test shared app for testing purposes. Also documented in the README file.

5) Finally, rewrote the tests so that the smoke tests pass in production with an ADMIN, and the full suite passes with a SUPERADMIN in other environments.