### PR TITLE
Adherence fixes

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/hibernate/QueryBuilder.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/QueryBuilder.java
@@ -149,7 +149,7 @@ class QueryBuilder {
             int i=0;
             for (String labelFilter : labelFilters) {
                 phrases.add("label LIKE :labelFilter"+i);
-                whereParams.put("labelFilter"+(i++),  "%:" + labelFilter + ":%");
+                whereParams.put("labelFilter"+(i++),  "%" + labelFilter + "%");
             }
             predicated.add("(" + Joiner.on(" OR ").join(phrases) + ")");
         }

--- a/src/main/java/org/sagebionetworks/bridge/models/ResourceList.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/ResourceList.java
@@ -48,7 +48,7 @@ public class ResourceList<T> {
     public static final String INCLUDE_DELETED = "includeDeleted";
     public static final String INCLUDE_REPEATS = "includeRepeats";
     public static final String INSTANCE_GUIDS = "instanceGuids";
-    public static final String LABEL_FILTER = "labelFilter";
+    public static final String LABEL_FILTERS = "labelFilters";
     public static final String LANGUAGE = "language";
     public static final String MAX_REVISION = "maxRevision";
     public static final String MIN_REVISION = "minRevision";

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/ParticipantStudyProgress.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/ParticipantStudyProgress.java
@@ -3,5 +3,6 @@ package org.sagebionetworks.bridge.models.schedules2.adherence;
 public enum ParticipantStudyProgress {
     UNSTARTED,
     IN_PROGRESS,
-    DONE
+    DONE,
+    NO_SCHEDULE
 }

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/weekly/WeeklyAdherenceReportGenerator.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/weekly/WeeklyAdherenceReportGenerator.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import static org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantStudyProgress.DONE;
 import static org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantStudyProgress.IN_PROGRESS;
+import static org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantStudyProgress.NO_SCHEDULE;
 import static org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantStudyProgress.UNSTARTED;
 import static org.sagebionetworks.bridge.models.schedules2.adherence.SessionCompletionState.NOT_APPLICABLE;
 
@@ -145,7 +146,9 @@ public class WeeklyAdherenceReportGenerator {
         int percentage = AdherenceUtils.calculateAdherencePercentage(ImmutableList.of(finalReport));
         
         ParticipantStudyProgress progression = IN_PROGRESS;
-        if (rowList.isEmpty() && nextDay == null) {
+        if (state.getMetadata().isEmpty()) {
+            progression = NO_SCHEDULE;
+        } else if (rowList.isEmpty() && nextDay == null) {
             long na = AdherenceUtils.counting(eventReport.getStreams(), ImmutableSet.of(NOT_APPLICABLE));
             long total = AdherenceUtils.counting(eventReport.getStreams(), EnumSet.allOf(SessionCompletionState.class));
             if (na == total) {

--- a/src/main/java/org/sagebionetworks/bridge/services/AdherenceService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AdherenceService.java
@@ -413,7 +413,7 @@ public class AdherenceService {
 
         return reportDao.getWeeklyAdherenceReports(appId, studyId, search)
                 .withRequestParam(PagedResourceList.TEST_FILTER, search.getTestFilter())
-                .withRequestParam(PagedResourceList.LABEL_FILTER, search.getLabelFilters())
+                .withRequestParam(PagedResourceList.LABEL_FILTERS, search.getLabelFilters())
                 .withRequestParam(PagedResourceList.ADHERENCE_MIN, search.getAdherenceMin())
                 .withRequestParam(PagedResourceList.ADHERENCE_MAX, search.getAdherenceMax())
                 .withRequestParam(PagedResourceList.PROGRESSION_FILTERS, search.getProgressionFilters())

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAdherenceReportDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateAdherenceReportDaoTest.java
@@ -41,21 +41,23 @@ import org.sagebionetworks.bridge.models.schedules2.adherence.weekly.WeeklyAdher
 
 public class HibernateAdherenceReportDaoTest extends Mockito {
 
-    private static String ORDER_BY = " ORDER BY weeklyAdherencePercent, lastName, firstName, email, phone, externalId";
+    private static String ORDER_BY = " ORDER BY h.weeklyAdherencePercent, h.participant.lastName, "
+            +"h.participant.firstName, h.participant.email, h.participant.phone, h.participant.externalId";
     
-    private static String FULL_SQL = "FROM WeeklyAdherenceReport h JOIN h.searchableLabels label WHERE "
-            +"h.appId = :appId AND h.studyId = :studyId AND weeklyAdherencePercent >= :adherenceMin AND "
-            +"weeklyAdherencePercent <= :adherenceMax AND progression IN :progressionFilters AND (label "
-            +"LIKE :labelFilter0) AND (externalId LIKE :id OR identifier LIKE :id OR firstName LIKE :id "
-            +"OR lastName LIKE :id OR email LIKE :id OR phone LIKE :id)"+ORDER_BY;
+    private static String FULL_SQL = "FROM WeeklyAdherenceReport h LEFT JOIN h.searchableLabels label WHERE "
+            +"h.appId = :appId AND h.studyId = :studyId AND h.weeklyAdherencePercent >= :adherenceMin AND "
+            +"h.weeklyAdherencePercent <= :adherenceMax AND h.progression IN :progressionFilters AND (label "
+            +"LIKE :labelFilter0) AND (h.participant.externalId LIKE :id OR h.participant.identifier LIKE :id "
+            +"OR h.participant.firstName LIKE :id OR h.participant.lastName LIKE :id OR h.participant.email "
+            +"LIKE :id OR h.participant.phone.number LIKE :id)"+ORDER_BY;
     
     private static String TEST_ACCOUNTS_SQL = "FROM WeeklyAdherenceReport h WHERE h.appId = :appId AND "
-            +"h.studyId = :studyId AND testAccount = 1"+ORDER_BY;
+            +"h.studyId = :studyId AND h.testAccount = 1"+ORDER_BY;
     
     private static String PROD_ACCOUNTS_SQL = "FROM WeeklyAdherenceReport h WHERE h.appId = :appId AND "
-            +"h.studyId = :studyId AND testAccount = 0"+ORDER_BY;
+            +"h.studyId = :studyId AND h.testAccount = 0"+ORDER_BY;
     
-    private static String LABELS_SQL = "FROM WeeklyAdherenceReport h JOIN h.searchableLabels label WHERE "
+    private static String LABELS_SQL = "FROM WeeklyAdherenceReport h LEFT JOIN h.searchableLabels label WHERE "
             +"h.appId = :appId AND h.studyId = :studyId AND (label LIKE :labelFilter0 OR label LIKE "
             +":labelFilter1)"+ORDER_BY;
     
@@ -63,17 +65,17 @@ public class HibernateAdherenceReportDaoTest extends Mockito {
             +"h.studyId = :studyId"+ORDER_BY;
 
     private static String MIN_NO_MAX_SQL = "FROM WeeklyAdherenceReport h WHERE h.appId = :appId AND "
-            +"h.studyId = :studyId AND weeklyAdherencePercent >= :adherenceMin"+ORDER_BY;
+            +"h.studyId = :studyId AND h.weeklyAdherencePercent >= :adherenceMin"+ORDER_BY;
 
     private static String MAX_NO_MIN_SQL = "FROM WeeklyAdherenceReport h WHERE h.appId = :appId AND "
-            +"h.studyId = :studyId AND weeklyAdherencePercent <= :adherenceMax"+ORDER_BY;
+            +"h.studyId = :studyId AND h.weeklyAdherencePercent <= :adherenceMax"+ORDER_BY;
     
-    private static String ID_FILTER = "FROM WeeklyAdherenceReport h WHERE h.appId = "
-            +":appId AND h.studyId = :studyId AND (externalId LIKE :id OR identifier LIKE :id OR firstName "
-            +"LIKE :id OR lastName LIKE :id OR email LIKE :id OR phone LIKE :id)"+ORDER_BY;
+    private static String ID_FILTER = "FROM WeeklyAdherenceReport h WHERE h.appId = :appId AND h.studyId = :studyId "
+            +"AND (h.participant.externalId LIKE :id OR h.participant.identifier LIKE :id OR h.participant.firstName "
+            +"LIKE :id OR h.participant.lastName LIKE :id OR h.participant.email LIKE :id OR h.participant.phone.number LIKE :id)"+ORDER_BY;
     
     private static String PROGRESSION_FILTER = "FROM WeeklyAdherenceReport h WHERE h.appId = :appId AND h.studyId "
-            +"= :studyId AND progression IN :progressionFilters"+ORDER_BY;
+            +"= :studyId AND h.progression IN :progressionFilters"+ORDER_BY;
     
     @Mock
     HibernateHelper mockHelper;
@@ -127,7 +129,7 @@ public class HibernateAdherenceReportDaoTest extends Mockito {
         
         assertEquals(stringCaptor.getAllValues().get(0), SELECT_COUNT + FULL_SQL);
         assertEquals(stringCaptor.getAllValues().get(1), SELECT_DISTINCT + FULL_SQL);
-        assertEquals(paramsCaptor.getValue().get(LABEL_FILTER_FIELD+"0"), "%:label:%");
+        assertEquals(paramsCaptor.getValue().get(LABEL_FILTER_FIELD+"0"), "%label%");
         assertEquals(paramsCaptor.getValue().get(ADHERENCE_MIN_FIELD), 10);
         assertEquals(paramsCaptor.getValue().get(ADHERENCE_MAX_FIELD), 75);
         assertEquals(paramsCaptor.getValue().get(PROGRESSION_FILTER_FIELD), ImmutableSet.of(IN_PROGRESS));
@@ -199,8 +201,8 @@ public class HibernateAdherenceReportDaoTest extends Mockito {
         
         assertEquals(stringCaptor.getAllValues().get(0), SELECT_COUNT + LABELS_SQL);
         assertEquals(stringCaptor.getAllValues().get(1), SELECT_DISTINCT + LABELS_SQL);
-        assertEquals(paramsCaptor.getValue().get(LABEL_FILTER_FIELD+"0"), "%:A:%");
-        assertEquals(paramsCaptor.getValue().get(LABEL_FILTER_FIELD+"1"), "%:B:%");
+        assertEquals(paramsCaptor.getValue().get(LABEL_FILTER_FIELD+"0"), "%A%");
+        assertEquals(paramsCaptor.getValue().get(LABEL_FILTER_FIELD+"1"), "%B%");
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/adherence/weekly/WeeklyAdherenceReportGeneratorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/adherence/weekly/WeeklyAdherenceReportGeneratorTest.java
@@ -332,16 +332,12 @@ public class WeeklyAdherenceReportGeneratorTest extends Mockito {
     
     @Test
     public void progressionStates() {
-        DateTime timestamp = DateTime.now();
-        AdherenceState state = new AdherenceState.Builder()
-                .withClientTimeZone(TEST_CLIENT_TIME_ZONE)
-                .withNow(timestamp.plusDays(10))
-                .withShowActive(false).build();
-        
-        WeeklyAdherenceReport report = WeeklyAdherenceReportGenerator.INSTANCE.generate(state);
+        AdherenceState.Builder builder = TestUtils.getAdherenceStateBuilder();
+        builder.withMetadata(ImmutableList.of());
+        WeeklyAdherenceReport report = WeeklyAdherenceReportGenerator.INSTANCE.generate(builder.build());
         assertEquals(report.getProgression(), ParticipantStudyProgress.NO_SCHEDULE);
         
-        AdherenceState.Builder builder = TestUtils.getAdherenceStateBuilder();
+        builder = TestUtils.getAdherenceStateBuilder();
         report = WeeklyAdherenceReportGenerator.INSTANCE.generate(builder.build());
         assertEquals(report.getProgression(), ParticipantStudyProgress.IN_PROGRESS);
         

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/adherence/weekly/WeeklyAdherenceReportGeneratorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/adherence/weekly/WeeklyAdherenceReportGeneratorTest.java
@@ -21,6 +21,7 @@ import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.activities.StudyActivityEvent;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceState;
+import org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantStudyProgress;
 import org.sagebionetworks.bridge.models.schedules2.adherence.eventstream.EventStreamDay;
 import org.sagebionetworks.bridge.models.schedules2.timelines.TimelineMetadata;
 import org.testng.annotations.Test;
@@ -327,6 +328,40 @@ public class WeeklyAdherenceReportGeneratorTest extends Mockito {
         
         List<EventStreamDay> days = report.getByDayEntries().get(0);
         assertEquals(days.size(), 2);
+    }
+    
+    @Test
+    public void progressionStates() {
+        DateTime timestamp = DateTime.now();
+        AdherenceState state = new AdherenceState.Builder()
+                .withClientTimeZone(TEST_CLIENT_TIME_ZONE)
+                .withNow(timestamp.plusDays(10))
+                .withShowActive(false).build();
+        
+        WeeklyAdherenceReport report = WeeklyAdherenceReportGenerator.INSTANCE.generate(state);
+        assertEquals(report.getProgression(), ParticipantStudyProgress.NO_SCHEDULE);
+        
+        AdherenceState.Builder builder = TestUtils.getAdherenceStateBuilder();
+        report = WeeklyAdherenceReportGenerator.INSTANCE.generate(builder.build());
+        assertEquals(report.getProgression(), ParticipantStudyProgress.IN_PROGRESS);
+        
+        builder = TestUtils.getAdherenceStateBuilder();
+        builder.withEvents(ImmutableList.of());
+        report = WeeklyAdherenceReportGenerator.INSTANCE.generate(builder.build());
+        assertEquals(report.getProgression(), ParticipantStudyProgress.UNSTARTED);
+        
+        builder = TestUtils.getAdherenceStateBuilder();
+        StudyActivityEvent e1 = new StudyActivityEvent.Builder()
+                .withEventId("event1")
+                .withTimestamp(ADHERENCE_STATE_EVENT_TS1.minusWeeks(50))
+                .build();
+        StudyActivityEvent e2 = new StudyActivityEvent.Builder()
+                .withEventId("event2")
+                .withTimestamp(ADHERENCE_STATE_EVENT_TS2.minusWeeks(50))
+                .build();
+        builder.withEvents(ImmutableList.of(e1, e2));
+        report = WeeklyAdherenceReportGenerator.INSTANCE.generate(builder.build());
+        assertEquals(report.getProgression(), ParticipantStudyProgress.DONE);
     }
     
 }


### PR DESCRIPTION
- searching for labels and anything else returned no results (a saga of rewriting HQL ensued, but it works now);
- removed colons from label search (these are visible in searchableLabels and if the caller wants to match a label exactly, they can supply the colons in their search string);
- labelFilter renamed to labelFilters, as it was turned into an array late in the process;
- adding "no schedule" progress state for cases where someone calls the weekly adherence report API and generates a report for a participant in a study that has—no schedule. Otherwise we report it as "done" which seems weird.