### PR TITLE
add admin.synapse.user.id

### DIFF
--- a/src/main/resources/BridgeServer2.conf
+++ b/src/main/resources/BridgeServer2.conf
@@ -151,7 +151,8 @@ prod.usersigned.consents.bucket = bridgepf-prod-awss3usersignedconsentsdownloadb
 # in your bridge-sdk-test.properties file.
 admin.email = dummy-value
 admin.password = dummy-value
-admin.synapse.user.id = dummy-value
+admin.synapse.user.id = 3336429
+prod.admin.synapse.user.id = 3399057
 
 synapse.oauth.url = https://repo-dev.dev.sagebase.org/auth/v1/oauth2/token
 prod.synapse.oauth.url = https://repo-prod.prod.sagebase.org/auth/v1/oauth2/token


### PR DESCRIPTION
DefaultAppBootstrapper will fail because it's looking for an account with Synapse ID "dummy-value". This fixes that by adding the Synapse user IDs to our configs.

This is safe to add to our configs because user IDs are not sensitive information.