### PR TITLE
Adding additional parameters for adherence report search

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/src/main/java/org/sagebionetworks/bridge/BridgeConstants.java
@@ -152,6 +152,8 @@ public class BridgeConstants {
     
     public static final String ADHERENCE_RANGE_ERROR = "% must be from 0-100";
     
+    public static final String ADHERENCE_RANGE_ORDER_ERROR = "cannot be less than adherenceMin";
+    
     public static final String TEST_USER_GROUP = "test_user";
     
     public static final String EXPIRATION_PERIOD_KEY = "expirationPeriod";

--- a/src/main/java/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/src/main/java/org/sagebionetworks/bridge/BridgeConstants.java
@@ -146,11 +146,11 @@ public class BridgeConstants {
     
     public static final String PAGE_SIZE_ERROR = "pageSize must be from "+API_MINIMUM_PAGE_SIZE+"-"+API_MAXIMUM_PAGE_SIZE+" records";
     
-    public static final String LABEL_FILTER_COUNT_ERROR = "labelFilter cannot have over 50 entries";
+    public static final String LABEL_FILTER_COUNT_ERROR = "cannot have over 50 entries";
     
-    public static final String LABEL_FILTER_LENGTH_ERROR = "labelFilter cannot be over 100 characters";
+    public static final String LABEL_FILTER_LENGTH_ERROR = "cannot be over 100 characters";
     
-    public static final String COMPLIANCE_UNDER_ERROR = "complianceUnder percentage must be from 1-100";
+    public static final String ADHERENCE_RANGE_ERROR = "% must be from 0-100";
     
     public static final String TEST_USER_GROUP = "test_user";
     

--- a/src/main/java/org/sagebionetworks/bridge/dao/AdherenceReportDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dao/AdherenceReportDao.java
@@ -1,8 +1,6 @@
 package org.sagebionetworks.bridge.dao;
 
-import java.util.List;
-
-import org.sagebionetworks.bridge.models.AccountTestFilter;
+import org.sagebionetworks.bridge.models.AdherenceReportSearch;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.schedules2.adherence.weekly.WeeklyAdherenceReport;
 
@@ -11,7 +9,6 @@ public interface AdherenceReportDao {
     void saveWeeklyAdherenceReport(WeeklyAdherenceReport report);
     
     PagedResourceList<WeeklyAdherenceReport> getWeeklyAdherenceReports(String appId, String studyId,
-            AccountTestFilter testFilter, List<String> labelFilter, Integer complianceUnder, Integer offsetBy,
-            Integer pageSize);
+            AdherenceReportSearch search);
     
 }

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAdherenceReportDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAdherenceReportDao.java
@@ -25,7 +25,7 @@ public class HibernateAdherenceReportDao implements AdherenceReportDao {
     static final String ADHERENCE_MIN_FIELD = "adherenceMin";
     static final String ADHERENCE_MAX_FIELD = "adherenceMax";
     static final String ID_FILTER_FIELD = "id";
-    static final String PROGRESSION_FIELD = "progressionFilter"; 
+    static final String PROGRESSION_FILTER_FIELD = "progressionFilters"; 
     static final String LABEL_FILTER_FIELD = "labelFilter";
     static final String STUDY_ID_FIELD = "studyId";
     static final String APP_ID_FIELD = "appId";
@@ -60,13 +60,13 @@ public class HibernateAdherenceReportDao implements AdherenceReportDao {
         where.append("h.appId = :appId", APP_ID_FIELD, appId);
         where.append("h.studyId = :studyId", STUDY_ID_FIELD, studyId);
         if (search.getAdherenceMin() > 0) {
-            where.append("weeklyAdherencePercent >= :adherenceMin", "adherenceMin", search.getAdherenceMin());    
+            where.append("weeklyAdherencePercent >= :adherenceMin", ADHERENCE_MIN_FIELD, search.getAdherenceMin());    
         }
         if (search.getAdherenceMax() < 100) {
-            where.append("weeklyAdherencePercent <= :adherenceMax", "adherenceMax", search.getAdherenceMax());    
+            where.append("weeklyAdherencePercent <= :adherenceMax", ADHERENCE_MAX_FIELD, search.getAdherenceMax());    
         }
-        if (search.getProgressionFilter() != null) {
-            where.append("progression = :progressionFilter", PROGRESSION_FIELD, search.getProgressionFilter());
+        if (search.getProgressionFilters() != null && !search.getProgressionFilters().isEmpty()) {
+            where.append("progression IN :progressionFilters", PROGRESSION_FILTER_FIELD, search.getProgressionFilters());
         }
         if (hasLabels) {
             where.labels(search.getLabelFilters());

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAdherenceReportDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateAdherenceReportDao.java
@@ -1,8 +1,10 @@
 package org.sagebionetworks.bridge.hibernate;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.sagebionetworks.bridge.BridgeUtils.OR_JOINER;
 import static org.sagebionetworks.bridge.models.SearchTermPredicate.AND;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.Resource;
@@ -10,6 +12,7 @@ import javax.annotation.Resource;
 import org.sagebionetworks.bridge.dao.AdherenceReportDao;
 import org.sagebionetworks.bridge.hibernate.QueryBuilder.WhereClauseBuilder;
 import org.sagebionetworks.bridge.models.AccountTestFilter;
+import org.sagebionetworks.bridge.models.AdherenceReportSearch;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.schedules2.adherence.weekly.WeeklyAdherenceReport;
 import org.springframework.stereotype.Component;
@@ -17,7 +20,12 @@ import org.springframework.stereotype.Component;
 @Component
 public class HibernateAdherenceReportDao implements AdherenceReportDao {
 
-    static final String COMPLIANCE_UNDER_FIELD = "complianceUnder";
+    static final String SELECT_COUNT = "SELECT COUNT(*) ";
+    static final String SELECT_DISTINCT = "SELECT DISTINCT h ";
+    static final String ADHERENCE_MIN_FIELD = "adherenceMin";
+    static final String ADHERENCE_MAX_FIELD = "adherenceMax";
+    static final String ID_FILTER_FIELD = "id";
+    static final String PROGRESSION_FIELD = "progressionFilter"; 
     static final String LABEL_FILTER_FIELD = "labelFilter";
     static final String STUDY_ID_FIELD = "studyId";
     static final String APP_ID_FIELD = "appId";
@@ -37,13 +45,11 @@ public class HibernateAdherenceReportDao implements AdherenceReportDao {
 
     @Override
     public PagedResourceList<WeeklyAdherenceReport> getWeeklyAdherenceReports(String appId, String studyId,
-            AccountTestFilter testFilter, List<String> labelFilter, Integer complianceUnder, Integer offsetBy,
-            Integer pageSize) {
+            AdherenceReportSearch search) {
         checkNotNull(appId);
         checkNotNull(studyId);
-        checkNotNull(testFilter);
         
-        boolean hasLabels = (labelFilter != null && !labelFilter.isEmpty());
+        boolean hasLabels = (search.getLabelFilters() != null && !search.getLabelFilters().isEmpty());
         
         QueryBuilder builder = new QueryBuilder();
         builder.append("FROM WeeklyAdherenceReport h");
@@ -53,23 +59,39 @@ public class HibernateAdherenceReportDao implements AdherenceReportDao {
         WhereClauseBuilder where = builder.startWhere(AND);
         where.append("h.appId = :appId", APP_ID_FIELD, appId);
         where.append("h.studyId = :studyId", STUDY_ID_FIELD, studyId);
-        if (complianceUnder != null) {
-            where.append("weeklyAdherencePercent < :complianceUnder", COMPLIANCE_UNDER_FIELD, complianceUnder);
+        if (search.getAdherenceMin() > 0) {
+            where.append("weeklyAdherencePercent >= :adherenceMin", "adherenceMin", search.getAdherenceMin());    
+        }
+        if (search.getAdherenceMax() < 100) {
+            where.append("weeklyAdherencePercent <= :adherenceMax", "adherenceMax", search.getAdherenceMax());    
+        }
+        if (search.getProgressionFilter() != null) {
+            where.append("progression = :progressionFilter", PROGRESSION_FIELD, search.getProgressionFilter());
         }
         if (hasLabels) {
-            where.labels(labelFilter);
+            where.labels(search.getLabelFilters());
         }
-        if (testFilter == AccountTestFilter.TEST) {
+        if (search.getTestFilter() == AccountTestFilter.TEST) {
             where.append("testAccount = 1");
-        } else if (testFilter == AccountTestFilter.PRODUCTION) {
+        } else if (search.getTestFilter() == AccountTestFilter.PRODUCTION) {
             where.append("testAccount = 0");
+        }
+        if (search.getIdFilter() != null) {
+            List<String> clauses = new ArrayList<>();
+            clauses.add("externalId LIKE :id");
+            clauses.add("identifier LIKE :id");
+            clauses.add("firstName LIKE :id");
+            clauses.add("lastName LIKE :id");
+            clauses.add("email LIKE :id");
+            clauses.add("phone LIKE :id");
+            where.append("(" + OR_JOINER.join(clauses) + ")", "id", "%" + search.getIdFilter() + "%");
         }
         builder.append("ORDER BY weeklyAdherencePercent, lastName, firstName, email, phone, externalId");
         
-        int total = hibernateHelper.queryCount("SELECT COUNT(*) " + builder.getQuery(), builder.getParameters());
+        int total = hibernateHelper.queryCount(SELECT_COUNT + builder.getQuery(), builder.getParameters());
         
-        List<WeeklyAdherenceReport> reports = hibernateHelper.queryGet("SELECT DISTINCT h " + builder.getQuery(),
-                builder.getParameters(), offsetBy, pageSize, WeeklyAdherenceReport.class);
+        List<WeeklyAdherenceReport> reports = hibernateHelper.queryGet(SELECT_DISTINCT + builder.getQuery(),
+                builder.getParameters(), search.getOffsetBy(), search.getPageSize(), WeeklyAdherenceReport.class);
 
         return new PagedResourceList<>(reports, total, true);
     }

--- a/src/main/java/org/sagebionetworks/bridge/hibernate/QueryBuilder.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/QueryBuilder.java
@@ -14,6 +14,7 @@ import static org.sagebionetworks.bridge.models.studies.EnrollmentFilter.ENROLLE
 import static org.sagebionetworks.bridge.models.studies.EnrollmentFilter.WITHDRAWN;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -143,11 +144,12 @@ class QueryBuilder {
                 whereParams.put(key, searchString);
             }
         }
-        public void labels(List<String> labelFilter) {
+        public void labels(Collection<String> labelFilters) {
             List<String> phrases = new ArrayList<>();
-            for (int i=0; i < labelFilter.size(); i++) {
+            int i=0;
+            for (String labelFilter : labelFilters) {
                 phrases.add("label LIKE :labelFilter"+i);
-                whereParams.put("labelFilter"+i,  "%:" + labelFilter.get(i) + ":%");
+                whereParams.put("labelFilter"+(i++),  "%:" + labelFilter + ":%");
             }
             predicated.add("(" + Joiner.on(" OR ").join(phrases) + ")");
         }

--- a/src/main/java/org/sagebionetworks/bridge/models/AdherenceReportSearch.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/AdherenceReportSearch.java
@@ -2,17 +2,17 @@ package org.sagebionetworks.bridge.models;
 
 import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 
-import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
-import org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantProgressionState;
+import org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantStudyProgress;
 
 public final class AdherenceReportSearch implements BridgeEntity {
     private AccountTestFilter testFilter;
-    private List<String> labelFilters; 
+    private Set<String> labelFilters; 
     private Integer adherenceMin = 0;
     private Integer adherenceMax = 100;
-    private ParticipantProgressionState progressionFilter;
+    private Set<ParticipantStudyProgress> progressionFilters;
     private String idFilter;
     private Integer offsetBy = 0; 
     private Integer pageSize = API_DEFAULT_PAGE_SIZE;
@@ -23,10 +23,10 @@ public final class AdherenceReportSearch implements BridgeEntity {
     public void setTestFilter(AccountTestFilter testFilter) {
         this.testFilter = testFilter;
     }
-    public List<String> getLabelFilters() {
+    public Set<String> getLabelFilters() {
         return labelFilters;
     }
-    public void setLabelFilters(List<String> labelFilters) {
+    public void setLabelFilters(Set<String> labelFilters) {
         this.labelFilters = labelFilters;
     }
     public Integer getAdherenceMin() {
@@ -45,11 +45,11 @@ public final class AdherenceReportSearch implements BridgeEntity {
             this.adherenceMax = adherenceMax;    
         }
     }
-    public ParticipantProgressionState getProgressionFilter() {
-        return progressionFilter;
+    public Set<ParticipantStudyProgress> getProgressionFilters() {
+        return progressionFilters;
     }
-    public void setProgressionFilter(ParticipantProgressionState progressionFilter) {
-        this.progressionFilter = progressionFilter;
+    public void setProgressionFilters(Set<ParticipantStudyProgress> progressionFilters) {
+        this.progressionFilters = progressionFilters;
     }
     public String getIdFilter() {
         return idFilter;
@@ -75,7 +75,7 @@ public final class AdherenceReportSearch implements BridgeEntity {
     }
     @Override
     public int hashCode() {
-        return Objects.hash(adherenceMin, adherenceMax, idFilter, labelFilters, offsetBy, pageSize, progressionFilter,
+        return Objects.hash(adherenceMin, adherenceMax, idFilter, labelFilters, offsetBy, pageSize, progressionFilters,
                 testFilter);
     }
     @Override
@@ -88,6 +88,6 @@ public final class AdherenceReportSearch implements BridgeEntity {
         return Objects.equals(adherenceMin, other.adherenceMin) && Objects.equals(adherenceMax, other.adherenceMax)
                 && Objects.equals(idFilter, other.idFilter) && Objects.equals(labelFilters, other.labelFilters)
                 && Objects.equals(offsetBy, other.offsetBy) && Objects.equals(pageSize, other.pageSize)
-                && progressionFilter == other.progressionFilter && testFilter == other.testFilter;
+                && Objects.equals(progressionFilters, other.progressionFilters) && testFilter == other.testFilter;
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/models/AdherenceReportSearch.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/AdherenceReportSearch.java
@@ -1,0 +1,93 @@
+package org.sagebionetworks.bridge.models;
+
+import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantProgressionState;
+
+public final class AdherenceReportSearch implements BridgeEntity {
+    private AccountTestFilter testFilter;
+    private List<String> labelFilters; 
+    private Integer adherenceMin = 0;
+    private Integer adherenceMax = 100;
+    private ParticipantProgressionState progressionFilter;
+    private String idFilter;
+    private Integer offsetBy = 0; 
+    private Integer pageSize = API_DEFAULT_PAGE_SIZE;
+    
+    public AccountTestFilter getTestFilter() {
+        return testFilter;
+    }
+    public void setTestFilter(AccountTestFilter testFilter) {
+        this.testFilter = testFilter;
+    }
+    public List<String> getLabelFilters() {
+        return labelFilters;
+    }
+    public void setLabelFilters(List<String> labelFilters) {
+        this.labelFilters = labelFilters;
+    }
+    public Integer getAdherenceMin() {
+        return adherenceMin;
+    }
+    public void setAdherenceMin(Integer adherenceMin) {
+        if (adherenceMin != null) {
+            this.adherenceMin = adherenceMin;    
+        }
+    }
+    public Integer getAdherenceMax() {
+        return adherenceMax;
+    }
+    public void setAdherenceMax(Integer adherenceMax) {
+        if (adherenceMax != null) {
+            this.adherenceMax = adherenceMax;    
+        }
+    }
+    public ParticipantProgressionState getProgressionFilter() {
+        return progressionFilter;
+    }
+    public void setProgressionFilter(ParticipantProgressionState progressionFilter) {
+        this.progressionFilter = progressionFilter;
+    }
+    public String getIdFilter() {
+        return idFilter;
+    }
+    public void setIdFilter(String idFilter) {
+        this.idFilter = idFilter;
+    }
+    public Integer getOffsetBy() {
+        return offsetBy;
+    }
+    public void setOffsetBy(Integer offsetBy) {
+        if (offsetBy != null) {
+            this.offsetBy = offsetBy;
+        }
+    }
+    public Integer getPageSize() {
+        return pageSize;
+    }
+    public void setPageSize(Integer pageSize) {
+        if (pageSize != null) {
+            this.pageSize = pageSize;    
+        }
+    }
+    @Override
+    public int hashCode() {
+        return Objects.hash(adherenceMin, adherenceMax, idFilter, labelFilters, offsetBy, pageSize, progressionFilter,
+                testFilter);
+    }
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null || getClass() != obj.getClass())
+            return false;
+        AdherenceReportSearch other = (AdherenceReportSearch) obj;
+        return Objects.equals(adherenceMin, other.adherenceMin) && Objects.equals(adherenceMax, other.adherenceMax)
+                && Objects.equals(idFilter, other.idFilter) && Objects.equals(labelFilters, other.labelFilters)
+                && Objects.equals(offsetBy, other.offsetBy) && Objects.equals(pageSize, other.pageSize)
+                && progressionFilter == other.progressionFilter && testFilter == other.testFilter;
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/models/ResourceList.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/ResourceList.java
@@ -60,7 +60,7 @@ public class ResourceList<T> {
     public static final String PAGE_SIZE = "pageSize";
     public static final String PHONE_FILTER = "phoneFilter";
     public static final String PREDICATE = "predicate";
-    public static final String PROGRESSION_FILTER = "progressionFilter";
+    public static final String PROGRESSION_FILTERS = "progressionFilters";
     public static final String REPORT_TYPE = "reportType";
     public static final String SCHEDULED_ON_END = "scheduledOnEnd";
     public static final String SCHEDULED_ON_START = "scheduledOnStart";

--- a/src/main/java/org/sagebionetworks/bridge/models/ResourceList.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/ResourceList.java
@@ -23,6 +23,8 @@ import com.google.common.collect.ImmutableMap;
  */
 public class ResourceList<T> {
     
+    public static final String ADHERENCE_MAX = "adherenceMax";
+    public static final String ADHERENCE_MIN = "adherenceMin";
     public static final String ADHERENCE_RECORD_TYPE = "adherenceRecordType";
     public static final String ADMIN_ONLY = "adminOnly";
     public static final String ALL_OF_GROUPS = "allOfGroups";
@@ -31,7 +33,6 @@ public class ResourceList<T> {
     public static final String ATTRIBUTE_KEY = "attributeKey";
     public static final String ATTRIBUTE_VALUE_FILTER = "attributeValueFilter";
     public static final String CATEGORIES = "categories"; // should be a set or list
-    public static final String COMPLIANCE_UNDER = "complianceUnder";
     public static final String CURRENT_TIMESTAMPS_ONLY = "currentTimestampsOnly";
     public static final String EMAIL_FILTER = "emailFilter";
     public static final String END_DATE = "endDate";
@@ -59,6 +60,7 @@ public class ResourceList<T> {
     public static final String PAGE_SIZE = "pageSize";
     public static final String PHONE_FILTER = "phoneFilter";
     public static final String PREDICATE = "predicate";
+    public static final String PROGRESSION_FILTER = "progressionFilter";
     public static final String REPORT_TYPE = "reportType";
     public static final String SCHEDULED_ON_END = "scheduledOnEnd";
     public static final String SCHEDULED_ON_START = "scheduledOnStart";

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceState.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceState.java
@@ -36,11 +36,17 @@ public final class AdherenceState {
     private final DateTimeZone zone;
     
     public AdherenceState(AdherenceState.Builder builder) {
-        LocalDate localNow = builder.now.toLocalDate(); 
+        // All times should be adjusted to the same time zone. This will be the participant’s 
+        // declared time zone if we have it, otherwise it will be the server’s default time zone.
+        // In general it doesn’t make a difference, with the exception of edge cases like daylight
+        // savings time for short periods of time. We’d prefer to be accurate in the participant’s
+        // local time zone if we can be.
         zone = builder.zone;
+        now = builder.now.withZone(zone);
+        LocalDate localNow = now.toLocalDate();
+        
         showActive = builder.showActiveOnly;
         clientTimeZone = builder.clientTimeZone;
-        now = builder.now.withZone(zone);
         metadata = builder.metadata;
         events = builder.events;
         adherenceRecords = builder.adherenceRecords;
@@ -56,6 +62,7 @@ public final class AdherenceState {
             // DateTime eventTimestamp = event.getTimestamp();
             DateTime eventTimestamp = event.getTimestamp().withZone(zone);
             int daysSince = Days.daysBetween(eventTimestamp.toLocalDate(), localNow).getDays();
+            
             daysSinceEventByEventId.put(event.getEventId(), daysSince);
             eventTimestampByEventId.put(event.getEventId(), eventTimestamp);
         }

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceUtils.java
@@ -64,7 +64,7 @@ public class AdherenceUtils {
         return (int) (percentage * 100);
     }
     
-    private static long counting(Collection<EventStream> streams, Set<SessionCompletionState> states) {
+    public static long counting(Collection<EventStream> streams, Set<SessionCompletionState> states) {
       return streams.stream()
           .flatMap(es -> es.getByDayEntries().values().stream())
           .flatMap(list -> list.stream())

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/ParticipantProgressionState.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/ParticipantProgressionState.java
@@ -1,0 +1,7 @@
+package org.sagebionetworks.bridge.models.schedules2.adherence;
+
+public enum ParticipantProgressionState {
+    UNSTARTED,
+    IN_PROGRESS,
+    DONE
+}

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/ParticipantStudyProgress.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/ParticipantStudyProgress.java
@@ -1,6 +1,6 @@
 package org.sagebionetworks.bridge.models.schedules2.adherence;
 
-public enum ParticipantProgressionState {
+public enum ParticipantStudyProgress {
     UNSTARTED,
     IN_PROGRESS,
     DONE

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/weekly/WeeklyAdherenceReport.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/weekly/WeeklyAdherenceReport.java
@@ -27,7 +27,7 @@ import org.sagebionetworks.bridge.hibernate.NextActivityConverter;
 import org.sagebionetworks.bridge.hibernate.WeeklyAdherenceReportRowListConverter;
 import org.sagebionetworks.bridge.json.DateTimeSerializer;
 import org.sagebionetworks.bridge.models.accounts.AccountRef;
-import org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantProgressionState;
+import org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantStudyProgress;
 import org.sagebionetworks.bridge.models.schedules2.adherence.eventstream.EventStreamDay;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -50,7 +50,7 @@ public class WeeklyAdherenceReport {
     @Embedded
     private AccountRef participant;
     @Enumerated(EnumType.STRING)
-    private ParticipantProgressionState progression;
+    private ParticipantStudyProgress progression;
     private boolean testAccount;
     private String clientTimeZone;
     private int weeklyAdherencePercent;
@@ -98,10 +98,10 @@ public class WeeklyAdherenceReport {
     public void setParticipant(AccountRef participant) {
         this.participant = participant;
     }
-    public ParticipantProgressionState getProgression() {
+    public ParticipantStudyProgress getProgression() {
         return progression;
     }
-    public void setProgression(ParticipantProgressionState progression) {
+    public void setProgression(ParticipantStudyProgress progression) {
         this.progression = progression;
     }
     public boolean isTestAccount() {

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/weekly/WeeklyAdherenceReport.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/weekly/WeeklyAdherenceReport.java
@@ -11,6 +11,8 @@ import javax.persistence.Convert;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
@@ -25,6 +27,7 @@ import org.sagebionetworks.bridge.hibernate.NextActivityConverter;
 import org.sagebionetworks.bridge.hibernate.WeeklyAdherenceReportRowListConverter;
 import org.sagebionetworks.bridge.json.DateTimeSerializer;
 import org.sagebionetworks.bridge.models.accounts.AccountRef;
+import org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantProgressionState;
 import org.sagebionetworks.bridge.models.schedules2.adherence.eventstream.EventStreamDay;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -34,8 +37,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 @Entity
 @Table(name = "WeeklyAdherenceReports")
 @IdClass(WeeklyAdherenceReportId.class)
-@JsonPropertyOrder({ "participant", "rowLabels", "rows", "weeklyAdherencePercent", "clientTimeZone",
-        "createdOn", "byDayEntries", "type" })
+@JsonPropertyOrder({ "participant", "testAccount", "progression", "weeklyAdherencePercent", "clientTimeZone",
+        "createdOn", "rows", "byDayEntries", "type" })
 public class WeeklyAdherenceReport {
     
     @Id
@@ -46,6 +49,8 @@ public class WeeklyAdherenceReport {
     private String userId;
     @Embedded
     private AccountRef participant;
+    @Enumerated(EnumType.STRING)
+    private ParticipantProgressionState progression;
     private boolean testAccount;
     private String clientTimeZone;
     private int weeklyAdherencePercent;
@@ -92,6 +97,12 @@ public class WeeklyAdherenceReport {
     }
     public void setParticipant(AccountRef participant) {
         this.participant = participant;
+    }
+    public ParticipantProgressionState getProgression() {
+        return progression;
+    }
+    public void setProgression(ParticipantProgressionState progression) {
+        this.progression = progression;
     }
     public boolean isTestAccount() {
         return testAccount;

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/weekly/WeeklyAdherenceReportGenerator.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/weekly/WeeklyAdherenceReportGenerator.java
@@ -2,9 +2,9 @@ package org.sagebionetworks.bridge.models.schedules2.adherence.weekly;
 
 import java.util.ArrayList;
 import java.util.Comparator;
-import static org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantProgressionState.DONE;
-import static org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantProgressionState.IN_PROGRESS;
-import static org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantProgressionState.UNSTARTED;
+import static org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantStudyProgress.DONE;
+import static org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantStudyProgress.IN_PROGRESS;
+import static org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantStudyProgress.UNSTARTED;
 import static org.sagebionetworks.bridge.models.schedules2.adherence.SessionCompletionState.NOT_APPLICABLE;
 
 import java.util.EnumSet;
@@ -16,7 +16,7 @@ import java.util.Set;
 import org.joda.time.LocalDate;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceState;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceUtils;
-import org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantProgressionState;
+import org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantStudyProgress;
 import org.sagebionetworks.bridge.models.schedules2.adherence.SessionCompletionState;
 import org.sagebionetworks.bridge.models.schedules2.adherence.eventstream.EventStream;
 import org.sagebionetworks.bridge.models.schedules2.adherence.eventstream.EventStreamAdherenceReport;
@@ -144,7 +144,7 @@ public class WeeklyAdherenceReportGenerator {
         }
         int percentage = AdherenceUtils.calculateAdherencePercentage(ImmutableList.of(finalReport));
         
-        ParticipantProgressionState progression = IN_PROGRESS;
+        ParticipantStudyProgress progression = IN_PROGRESS;
         if (rowList.isEmpty() && nextDay == null) {
             long na = AdherenceUtils.counting(eventReport.getStreams(), ImmutableSet.of(NOT_APPLICABLE));
             long total = AdherenceUtils.counting(eventReport.getStreams(), EnumSet.allOf(SessionCompletionState.class));

--- a/src/main/java/org/sagebionetworks/bridge/services/AdherenceService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AdherenceService.java
@@ -5,13 +5,6 @@ import static java.lang.Boolean.TRUE;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_ACCESS_ADHERENCE_DATA;
-import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
-import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
-import static org.sagebionetworks.bridge.BridgeConstants.COMPLIANCE_UNDER_ERROR;
-import static org.sagebionetworks.bridge.BridgeConstants.LABEL_FILTER_COUNT_ERROR;
-import static org.sagebionetworks.bridge.BridgeConstants.LABEL_FILTER_LENGTH_ERROR;
-import static org.sagebionetworks.bridge.BridgeConstants.NEGATIVE_OFFSET_ERROR;
-import static org.sagebionetworks.bridge.BridgeConstants.PAGE_SIZE_ERROR;
 import static org.sagebionetworks.bridge.BridgeConstants.TEST_USER_GROUP;
 import static org.sagebionetworks.bridge.BridgeUtils.formatActivityEventId;
 import static org.sagebionetworks.bridge.models.ResourceList.ADHERENCE_RECORD_TYPE;
@@ -55,7 +48,7 @@ import org.sagebionetworks.bridge.AuthEvaluatorField;
 import org.sagebionetworks.bridge.dao.AdherenceRecordDao;
 import org.sagebionetworks.bridge.dao.AdherenceReportDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
-import org.sagebionetworks.bridge.models.AccountTestFilter;
+import org.sagebionetworks.bridge.models.AdherenceReportSearch;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountRef;
@@ -75,6 +68,7 @@ import org.sagebionetworks.bridge.models.schedules2.timelines.SessionState;
 import org.sagebionetworks.bridge.models.schedules2.timelines.TimelineMetadata;
 import org.sagebionetworks.bridge.models.studies.Study;
 import org.sagebionetworks.bridge.validators.AdherenceRecordsSearchValidator;
+import org.sagebionetworks.bridge.validators.AdherenceReportSearchValidator;
 import org.sagebionetworks.bridge.validators.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -410,37 +404,22 @@ public class AdherenceService {
     }
     
     public PagedResourceList<WeeklyAdherenceReport> getWeeklyAdherenceReports(String appId, String studyId,
-            AccountTestFilter testFilter, List<String> labelFilter, Integer complianceUnder, Integer offsetBy, 
-            Integer pageSize) {
+            AdherenceReportSearch search) {
         checkNotNull(appId);
         checkNotNull(studyId);
-        checkNotNull(testFilter);
+        checkNotNull(search);
         
-        if (offsetBy != null && offsetBy < 0) {
-            throw new BadRequestException(NEGATIVE_OFFSET_ERROR);
-        }
-        if (pageSize != null && (pageSize < API_MINIMUM_PAGE_SIZE || pageSize > API_MAXIMUM_PAGE_SIZE)) {
-            throw new BadRequestException(PAGE_SIZE_ERROR);
-        }
-        if (labelFilter != null) {
-            if (labelFilter.size() > 50) {
-                throw new BadRequestException(LABEL_FILTER_COUNT_ERROR);   
-            } else {
-                if (labelFilter.stream().anyMatch(oneLabel -> oneLabel.length() > 25)) {
-                    throw new BadRequestException(LABEL_FILTER_LENGTH_ERROR);   
-                }
-            }
-        }
-        if (complianceUnder != null && (complianceUnder < 1 ||  complianceUnder > 100)) {
-            throw new BadRequestException(COMPLIANCE_UNDER_ERROR);
-        }
-        return reportDao.getWeeklyAdherenceReports(
-                appId, studyId, testFilter, labelFilter, complianceUnder, offsetBy, pageSize)
-                .withRequestParam(PagedResourceList.TEST_FILTER, testFilter)
-                .withRequestParam(PagedResourceList.LABEL_FILTER, labelFilter)
-                .withRequestParam(PagedResourceList.COMPLIANCE_UNDER, complianceUnder)
-                .withRequestParam(PagedResourceList.OFFSET_BY, offsetBy)
-                .withRequestParam(PagedResourceList.PAGE_SIZE, pageSize);
+        Validate.entityThrowingException(AdherenceReportSearchValidator.INSTANCE, search);
+
+        return reportDao.getWeeklyAdherenceReports(appId, studyId, search)
+                .withRequestParam(PagedResourceList.TEST_FILTER, search.getTestFilter())
+                .withRequestParam(PagedResourceList.LABEL_FILTER, search.getLabelFilters())
+                .withRequestParam(PagedResourceList.ADHERENCE_MIN, search.getAdherenceMin())
+                .withRequestParam(PagedResourceList.ADHERENCE_MAX, search.getAdherenceMax())
+                .withRequestParam(PagedResourceList.PROGRESSION_FILTER, search.getProgressionFilter())
+                .withRequestParam(PagedResourceList.ID_FILTER, search.getIdFilter())
+                .withRequestParam(PagedResourceList.OFFSET_BY, search.getOffsetBy())
+                .withRequestParam(PagedResourceList.PAGE_SIZE, search.getPageSize());
     }
     
     private WeeklyAdherenceReport getWeeklyAdherenceReportInternal(String appId, String studyId, String userId,

--- a/src/main/java/org/sagebionetworks/bridge/services/AdherenceService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AdherenceService.java
@@ -416,7 +416,7 @@ public class AdherenceService {
                 .withRequestParam(PagedResourceList.LABEL_FILTER, search.getLabelFilters())
                 .withRequestParam(PagedResourceList.ADHERENCE_MIN, search.getAdherenceMin())
                 .withRequestParam(PagedResourceList.ADHERENCE_MAX, search.getAdherenceMax())
-                .withRequestParam(PagedResourceList.PROGRESSION_FILTER, search.getProgressionFilter())
+                .withRequestParam(PagedResourceList.PROGRESSION_FILTERS, search.getProgressionFilters())
                 .withRequestParam(PagedResourceList.ID_FILTER, search.getIdFilter())
                 .withRequestParam(PagedResourceList.OFFSET_BY, search.getOffsetBy())
                 .withRequestParam(PagedResourceList.PAGE_SIZE, search.getPageSize());

--- a/src/main/java/org/sagebionetworks/bridge/validators/AdherenceReportSearchValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/AdherenceReportSearchValidator.java
@@ -1,0 +1,59 @@
+package org.sagebionetworks.bridge.validators;
+
+import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
+import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
+import static org.sagebionetworks.bridge.BridgeConstants.ADHERENCE_RANGE_ERROR;
+import static org.sagebionetworks.bridge.BridgeConstants.LABEL_FILTER_COUNT_ERROR;
+import static org.sagebionetworks.bridge.BridgeConstants.LABEL_FILTER_LENGTH_ERROR;
+import static org.sagebionetworks.bridge.BridgeConstants.PAGE_SIZE_ERROR;
+import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NEGATIVE;
+
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.sagebionetworks.bridge.models.AdherenceReportSearch;
+import org.springframework.validation.Errors;
+
+public class AdherenceReportSearchValidator extends AbstractValidator {
+    
+    public static final AdherenceReportSearchValidator INSTANCE = new AdherenceReportSearchValidator();
+
+    @Override
+    public void validate(Object object, Errors errors) {
+        AdherenceReportSearch search = (AdherenceReportSearch)object;
+        
+        if (search.getOffsetBy() < 0) {
+            errors.rejectValue("offsetBy", CANNOT_BE_NEGATIVE);
+        }
+        // Just set a sane upper limit on this.
+        if (search.getPageSize() < API_MINIMUM_PAGE_SIZE || search.getPageSize() > API_MAXIMUM_PAGE_SIZE) {
+            errors.rejectValue("pageSize", PAGE_SIZE_ERROR);
+        }
+        List<String> labelFilters = search.getLabelFilters();
+        if (labelFilters != null) {
+            if (labelFilters.size() > 50) {
+                errors.rejectValue("labelFilters", LABEL_FILTER_COUNT_ERROR);   
+            } else {
+                for (int i=0; i < labelFilters.size(); i++) {
+                    String value = labelFilters.get(i);
+                    if (StringUtils.isBlank(value)) {
+                        errors.rejectValue("labelFilters["+i+"]", Validate.CANNOT_BE_BLANK);
+                    } else if (value.length() > 100) {
+                        errors.rejectValue("labelFilters["+i+"]", LABEL_FILTER_LENGTH_ERROR);
+                    }
+                }
+            }
+        }
+        Integer adherenceMin = search.getAdherenceMin();
+        Integer adherenceMax = search.getAdherenceMax();
+        if (adherenceMax < adherenceMin) {
+            errors.rejectValue("adherenceMax", "cannot be less than adherenceMin");
+        }
+        if ((adherenceMin < 0 ||  adherenceMin > 100)) {
+            errors.rejectValue("adherenceMin", ADHERENCE_RANGE_ERROR);   
+        }
+        if ((adherenceMax < 0 ||  adherenceMax > 100)) {
+            errors.rejectValue("adherenceMax", ADHERENCE_RANGE_ERROR);   
+        }
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/validators/AdherenceReportSearchValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/AdherenceReportSearchValidator.java
@@ -3,12 +3,13 @@ package org.sagebionetworks.bridge.validators;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.ADHERENCE_RANGE_ERROR;
+import static org.sagebionetworks.bridge.BridgeConstants.ADHERENCE_RANGE_ORDER_ERROR;
 import static org.sagebionetworks.bridge.BridgeConstants.LABEL_FILTER_COUNT_ERROR;
 import static org.sagebionetworks.bridge.BridgeConstants.LABEL_FILTER_LENGTH_ERROR;
 import static org.sagebionetworks.bridge.BridgeConstants.PAGE_SIZE_ERROR;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NEGATIVE;
 
-import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.sagebionetworks.bridge.models.AdherenceReportSearch;
@@ -29,25 +30,26 @@ public class AdherenceReportSearchValidator extends AbstractValidator {
         if (search.getPageSize() < API_MINIMUM_PAGE_SIZE || search.getPageSize() > API_MAXIMUM_PAGE_SIZE) {
             errors.rejectValue("pageSize", PAGE_SIZE_ERROR);
         }
-        List<String> labelFilters = search.getLabelFilters();
+        Set<String> labelFilters = search.getLabelFilters();
         if (labelFilters != null) {
             if (labelFilters.size() > 50) {
                 errors.rejectValue("labelFilters", LABEL_FILTER_COUNT_ERROR);   
             } else {
-                for (int i=0; i < labelFilters.size(); i++) {
-                    String value = labelFilters.get(i);
+                int i=0;
+                for (String value : labelFilters) {
                     if (StringUtils.isBlank(value)) {
                         errors.rejectValue("labelFilters["+i+"]", Validate.CANNOT_BE_BLANK);
                     } else if (value.length() > 100) {
                         errors.rejectValue("labelFilters["+i+"]", LABEL_FILTER_LENGTH_ERROR);
                     }
+                    i++;
                 }
             }
         }
         Integer adherenceMin = search.getAdherenceMin();
         Integer adherenceMax = search.getAdherenceMax();
         if (adherenceMax < adherenceMin) {
-            errors.rejectValue("adherenceMax", "cannot be less than adherenceMin");
+            errors.rejectValue("adherenceMax", ADHERENCE_RANGE_ORDER_ERROR);
         }
         if ((adherenceMin < 0 ||  adherenceMin > 100)) {
             errors.rejectValue("adherenceMin", ADHERENCE_RANGE_ERROR);   

--- a/src/main/resources/db/changelog/changelog.sql
+++ b/src/main/resources/db/changelog/changelog.sql
@@ -910,3 +910,8 @@ ADD COLUMN `phone` varchar(20),
 ADD COLUMN `phoneRegion` varchar(2),
 ADD COLUMN `synapseUserId` varchar(255),
 ADD COLUMN `externalId` varchar(255);
+
+-- changeset bridge:61
+
+ALTER TABLE `WeeklyAdherenceReports`
+ADD COLUMN `progression` varchar(255);

--- a/src/test/java/org/sagebionetworks/bridge/models/AdherenceReportSearchTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/AdherenceReportSearchTest.java
@@ -2,8 +2,11 @@ package org.sagebionetworks.bridge.models;
 
 import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.models.AccountTestFilter.BOTH;
-import static org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantProgressionState.DONE;
+import static org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantStudyProgress.DONE;
+import static org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantStudyProgress.IN_PROGRESS;
 import static org.testng.Assert.assertEquals;
+
+import java.util.Set;
 
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.testng.annotations.Test;
@@ -11,7 +14,7 @@ import org.testng.annotations.Test;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
@@ -28,9 +31,9 @@ public class AdherenceReportSearchTest {
     public void canSerialize() throws JsonMappingException, JsonProcessingException {
         AdherenceReportSearch search = new AdherenceReportSearch();
         search.setTestFilter(BOTH);
-        search.setLabelFilters(ImmutableList.of("labelFilters"));
+        search.setLabelFilters(ImmutableSet.of("labelFilters"));
         search.setAdherenceMax(53);
-        search.setProgressionFilter(DONE);
+        search.setProgressionFilters(ImmutableSet.of(IN_PROGRESS, DONE));
         search.setIdFilter("idFilter");
         search.setOffsetBy(5);
         search.setPageSize(10);
@@ -40,11 +43,13 @@ public class AdherenceReportSearchTest {
         assertEquals(node.get("labelFilters").get(0).textValue(), "labelFilters");
         assertEquals(node.get("adherenceMin").intValue(), 0);
         assertEquals(node.get("adherenceMax").intValue(), 53);
-        assertEquals(node.get("progressionFilter").textValue(), "done");
+        Set<String> progressions = ImmutableSet.of(
+                node.get("progressionFilters").get(0).textValue(),
+                node.get("progressionFilters").get(1).textValue());
+        assertEquals(progressions, ImmutableSet.of("in_progress", "done"));
         assertEquals(node.get("idFilter").textValue(), "idFilter");
         assertEquals(node.get("offsetBy").intValue(), 5);
         assertEquals(node.get("pageSize").intValue(), 10);
-        
         
         AdherenceReportSearch deser = BridgeObjectMapper.get()
                 .readValue(node.toString(), AdherenceReportSearch.class);

--- a/src/test/java/org/sagebionetworks/bridge/models/AdherenceReportSearchTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/AdherenceReportSearchTest.java
@@ -1,0 +1,67 @@
+package org.sagebionetworks.bridge.models;
+
+import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
+import static org.sagebionetworks.bridge.models.AccountTestFilter.BOTH;
+import static org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantProgressionState.DONE;
+import static org.testng.Assert.assertEquals;
+
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.testng.annotations.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
+public class AdherenceReportSearchTest {
+    
+    @Test
+    public void hashCodeEquals() {
+        EqualsVerifier.forClass(AdherenceReportSearch.class)
+            .allFieldsShouldBeUsed().suppress(Warning.NONFINAL_FIELDS).verify();
+    }
+    
+    @Test
+    public void canSerialize() throws JsonMappingException, JsonProcessingException {
+        AdherenceReportSearch search = new AdherenceReportSearch();
+        search.setTestFilter(BOTH);
+        search.setLabelFilters(ImmutableList.of("labelFilters"));
+        search.setAdherenceMax(53);
+        search.setProgressionFilter(DONE);
+        search.setIdFilter("idFilter");
+        search.setOffsetBy(5);
+        search.setPageSize(10);
+        
+        JsonNode node = BridgeObjectMapper.get().valueToTree(search);
+        assertEquals(node.get("testFilter").textValue(), "both");
+        assertEquals(node.get("labelFilters").get(0).textValue(), "labelFilters");
+        assertEquals(node.get("adherenceMin").intValue(), 0);
+        assertEquals(node.get("adherenceMax").intValue(), 53);
+        assertEquals(node.get("progressionFilter").textValue(), "done");
+        assertEquals(node.get("idFilter").textValue(), "idFilter");
+        assertEquals(node.get("offsetBy").intValue(), 5);
+        assertEquals(node.get("pageSize").intValue(), 10);
+        
+        
+        AdherenceReportSearch deser = BridgeObjectMapper.get()
+                .readValue(node.toString(), AdherenceReportSearch.class);
+        assertEquals(deser, search);
+    }
+    
+    @Test
+    public void nullValuesDoNotOverrideInitialObjectFields() throws JsonMappingException, JsonProcessingException {
+        // These are explicit nulls. Does Jackson overwrite these values?
+        String json = "{\"adherenceMin\":null,\"adherenceMax\":null,\"offsetBy\":null,\"pageSize\":null}";
+        
+        AdherenceReportSearch deser = BridgeObjectMapper.get()
+                .readValue(json, AdherenceReportSearch.class);
+        assertEquals(deser.getAdherenceMin(), Integer.valueOf(0));
+        assertEquals(deser.getAdherenceMax(), Integer.valueOf(100));
+        assertEquals(deser.getOffsetBy(), Integer.valueOf(0));
+        assertEquals(deser.getPageSize(), Integer.valueOf(API_DEFAULT_PAGE_SIZE));
+    }
+
+}

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/adherence/weekly/WeeklyAdherenceReportGeneratorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/adherence/weekly/WeeklyAdherenceReportGeneratorTest.java
@@ -41,7 +41,7 @@ public class WeeklyAdherenceReportGeneratorTest extends Mockito {
 
         // Because these are different from what is serialized in the JSON, test them here.
         assertEquals(report.getSearchableLabels(), ImmutableSet.of(":session3:Week 1:", 
-                ":session1:Week 2:", ":burst 2:Week 1:session2:"));
+                ":session1:Week 2:", ":burst:burst 2:Week 1:session2:"));
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(report);
         
@@ -327,8 +327,6 @@ public class WeeklyAdherenceReportGeneratorTest extends Mockito {
         
         List<EventStreamDay> days = report.getByDayEntries().get(0);
         assertEquals(days.size(), 2);
-        assertEquals(days.get(0).getStartEventId(), "custom:Clinic Visit");
-        assertEquals(days.get(1).getStartEventId(), "custom:Survey Returned");
     }
     
 }

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/adherence/weekly/WeeklyAdherenceReportTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/adherence/weekly/WeeklyAdherenceReportTest.java
@@ -5,6 +5,7 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_CLIENT_TIME_ZONE;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
+import static org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantStudyProgress.IN_PROGRESS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
@@ -51,6 +52,7 @@ public class WeeklyAdherenceReportTest {
         report.setSearchableLabels(ImmutableSet.of("label1", "label2"));
         report.setParticipant(new AccountRef(account, "study1"));
         report.setTestAccount(true);
+        report.setProgression(IN_PROGRESS);
         report.setWeeklyAdherencePercent(79);
         report.setRows(ImmutableList.of(row));
         report.setByDayEntries(ImmutableMap.of(
@@ -68,7 +70,7 @@ public class WeeklyAdherenceReportTest {
         
         JsonNode node = BridgeObjectMapper.get().valueToTree(report);
         
-        assertEquals(node.size(), 9);
+        assertEquals(node.size(), 10);
         assertNull(node.get("appId"));
         assertNull(node.get("studyId"));
         assertNull(node.get("userId"));
@@ -77,6 +79,7 @@ public class WeeklyAdherenceReportTest {
         assertEquals(node.get("weeklyAdherencePercent").intValue(), 79);
         assertEquals(node.get("participant").get("identifier").textValue(), TEST_USER_ID);
         assertTrue(node.get("testAccount").booleanValue());
+        assertEquals(node.get("progression").textValue(), "in_progress");
         assertEquals(node.get("nextActivity").get("type").textValue(), "NextActivity");
         assertEquals(node.get("byDayEntries").get("6").get(0).get("type").textValue(), "EventStreamDay");
         assertEquals(node.get("type").textValue(), "WeeklyAdherenceReport");

--- a/src/test/java/org/sagebionetworks/bridge/services/AdherenceServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AdherenceServiceTest.java
@@ -1,11 +1,6 @@
 package org.sagebionetworks.bridge.services;
 
 import static java.lang.Boolean.TRUE;
-import static org.sagebionetworks.bridge.BridgeConstants.COMPLIANCE_UNDER_ERROR;
-import static org.sagebionetworks.bridge.BridgeConstants.LABEL_FILTER_COUNT_ERROR;
-import static org.sagebionetworks.bridge.BridgeConstants.LABEL_FILTER_LENGTH_ERROR;
-import static org.sagebionetworks.bridge.BridgeConstants.NEGATIVE_OFFSET_ERROR;
-import static org.sagebionetworks.bridge.BridgeConstants.PAGE_SIZE_ERROR;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
 import static org.sagebionetworks.bridge.Roles.RESEARCHER;
 import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
@@ -17,7 +12,6 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_EXTERNAL_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestUtils.createEvent;
-import static org.sagebionetworks.bridge.models.AccountTestFilter.PRODUCTION;
 import static org.sagebionetworks.bridge.models.ResourceList.ADHERENCE_RECORD_TYPE;
 import static org.sagebionetworks.bridge.models.ResourceList.ASSESSMENT_IDS;
 import static org.sagebionetworks.bridge.models.ResourceList.CURRENT_TIMESTAMPS_ONLY;
@@ -68,7 +62,6 @@ import org.mockito.Spy;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import org.thymeleaf.util.StringUtils;
 import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dao.AdherenceRecordDao;
@@ -76,6 +69,7 @@ import org.sagebionetworks.bridge.dao.AdherenceReportDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
+import org.sagebionetworks.bridge.models.AdherenceReportSearch;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
@@ -922,73 +916,24 @@ public class AdherenceServiceTest extends Mockito {
     
     @Test
     public void getWeeklyAdherenceReports() {
-        PagedResourceList<WeeklyAdherenceReport> page = new PagedResourceList<>(ImmutableList.of(), 2);
-        when(mockReportDao.getWeeklyAdherenceReports(
-                TEST_APP_ID, TEST_STUDY_ID, PRODUCTION, ImmutableList.of("label"), 75, 100, 50)).thenReturn(page);
+        AdherenceReportSearch search = new AdherenceReportSearch();
         
-        PagedResourceList<WeeklyAdherenceReport> retValue = service.getWeeklyAdherenceReports(
-                TEST_APP_ID, TEST_STUDY_ID, PRODUCTION, ImmutableList.of("label"), 75, 100, 50);
+        PagedResourceList<WeeklyAdherenceReport> page = new PagedResourceList<>(ImmutableList.of(), 2);
+        when(mockReportDao.getWeeklyAdherenceReports(TEST_APP_ID, TEST_STUDY_ID, search)).thenReturn(page);
+        
+        PagedResourceList<WeeklyAdherenceReport> retValue = service.getWeeklyAdherenceReports(TEST_APP_ID,
+                TEST_STUDY_ID, search);
         assertSame(retValue, page);
     }
     
-    @Test(expectedExceptions = BadRequestException.class, 
-            expectedExceptionsMessageRegExp = NEGATIVE_OFFSET_ERROR)
-    public void getWeeklyAdherenceReports_offsetNegative() {
-        service.getWeeklyAdherenceReports(TEST_APP_ID, TEST_STUDY_ID, PRODUCTION, ImmutableList.of("label"), 75, -1, 50);
-    }    
+    @Test(expectedExceptions = InvalidEntityException.class)
+    public void getWeeklyAdherenceReports_validates() {
+        AdherenceReportSearch search = new AdherenceReportSearch();
+        search.setAdherenceMax(101);
 
-    @Test(expectedExceptions = BadRequestException.class, 
-            expectedExceptionsMessageRegExp = PAGE_SIZE_ERROR)
-    public void getWeeklyAdherenceReports_pageSizeTooSmall() {
-        service.getWeeklyAdherenceReports(TEST_APP_ID, TEST_STUDY_ID, PRODUCTION, ImmutableList.of("label"), 75, 100, 1);
-    }    
-
-    @Test(expectedExceptions = BadRequestException.class, 
-            expectedExceptionsMessageRegExp = PAGE_SIZE_ERROR)
-    public void getWeeklyAdherenceReports_pageSizeTooLarge() {
-        service.getWeeklyAdherenceReports(TEST_APP_ID, TEST_STUDY_ID, PRODUCTION, ImmutableList.of("label"), 75, 100, 300);
-    }
-    
-    @Test(expectedExceptions = BadRequestException.class,
-            expectedExceptionsMessageRegExp = LABEL_FILTER_COUNT_ERROR)
-    public void getWeeklyAdherenceReports_labelFilterTooManyEntries() {
-        List<String> labelFilter = new ArrayList<>();
-        for (int i=0; i < 52; i++) {
-            labelFilter.add("label");
-        }
-        service.getWeeklyAdherenceReports(TEST_APP_ID, TEST_STUDY_ID, PRODUCTION, labelFilter, 75, 50, 100);
-    }    
-
-    @Test(expectedExceptions = BadRequestException.class,
-            expectedExceptionsMessageRegExp = LABEL_FILTER_LENGTH_ERROR)
-    public void getWeeklyAdherenceReports_labelFilterTooLong() {
-        String tooLongString = StringUtils.randomAlphanumeric(101);
-        service.getWeeklyAdherenceReports(TEST_APP_ID, TEST_STUDY_ID, PRODUCTION, ImmutableList.of(tooLongString), 75, 50, 100);
-    }    
-
-    @Test(expectedExceptions = BadRequestException.class,
-            expectedExceptionsMessageRegExp = COMPLIANCE_UNDER_ERROR)
-    public void getWeeklyAdherenceReports_complianceTooSmall() {
-        service.getWeeklyAdherenceReports(TEST_APP_ID, TEST_STUDY_ID, PRODUCTION, ImmutableList.of("label"), 0, 50, 100);
-    }    
-
-    @Test(expectedExceptions = BadRequestException.class,
-            expectedExceptionsMessageRegExp = COMPLIANCE_UNDER_ERROR)
-    public void getWeeklyAdherenceReports_complianceTooLarge() {
-        service.getWeeklyAdherenceReports(TEST_APP_ID, TEST_STUDY_ID, PRODUCTION, ImmutableList.of("label"), 101, 50, 100);
+        service.getWeeklyAdherenceReports(TEST_APP_ID, TEST_STUDY_ID, search);
     }
 
-    @Test
-    public void getWeeklyAdherenceReports_defaults() {
-        PagedResourceList<WeeklyAdherenceReport> page = new PagedResourceList<>(ImmutableList.of(), 2);
-        when(mockReportDao.getWeeklyAdherenceReports(
-                TEST_APP_ID, TEST_STUDY_ID, PRODUCTION, null, null, null, null)).thenReturn(page);
-        
-        PagedResourceList<WeeklyAdherenceReport> retValue = service.getWeeklyAdherenceReports(
-                TEST_APP_ID, TEST_STUDY_ID, PRODUCTION, null, null, null, null);
-        assertSame(retValue, page);
-    }
-    
     private AdherenceRecord ar(DateTime startedOn, DateTime finishedOn, String guid, boolean declined) {
         AdherenceRecord sess = new AdherenceRecord();
         sess.setAppId(TEST_APP_ID);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AdherenceControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AdherenceControllerTest.java
@@ -20,7 +20,7 @@ import static org.sagebionetworks.bridge.TestUtils.mockRequestBody;
 import static org.sagebionetworks.bridge.models.AccountTestFilter.BOTH;
 import static org.sagebionetworks.bridge.models.AccountTestFilter.PRODUCTION;
 import static org.sagebionetworks.bridge.models.AccountTestFilter.TEST;
-import static org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantProgressionState.IN_PROGRESS;
+import static org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantStudyProgress.IN_PROGRESS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
 
@@ -480,8 +480,8 @@ public class AdherenceControllerTest extends Mockito {
         
         AdherenceReportSearch search = new AdherenceReportSearch();
         search.setTestFilter(PRODUCTION);
-        search.setLabelFilters(ImmutableList.of("label1", "label2"));
-        search.setProgressionFilter(IN_PROGRESS);
+        search.setLabelFilters(ImmutableSet.of("label1", "label2"));
+        search.setProgressionFilters(ImmutableSet.of(IN_PROGRESS));
         search.setIdFilter("id");
         search.setAdherenceMax(75);
         search.setOffsetBy(50);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AdherenceControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AdherenceControllerTest.java
@@ -20,6 +20,7 @@ import static org.sagebionetworks.bridge.TestUtils.mockRequestBody;
 import static org.sagebionetworks.bridge.models.AccountTestFilter.BOTH;
 import static org.sagebionetworks.bridge.models.AccountTestFilter.PRODUCTION;
 import static org.sagebionetworks.bridge.models.AccountTestFilter.TEST;
+import static org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantProgressionState.IN_PROGRESS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
 
@@ -47,6 +48,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.models.AdherenceReportSearch;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.StatusMessage;
 import org.sagebionetworks.bridge.models.accounts.Account;
@@ -91,6 +93,9 @@ public class AdherenceControllerTest extends Mockito {
 
     @Captor
     ArgumentCaptor<AdherenceRecord> recordCaptor;
+    
+    @Captor
+    ArgumentCaptor<AdherenceReportSearch> searchParamsCaptor;
     
     UserSession session;
     
@@ -469,42 +474,52 @@ public class AdherenceControllerTest extends Mockito {
     }
 
     @Test
-    public void getWeeklyAdherenceReports() {
+    public void getWeeklyAdherenceReports() throws Exception {
         doReturn(session).when(controller)
             .getAuthenticatedSession(DEVELOPER, RESEARCHER, STUDY_DESIGNER, STUDY_COORDINATOR);
+        
+        AdherenceReportSearch search = new AdherenceReportSearch();
+        search.setTestFilter(PRODUCTION);
+        search.setLabelFilters(ImmutableList.of("label1", "label2"));
+        search.setProgressionFilter(IN_PROGRESS);
+        search.setIdFilter("id");
+        search.setAdherenceMax(75);
+        search.setOffsetBy(50);
+        search.setPageSize(100);
+        
+        TestUtils.mockRequestBody(mockRequest, search);
 
-        List<String> labelsFilter = ImmutableList.of("label1", "label2");
         PagedResourceList<WeeklyAdherenceReport> page = new PagedResourceList<>(ImmutableList.of(), 0);
-        when(mockService.getWeeklyAdherenceReports(
-                TEST_APP_ID, TEST_STUDY_ID, PRODUCTION, labelsFilter, 75, 50, 100)).thenReturn(page);
+        when(mockService.getWeeklyAdherenceReports(TEST_APP_ID, TEST_STUDY_ID, search)).thenReturn(page);
 
-        PagedResourceList<WeeklyAdherenceReport> retValue = controller.getWeeklyAdherenceReports(
-                TEST_STUDY_ID, "production", labelsFilter, "75", "50", "100");
+        PagedResourceList<WeeklyAdherenceReport> retValue = controller.getWeeklyAdherenceReports(TEST_STUDY_ID);
         assertSame(retValue, page);
 
-        verify(mockService).getWeeklyAdherenceReports(
-                TEST_APP_ID, TEST_STUDY_ID, PRODUCTION, labelsFilter, 75, 50, 100);
+        verify(mockService).getWeeklyAdherenceReports(TEST_APP_ID, TEST_STUDY_ID, search);
     }
 
     @Test
-    public void getWeeklyAdherenceReports_defaults() {
+    public void getWeeklyAdherenceReports_defaults() throws Exception {
         doReturn(session).when(controller)
             .getAuthenticatedSession(DEVELOPER, RESEARCHER, STUDY_DESIGNER, STUDY_COORDINATOR);
 
-        PagedResourceList<WeeklyAdherenceReport> page = new PagedResourceList<>(ImmutableList.of(), 0);
-        when(mockService.getWeeklyAdherenceReports(
-                TEST_APP_ID, TEST_STUDY_ID, PRODUCTION, null, null, 0, API_DEFAULT_PAGE_SIZE)).thenReturn(page);
+        AdherenceReportSearch search = new AdherenceReportSearch();
 
-        PagedResourceList<WeeklyAdherenceReport> retValue = controller.getWeeklyAdherenceReports(
-                TEST_STUDY_ID, null, null, null, null, null);
+        TestUtils.mockRequestBody(mockRequest, search);
+        
+        PagedResourceList<WeeklyAdherenceReport> page = new PagedResourceList<>(ImmutableList.of(), 0);
+        when(mockService.getWeeklyAdherenceReports(TEST_APP_ID, TEST_STUDY_ID, search)).thenReturn(page);
+
+        PagedResourceList<WeeklyAdherenceReport> retValue = controller.getWeeklyAdherenceReports(TEST_STUDY_ID);
         assertSame(retValue, page);
 
-        verify(mockService).getWeeklyAdherenceReports(
-                TEST_APP_ID, TEST_STUDY_ID, PRODUCTION, null, null, 0, API_DEFAULT_PAGE_SIZE);
+        verify(mockService).getWeeklyAdherenceReports(eq(TEST_APP_ID), eq(TEST_STUDY_ID), searchParamsCaptor.capture());
+        assertEquals(searchParamsCaptor.getValue().getOffsetBy(), Integer.valueOf(0));
+        assertEquals(searchParamsCaptor.getValue().getPageSize(), Integer.valueOf(API_DEFAULT_PAGE_SIZE));
     }
     
     @Test
-    public void getWeeklyAdherenceReports_forcesTestForDevelopers() {
+    public void getWeeklyAdherenceReports_forcesTestForDevelopers() throws Exception {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId(TEST_USER_ID)
                 .withCallerRoles(ImmutableSet.of(STUDY_DESIGNER))
@@ -512,31 +527,38 @@ public class AdherenceControllerTest extends Mockito {
         doReturn(session).when(controller)
             .getAuthenticatedSession(DEVELOPER, RESEARCHER, STUDY_DESIGNER, STUDY_COORDINATOR);
 
+        AdherenceReportSearch search = new AdherenceReportSearch();
+        search.setTestFilter(PRODUCTION);
+
+        TestUtils.mockRequestBody(mockRequest, search);
+
         PagedResourceList<WeeklyAdherenceReport> page = new PagedResourceList<>(ImmutableList.of(), 0);
-        when(mockService.getWeeklyAdherenceReports(
-                TEST_APP_ID, TEST_STUDY_ID, TEST, null, null, 0, API_DEFAULT_PAGE_SIZE)).thenReturn(page);
+        when(mockService.getWeeklyAdherenceReports(eq(TEST_APP_ID), eq(TEST_STUDY_ID), any())).thenReturn(page);
 
-        PagedResourceList<WeeklyAdherenceReport> retValue = controller.getWeeklyAdherenceReports(
-                TEST_STUDY_ID, "production", null, null, null, null);
+        PagedResourceList<WeeklyAdherenceReport> retValue = controller.getWeeklyAdherenceReports(TEST_STUDY_ID);
         assertSame(retValue, page);
-
-        verify(mockService).getWeeklyAdherenceReports(
-                TEST_APP_ID, TEST_STUDY_ID, TEST, null, null, 0, API_DEFAULT_PAGE_SIZE);
+        
+        verify(mockService).getWeeklyAdherenceReports(eq(TEST_APP_ID), eq(TEST_STUDY_ID), searchParamsCaptor.capture());
+        assertEquals(searchParamsCaptor.getValue().getTestFilter(), TEST);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
-    public void getWeeklyAdherenceReports_authRequiredDevelopers() {
+    public void getWeeklyAdherenceReports_authRequiredDevelopers() throws Exception {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId(TEST_USER_ID)
                 .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR)).build());
         doReturn(session).when(controller)
             .getAuthenticatedSession(DEVELOPER, RESEARCHER, STUDY_DESIGNER, STUDY_COORDINATOR);
+        
+        AdherenceReportSearch search = new AdherenceReportSearch();
 
-        controller.getWeeklyAdherenceReports(TEST_STUDY_ID, null, null, null, null, null);
+        TestUtils.mockRequestBody(mockRequest, search);
+
+        controller.getWeeklyAdherenceReports(TEST_STUDY_ID);
     }
 
     @Test
-    public void getWeeklyAdherenceReports_allowsTestOrProdForResearchers() {
+    public void getWeeklyAdherenceReports_allowsTestOrProdForResearchers() throws Exception {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId(TEST_USER_ID)
                 .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR))
@@ -544,20 +566,22 @@ public class AdherenceControllerTest extends Mockito {
         doReturn(session).when(controller)
             .getAuthenticatedSession(DEVELOPER, RESEARCHER, STUDY_DESIGNER, STUDY_COORDINATOR);
 
+        AdherenceReportSearch search = new AdherenceReportSearch();
+        search.setTestFilter(BOTH);
+        
+        TestUtils.mockRequestBody(mockRequest, search);
+        
         PagedResourceList<WeeklyAdherenceReport> page = new PagedResourceList<>(ImmutableList.of(), 0);
-        when(mockService.getWeeklyAdherenceReports(
-                TEST_APP_ID, TEST_STUDY_ID, PRODUCTION, null, null, 0, API_DEFAULT_PAGE_SIZE)).thenReturn(page);
+        when(mockService.getWeeklyAdherenceReports(TEST_APP_ID, TEST_STUDY_ID, search)).thenReturn(page);
 
-        PagedResourceList<WeeklyAdherenceReport> retValue = controller.getWeeklyAdherenceReports(
-                TEST_STUDY_ID, "production", null, null, null, null);
+        PagedResourceList<WeeklyAdherenceReport> retValue = controller.getWeeklyAdherenceReports(TEST_STUDY_ID);
         assertSame(retValue, page);
 
-        verify(mockService).getWeeklyAdherenceReports(
-                TEST_APP_ID, TEST_STUDY_ID, PRODUCTION, null, null, 0, API_DEFAULT_PAGE_SIZE);
+        verify(mockService).getWeeklyAdherenceReports(TEST_APP_ID, TEST_STUDY_ID, search);
     }
 
     @Test
-    public void getWeeklyAdherenceReports_allowsProdForResearchers() {
+    public void getWeeklyAdherenceReports_allowsProdForResearchers() throws Exception {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId(TEST_USER_ID)
                 .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR))
@@ -565,36 +589,40 @@ public class AdherenceControllerTest extends Mockito {
         doReturn(session).when(controller)
             .getAuthenticatedSession(DEVELOPER, RESEARCHER, STUDY_DESIGNER, STUDY_COORDINATOR);
 
-        PagedResourceList<WeeklyAdherenceReport> page = new PagedResourceList<>(ImmutableList.of(), 0);
-        when(mockService.getWeeklyAdherenceReports(
-                TEST_APP_ID, TEST_STUDY_ID, TEST, null, null, 0, API_DEFAULT_PAGE_SIZE)).thenReturn(page);
+        AdherenceReportSearch search = new AdherenceReportSearch();
+        search.setTestFilter(PRODUCTION);
+        
+        TestUtils.mockRequestBody(mockRequest, search);
 
-        PagedResourceList<WeeklyAdherenceReport> retValue = controller.getWeeklyAdherenceReports(
-                TEST_STUDY_ID, "test", null, null, null, null);
+        PagedResourceList<WeeklyAdherenceReport> page = new PagedResourceList<>(ImmutableList.of(), 0);
+        when(mockService.getWeeklyAdherenceReports(TEST_APP_ID, TEST_STUDY_ID, search)).thenReturn(page);
+
+        PagedResourceList<WeeklyAdherenceReport> retValue = controller.getWeeklyAdherenceReports(TEST_STUDY_ID);
         assertSame(retValue, page);
 
-        verify(mockService).getWeeklyAdherenceReports(
-                TEST_APP_ID, TEST_STUDY_ID, TEST, null, null, 0, API_DEFAULT_PAGE_SIZE);
-   }
+        verify(mockService).getWeeklyAdherenceReports(TEST_APP_ID, TEST_STUDY_ID, search);
+    }
 
     @Test
-    public void getWeeklyAdherenceReports_allowsTestForResearchers() {
+    public void getWeeklyAdherenceReports_allowsTestForResearchers() throws Exception {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerUserId(TEST_USER_ID)
                 .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
         doReturn(session).when(controller)
             .getAuthenticatedSession(DEVELOPER, RESEARCHER, STUDY_DESIGNER, STUDY_COORDINATOR);
 
-        PagedResourceList<WeeklyAdherenceReport> page = new PagedResourceList<>(ImmutableList.of(), 0);
-        when(mockService.getWeeklyAdherenceReports(
-                TEST_APP_ID, TEST_STUDY_ID, BOTH, null, null, 0, API_DEFAULT_PAGE_SIZE)).thenReturn(page);
+        AdherenceReportSearch search = new AdherenceReportSearch();
+        search.setTestFilter(TEST);
+        
+        TestUtils.mockRequestBody(mockRequest, search);
 
-        PagedResourceList<WeeklyAdherenceReport> retValue = controller.getWeeklyAdherenceReports(
-                TEST_STUDY_ID, "both", null, null, null, null);
+        PagedResourceList<WeeklyAdherenceReport> page = new PagedResourceList<>(ImmutableList.of(), 0);
+        when(mockService.getWeeklyAdherenceReports(TEST_APP_ID, TEST_STUDY_ID, search)).thenReturn(page);
+
+        PagedResourceList<WeeklyAdherenceReport> retValue = controller.getWeeklyAdherenceReports(TEST_STUDY_ID);
         assertSame(retValue, page);
 
-        verify(mockService).getWeeklyAdherenceReports(
-                TEST_APP_ID, TEST_STUDY_ID, BOTH, null, null, 0, API_DEFAULT_PAGE_SIZE);
+        verify(mockService).getWeeklyAdherenceReports(TEST_APP_ID, TEST_STUDY_ID, search);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/validators/AdherenceReportSearchValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/AdherenceReportSearchValidatorTest.java
@@ -1,0 +1,139 @@
+package org.sagebionetworks.bridge.validators;
+
+import static org.sagebionetworks.bridge.BridgeConstants.ADHERENCE_RANGE_ERROR;
+import static org.sagebionetworks.bridge.BridgeConstants.LABEL_FILTER_COUNT_ERROR;
+import static org.sagebionetworks.bridge.BridgeConstants.LABEL_FILTER_LENGTH_ERROR;
+import static org.sagebionetworks.bridge.BridgeConstants.PAGE_SIZE_ERROR;
+import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
+import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
+import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NEGATIVE;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.sagebionetworks.bridge.models.AdherenceReportSearch;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class AdherenceReportSearchValidatorTest {
+    
+    AdherenceReportSearchValidator validator;
+    
+    @BeforeMethod
+    public void beforeMethod() {
+        validator = new AdherenceReportSearchValidator();
+    }
+    
+    @Test
+    public void valid() {
+        AdherenceReportSearch search = new AdherenceReportSearch();
+        Validate.entityThrowingException(validator, search);
+    }
+    
+    @Test
+    public void offsetByNegative() { 
+        AdherenceReportSearch search = new AdherenceReportSearch();
+        search.setOffsetBy(-1);
+        
+        assertValidatorMessage(validator, search, "offsetBy", CANNOT_BE_NEGATIVE);
+    }
+    
+    @Test
+    public void pageSizeBelowMin() { 
+        AdherenceReportSearch search = new AdherenceReportSearch();
+        search.setPageSize(1);
+        
+        assertValidatorMessage(validator, search, "pageSize", PAGE_SIZE_ERROR);
+    }
+
+    @Test
+    public void pageSizeAboveMax() { 
+        AdherenceReportSearch search = new AdherenceReportSearch();
+        search.setPageSize(300);
+        
+        assertValidatorMessage(validator, search, "pageSize", PAGE_SIZE_ERROR);
+    }
+
+    @Test
+    public void tooManyLabelOptions() { 
+        List<String> labels = new ArrayList<>();
+        for (int i=0; i < 300; i++) {
+            labels.add("abc");
+        }
+        AdherenceReportSearch search = new AdherenceReportSearch();
+        search.setLabelFilters(labels);
+        
+        assertValidatorMessage(validator, search, "labelFilters", LABEL_FILTER_COUNT_ERROR);
+    }
+
+    @Test
+    public void nullLabelOption() { 
+        List<String> labels = new ArrayList<>();
+        labels.add(null);
+        AdherenceReportSearch search = new AdherenceReportSearch();
+        search.setLabelFilters(labels);
+        
+        assertValidatorMessage(validator, search, "labelFilters[0]", CANNOT_BE_BLANK);
+    }
+
+    @Test
+    public void blankLabelOption() { 
+        List<String> labels = new ArrayList<>();
+        labels.add(" ");
+        AdherenceReportSearch search = new AdherenceReportSearch();
+        search.setLabelFilters(labels);
+        
+        assertValidatorMessage(validator, search, "labelFilters[0]", CANNOT_BE_BLANK);
+    }
+    
+    @Test
+    public void negativeLabelTooLong() { 
+        List<String> labels = new ArrayList<>();
+        labels.add(StringUtils.repeat("A", 300));
+        AdherenceReportSearch search = new AdherenceReportSearch();
+        search.setLabelFilters(labels);
+        
+        assertValidatorMessage(validator, search, "labelFilters[0]", LABEL_FILTER_LENGTH_ERROR);
+    }
+
+    @Test
+    public void adherenceMinTooLow() { 
+        AdherenceReportSearch search = new AdherenceReportSearch();
+        search.setAdherenceMin(-1);
+        
+        assertValidatorMessage(validator, search, "adherenceMin", ADHERENCE_RANGE_ERROR);
+    }
+
+    @Test
+    public void adherenceMinTooHigh() { 
+        AdherenceReportSearch search = new AdherenceReportSearch();
+        search.setAdherenceMin(101);
+        
+        assertValidatorMessage(validator, search, "adherenceMin", ADHERENCE_RANGE_ERROR);
+    }
+
+    @Test
+    public void adherenceMaxTooLow() { 
+        AdherenceReportSearch search = new AdherenceReportSearch();
+        search.setAdherenceMax(-1);
+        
+        assertValidatorMessage(validator, search, "adherenceMax", ADHERENCE_RANGE_ERROR);
+    }
+
+    @Test
+    public void adherenceMaxTooHigh() { 
+        AdherenceReportSearch search = new AdherenceReportSearch();
+        search.setAdherenceMax(101);
+        
+        assertValidatorMessage(validator, search, "adherenceMax", ADHERENCE_RANGE_ERROR);
+    }
+
+    @Test
+    public void adherenceMaxHigherThanMin() { 
+        AdherenceReportSearch search = new AdherenceReportSearch();
+        search.setAdherenceMax(101);
+        
+        assertValidatorMessage(validator, search, "adherenceMax", ADHERENCE_RANGE_ERROR);
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/validators/AdherenceReportSearchValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/AdherenceReportSearchValidatorTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.validators;
 
 import static org.sagebionetworks.bridge.BridgeConstants.ADHERENCE_RANGE_ERROR;
+import static org.sagebionetworks.bridge.BridgeConstants.ADHERENCE_RANGE_ORDER_ERROR;
 import static org.sagebionetworks.bridge.BridgeConstants.LABEL_FILTER_COUNT_ERROR;
 import static org.sagebionetworks.bridge.BridgeConstants.LABEL_FILTER_LENGTH_ERROR;
 import static org.sagebionetworks.bridge.BridgeConstants.PAGE_SIZE_ERROR;
@@ -8,8 +9,8 @@ import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NEGATIVE;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.sagebionetworks.bridge.models.AdherenceReportSearch;
@@ -57,9 +58,9 @@ public class AdherenceReportSearchValidatorTest {
 
     @Test
     public void tooManyLabelOptions() { 
-        List<String> labels = new ArrayList<>();
+        Set<String> labels = new HashSet<>();
         for (int i=0; i < 300; i++) {
-            labels.add("abc");
+            labels.add("abc"+i);
         }
         AdherenceReportSearch search = new AdherenceReportSearch();
         search.setLabelFilters(labels);
@@ -69,7 +70,7 @@ public class AdherenceReportSearchValidatorTest {
 
     @Test
     public void nullLabelOption() { 
-        List<String> labels = new ArrayList<>();
+        Set<String> labels = new HashSet<>();
         labels.add(null);
         AdherenceReportSearch search = new AdherenceReportSearch();
         search.setLabelFilters(labels);
@@ -79,7 +80,7 @@ public class AdherenceReportSearchValidatorTest {
 
     @Test
     public void blankLabelOption() { 
-        List<String> labels = new ArrayList<>();
+        Set<String> labels = new HashSet<>();
         labels.add(" ");
         AdherenceReportSearch search = new AdherenceReportSearch();
         search.setLabelFilters(labels);
@@ -89,7 +90,7 @@ public class AdherenceReportSearchValidatorTest {
     
     @Test
     public void negativeLabelTooLong() { 
-        List<String> labels = new ArrayList<>();
+        Set<String> labels = new HashSet<>();
         labels.add(StringUtils.repeat("A", 300));
         AdherenceReportSearch search = new AdherenceReportSearch();
         search.setLabelFilters(labels);
@@ -132,8 +133,9 @@ public class AdherenceReportSearchValidatorTest {
     @Test
     public void adherenceMaxHigherThanMin() { 
         AdherenceReportSearch search = new AdherenceReportSearch();
-        search.setAdherenceMax(101);
+        search.setAdherenceMin(80);
+        search.setAdherenceMax(70);
         
-        assertValidatorMessage(validator, search, "adherenceMax", ADHERENCE_RANGE_ERROR);
+        assertValidatorMessage(validator, search, "adherenceMax", ADHERENCE_RANGE_ORDER_ERROR);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/validators/ConsentSignatureValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/ConsentSignatureValidatorTest.java
@@ -9,8 +9,6 @@ import static org.testng.Assert.fail;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
-import org.joda.time.LocalDate;
-import org.joda.time.Period;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;


### PR DESCRIPTION
- added a (hopefully definitive) "progression" flag on the report to indicate that the participant is unstated, in progress or done;
- Added an ID filter;
- Explained the adherence (no longer compliance) filter so it takes a range;
- Added a filter on progression;
- There are so many filters I switched to a POST of a search options object, as we do for other complicated queries (accounts, enrollments);
