### PR TITLE
Adding validation of studies removing custom events currently in their schedule

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
@@ -157,7 +157,9 @@ public class StudyService {
         
         study.setAppId(appId);
         study.setPhase(DESIGN);
-        Validate.entityThrowingException(StudyValidator.INSTANCE, study);
+        
+        StudyValidator validator = new StudyValidator(scheduleService);
+        Validate.entityThrowingException(validator, study);
         
         study.setVersion(null);
         study.setDeleted(false);
@@ -203,8 +205,9 @@ public class StudyService {
         study.setCreatedOn(existing.getCreatedOn());
         study.setModifiedOn(DateTime.now());
         study.setPhase(existing.getPhase());
-
-        Validate.entityThrowingException(StudyValidator.INSTANCE, study);
+    
+        StudyValidator validator = new StudyValidator(scheduleService);
+        Validate.entityThrowingException(validator, study);
         
         VersionHolder keys = studyDao.updateStudy(study);
         

--- a/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
@@ -357,12 +357,14 @@ public class StudyService {
     }
     
     private Set<String> getCustomEventIdsFromSchedule(String appId, String scheduleGuid) {
-        Schedule2 schedule = scheduleService.getSchedule(appId, scheduleGuid);
         Set<String> existingEventIds = new HashSet<>();
-        if (schedule != null) {
-            existingEventIds = schedule.getSessions().stream()
-                    .flatMap(session -> session.getStartEventIds().stream())
-                    .filter(s -> s.startsWith("custom")).collect(Collectors.toSet());
+        if (scheduleGuid != null) {
+            Schedule2 schedule = scheduleService.getSchedule(appId, scheduleGuid);
+            if (schedule != null) {
+                existingEventIds = schedule.getSessions().stream()
+                        .flatMap(session -> session.getStartEventIds().stream())
+                        .filter(s -> s.startsWith("custom:")).collect(Collectors.toSet());
+            }
         }
         return existingEventIds;
     }

--- a/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
@@ -356,15 +356,20 @@ public class StudyService {
         return study;
     }
     
-    private Set<String> getCustomEventIdsFromSchedule(String appId, String scheduleGuid) {
+    /**
+     * Retrieves the custom event IDs from a schedule. The returned event IDs will 
+     * have the "custom:" prefix removed. If scheduleGuid is null, will return
+     * an empty set.
+     */
+    protected Set<String> getCustomEventIdsFromSchedule(String appId, String scheduleGuid) {
         Set<String> existingEventIds = new HashSet<>();
         if (scheduleGuid != null) {
             Schedule2 schedule = scheduleService.getSchedule(appId, scheduleGuid);
-            if (schedule != null) {
-                existingEventIds = schedule.getSessions().stream()
-                        .flatMap(session -> session.getStartEventIds().stream())
-                        .filter(s -> s.startsWith("custom:")).collect(Collectors.toSet());
-            }
+            existingEventIds = schedule.getSessions().stream()
+                    .flatMap(session -> session.getStartEventIds().stream())
+                    .filter(s -> s.startsWith("custom:"))
+                    .map(s -> s.substring(7))
+                    .collect(Collectors.toSet());
         }
         return existingEventIds;
     }

--- a/src/main/java/org/sagebionetworks/bridge/validators/StudyValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/StudyValidator.java
@@ -154,7 +154,7 @@ public class StudyValidator implements Validator {
         if (protectedCustomEventIds != null && !uniqueIds.containsAll(protectedCustomEventIds)) {
             protectedCustomEventIds.removeAll(uniqueIds);
             errors.rejectValue(CUSTOM_EVENTS_FIELD, 
-                    String.format("cannot remove custom events currently used in a schedule: [%s]",
+                    String.format("cannot remove custom events currently used in a schedule: %s",
                             COMMA_SPACE_JOINER.join(protectedCustomEventIds)));
         }
         for (int i=0; i < study.getContacts().size(); i++) {

--- a/src/main/java/org/sagebionetworks/bridge/validators/StudyValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/StudyValidator.java
@@ -67,10 +67,10 @@ public class StudyValidator implements Validator {
     static final String STUDY_TIME_ZONE_FIELD = "studyTimeZone";
     static final String ADHERENCE_THRESHOLD_PERCENTAGE_FIELD = "adherenceThresholdPercentage";
     
-    private final Set<String> scheduledCustomEventIds;
+    private final Set<String> protectedCustomEventIds;
     
-    public StudyValidator(Set<String> scheduledCustomEventIds) {
-        this.scheduledCustomEventIds = scheduledCustomEventIds;
+    public StudyValidator(Set<String> protectedCustomEventIds) {
+        this.protectedCustomEventIds = protectedCustomEventIds;
     }
 
     @Override
@@ -146,15 +146,16 @@ public class StudyValidator implements Validator {
             if (customEvent.getUpdateType() == null) {
                 errors.rejectValue("updateType", CANNOT_BE_NULL);
             }
-            scheduledCustomEventIds.remove(customEvent.getEventId());
+            protectedCustomEventIds.remove(customEvent.getEventId());
             errors.popNestedPath();
         }
         if (uniqueIds.size() > 0 && (uniqueIds.size() != study.getCustomEvents().size())) {
             errors.rejectValue(CUSTOM_EVENTS_FIELD, "cannot contain duplicate event IDs");
         }
-        if (!scheduledCustomEventIds.isEmpty()) {
+        // Any EventIds not removed from the set are on a schedule but missing from the validated study
+        if (!protectedCustomEventIds.isEmpty()) {
             errors.rejectValue(CUSTOM_EVENTS_FIELD, 
-                    String.format("cannot remove custom events currently used in a schedule: %s", scheduledCustomEventIds.toString()));
+                    String.format("cannot remove custom events currently used in a schedule: %s", protectedCustomEventIds.toString()));
         }
         for (int i=0; i < study.getContacts().size(); i++) {
             Contact contact = study.getContacts().get(i);

--- a/src/test/java/org/sagebionetworks/bridge/services/StudyServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/StudyServiceTest.java
@@ -96,10 +96,10 @@ public class StudyServiceTest {
         MockitoAnnotations.initMocks(this);
     }
     
-    @AfterMethod
-    public void afterEmthod() {
-        RequestContext.set(NULL_INSTANCE);
-    }
+//    @AfterMethod
+//    public void afterEmthod() {
+//        RequestContext.set(NULL_INSTANCE);
+//    }
     
     @AfterMethod
     public void afterMethod( ) {

--- a/src/test/java/org/sagebionetworks/bridge/services/StudyServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/StudyServiceTest.java
@@ -31,7 +31,6 @@ import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 import java.util.List;
 import java.util.Set;

--- a/src/test/java/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -303,14 +303,14 @@ public class StudyValidatorTest {
         study = createStudy();
         study.setScheduleGuid(SCHEDULE_GUID);
         
-        validator = new StudyValidator(Sets.newHashSet("custom-aaa", "custom-ccc"));
+        validator = new StudyValidator(Sets.newHashSet("custom:aaa", "custom:ccc"));
     
         StudyCustomEvent studyCustomEvent = new StudyCustomEvent();
-        studyCustomEvent.setEventId("custom-aaa");
+        studyCustomEvent.setEventId("custom:aaa");
         
         study.setCustomEvents(ImmutableList.of(studyCustomEvent));
         
-        assertValidatorMessage(validator, study, CUSTOM_EVENTS_FIELD, "cannot remove custom events currently used in a schedule: [custom-ccc]");
+        assertValidatorMessage(validator, study, CUSTOM_EVENTS_FIELD, "cannot remove custom events currently used in a schedule: [custom:ccc]");
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -310,7 +310,7 @@ public class StudyValidatorTest {
         
         study.setCustomEvents(ImmutableList.of(studyCustomEvent));
         
-        assertValidatorMessage(validator, study, CUSTOM_EVENTS_FIELD, "cannot remove custom events currently used in a schedule: [ccc]");
+        assertValidatorMessage(validator, study, CUSTOM_EVENTS_FIELD, "cannot remove custom events currently used in a schedule: ccc");
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_EVENT_ID_ERROR;
 import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_RELAXED_ID_ERROR;
 import static org.sagebionetworks.bridge.TestConstants.EMAIL;
@@ -29,14 +28,10 @@ import static org.sagebionetworks.bridge.validators.ValidatorUtils.TEXT_SIZE;
 import com.google.common.collect.ImmutableList;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.sagebionetworks.bridge.models.schedules2.Schedule2;
-import org.sagebionetworks.bridge.models.schedules2.Session;
 import org.sagebionetworks.bridge.models.studies.Address;
-import org.sagebionetworks.bridge.services.Schedule2Service;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.sagebionetworks.bridge.models.accounts.Phone;
@@ -53,14 +48,9 @@ public class StudyValidatorTest {
     
     private StudyValidator validator;
     
-    @Mock
-    private Schedule2Service schedule2Service;
-    
     @BeforeMethod
     public void before() {
-        MockitoAnnotations.initMocks(this);
-        
-        validator = new StudyValidator(schedule2Service);
+        validator = new StudyValidator(Sets.newHashSet());
     }
     
     @Test
@@ -312,20 +302,15 @@ public class StudyValidatorTest {
     public void customEvents_missingEventIdInSchedule() {
         study = createStudy();
         study.setScheduleGuid(SCHEDULE_GUID);
-    
-        Schedule2 schedule = new Schedule2();
-        Session session = new Session();
-        session.setStartEventIds(ImmutableList.of("custom-aaa","bbb","custom-ccc"));
-        schedule.setSessions(ImmutableList.of(session));
         
+        validator = new StudyValidator(Sets.newHashSet("custom-aaa", "custom-ccc"));
+    
         StudyCustomEvent studyCustomEvent = new StudyCustomEvent();
         studyCustomEvent.setEventId("custom-aaa");
         
         study.setCustomEvents(ImmutableList.of(studyCustomEvent));
         
-        when(schedule2Service.getSchedule(study.getAppId(), SCHEDULE_GUID)).thenReturn(schedule);
-        
-        assertValidatorMessage(validator, study, CUSTOM_EVENTS_FIELD, "cannot remove custom events currently used in a schedule");
+        assertValidatorMessage(validator, study, CUSTOM_EVENTS_FIELD, "cannot remove custom events currently used in a schedule: [custom-ccc]");
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -299,18 +299,50 @@ public class StudyValidatorTest {
     }
     
     @Test
-    public void customEvents_missingEventIdInSchedule() {
+    public void customEvents_missingEventIdInExistingSchedule() {
         study = createStudy();
         study.setScheduleGuid(SCHEDULE_GUID);
         
-        validator = new StudyValidator(Sets.newHashSet("custom:aaa", "custom:ccc"));
+        validator = new StudyValidator(Sets.newHashSet("aaa", "ccc"));
     
         StudyCustomEvent studyCustomEvent = new StudyCustomEvent();
-        studyCustomEvent.setEventId("custom:aaa");
+        studyCustomEvent.setEventId("aaa");
         
         study.setCustomEvents(ImmutableList.of(studyCustomEvent));
         
-        assertValidatorMessage(validator, study, CUSTOM_EVENTS_FIELD, "cannot remove custom events currently used in a schedule: [custom:ccc]");
+        assertValidatorMessage(validator, study, CUSTOM_EVENTS_FIELD, "cannot remove custom events currently used in a schedule: [ccc]");
+    }
+    
+    @Test
+    public void customEvents_emptySetOk() {
+        study = createStudy();
+        study.setScheduleGuid(SCHEDULE_GUID);
+        
+        validator = new StudyValidator(Sets.newHashSet());
+        
+        StudyCustomEvent studyCustomEvent = new StudyCustomEvent();
+        studyCustomEvent.setEventId("aaa");
+        studyCustomEvent.setUpdateType(MUTABLE);
+        
+        study.setCustomEvents(ImmutableList.of(studyCustomEvent));
+        
+        Validate.entityThrowingException(validator, study);
+    }
+    
+    @Test
+    public void customEvents_nullSetOk() {
+        study = createStudy();
+        study.setScheduleGuid(SCHEDULE_GUID);
+        
+        validator = new StudyValidator(null);
+        
+        StudyCustomEvent studyCustomEvent = new StudyCustomEvent();
+        studyCustomEvent.setEventId("aaa");
+        studyCustomEvent.setUpdateType(MUTABLE);
+        
+        study.setCustomEvents(ImmutableList.of(studyCustomEvent));
+        
+        Validate.entityThrowingException(validator, study);
     }
     
     @Test


### PR DESCRIPTION
For Bridge-3135.

- Preventing removal of a custom event from a study if that event is being used by a schedule.