### PR TITLE
Log4j fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <jackson.version>2.10.0</jackson.version>
         <java.version>1.8</java.version>
         <logback.version>1.2.3</logback.version>
+        <log4j.version>2.15.0</log4j.version>
         <!-- NOTE: this is not the version of Spring Boot, declared below -->
         <spring.version>5.1.8.RELEASE</spring.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -225,6 +226,25 @@
             <artifactId>hapi-fhir-structures-dstu3</artifactId>
             <version>4.2.0</version>
         </dependency>
+        <!-- Forcing dependencies to reference a more secure version of log4j (our code uses 
+          Logback so it's not clear if log4j is ever successfully executed by dependent code). 
+          See: https://www.randori.com/blog/cve-2021-44228/
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>        
+        -->
         
         <dependency>
             <groupId>org.mockito</groupId>
@@ -281,6 +301,7 @@
             <version>${logback.version}</version>
             <scope>runtime</scope>
         </dependency>
+
         <dependency>
             <groupId>com.newrelic.agent.java</groupId>
             <artifactId>newrelic-agent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -227,8 +227,8 @@
             <version>4.2.0</version>
         </dependency>
         <!-- Forcing dependencies to reference a more secure version of log4j (our code uses 
-          Logback so it's not clear if log4j is ever successfully executed by dependent code). 
-          See: https://www.randori.com/blog/cve-2021-44228/
+          Logback and only Synapse Java Client references log4j...Spring Boot appears to have 
+          adapters to Commons Logging). See: https://www.randori.com/blog/cve-2021-44228/ -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
@@ -244,7 +244,6 @@
             <artifactId>log4j-to-slf4j</artifactId>
             <version>${log4j.version}</version>
         </dependency>        
-        -->
         
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
Another alternative would be to update the Synapse Client, which may be updated to the new log4j library some time today. I'm watching for this.