### PR TITLE
Refactor how adherence report generator gets the data to operate on.

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceState.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceState.java
@@ -1,0 +1,188 @@
+package org.sagebionetworks.bridge.models.schedules2.adherence;
+
+import static java.util.stream.Collectors.counting;
+import static java.util.stream.Collectors.toMap;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Days;
+import org.joda.time.LocalDate;
+import org.sagebionetworks.bridge.models.activities.StudyActivityEvent;
+import org.sagebionetworks.bridge.models.schedules2.adherence.eventstream.EventStream;
+import org.sagebionetworks.bridge.models.schedules2.adherence.eventstream.EventStreamDay;
+import org.sagebionetworks.bridge.models.schedules2.timelines.TimelineMetadata;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+public final class AdherenceState {
+
+    private final boolean showActive;
+    private final DateTime now;
+    private final String clientTimeZone;
+    private final List<TimelineMetadata> metadata;
+    private final Map<String, EventStream> streamsByEventId;
+    private final Map<String, EventStreamDay> streamsByStreamKey;
+    private final Map<String, AdherenceRecord> adherenceByGuid;
+    private final Map<String, Integer> daysSinceEventByEventId;
+    private final Map<String, DateTime> eventTimestampByEventId;
+    private DateTimeZone zone;
+    
+    public AdherenceState(AdherenceState.Builder builder) {
+        showActive = builder.showActiveOnly;
+        clientTimeZone = builder.clientTimeZone;
+        now = builder.now;
+        metadata = builder.metadata;
+        streamsByEventId = new HashMap<>();
+        daysSinceEventByEventId = new HashMap<>();
+        eventTimestampByEventId = new HashMap<>();
+        streamsByStreamKey = new HashMap<>();
+        adherenceByGuid = builder.adherenceRecords.stream()
+                .collect(toMap(AdherenceRecord::getInstanceGuid, (a) -> a));
+        
+        LocalDate localNow = null;
+        zone = null;
+        if (builder.now != null) {
+            localNow = builder.now.toLocalDate();
+            zone = builder.now.getZone();    
+        }
+        // however, use the subject’s preferred time zone if available
+        if (clientTimeZone != null) {
+            zone = DateTimeZone.forID(clientTimeZone);
+        }
+        
+        // LocalDate localNow = (builder.now != null) ? builder.now.toLocalDate() : null;
+        for (StudyActivityEvent event : builder.events) {
+            // DateTime eventTimestamp = event.getTimestamp();
+            DateTime eventTimestamp = event.getTimestamp().withZone(zone);
+            int daysSince = Days.daysBetween(eventTimestamp.toLocalDate(), localNow).getDays();
+            daysSinceEventByEventId.put(event.getEventId(), daysSince);
+            eventTimestampByEventId.put(event.getEventId(), eventTimestamp);
+        }
+    }
+    
+    public List<TimelineMetadata> getMetadata() {
+        return metadata;
+    }
+    public boolean showActive() {
+        return showActive;
+    }
+    public DateTime getNow() {
+        return now;
+    }
+    public String getClientTimeZone() {
+        return clientTimeZone;
+    }
+    public EventStream getEventStreamById(String eventId) {
+        EventStream stream = streamsByEventId.get(eventId);
+        if (stream == null) {
+            stream = new EventStream();
+            stream.setStartEventId(eventId);
+            stream.setEventTimestamp(eventTimestampByEventId.get(eventId));
+            streamsByEventId.put(eventId, stream);
+        }
+        return stream;
+    }
+    public EventStreamDay getEventStreamDayByKey(TimelineMetadata meta) {
+        String streamKey = String.format("%s:%s:%s", meta.getSessionGuid(), 
+                meta.getSessionStartEventId(), meta.getSessionInstanceStartDay());
+        EventStreamDay eventStreamDay = streamsByStreamKey.get(streamKey);
+        
+        if (eventStreamDay == null) {
+            int startDay = meta.getSessionInstanceStartDay();
+            String eventId = meta.getSessionStartEventId();
+            
+            eventStreamDay = new EventStreamDay();
+            eventStreamDay.setSessionGuid(meta.getSessionGuid());
+            eventStreamDay.setSessionName(meta.getSessionName());
+            eventStreamDay.setSessionSymbol(meta.getSessionSymbol());
+            eventStreamDay.setWeek(startDay / 7);
+            eventStreamDay.setStudyBurstId(meta.getStudyBurstId());
+            eventStreamDay.setStudyBurstNum(meta.getStudyBurstNum());
+            streamsByStreamKey.put(streamKey, eventStreamDay);
+            getEventStreamById(eventId).addEntry(startDay, eventStreamDay);
+        }
+        return eventStreamDay;
+    }
+    public AdherenceRecord getAdherenceRecordByGuid(String guid) {
+        return adherenceByGuid.get(guid);    
+    }
+    public Integer getDaysSinceEventById(String eventId) {
+        return daysSinceEventByEventId.get(eventId);
+    }
+    public DateTime getEventTimestampById(String eventId) {
+        return eventTimestampByEventId.get(eventId);
+    }
+    public DateTimeZone getTimeZone() {
+        return zone;
+    }
+    public long getSessionStateCount(Set<SessionCompletionState> states) {
+        return streamsByEventId.values().stream()
+                .flatMap(es -> es.getByDayEntries().values().stream())
+                .flatMap(list -> list.stream())
+                .flatMap(esd -> esd.getTimeWindows().stream())
+                .filter(win -> states.contains(win.getState()))
+                .collect(counting());
+    }
+    /**
+     * This only returns the event IDs that are actually being used by streams (so 
+     * if a stream is not included, even if there are metadata or adherence records
+     * referencing that event ID, it will not be returned by this method). They are
+     * sorted alphabetically.
+     */
+    public List<String> getStreamEventIds() {
+        List<String> keysSorted = Lists.newArrayList(streamsByEventId.keySet());
+        keysSorted.sort(String::compareToIgnoreCase);
+        return keysSorted;
+    }
+    public static class Builder {
+        private boolean showActiveOnly;
+        private List<TimelineMetadata> metadata;
+        private List<StudyActivityEvent> events;
+        private List<AdherenceRecord> adherenceRecords;
+        private DateTime now;
+        private String clientTimeZone;
+
+        public Builder withMetadata(List<TimelineMetadata> metadata) {
+            this.metadata = metadata;
+            return this;
+        }
+        public Builder withEvents(List<StudyActivityEvent> events) {
+            this.events = events;
+            return this;
+        }
+        public Builder withAdherenceRecords(List<AdherenceRecord> adherenceRecords) {
+            this.adherenceRecords = adherenceRecords;
+            return this;
+        }
+        public Builder withNow(DateTime now) {
+            this.now = now;
+            return this;
+        }
+        public Builder withShowActive(boolean showActiveOnly) {
+            this.showActiveOnly = showActiveOnly;
+            return this;
+        }
+        public Builder withClientTimeZone(String clientTimeZone) {
+            this.clientTimeZone = clientTimeZone;
+            return this;
+        }
+        public AdherenceState build() {
+            if (metadata == null) {
+                metadata = ImmutableList.of();
+            }
+            if (events == null) {
+                events = ImmutableList.of();
+            }
+            if (adherenceRecords == null) {
+                adherenceRecords = ImmutableList.of();
+            }
+            return new AdherenceState(this);
+        }
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/eventstream/EventStreamAdherenceReportGenerator.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/eventstream/EventStreamAdherenceReportGenerator.java
@@ -1,111 +1,55 @@
 package org.sagebionetworks.bridge.models.schedules2.adherence.eventstream;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static java.util.stream.Collectors.counting;
-import static java.util.stream.Collectors.toMap;
 import static org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceUtils.calculateSessionState;
 import static org.sagebionetworks.bridge.models.schedules2.adherence.SessionCompletionState.COMPLIANT;
 import static org.sagebionetworks.bridge.models.schedules2.adherence.SessionCompletionState.NONCOMPLIANT;
 import static org.sagebionetworks.bridge.models.schedules2.adherence.SessionCompletionState.UNKNOWN;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.Days;
 import org.joda.time.LocalDate;
-import org.sagebionetworks.bridge.models.activities.StudyActivityEvent;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecord;
+import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceState;
 import org.sagebionetworks.bridge.models.schedules2.adherence.SessionCompletionState;
 import org.sagebionetworks.bridge.models.schedules2.timelines.TimelineMetadata;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-
 public class EventStreamAdherenceReportGenerator {
-
-    private final boolean showActive;
-    private final DateTime now;
-    private final String clientTimeZone;
-    private final List<TimelineMetadata> metadata;
-    private final Map<String, EventStream> streamsByEventId;
-    private final Map<String, EventStreamDay> streamsByStreamKey;
-    private final Map<String, AdherenceRecord> adherenceByEventId;
-    private final Map<String, Integer> daysSinceEventByEventId;
-    private final Map<String, DateTime> eventTimestampByEventId;
-    private DateTimeZone zone;
     
-    public EventStreamAdherenceReportGenerator(EventStreamAdherenceReportGenerator.Builder builder) {
-        showActive = builder.showActiveOnly;
-        clientTimeZone = builder.clientTimeZone;
-        now = builder.now;
-        metadata = builder.metadata;
-        streamsByEventId = new HashMap<>();
-        daysSinceEventByEventId = new HashMap<>();
-        eventTimestampByEventId = new HashMap<>();
-        streamsByStreamKey = new HashMap<>();
-        adherenceByEventId = builder.adherenceRecords.stream()
-                .collect(toMap(AdherenceRecord::getInstanceGuid, (a) -> a));
-        
-        LocalDate localNow = (builder.now != null) ? builder.now.toLocalDate() : null;
-        for (StudyActivityEvent event : builder.events) {
-            DateTime eventTimestamp = event.getTimestamp();
-            if (event.getClientTimeZone() != null) {
-                zone = DateTimeZone.forID(event.getClientTimeZone());
-            } else if (clientTimeZone != null) {
-                zone = DateTimeZone.forID(clientTimeZone);
-            } else {
-                zone = builder.now.getZone();
-            }
-            eventTimestamp = event.getTimestamp().withZone(zone);
-            int daysSince = Days.daysBetween(eventTimestamp.toLocalDate(), localNow).getDays();
-            daysSinceEventByEventId.put(event.getEventId(), daysSince);
-            eventTimestampByEventId.put(event.getEventId(), eventTimestamp);
-        }
-    }
-    
-    public DateTimeZone getTimeZone() {
-        return zone;
-    }
+    public static final EventStreamAdherenceReportGenerator INSTANCE = new EventStreamAdherenceReportGenerator();
 
-    public EventStreamAdherenceReport generate() {
-        for (TimelineMetadata meta : metadata) {
+    public EventStreamAdherenceReport generate(AdherenceState state) {
+        for (TimelineMetadata meta : state.getMetadata()) {
             if (meta.isTimeWindowPersistent()) {
                 continue;
             }
             int startDay = meta.getSessionInstanceStartDay();
             int endDay = meta.getSessionInstanceEndDay();
             String eventId = meta.getSessionStartEventId();
-            Integer daysSinceEvent = daysSinceEventByEventId.get(eventId);
+            Integer daysSinceEvent = state.getDaysSinceEventById(eventId);
 
-            DateTime timestamp = eventTimestampByEventId.get(eventId);
+            DateTime timestamp = state.getEventTimestampById(eventId);
             LocalDate localDate = (timestamp == null) ? null : timestamp.toLocalDate();
             LocalDate startDate = (localDate == null) ? null : localDate.plusDays(startDay);
             LocalDate endDate = (localDate == null) ? null : localDate.plusDays(endDay);
 
             // Skip entries that are not currently active, according to the server.
-            if (showActive && (daysSinceEvent == null || (startDay > daysSinceEvent || endDay < daysSinceEvent))) {
+            if (state.showActive() && (daysSinceEvent == null || (startDay > daysSinceEvent || endDay < daysSinceEvent))) {
                 continue;
             }
 
             // Produce one report for each event ID. Create them lazily as we find each eventId;
-            EventStream stream = retrieveStream(eventId);
-            // (These should be same every time you add a day to the stream.)
-            stream.setEventTimestamp(timestamp);
+            EventStream stream = state.getEventStreamById(eventId);
             stream.setDaysSinceEvent(daysSinceEvent);
             stream.setStudyBurstId(meta.getStudyBurstId());
             stream.setStudyBurstNum(meta.getStudyBurstNum());
 
             // Get the adherence information for this session instance and derive the state of the session
-            AdherenceRecord record = adherenceByEventId.get(meta.getSessionInstanceGuid());
-            SessionCompletionState state = calculateSessionState(record, startDay, endDay, daysSinceEvent);
+            AdherenceRecord record = state.getAdherenceRecordByGuid(meta.getSessionInstanceGuid());
+            SessionCompletionState sessionState = calculateSessionState(record, startDay, endDay, daysSinceEvent);
 
             // Retrieve the event stream. All items in this stream start on the same day, but can end on different days
-            EventStreamDay eventStream = retrieveDay(stream, meta);
-            eventStream.setStartDay(startDay);
-            eventStream.setStartDate(startDate);
+            EventStreamDay eventStreamDay = state.getEventStreamDayByKey(meta);
+            eventStreamDay.setStartDay(startDay);
+            eventStreamDay.setStartDate(startDate);
 
             // Create a window entry (windows are flattened in the list of timeline metadata records...all session
             // records in the metadata table are actually session window records)
@@ -114,22 +58,13 @@ public class EventStreamAdherenceReportGenerator {
             windowEntry.setTimeWindowGuid(meta.getTimeWindowGuid());
             windowEntry.setEndDay(endDay);
             windowEntry.setEndDate(endDate);
-            windowEntry.setState(state);
-            eventStream.addTimeWindow(windowEntry);
+            windowEntry.setState(sessionState);
+            eventStreamDay.addTimeWindow(windowEntry);
         }
 
-        long compliantSessions = streamsByEventId.values().stream()
-                .flatMap(es -> es.getByDayEntries().values().stream()).flatMap(list -> list.stream())
-                .flatMap(esd -> esd.getTimeWindows().stream()).filter(tw -> COMPLIANT.contains(tw.getState()))
-                .collect(counting());
-        long noncompliantSessions = streamsByEventId.values().stream()
-                .flatMap(es -> es.getByDayEntries().values().stream()).flatMap(list -> list.stream())
-                .flatMap(esd -> esd.getTimeWindows().stream()).filter(tw -> NONCOMPLIANT.contains(tw.getState()))
-                .collect(counting());
-        long unkSessions = streamsByEventId.values().stream().flatMap(es -> es.getByDayEntries().values().stream())
-                .flatMap(list -> list.stream()).flatMap(esd -> esd.getTimeWindows().stream())
-                .filter(tw -> UNKNOWN.contains(tw.getState())).collect(counting());
-
+        long compliantSessions = state.getSessionStateCount(COMPLIANT);
+        long noncompliantSessions = state.getSessionStateCount(NONCOMPLIANT);
+        long unkSessions = state.getSessionStateCount(UNKNOWN);
         long totalSessions = compliantSessions + noncompliantSessions + unkSessions;
 
         float percentage = 1.0f;
@@ -137,101 +72,14 @@ public class EventStreamAdherenceReportGenerator {
             percentage = ((float) compliantSessions / (float) totalSessions);
         }
 
-        List<String> keysSorted = Lists.newArrayList(streamsByEventId.keySet());
-        keysSorted.sort(String::compareToIgnoreCase);
-
         EventStreamAdherenceReport report = new EventStreamAdherenceReport();
-        report.setActiveOnly(showActive);
-        report.setTimestamp(now);
-        report.setClientTimeZone(clientTimeZone);
+        report.setActiveOnly(state.showActive());
+        report.setTimestamp(state.getNow());
+        report.setClientTimeZone(state.getClientTimeZone());
         report.setAdherencePercent((int) (percentage * 100));
-        for (String key : keysSorted) {
-            report.getStreams().add(streamsByEventId.get(key));
+        for (String eventId : state.getStreamEventIds()) {
+            report.getStreams().add(state.getEventStreamById(eventId));
         }
         return report;
-    }
-
-    private EventStream retrieveStream(String eventId) {
-        EventStream stream = streamsByEventId.get(eventId);
-        if (stream == null) {
-            stream = new EventStream();
-            stream.setStartEventId(eventId);
-            streamsByEventId.put(eventId, stream);
-        }
-        return stream;
-    }
-
-    private EventStreamDay retrieveDay(EventStream stream, TimelineMetadata meta) {
-        checkNotNull(meta.getSessionGuid());
-
-        String eventId = meta.getSessionStartEventId();
-        int startDay = meta.getSessionInstanceStartDay();
-
-        String streamKey = String.format("%s:%s:%s", meta.getSessionGuid(), eventId, startDay);
-        EventStreamDay eventStreamDay = streamsByStreamKey.get(streamKey);
-        if (eventStreamDay == null) {
-            eventStreamDay = new EventStreamDay();
-            eventStreamDay.setSessionGuid(meta.getSessionGuid());
-            eventStreamDay.setSessionName(meta.getSessionName());
-            eventStreamDay.setSessionSymbol(meta.getSessionSymbol());
-            eventStreamDay.setWeek(startDay / 7);
-            eventStreamDay.setStudyBurstId(meta.getStudyBurstId());
-            eventStreamDay.setStudyBurstNum(meta.getStudyBurstNum());
-            streamsByStreamKey.put(streamKey, eventStreamDay);
-            stream.addEntry(startDay, eventStreamDay);
-        }
-        return eventStreamDay;
-    }
-
-    public static class Builder {
-        private boolean showActiveOnly;
-        private List<TimelineMetadata> metadata;
-        private List<StudyActivityEvent> events;
-        private List<AdherenceRecord> adherenceRecords;
-        private DateTime now;
-        private String clientTimeZone;
-
-        public Builder withMetadata(List<TimelineMetadata> metadata) {
-            this.metadata = metadata;
-            return this;
-        }
-
-        public Builder withEvents(List<StudyActivityEvent> events) {
-            this.events = events;
-            return this;
-        }
-
-        public Builder withAdherenceRecords(List<AdherenceRecord> adherenceRecords) {
-            this.adherenceRecords = adherenceRecords;
-            return this;
-        }
-
-        public Builder withNow(DateTime now) {
-            this.now = now;
-            return this;
-        }
-
-        public Builder withShowActive(boolean showActiveOnly) {
-            this.showActiveOnly = showActiveOnly;
-            return this;
-        }
-        
-        public Builder withClientTimeZone(String clientTimeZone) {
-            this.clientTimeZone = clientTimeZone;
-            return this;
-        }
-
-        public EventStreamAdherenceReportGenerator build() {
-            if (metadata == null) {
-                metadata = ImmutableList.of();
-            }
-            if (events == null) {
-                events = ImmutableList.of();
-            }
-            if (adherenceRecords == null) {
-                adherenceRecords = ImmutableList.of();
-            }
-            return new EventStreamAdherenceReportGenerator(this);
-        }
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/services/AdherenceService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AdherenceService.java
@@ -53,6 +53,7 @@ import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecord;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecordList;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecordType;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecordsSearch;
+import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceState;
 import org.sagebionetworks.bridge.models.schedules2.adherence.eventstream.EventStreamAdherenceReport;
 import org.sagebionetworks.bridge.models.schedules2.adherence.eventstream.EventStreamAdherenceReportGenerator;
 import org.sagebionetworks.bridge.models.schedules2.timelines.MetadataContainer;
@@ -326,7 +327,7 @@ public class AdherenceService {
 
         Stopwatch watch = Stopwatch.createStarted();
         
-        EventStreamAdherenceReportGenerator.Builder builder = new EventStreamAdherenceReportGenerator.Builder();
+        AdherenceState.Builder builder = new AdherenceState.Builder();
         builder.withShowActive(showActiveOnly);
         builder.withNow(now);
         builder.withClientTimeZone(clientTimeZone);
@@ -334,7 +335,7 @@ public class AdherenceService {
         Study study = studyService.getStudy(appId, studyId, true);
         if (study.getScheduleGuid() == null) {
             watch.stop();
-            return builder.build().generate();
+            return EventStreamAdherenceReportGenerator.INSTANCE.generate(builder.build());
         }
         List<TimelineMetadata> metadata = scheduleService.getScheduleMetadata(study.getScheduleGuid());
 
@@ -355,7 +356,7 @@ public class AdherenceService {
         builder.withEvents(events);
         builder.withAdherenceRecords(adherenceRecords);
 
-        EventStreamAdherenceReport report = builder.build().generate();
+        EventStreamAdherenceReport report = EventStreamAdherenceReportGenerator.INSTANCE.generate(builder.build());
         LOG.info("Event stream adherence report took " + watch.elapsed(TimeUnit.MILLISECONDS) + "ms");
         return report;
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/HealthDataController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/HealthDataController.java
@@ -22,7 +22,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import org.sagebionetworks.bridge.BridgeUtils;
-import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.models.DateTimeRangeResourceList;
 import org.sagebionetworks.bridge.models.Metrics;
 import org.sagebionetworks.bridge.models.RequestInfo;

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceStateTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceStateTest.java
@@ -1,0 +1,225 @@
+package org.sagebionetworks.bridge.models.schedules2.adherence;
+
+import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
+import static org.sagebionetworks.bridge.TestConstants.TEST_CLIENT_TIME_ZONE;
+import static org.sagebionetworks.bridge.models.schedules2.adherence.SessionCompletionState.COMPLIANT;
+import static org.sagebionetworks.bridge.models.schedules2.adherence.SessionCompletionState.NONCOMPLIANT;
+import static org.sagebionetworks.bridge.models.schedules2.adherence.SessionCompletionState.UNKNOWN;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+import java.util.List;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.LocalDate;
+import org.mockito.Mockito;
+import org.sagebionetworks.bridge.models.activities.StudyActivityEvent;
+import org.sagebionetworks.bridge.models.schedules2.adherence.eventstream.EventStream;
+import org.sagebionetworks.bridge.models.schedules2.adherence.eventstream.EventStreamDay;
+import org.sagebionetworks.bridge.models.schedules2.adherence.eventstream.EventStreamWindow;
+import org.sagebionetworks.bridge.models.schedules2.timelines.TimelineMetadata;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.newrelic.agent.deps.com.google.common.collect.ImmutableList;
+
+public class AdherenceStateTest extends Mockito {
+    
+    private static final DateTimeZone TEST_TIME_ZONE = DateTimeZone.forID(TEST_CLIENT_TIME_ZONE);
+    private static final DateTime NOW = CREATED_ON.plusDays(10).withZone(DateTimeZone.forID("America/Chicago"));
+    private static final DateTime EVENT_TS1 = CREATED_ON;
+    private static final DateTime EVENT_TS2 = CREATED_ON.plusDays(5);
+
+    TimelineMetadata meta1;
+    TimelineMetadata meta2;
+    List<TimelineMetadata> metadata;
+    
+    AdherenceRecord rec1;
+    AdherenceRecord rec2;
+    
+    AdherenceState state;
+
+    @BeforeMethod
+    public void beforeMethod() { 
+        meta1 = new TimelineMetadata();
+        meta1.setSessionStartEventId("event1");
+        meta1.setSessionGuid("guid1");
+        meta1.setSessionInstanceStartDay(1);
+        meta1.setSessionName("session1");
+        meta1.setSessionSymbol("1");
+        
+        meta2 = new TimelineMetadata();
+        meta2.setSessionStartEventId("event2");
+        meta2.setSessionGuid("guid2");
+        meta2.setSessionInstanceStartDay(2);
+        meta2.setSessionName("session2");
+        meta2.setSessionSymbol("2");
+        meta2.setStudyBurstId("burst2");
+        meta2.setStudyBurstNum(2);
+        metadata = ImmutableList.of(meta1, meta2);
+        
+        StudyActivityEvent e1 = new StudyActivityEvent.Builder()
+                .withEventId("event1")
+                .withTimestamp(EVENT_TS1)
+                .build();
+        
+        StudyActivityEvent e2 = new StudyActivityEvent.Builder()
+                .withEventId("event2")
+                .withTimestamp(EVENT_TS2)
+                .build();
+        
+        List<StudyActivityEvent> events = ImmutableList.of(e1, e2);
+        
+        rec1 = new AdherenceRecord();
+        rec1.setInstanceGuid("ar1");
+        rec1.setEventTimestamp(EVENT_TS1);
+        
+        rec2 = new AdherenceRecord();
+        rec2.setInstanceGuid("ar2");
+        rec2.setEventTimestamp(EVENT_TS2);
+        
+        List<AdherenceRecord> adherenceRecords = ImmutableList.of(rec1, rec2);
+        
+        state = new AdherenceState.Builder()
+            .withMetadata(metadata)
+            .withEvents(events)
+            .withAdherenceRecords(adherenceRecords)
+            .withNow(NOW)
+            .withShowActive(true)
+            .withClientTimeZone(TEST_CLIENT_TIME_ZONE)
+            .build();
+    }
+    
+    @Test
+    public void testConstruction_nulls() {
+        AdherenceState emptyState = new AdherenceState.Builder().build();
+        assertEquals(emptyState.getMetadata(), ImmutableList.of());
+        assertNull(emptyState.getAdherenceRecordByGuid("event1"));
+        try {
+            emptyState.getEventStreamById("event1");    
+        } catch(IllegalArgumentException e) {
+        }
+        try {
+            emptyState.getEventStreamDayByKey(meta1);    
+        } catch(IllegalArgumentException e) {
+        }
+        try {
+            emptyState.getDaysSinceEventById("event1");    
+        } catch(IllegalArgumentException e) {
+        }
+        try {
+            emptyState.getEventTimestampById("event1");    
+        } catch(IllegalArgumentException e) {
+        }
+    }
+    
+    @Test
+    public void testConstruction() {
+        assertSame(state.getMetadata(), metadata);
+        assertTrue(state.showActive());
+        assertEquals(state.getNow(), NOW);
+        assertEquals(state.getClientTimeZone(), TEST_CLIENT_TIME_ZONE);
+        assertEquals(state.getTimeZone(), TEST_TIME_ZONE);
+        
+        EventStream stream1 = state.getEventStreamById("event1");
+        assertEquals(stream1.getStartEventId(), "event1");
+        assertEquals(stream1.getEventTimestamp(), EVENT_TS1.withZone(TEST_TIME_ZONE));
+        // We're not creating a new one each time
+        assertSame(state.getEventStreamById("event1"), state.getEventStreamById("event1"));
+        
+        EventStream stream2 = state.getEventStreamById("event2");
+        assertEquals(stream2.getStartEventId(), "event2");
+        assertEquals(stream2.getEventTimestamp(), EVENT_TS2.withZone(TEST_TIME_ZONE));
+        
+        assertSame(state.getMetadata().get(0), meta1);
+        assertSame(state.getMetadata().get(1), meta2);
+        
+        EventStreamDay day1 = state.getEventStreamDayByKey(meta1);
+        // We're not creating a new one each time
+        assertSame(state.getEventStreamDayByKey(meta1), state.getEventStreamDayByKey(meta1));
+        assertEquals(day1.getSessionGuid(), "guid1");
+        assertEquals(day1.getSessionName(), "session1");
+        assertEquals(day1.getSessionSymbol(), "1");
+        assertNull(day1.getStudyBurstId());
+        assertNull(day1.getStudyBurstNum());
+        
+        EventStreamDay day2 = state.getEventStreamDayByKey(meta2);
+        assertEquals(day2.getSessionGuid(), "guid2");
+        assertEquals(day2.getSessionName(), "session2");
+        assertEquals(day2.getSessionSymbol(), "2");
+        assertEquals(day2.getStudyBurstId(), "burst2");
+        assertEquals(day2.getStudyBurstNum(), Integer.valueOf(2));
+        
+        assertSame(state.getAdherenceRecordByGuid("ar1"), rec1);
+        assertSame(state.getAdherenceRecordByGuid("ar2"), rec2);
+
+        assertEquals(state.getDaysSinceEventById("event1"), Integer.valueOf(10));
+        assertEquals(state.getDaysSinceEventById("event2"), Integer.valueOf(5));
+
+        assertEquals(state.getEventTimestampById("event1"), EVENT_TS1.withZone(TEST_TIME_ZONE));
+        assertEquals(state.getEventTimestampById("event2"), EVENT_TS2.withZone(TEST_TIME_ZONE));
+        
+        // These are always going to return zero after construction because state calculation happens
+        // in the report generators. We can manually set and and test this in a separate test.
+        assertEquals(state.getSessionStateCount(COMPLIANT), 0L);
+        assertEquals(state.getSessionStateCount(NONCOMPLIANT), 0L);
+        assertEquals(state.getSessionStateCount(UNKNOWN), 0L);
+        
+        assertEquals(state.getStreamEventIds(), ImmutableList.of("event1", "event2"));
+    }
+    
+    @Test
+    public void getSessionStateCount() {
+        // We do have to manually set the states for some made-up windows in order
+        // to verify this getter works...
+        EventStreamDay day1 = state.getEventStreamDayByKey(meta1);
+        EventStreamWindow win1a = new EventStreamWindow();
+        win1a.setSessionInstanceGuid(meta1.getSessionInstanceGuid());
+        win1a.setTimeWindowGuid("win1a");
+        win1a.setState(SessionCompletionState.ABANDONED);
+        day1.addTimeWindow(win1a);
+        
+        EventStreamWindow win1b = new EventStreamWindow();
+        win1b.setSessionInstanceGuid(meta1.getSessionInstanceGuid());
+        win1b.setTimeWindowGuid("win1b");
+        win1b.setState(SessionCompletionState.EXPIRED);
+        day1.addTimeWindow(win1b);
+        
+        EventStreamDay day2 = state.getEventStreamDayByKey(meta2);
+        EventStreamWindow win2a = new EventStreamWindow();
+        win2a.setSessionInstanceGuid(meta2.getSessionInstanceGuid());
+        win2a.setTimeWindowGuid("win2a");
+        win2a.setState(SessionCompletionState.UNSTARTED);
+        day2.addTimeWindow(win2a);
+        
+        EventStreamWindow win2b = new EventStreamWindow();
+        win2b.setSessionInstanceGuid(meta2.getSessionInstanceGuid());
+        win2b.setTimeWindowGuid("win2b");
+        win2b.setState(SessionCompletionState.COMPLETED);
+        day2.addTimeWindow(win2b);
+
+        assertEquals(state.getSessionStateCount(COMPLIANT), 1L); // completed
+        assertEquals(state.getSessionStateCount(NONCOMPLIANT), 2L); // abandoned, expired
+        assertEquals(state.getSessionStateCount(UNKNOWN), 1L); // unstarted
+    }
+    
+    @Test
+    public void timeZone_fromNow() {
+        state = new AdherenceState.Builder()
+                .withMetadata(metadata)
+                .withNow(NOW)
+                .withShowActive(true)
+                // no time zone
+                .build();
+        // a time zone from the "now" value would be an offset, but same difference
+        assertEquals(state.getTimeZone(), DateTimeZone.forID("America/Chicago"));    
+    }
+    
+    @Test
+    public void timeZone_fromClientTimeZone() {
+        assertEquals(state.getTimeZone(), TEST_TIME_ZONE);    
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceStateTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceStateTest.java
@@ -6,9 +6,11 @@ import static org.sagebionetworks.bridge.models.schedules2.adherence.SessionComp
 import static org.sagebionetworks.bridge.models.schedules2.adherence.SessionCompletionState.NONCOMPLIANT;
 import static org.sagebionetworks.bridge.models.schedules2.adherence.SessionCompletionState.UNKNOWN;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.List;
 
@@ -97,22 +99,10 @@ public class AdherenceStateTest extends Mockito {
         AdherenceState emptyState = new AdherenceState.Builder().build();
         assertEquals(emptyState.getMetadata(), ImmutableList.of());
         assertNull(emptyState.getAdherenceRecordByGuid("event1"));
-        try {
-            emptyState.getEventStreamById("event1");    
-        } catch(IllegalArgumentException e) {
-        }
-        try {
-            emptyState.getEventStreamDayByKey(meta1);    
-        } catch(IllegalArgumentException e) {
-        }
-        try {
-            emptyState.getDaysSinceEventById("event1");    
-        } catch(IllegalArgumentException e) {
-        }
-        try {
-            emptyState.getEventTimestampById("event1");    
-        } catch(IllegalArgumentException e) {
-        }
+        assertNull(emptyState.getDaysSinceEventById("event1"));    
+        assertNull(emptyState.getEventTimestampById("event1"));    
+        assertNotNull(emptyState.getEventStreamById("event1"));
+        assertNotNull(emptyState.getEventStreamDayByKey(meta1));    
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceStateTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceStateTest.java
@@ -14,7 +14,6 @@ import java.util.List;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.joda.time.LocalDate;
 import org.mockito.Mockito;
 import org.sagebionetworks.bridge.models.activities.StudyActivityEvent;
 import org.sagebionetworks.bridge.models.schedules2.adherence.eventstream.EventStream;
@@ -24,7 +23,7 @@ import org.sagebionetworks.bridge.models.schedules2.timelines.TimelineMetadata;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.newrelic.agent.deps.com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList;
 
 public class AdherenceStateTest extends Mockito {
     


### PR DESCRIPTION
The next report needs all the same information, so changed this a bit so we can collect all the state and pass it in to the appropriate report generator.