### PR TITLE
Move some of this config into the default file (pull password from environment).

### DIFF
--- a/src/main/resources/BridgeServer2.conf
+++ b/src/main/resources/BridgeServer2.conf
@@ -149,9 +149,12 @@ prod.usersigned.consents.bucket = bridgepf-prod-awss3usersignedconsentsdownloadb
 # Bootstrap user for integration tests (will only be used when first initializing your database).
 # This should match the synapse.test.user.* credentials set for your integration test properties 
 # in your bridge-sdk-test.properties file.
-admin.email = dummy-value
+admin.email = bridgetest
+admin.synapse.user.id = 3336429
 admin.password = dummy-value
-admin.synapse.user.id = dummy-value
+prod.admin.email = bridge-testing
+prod.admin.synapse.user.id = 3399057
+
 
 synapse.oauth.url = https://repo-dev.dev.sagebase.org/auth/v1/oauth2/token
 prod.synapse.oauth.url = https://repo-prod.prod.sagebase.org/auth/v1/oauth2/token


### PR DESCRIPTION
Once this is deployed, we should be able to clean up the infrastructure scripts, which will remove the values from the environment.