### PR TITLE
Refactor validation code for better encapsulation

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/src/main/java/org/sagebionetworks/bridge/BridgeConstants.java
@@ -14,12 +14,12 @@ import com.google.common.collect.ImmutableList;
 public class BridgeConstants {
     public static final String CONFIG_KEY_WORKER_SQS_URL = "workerPlatform.request.sqs.queue.url";
     public static final String EXTERNAL_ID_NONE = "<none>";
+    
+    public static final String CANNOT_BE_BLANK = "%s cannot be null or blank";
+    public static final String CANNOT_BE_NULL = "%s cannot be null";
 
     // Excessively long User-Agent strings break the database and generally aren't parseable anyway.
     public static final int MAX_USER_AGENT_LENGTH = 255;
-
-    // see https://owasp.org/www-community/OWASP_Validation_Regex_Repository
-    public static final String OWASP_REGEXP_VALID_EMAIL = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$";
     
     public static final TypeReference<Set<String>> STRING_SET_TYPEREF = new TypeReference<Set<String>>() {};
     public static final TypeReference<Map<String, Map<String, JsonNode>>> UPDATES_TYPEREF = new TypeReference<Map<String, Map<String, JsonNode>>>() {};
@@ -42,37 +42,16 @@ public class BridgeConstants {
     public static final int SYNAPSE_TIMEOUT = 10000;
     
     public static final String MAX_USERS_ERROR = "While app is in evaluation mode, it may not exceed %s accounts.";
-    public static final String BRIDGE_IDENTIFIER_ERROR = "must contain only lower-case letters and/or numbers with optional dashes";
-    public static final String BRIDGE_EVENT_ID_ERROR = "must contain only lower- or upper-case letters, numbers, dashes, and/or underscores";
-    public static final String BRIDGE_RELAXED_ID_ERROR = "cannot contain colons";
-    public static final String CALLER_NOT_MEMBER_ERROR = "Assessment must be associated to the caller’s organization.";
     public static final String NEGATIVE_OFFSET_ERROR = "offsetBy cannot be negative";
     public static final String NONPOSITIVE_REVISION_ERROR = "revision cannot be less than 1";
 
     // App ID for the test app, used in local tests and most integ tests.
     public static final String API_APP_ID = "api";
 
-    /** A common string constraint we place on model identifiers. */
-    public static final String BRIDGE_IDENTIFIER_PATTERN = "^[a-z0-9-]+$";
-
     // App ID used for the Shared Module Library
     public static final String SHARED_APP_ID = "shared";
     
     public static final String API_2_APP_ID = "api-2";
-
-    /** A common string constraint Synapse places on model identifiers. */
-    public static final String SYNAPSE_IDENTIFIER_PATTERN = "^[a-zA-Z0-9_-]+$";
-    
-    /** The pattern used to validate activity event keys and automatic custom event keys. */
-    public static final String BRIDGE_EVENT_ID_PATTERN = "^[a-zA-Z0-9_-]+$";
-    
-    /** An identifier field that can contain spaces, some punctuation (but not colons) where it's infeasible 
-     * to include a separate label and unnecessary to restrict the string for external systems like Synapse. 
-     */
-    public static final String BRIDGE_RELAXED_ID_PATTERN = "^[^:]+$";
-    
-    /** The pattern of a valid JavaScript variable/object property name. */
-    public  static final String JS_IDENTIFIER_PATTERN = "^[a-zA-Z0-9_][a-zA-Z0-9_-]*$";
     
     public static final String BRIDGE_API_STATUS_HEADER = "Bridge-Api-Status";
 
@@ -111,24 +90,12 @@ public class BridgeConstants {
     // 7 days
     public static final int SIGNED_CONSENT_DOWNLOAD_EXPIRE_IN_SECONDS = (7 * 24 * 60 * 60);
     
-    // 5 minutes
-    public static final int BRIDGE_UPDATE_ATTEMPT_EXPIRE_IN_SECONDS = 5 * 60;
-    
     // 5 hrs
     public static final int BRIDGE_VIEW_EXPIRE_IN_SECONDS = 5 * 60 * 60;
     
     // 3 minutes
     public static final int APP_LINKS_EXPIRE_IN_SECONDS = 3* 60;
     
-    // 1 minute
-    public static final int BRIDGE_APP_EMAIL_STATUS_IN_SECONDS = 60;
-    
-    // 15 seconds
-    public static final int REAUTH_TOKEN_CACHE_LOOKUP_IN_SECONDS = 15;
-
-    // 3 days
-    public static final int REAUTH_TOKEN_GRACE_PERIOD_SECONDS = (3*24*60*60);
-
     public static final String SCHEDULE_STRATEGY_PACKAGE = "org.sagebionetworks.bridge.models.schedules.";
 
     public static final String ASSETS_HOST = "assets.sagebridge.org";
@@ -146,14 +113,6 @@ public class BridgeConstants {
     
     public static final String PAGE_SIZE_ERROR = "pageSize must be from "+API_MINIMUM_PAGE_SIZE+"-"+API_MAXIMUM_PAGE_SIZE+" records";
     
-    public static final String LABEL_FILTER_COUNT_ERROR = "cannot have over 50 entries";
-    
-    public static final String LABEL_FILTER_LENGTH_ERROR = "cannot be over 100 characters";
-    
-    public static final String ADHERENCE_RANGE_ERROR = "% must be from 0-100";
-    
-    public static final String ADHERENCE_RANGE_ORDER_ERROR = "cannot be less than adherenceMin";
-    
     public static final String TEST_USER_GROUP = "test_user";
     
     public static final String EXPIRATION_PERIOD_KEY = "expirationPeriod";
@@ -161,9 +120,6 @@ public class BridgeConstants {
     public static final String CONSENT_URL = "consentUrl";
     
     public static final int ONE_DAY_IN_SECONDS = 60*60*24;
-
-    /** We want app links to fit in a single SMS, so limit them to 140 chars. */
-    public static final int APP_LINK_MAX_LENGTH = 140;
 
     /**
      * 11 character label as to who sent the SMS message. Only in some supported countries (not US):

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoAppDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoAppDao.java
@@ -24,7 +24,6 @@ import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.apps.App;
-import org.sagebionetworks.bridge.validators.Validate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -58,7 +57,7 @@ public class DynamoAppDao implements AppDao {
     
     @Override
     public App getApp(String appId) {
-        checkArgument(isNotBlank(appId), Validate.CANNOT_BE_BLANK, "appId");
+        checkArgument(isNotBlank(appId));
         
         DynamoApp app = new DynamoApp();
         app.setIdentifier(appId);
@@ -81,7 +80,7 @@ public class DynamoAppDao implements AppDao {
 
     @Override
     public App createApp(App app) {
-        checkNotNull(app, Validate.CANNOT_BE_NULL, "app");
+        checkNotNull(app);
         checkArgument(app.getVersion() == null, "%s has a version; may not be new", "app");
         try {
             mapper.save(app);
@@ -93,8 +92,8 @@ public class DynamoAppDao implements AppDao {
 
     @Override
     public App updateApp(App app) {
-        checkNotNull(app, Validate.CANNOT_BE_NULL, "app");
-        checkNotNull(app.getVersion(), Validate.CANNOT_BE_NULL, "app version");
+        checkNotNull(app);
+        checkNotNull(app.getVersion());
         try {
             mapper.save(app);
         } catch(ConditionalCheckFailedException e) {
@@ -105,7 +104,7 @@ public class DynamoAppDao implements AppDao {
 
     @Override
     public void deleteApp(App app) {
-        checkNotNull(app, Validate.CANNOT_BE_BLANK, "app");
+        checkNotNull(app);
 
         String appId = app.getIdentifier();
         if (appWhitelist.contains(appId)) {
@@ -117,7 +116,7 @@ public class DynamoAppDao implements AppDao {
 
     @Override
     public void deactivateApp(String appId) {
-        checkNotNull(appId, Validate.CANNOT_BE_BLANK, "appId");
+        checkNotNull(appId);
 
         if (appWhitelist.contains(appId)) {
             throw new UnauthorizedException(appId + " is protected by whitelist.");

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchema.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadSchema.java
@@ -32,7 +32,6 @@ import org.sagebionetworks.bridge.models.upload.UploadFieldDefinition;
 import org.sagebionetworks.bridge.models.upload.UploadSchema;
 import org.sagebionetworks.bridge.models.upload.UploadSchemaType;
 import org.sagebionetworks.bridge.schema.UploadSchemaKey;
-import org.sagebionetworks.bridge.validators.Validate;
 
 /**
  * The DynamoDB implementation of UploadSchema. This is a mutable class with getters and setters so that it can work
@@ -106,8 +105,8 @@ public class DynamoUploadSchema implements UploadSchema {
      */
     @JsonProperty
     public void setKey(String key) {
-        Preconditions.checkNotNull(key, Validate.CANNOT_BE_NULL, "key");
-        Preconditions.checkArgument(!key.isEmpty(), Validate.CANNOT_BE_EMPTY_STRING, "key");
+        Preconditions.checkNotNull(key);
+        Preconditions.checkArgument(!key.isEmpty());
 
         String[] parts = key.split(":", 2);
         Preconditions.checkArgument(parts.length == 2, "key has wrong number of parts");

--- a/src/main/java/org/sagebionetworks/bridge/models/GuidCreatedOnVersionHolderImpl.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/GuidCreatedOnVersionHolderImpl.java
@@ -11,7 +11,6 @@ import org.sagebionetworks.bridge.json.DateTimeToLongDeserializer;
 import org.sagebionetworks.bridge.json.DateTimeToLongSerializer;
 import org.sagebionetworks.bridge.models.schedules.SurveyReference;
 import org.sagebionetworks.bridge.models.surveys.Survey;
-import org.sagebionetworks.bridge.validators.Validate;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -26,7 +25,7 @@ public final class GuidCreatedOnVersionHolderImpl implements GuidCreatedOnVersio
     private final Long version;
     
     public GuidCreatedOnVersionHolderImpl(Survey survey) {
-        checkNotNull(survey, Validate.CANNOT_BE_NULL, "survey");
+        checkNotNull(survey);
         this.guid = survey.getGuid();
         this.createdOn = survey.getCreatedOn();
         this.version = survey.getVersion();
@@ -42,7 +41,7 @@ public final class GuidCreatedOnVersionHolderImpl implements GuidCreatedOnVersio
     @JsonCreator
     public GuidCreatedOnVersionHolderImpl(@JsonProperty("guid") String guid,
             @JsonProperty("createdOn") @JsonDeserialize(using = DateTimeToLongDeserializer.class) long createdOn) {
-        checkArgument(isNotBlank(guid), Validate.CANNOT_BE_BLANK, "guid");
+        checkArgument(isNotBlank(guid));
         checkArgument(createdOn != 0, "createdOn cannot be zero");
         this.guid = guid;
         this.createdOn = createdOn;

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Timeline.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/timelines/Timeline.java
@@ -1,6 +1,6 @@
 package org.sagebionetworks.bridge.models.schedules2.timelines;
 
-import static org.sagebionetworks.bridge.validators.ValidatorUtils.periodInMinutes;
+import static org.sagebionetworks.bridge.BridgeUtils.periodInMinutes;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -14,7 +14,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.common.collect.ImmutableList;
 
 import org.joda.time.Period;
-
 import org.sagebionetworks.bridge.models.schedules2.Notification;
 import org.sagebionetworks.bridge.models.schedules2.Schedule2;
 

--- a/src/main/java/org/sagebionetworks/bridge/models/upload/UploadValidationStatus.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/upload/UploadValidationStatus.java
@@ -1,5 +1,8 @@
 package org.sagebionetworks.bridge.models.upload;
 
+import static org.sagebionetworks.bridge.BridgeConstants.CANNOT_BE_BLANK;
+import static org.sagebionetworks.bridge.BridgeConstants.CANNOT_BE_NULL;
+
 import java.util.List;
 
 import javax.annotation.Nonnull;
@@ -50,7 +53,7 @@ public class UploadValidationStatus implements BridgeEntity {
     public static UploadValidationStatus from(@Nonnull Upload upload, HealthDataRecord record)
             throws InvalidEntityException {
         if (upload == null) {
-            throw new InvalidEntityException(String.format(Validate.CANNOT_BE_NULL, "upload"));
+            throw new InvalidEntityException(String.format(CANNOT_BE_NULL, "upload"));
         }
         return new Builder().withId(upload.getUploadId()).withMessageList(upload.getValidationMessageList())
                 .withStatus(upload.getStatus()).withRecord(record).build();
@@ -123,12 +126,12 @@ public class UploadValidationStatus implements BridgeEntity {
             // Validate messageList. We need to do this upfront, since ImmutableList will crash if this is invalid.
             // We also can't use Validate.entityThrowingException(), since that only works with BridgeEntities.
             if (messageList == null) {
-                throw new InvalidEntityException(String.format(Validate.CANNOT_BE_NULL, "messageList"));
+                throw new InvalidEntityException(String.format(CANNOT_BE_NULL, "messageList"));
             }
             int numMessages = messageList.size();
             for (int i = 0; i < numMessages; i++) {
                 if (Strings.isNullOrEmpty(messageList.get(i))) {
-                    throw new InvalidEntityException(String.format(Validate.CANNOT_BE_BLANK,
+                    throw new InvalidEntityException(String.format(CANNOT_BE_BLANK,
                             String.format("messageList[%d]", i)));
                 }
             }

--- a/src/main/java/org/sagebionetworks/bridge/services/ConsentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ConsentService.java
@@ -170,11 +170,11 @@ public class ConsentService {
      */
     public void consentToResearch(App app, SubpopulationGuid subpopGuid, StudyParticipant participant,
             ConsentSignature consentSignature, SharingScope sharingScope, boolean sendSignedConsent) {
-        checkNotNull(app, Validate.CANNOT_BE_NULL, "app");
-        checkNotNull(subpopGuid, Validate.CANNOT_BE_NULL, "subpopulationGuid");
-        checkNotNull(participant, Validate.CANNOT_BE_NULL, "participant");
-        checkNotNull(consentSignature, Validate.CANNOT_BE_NULL, "consentSignature");
-        checkNotNull(sharingScope, Validate.CANNOT_BE_NULL, "sharingScope");
+        checkNotNull(app);
+        checkNotNull(subpopGuid);
+        checkNotNull(participant);
+        checkNotNull(consentSignature);
+        checkNotNull(sharingScope);
 
         ConsentSignatureValidator validator = new ConsentSignatureValidator(app.getMinAgeOfConsent());
         Validate.entityThrowingException(validator, consentSignature);

--- a/src/main/java/org/sagebionetworks/bridge/services/HealthDataService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/HealthDataService.java
@@ -1,5 +1,8 @@
 package org.sagebionetworks.bridge.services;
 
+import static org.sagebionetworks.bridge.BridgeConstants.CANNOT_BE_BLANK;
+import static org.sagebionetworks.bridge.BridgeConstants.CANNOT_BE_NULL;
+
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
@@ -11,7 +14,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
-
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.exceptions.NotFoundException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
@@ -326,7 +328,7 @@ public class HealthDataService {
     public String createOrUpdateRecord(HealthDataRecord record) {
         // validate record
         if (record == null) {
-            throw new InvalidEntityException(String.format(Validate.CANNOT_BE_NULL, "HealthDataRecord"));
+            throw new InvalidEntityException(String.format(CANNOT_BE_NULL, "HealthDataRecord"));
         }
         Validate.entityThrowingException(HealthDataRecordValidator.INSTANCE, record);
 
@@ -348,7 +350,7 @@ public class HealthDataService {
     public int deleteRecordsForHealthCode(String healthCode) {
         // validate health code
         if (StringUtils.isBlank(healthCode)) {
-            throw new BadRequestException(String.format(Validate.CANNOT_BE_BLANK, "healthCode"));
+            throw new BadRequestException(String.format(CANNOT_BE_BLANK, "healthCode"));
         }
         // TODO: validate health code against health code table
 
@@ -366,7 +368,7 @@ public class HealthDataService {
     public HealthDataRecord getRecordById(String id) {
         // validate ID
         if (StringUtils.isBlank(id)) {
-            throw new BadRequestException(String.format(Validate.CANNOT_BE_BLANK, "id"));
+            throw new BadRequestException(String.format(CANNOT_BE_BLANK, "id"));
         }
 
         // call through to DAO
@@ -384,7 +386,7 @@ public class HealthDataService {
     public List<HealthDataRecord> getRecordsForUploadDate(String uploadDate) {
         // validate upload date
         if (StringUtils.isBlank(uploadDate)) {
-            throw new BadRequestException(String.format(Validate.CANNOT_BE_BLANK, "uploadDate"));
+            throw new BadRequestException(String.format(CANNOT_BE_BLANK, "uploadDate"));
         }
 
         // use Joda to parse the upload date, to validate it
@@ -404,10 +406,10 @@ public class HealthDataService {
             DateTime createdOnEnd) {
         Preconditions.checkArgument(StringUtils.isNotBlank(healthCode));
         if (createdOnStart == null) {
-            throw new BadRequestException(String.format(Validate.CANNOT_BE_NULL, "createdOnStart"));
+            throw new BadRequestException(String.format(CANNOT_BE_NULL, "createdOnStart"));
         }
         if (createdOnEnd == null) {
-            throw new BadRequestException(String.format(Validate.CANNOT_BE_NULL, "createdOnEnd"));
+            throw new BadRequestException(String.format(CANNOT_BE_NULL, "createdOnEnd"));
         }
         if (createdOnStart.isAfter(createdOnEnd)) {
             throw new BadRequestException("createdOnStart can't be after createdOnEnd");

--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -27,7 +27,6 @@ import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectTy
 import static org.sagebionetworks.bridge.models.templates.TemplateType.EMAIL_APP_INSTALL_LINK;
 import static org.sagebionetworks.bridge.models.templates.TemplateType.SMS_APP_INSTALL_LINK;
 import static org.sagebionetworks.bridge.validators.IdentifierUpdateValidator.INSTANCE;
-import static org.sagebionetworks.bridge.validators.ValidatorUtils.accountHasValidIdentifier;
 
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -537,7 +536,7 @@ public class ParticipantService {
         // account record. We should handle this with validation, but it would break existing
         // clients that are known to submit an external ID during sign up. So we check again and do 
         // not save if the account is inaccessible after construction.
-        if (accountHasValidIdentifier(account)) {
+        if (BridgeUtils.hasValidIdentifier(account)) {
             accountService.createAccount(app, account);    
         }
         

--- a/src/main/java/org/sagebionetworks/bridge/services/SurveyService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/SurveyService.java
@@ -252,8 +252,8 @@ public class SurveyService {
      * @return
      */
     public List<Survey> getSurveyAllVersions(String appId, String guid, boolean includeDeleted) {
-        checkNotNull(appId, Validate.CANNOT_BE_NULL, "appId");
-        checkArgument(isNotBlank(guid), Validate.CANNOT_BE_BLANK, "survey guid");
+        checkNotNull(appId);
+        checkArgument(isNotBlank(guid));
 
         List<Survey> allVersions = surveyDao.getSurveyAllVersions(appId, guid, includeDeleted);
         if (allVersions.isEmpty()) {
@@ -270,8 +270,8 @@ public class SurveyService {
      * @return
      */
     public Survey getSurveyMostRecentVersion(String appId, String guid) {
-        checkNotNull(appId, Validate.CANNOT_BE_NULL, "appId");
-        checkArgument(isNotBlank(guid), Validate.CANNOT_BE_BLANK, "survey guid");
+        checkNotNull(appId);
+        checkArgument(isNotBlank(guid));
 
         Survey survey = surveyDao.getSurveyMostRecentVersion(appId, guid);
         if (survey == null || !isInApp(appId, survey)) {
@@ -291,8 +291,8 @@ public class SurveyService {
      * @return
      */
     public Survey getSurveyMostRecentlyPublishedVersion(String appId, String guid, boolean includeElements) {
-        checkNotNull(appId, Validate.CANNOT_BE_NULL, "appId");
-        checkArgument(isNotBlank(guid), Validate.CANNOT_BE_BLANK, "survey guid");
+        checkNotNull(appId);
+        checkArgument(isNotBlank(guid));
 
         Survey survey = surveyDao.getSurveyMostRecentlyPublishedVersion(appId, guid, includeElements);
         if (survey == null || !isInApp(appId, survey)) {
@@ -306,7 +306,7 @@ public class SurveyService {
      * published, nothing is returned.
      */
     public List<Survey> getAllSurveysMostRecentlyPublishedVersion(String appId, boolean includeDeleted) {
-        checkNotNull(appId, Validate.CANNOT_BE_NULL, "appId");
+        checkNotNull(appId);
 
         return surveyDao.getAllSurveysMostRecentlyPublishedVersion(appId, includeDeleted);
     }
@@ -318,7 +318,7 @@ public class SurveyService {
      * @return
      */
     public List<Survey> getAllSurveysMostRecentVersion(String appId, boolean includeDeleted) {
-        checkNotNull(appId, Validate.CANNOT_BE_NULL, "appId");
+        checkNotNull(appId);
 
         return surveyDao.getAllSurveysMostRecentVersion(appId, includeDeleted);
     }

--- a/src/main/java/org/sagebionetworks/bridge/services/UploadService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/UploadService.java
@@ -7,6 +7,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.sagebionetworks.bridge.BridgeConstants.API_APP_ID;
 import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
+import static org.sagebionetworks.bridge.BridgeConstants.CANNOT_BE_BLANK;
 
 import java.net.URL;
 import java.util.Date;
@@ -32,7 +33,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.dao.UploadDao;
@@ -245,14 +245,14 @@ public class UploadService {
      */
     public Upload getUpload(@Nonnull String uploadId) {
         if (Strings.isNullOrEmpty(uploadId)) {
-            throw new BadRequestException(String.format(Validate.CANNOT_BE_BLANK, "uploadId"));
+            throw new BadRequestException(String.format(CANNOT_BE_BLANK, "uploadId"));
         }
         return uploadDao.getUpload(uploadId);
     }
     
     public UploadView getUploadView(String uploadId) {
         if (Strings.isNullOrEmpty(uploadId)) {
-            throw new BadRequestException(String.format(Validate.CANNOT_BE_BLANK, "uploadId"));
+            throw new BadRequestException(String.format(CANNOT_BE_BLANK, "uploadId"));
         }
         Upload upload = uploadDao.getUpload(uploadId);
         return uploadToUploadView(upload, true);

--- a/src/main/java/org/sagebionetworks/bridge/validators/AdherenceRecordListValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/AdherenceRecordListValidator.java
@@ -3,13 +3,7 @@ package org.sagebionetworks.bridge.validators;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL;
-import static org.sagebionetworks.bridge.validators.Validate.CLIENT_TIME_ZONE_FIELD;
-import static org.sagebionetworks.bridge.validators.Validate.EVENT_TIMESTAMP_FIELD;
-import static org.sagebionetworks.bridge.validators.Validate.INSTANCE_GUID_FIELD;
-import static org.sagebionetworks.bridge.validators.Validate.STARTED_ON_FIELD;
-import static org.sagebionetworks.bridge.validators.Validate.STUDY_ID_FIELD;
-import static org.sagebionetworks.bridge.validators.Validate.TIME_ZONE_ERROR;
-import static org.sagebionetworks.bridge.validators.Validate.USER_ID_FIELD;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_TIME_ZONE;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.TEXT_SIZE;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.validateJsonLength;
 
@@ -24,6 +18,13 @@ public class AdherenceRecordListValidator extends AbstractValidator {
     
     public static final AdherenceRecordListValidator INSTANCE = new AdherenceRecordListValidator();
     
+    static final String CLIENT_TIME_ZONE_FIELD = "clientTimeZone";
+    static final String EVENT_TIMESTAMP_FIELD = "eventTimestamp";
+    static final String INSTANCE_GUID_FIELD = "instanceGuid";
+    static final String STARTED_ON_FIELD = "startedOn";
+    static final String STUDY_ID_FIELD = "studyId";
+    static final String USER_ID_FIELD = "userId";
+
     private AdherenceRecordListValidator() {}
 
     @Override
@@ -54,7 +55,7 @@ public class AdherenceRecordListValidator extends AbstractValidator {
                 try {
                     ZoneId.of(record.getClientTimeZone());
                 } catch (Exception e) {
-                    errors.rejectValue(CLIENT_TIME_ZONE_FIELD, TIME_ZONE_ERROR);
+                    errors.rejectValue(CLIENT_TIME_ZONE_FIELD, INVALID_TIME_ZONE);
                 }
             }
             validateJsonLength(errors, TEXT_SIZE,record.getClientData(), "clientData");

--- a/src/main/java/org/sagebionetworks/bridge/validators/AdherenceReportSearchValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/AdherenceReportSearchValidator.java
@@ -2,10 +2,6 @@ package org.sagebionetworks.bridge.validators;
 
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
-import static org.sagebionetworks.bridge.BridgeConstants.ADHERENCE_RANGE_ERROR;
-import static org.sagebionetworks.bridge.BridgeConstants.ADHERENCE_RANGE_ORDER_ERROR;
-import static org.sagebionetworks.bridge.BridgeConstants.LABEL_FILTER_COUNT_ERROR;
-import static org.sagebionetworks.bridge.BridgeConstants.LABEL_FILTER_LENGTH_ERROR;
 import static org.sagebionetworks.bridge.BridgeConstants.PAGE_SIZE_ERROR;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NEGATIVE;
 
@@ -18,6 +14,11 @@ import org.springframework.validation.Errors;
 public class AdherenceReportSearchValidator extends AbstractValidator {
     
     public static final AdherenceReportSearchValidator INSTANCE = new AdherenceReportSearchValidator();
+
+    static final String ADHERENCE_RANGE_ERROR = "% must be from 0-100";
+    static final String ADHERENCE_RANGE_ORDER_ERROR = "cannot be less than adherenceMin";
+    static final String LABEL_FILTER_COUNT_ERROR = "cannot have over 50 entries";
+    static final String LABEL_FILTER_LENGTH_ERROR = "cannot be over 100 characters";
 
     @Override
     public void validate(Object object, Errors errors) {

--- a/src/main/java/org/sagebionetworks/bridge/validators/AppConfigElementValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/AppConfigElementValidator.java
@@ -1,8 +1,8 @@
 package org.sagebionetworks.bridge.validators;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.sagebionetworks.bridge.validators.Validate.BRIDGE_EVENT_ID_ERROR;
 
-import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.models.appconfig.AppConfigElement;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
@@ -22,8 +22,8 @@ public class AppConfigElementValidator implements Validator {
         
         if (isBlank(appConfigElement.getId())) {
             errors.rejectValue("id", "is required");
-        } else if (!appConfigElement.getId().matches(BridgeConstants.BRIDGE_EVENT_ID_PATTERN)) {
-            errors.rejectValue("id", BridgeConstants.BRIDGE_EVENT_ID_ERROR);
+        } else if (!appConfigElement.getId().matches(Validate.BRIDGE_EVENT_ID_PATTERN)) {
+            errors.rejectValue("id", BRIDGE_EVENT_ID_ERROR);
         }
         if (appConfigElement.getRevision() == null) {
             errors.rejectValue("revision", "is required");

--- a/src/main/java/org/sagebionetworks/bridge/validators/AssessmentValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/AssessmentValidator.java
@@ -1,9 +1,9 @@
 package org.sagebionetworks.bridge.validators;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_EVENT_ID_ERROR;
-import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_EVENT_ID_PATTERN;
 import static org.sagebionetworks.bridge.BridgeConstants.SHARED_APP_ID;
+import static org.sagebionetworks.bridge.validators.Validate.BRIDGE_EVENT_ID_ERROR;
+import static org.sagebionetworks.bridge.validators.Validate.BRIDGE_EVENT_ID_PATTERN;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NEGATIVE;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.TEXT_SIZE;

--- a/src/main/java/org/sagebionetworks/bridge/validators/HealthDataDocumentationValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/HealthDataDocumentationValidator.java
@@ -14,6 +14,8 @@ public class HealthDataDocumentationValidator implements Validator {
     /** Singleton instance of this validator. */
     public static final HealthDataDocumentationValidator INSTANCE = new HealthDataDocumentationValidator();
 
+    static final String EXCEEDS_MAXIMUM_SIZE = "%s exceeds the maximum allowed size";
+
     /** {@inheritDoc} */
     @Override
     public boolean supports(Class<?> clazz) {
@@ -25,7 +27,7 @@ public class HealthDataDocumentationValidator implements Validator {
         if (object == null) {
             errors.rejectValue("HealthDataDocumentation", Validate.CANNOT_BE_NULL);
         } else if (!(object instanceof HealthDataDocumentation)) {
-            errors.rejectValue("HealthDataDocumentation", Validate.WRONG_TYPE);
+            errors.rejectValue("HealthDataDocumentation", Validate.INVALID_TYPE);
         } else {
             HealthDataDocumentation doc = (HealthDataDocumentation) object;
 
@@ -60,7 +62,7 @@ public class HealthDataDocumentationValidator implements Validator {
             } else if (StringUtils.isBlank(documentation)) {
                 errors.rejectValue("documentation", Validate.CANNOT_BE_EMPTY_STRING);
             } else if (documentation.getBytes(StandardCharsets.UTF_8).length > MAX_DOCUMENTATION_BYTES) {
-                errors.rejectValue("documentation", Validate.EXCEEDS_MAXIMUM_SIZE);
+                errors.rejectValue("documentation", EXCEEDS_MAXIMUM_SIZE);
             }
         }
     }

--- a/src/main/java/org/sagebionetworks/bridge/validators/HealthDataRecordEx3Validator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/HealthDataRecordEx3Validator.java
@@ -25,7 +25,7 @@ public class HealthDataRecordEx3Validator implements Validator {
         if (object == null) {
             errors.rejectValue("HealthDataRecordEx3", Validate.CANNOT_BE_NULL);
         } else if (!(object instanceof HealthDataRecordEx3)) {
-            errors.rejectValue("HealthDataRecordEx3", Validate.WRONG_TYPE);
+            errors.rejectValue("HealthDataRecordEx3", Validate.INVALID_TYPE);
         } else {
             HealthDataRecordEx3 record = (HealthDataRecordEx3) object;
 

--- a/src/main/java/org/sagebionetworks/bridge/validators/HealthDataRecordValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/HealthDataRecordValidator.java
@@ -48,7 +48,7 @@ public class HealthDataRecordValidator implements Validator {
         if (object == null) {
             errors.rejectValue("HealthDataRecord", Validate.CANNOT_BE_NULL);
         } else if (!(object instanceof HealthDataRecord)) {
-            errors.rejectValue("HealthDataRecord", Validate.WRONG_TYPE);
+            errors.rejectValue("HealthDataRecord", Validate.INVALID_TYPE);
         } else {
             HealthDataRecord record = (HealthDataRecord) object;
 
@@ -63,7 +63,7 @@ public class HealthDataRecordValidator implements Validator {
                 errors.rejectValue("data", Validate.CANNOT_BE_NULL);
             } else if (!data.isObject()) {
                 // We don't need to check isNull(). If it's null, then it's not an object.
-                errors.rejectValue("data", Validate.WRONG_TYPE);
+                errors.rejectValue("data", Validate.INVALID_TYPE);
             }
 
             // health code
@@ -83,7 +83,7 @@ public class HealthDataRecordValidator implements Validator {
                 errors.rejectValue("metadata", Validate.CANNOT_BE_NULL);
             } else if (!metadata.isObject()) {
                 // We don't need to check isNull(). If it's null, then it's not an object.
-                errors.rejectValue("metadata", Validate.WRONG_TYPE);
+                errors.rejectValue("metadata", Validate.INVALID_TYPE);
             }
 
             // If schema ID is specified, it can't be blank.

--- a/src/main/java/org/sagebionetworks/bridge/validators/OrganizationValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/OrganizationValidator.java
@@ -1,8 +1,8 @@
 package org.sagebionetworks.bridge.validators;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_IDENTIFIER_ERROR;
-import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_IDENTIFIER_PATTERN;
+import static org.sagebionetworks.bridge.validators.Validate.BRIDGE_IDENTIFIER_ERROR;
+import static org.sagebionetworks.bridge.validators.Validate.BRIDGE_IDENTIFIER_PATTERN;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.TEXT_SIZE;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.validateStringLength;

--- a/src/main/java/org/sagebionetworks/bridge/validators/ParticipantRosterRequestValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/ParticipantRosterRequestValidator.java
@@ -22,7 +22,7 @@ public class ParticipantRosterRequestValidator implements Validator {
         if (target == null) {
             errors.rejectValue("ParticipantRosterRequest", Validate.CANNOT_BE_NULL);
         } else if (!(target instanceof ParticipantRosterRequest)) {
-            errors.rejectValue("ParticipantRosterRequest", Validate.WRONG_TYPE);
+            errors.rejectValue("ParticipantRosterRequest", Validate.INVALID_TYPE);
         } else {
             ParticipantRosterRequest request = (ParticipantRosterRequest) target;
 
@@ -31,7 +31,7 @@ public class ParticipantRosterRequestValidator implements Validator {
                 errors.rejectValue("password", Validate.CANNOT_BE_BLANK);
             } else {
                 PasswordPolicy passwordPolicy = new PasswordPolicy(8, true, false, true, true);
-                ValidatorUtils.validatePassword(errors, passwordPolicy, request.getPassword());
+                ValidatorUtils.password(errors, passwordPolicy, request.getPassword());
             }
             if (isBlank(request.getStudyId())) {
                 errors.rejectValue("studyId", Validate.CANNOT_BE_BLANK);

--- a/src/main/java/org/sagebionetworks/bridge/validators/PasswordResetValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/PasswordResetValidator.java
@@ -46,6 +46,6 @@ public class PasswordResetValidator implements Validator {
         App app = appService.getApp(passwordReset.getAppId());
         PasswordPolicy passwordPolicy = app.getPasswordPolicy();
         String password = passwordReset.getPassword();
-        ValidatorUtils.validatePassword(errors, passwordPolicy, password);
+        ValidatorUtils.password(errors, passwordPolicy, password);
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/validators/RecordExportStatusRequestValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/RecordExportStatusRequestValidator.java
@@ -29,7 +29,7 @@ public class RecordExportStatusRequestValidator implements Validator {
         if (target == null) {
             errors.rejectValue("RecordExportStatusRequest", Validate.CANNOT_BE_NULL);
         } else if (!(target instanceof RecordExportStatusRequest)) {
-            errors.rejectValue("RecordExportStatusRequest", Validate.WRONG_TYPE);
+            errors.rejectValue("RecordExportStatusRequest", Validate.INVALID_TYPE);
         } else {
             RecordExportStatusRequest record = (RecordExportStatusRequest) target;
 

--- a/src/main/java/org/sagebionetworks/bridge/validators/ReportDataKeyValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/ReportDataKeyValidator.java
@@ -5,7 +5,8 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
-import org.sagebionetworks.bridge.BridgeConstants;
+import static org.sagebionetworks.bridge.validators.Validate.SYNAPSE_IDENTIFIER_PATTERN;
+
 import org.sagebionetworks.bridge.models.reports.ReportDataKey;
 import org.sagebionetworks.bridge.models.reports.ReportType;
 
@@ -34,7 +35,7 @@ public class ReportDataKeyValidator implements Validator {
         }
         if (isBlank(key.getIdentifier())) {
             errors.rejectValue("identifier", "cannot be missing or blank");
-        } else if (!key.getIdentifier().matches(BridgeConstants.SYNAPSE_IDENTIFIER_PATTERN)) {
+        } else if (!key.getIdentifier().matches(SYNAPSE_IDENTIFIER_PATTERN)) {
             errors.rejectValue("identifier", "can only contain letters, numbers, underscore and dash");
         }
     }

--- a/src/main/java/org/sagebionetworks/bridge/validators/Schedule2Validator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/Schedule2Validator.java
@@ -1,14 +1,14 @@
 package org.sagebionetworks.bridge.validators;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_RELAXED_ID_ERROR;
-import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_RELAXED_ID_PATTERN;
+import static org.sagebionetworks.bridge.BridgeUtils.periodInDays;
+import static org.sagebionetworks.bridge.BridgeUtils.periodInMinutes;
+import static org.sagebionetworks.bridge.validators.Validate.BRIDGE_RELAXED_ID_ERROR;
+import static org.sagebionetworks.bridge.validators.Validate.BRIDGE_RELAXED_ID_PATTERN;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_DUPLICATE;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.TEXT_SIZE;
-import static org.sagebionetworks.bridge.validators.ValidatorUtils.periodInDays;
-import static org.sagebionetworks.bridge.validators.ValidatorUtils.periodInMinutes;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.validateFixedLengthLongPeriod;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.validateJsonLength;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.validateStringLength;

--- a/src/main/java/org/sagebionetworks/bridge/validators/SessionValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/SessionValidator.java
@@ -1,15 +1,15 @@
 package org.sagebionetworks.bridge.validators;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_RELAXED_ID_ERROR;
-import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_RELAXED_ID_PATTERN;
+import static org.sagebionetworks.bridge.BridgeUtils.periodInMinutes;
+import static org.sagebionetworks.bridge.validators.Validate.BRIDGE_RELAXED_ID_ERROR;
+import static org.sagebionetworks.bridge.validators.Validate.BRIDGE_RELAXED_ID_PATTERN;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_DUPLICATE;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL_OR_EMPTY;
 import static org.sagebionetworks.bridge.validators.Validate.INVALID_EVENT_ID;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.TEXT_SIZE;
-import static org.sagebionetworks.bridge.validators.ValidatorUtils.periodInMinutes;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.validateColorScheme;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.validateFixedLengthLongPeriod;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.validateFixedLengthPeriod;
@@ -30,7 +30,6 @@ import org.joda.time.LocalTime;
 import org.joda.time.Period;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
-
 import org.sagebionetworks.bridge.models.schedules2.AssessmentReference;
 import org.sagebionetworks.bridge.models.schedules2.Notification;
 import org.sagebionetworks.bridge.models.schedules2.Session;

--- a/src/main/java/org/sagebionetworks/bridge/validators/StudyActivityEventValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/StudyActivityEventValidator.java
@@ -2,9 +2,8 @@ package org.sagebionetworks.bridge.validators;
 
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL;
-import static org.sagebionetworks.bridge.validators.Validate.CLIENT_TIME_ZONE_FIELD;
 import static org.sagebionetworks.bridge.validators.Validate.INVALID_EVENT_ID;
-import static org.sagebionetworks.bridge.validators.Validate.TIME_ZONE_ERROR;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_TIME_ZONE;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.validateStringLength;
 
 import java.time.ZoneId;
@@ -19,6 +18,8 @@ public class StudyActivityEventValidator extends AbstractValidator implements Va
 
     public static final StudyActivityEventValidator CREATE_INSTANCE = new StudyActivityEventValidator(true);
     public static final StudyActivityEventValidator DELETE_INSTANCE = new StudyActivityEventValidator(false);
+    
+    static final String CLIENT_TIME_ZONE_FIELD = "clientTimeZone";
     
     private final boolean createOnly;
     
@@ -54,7 +55,7 @@ public class StudyActivityEventValidator extends AbstractValidator implements Va
                 try {
                     ZoneId.of(event.getClientTimeZone());
                 } catch (Exception e) {
-                    errors.rejectValue(CLIENT_TIME_ZONE_FIELD, TIME_ZONE_ERROR);
+                    errors.rejectValue(StudyActivityEventValidator.CLIENT_TIME_ZONE_FIELD, INVALID_TIME_ZONE);
                 }
             }
         }

--- a/src/main/java/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
@@ -4,11 +4,11 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.sagebionetworks.bridge.AuthEvaluatorField.ORG_ID;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_MEMBERS;
-import static org.sagebionetworks.bridge.BridgeConstants.OWASP_REGEXP_VALID_EMAIL;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.INVALID_EMAIL_ERROR;
 import static org.sagebionetworks.bridge.validators.Validate.INVALID_PHONE_ERROR;
-import static org.sagebionetworks.bridge.validators.Validate.TIME_ZONE_ERROR;
+import static org.sagebionetworks.bridge.validators.Validate.OWASP_REGEXP_VALID_EMAIL;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_TIME_ZONE;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.TEXT_SIZE;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.validateJsonLength;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.validateStringLength;
@@ -83,7 +83,7 @@ public class StudyParticipantValidator implements Validator {
             String password = participant.getPassword();
             if (password != null) {
                 PasswordPolicy passwordPolicy = app.getPasswordPolicy();
-                ValidatorUtils.validatePassword(errors, passwordPolicy, password);
+                ValidatorUtils.password(errors, passwordPolicy, password);
             }
             
             // After account creation, organizational membership cannot be changed by updating an account
@@ -143,7 +143,7 @@ public class StudyParticipantValidator implements Validator {
             try {
                 ZoneId.of(participant.getClientTimeZone());
             } catch (DateTimeException e) {
-                errors.rejectValue("clientTimeZone", TIME_ZONE_ERROR);
+                errors.rejectValue("clientTimeZone", INVALID_TIME_ZONE);
             }
         }
         validateStringLength(errors, 255, participant.getEmail(), "email");

--- a/src/main/java/org/sagebionetworks/bridge/validators/StudyValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/StudyValidator.java
@@ -1,18 +1,18 @@
 package org.sagebionetworks.bridge.validators;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_EVENT_ID_ERROR;
-import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_EVENT_ID_PATTERN;
-import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_RELAXED_ID_ERROR;
-import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_RELAXED_ID_PATTERN;
-import static org.sagebionetworks.bridge.BridgeConstants.OWASP_REGEXP_VALID_EMAIL;
 import static org.sagebionetworks.bridge.BridgeUtils.COMMA_SPACE_JOINER;
 import static org.sagebionetworks.bridge.models.studies.IrbDecisionType.APPROVED;
+import static org.sagebionetworks.bridge.validators.Validate.BRIDGE_EVENT_ID_ERROR;
+import static org.sagebionetworks.bridge.validators.Validate.BRIDGE_EVENT_ID_PATTERN;
+import static org.sagebionetworks.bridge.validators.Validate.BRIDGE_RELAXED_ID_ERROR;
+import static org.sagebionetworks.bridge.validators.Validate.BRIDGE_RELAXED_ID_PATTERN;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL;
 import static org.sagebionetworks.bridge.validators.Validate.INVALID_EMAIL_ERROR;
 import static org.sagebionetworks.bridge.validators.Validate.INVALID_PHONE_ERROR;
-import static org.sagebionetworks.bridge.validators.Validate.TIME_ZONE_ERROR;
+import static org.sagebionetworks.bridge.validators.Validate.OWASP_REGEXP_VALID_EMAIL;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_TIME_ZONE;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.TEXT_SIZE;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.validateJsonLength;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.validateStringLength;
@@ -108,7 +108,7 @@ public class StudyValidator implements Validator {
             try {
                 ZoneId.of(study.getStudyTimeZone());
             } catch (DateTimeException e) {
-                errors.rejectValue(STUDY_TIME_ZONE_FIELD, TIME_ZONE_ERROR);
+                errors.rejectValue(STUDY_TIME_ZONE_FIELD, INVALID_TIME_ZONE);
             }
         }
         

--- a/src/main/java/org/sagebionetworks/bridge/validators/UploadValidationStatusValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/UploadValidationStatusValidator.java
@@ -29,7 +29,7 @@ public class UploadValidationStatusValidator implements Validator {
         if (target == null) {
             errors.rejectValue("uploadValidationStatus", Validate.CANNOT_BE_NULL);
         } else if (!(target instanceof UploadValidationStatus)) {
-            errors.rejectValue("uploadValidationStatus", Validate.WRONG_TYPE);
+            errors.rejectValue("uploadValidationStatus", Validate.INVALID_TYPE);
         } else {
             UploadValidationStatus validationStatus = (UploadValidationStatus) target;
 

--- a/src/main/java/org/sagebionetworks/bridge/validators/Validate.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/Validate.java
@@ -21,30 +21,46 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 public class Validate {
+    
+    // see https://owasp.org/www-community/OWASP_Validation_Regex_Repository
+    static final String OWASP_REGEXP_VALID_EMAIL = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$";
 
-    public static final String EVENT_TIMESTAMP_FIELD = "eventTimestamp";
-    public static final String STARTED_ON_FIELD = "startedOn";
-    public static final String INSTANCE_GUID_FIELD = "instanceGuid";
-    public static final String STUDY_ID_FIELD = "studyId";
-    public static final String USER_ID_FIELD = "userId";
-    public static final String CLIENT_TIME_ZONE_FIELD = "clientTimeZone";
+    /** A common string constraint Synapse places on model identifiers. */
+    static final String SYNAPSE_IDENTIFIER_PATTERN = "^[a-zA-Z0-9_-]+$";
     
-    public static final String CANNOT_BE_BLANK = "%s cannot be null or blank";
-    public static final String CANNOT_BE_DUPLICATE = "%s cannot duplicate an earlier value";
-    public static final String CANNOT_BE_EMPTY = "%s cannot be empty";
-    public static final String CANNOT_BE_EMPTY_STRING = "%s cannot be an empty string";
-    public static final String CANNOT_BE_NEGATIVE = "%s cannot be negative";
-    public static final String CANNOT_BE_NULL = "%s cannot be null";
-    public static final String CANNOT_BE_NULL_OR_EMPTY = "%s cannot be null or empty";
-    public static final String CANNOT_BE_ZERO_OR_NEGATIVE = "%s cannot be zero or negative";
-    public static final String WRONG_TYPE = "%s is the wrong type";
-    public static final String TIME_ZONE_ERROR = "is not a recognized IANA time zone name (eg. “America/Los_Angeles”)";
-    public static final String INVALID_EVENT_ID = "is not a valid custom event ID";
-    public static final String INVALID_EMAIL_ERROR = "does not appear to be an email address";
-    public static final String INVALID_PHONE_ERROR = "does not appear to be a phone number";
-    public static final String EXCEEDS_MAXIMUM_SIZE = "%s exceeds the maximum allowed size";
+    /** The pattern used to validate activity event keys and automatic custom event keys. */
+    static final String BRIDGE_EVENT_ID_PATTERN = "^[a-zA-Z0-9_-]+$";
     
-    public static Errors getErrorsFor(Object object) {
+    /** An identifier field that can contain spaces, some punctuation (but not colons) where it's infeasible 
+     * to include a separate label and unnecessary to restrict the string for external systems like Synapse. 
+     */
+    static final String BRIDGE_RELAXED_ID_PATTERN = "^[^:]+$";
+
+    /** A common string constraint we place on model identifiers. */
+    static final String BRIDGE_IDENTIFIER_PATTERN = "^[a-z0-9-]+$";
+
+    /** The pattern of a valid JavaScript variable/object property name. */
+    static final String JS_IDENTIFIER_PATTERN = "^[a-zA-Z0-9_][a-zA-Z0-9_-]*$";
+
+    static final String BRIDGE_EVENT_ID_ERROR = "must contain only lower- or upper-case letters, numbers, dashes, and/or underscores";
+    static final String BRIDGE_IDENTIFIER_ERROR = "must contain only lower-case letters and/or numbers with optional dashes";
+    static final String BRIDGE_RELAXED_ID_ERROR = "cannot contain colons";
+    
+    static final String CANNOT_BE_BLANK = "%s cannot be null or blank";
+    static final String CANNOT_BE_DUPLICATE = "cannot duplicate an earlier value";
+    static final String CANNOT_BE_EMPTY = "cannot be empty";
+    static final String CANNOT_BE_EMPTY_STRING = "cannot be an empty string";
+    static final String CANNOT_BE_NEGATIVE = "cannot be negative";
+    static final String CANNOT_BE_NULL = "%s cannot be null";
+    static final String CANNOT_BE_NULL_OR_EMPTY = "cannot be null or empty";
+    static final String CANNOT_BE_ZERO_OR_NEGATIVE = "cannot be zero or negative";
+    static final String INVALID_EMAIL_ERROR = "does not appear to be an email address";
+    static final String INVALID_EVENT_ID = "is not a valid custom event ID";
+    static final String INVALID_PHONE_ERROR = "does not appear to be a phone number";
+    static final String INVALID_TIME_ZONE = "is not a recognized IANA time zone name (eg. “America/Los_Angeles”)";
+    static final String INVALID_TYPE = "is the wrong type";
+
+    private static Errors getErrorsFor(Object object) {
         String entityName = BridgeUtils.getTypeName(object.getClass());
         return new MapBindingResult(Maps.newHashMap(), entityName);
     }
@@ -88,7 +104,7 @@ public class Validate {
         throwException(errors, (BridgeEntity)object);
     }
     
-    public static void entity(Validator validator, Errors errors, Object object) {
+    static void entity(Validator validator, Errors errors, Object object) {
         checkNotNull(validator);
         checkArgument(object instanceof BridgeEntity);
         checkArgument(validator.supports(object.getClass()), "Invalid validator");
@@ -97,7 +113,7 @@ public class Validate {
         
         validator.validate(object, errors);
     }
-    public static void throwException(Errors errors, BridgeEntity entity) {
+    static void throwException(Errors errors, BridgeEntity entity) {
         if (errors.hasErrors()) {
             String message = convertErrorToMessage(errors);
             Map<String,List<String>> map = convertErrorsToSimpleMap(errors);
@@ -105,7 +121,7 @@ public class Validate {
             throw new InvalidEntityException(entity, message, map);
         }
     }
-    public static Map<String,List<String>> convertErrorsToSimpleMap(Errors errors) {
+    static Map<String,List<String>> convertErrorsToSimpleMap(Errors errors) {
         Map<String,List<String>> map = Maps.newHashMap();
         
         if (errors.hasGlobalErrors()) {

--- a/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -9,6 +9,7 @@ import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
 import static org.sagebionetworks.bridge.TestConstants.EMAIL;
 import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
 import static org.sagebionetworks.bridge.TestConstants.PHONE;
+import static org.sagebionetworks.bridge.TestConstants.SYNAPSE_USER_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
@@ -46,6 +47,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.joda.time.LocalDateTime;
+import org.joda.time.Period;
 import org.jsoup.safety.Safelist;
 import org.mockito.Mockito;
 import org.testng.annotations.AfterMethod;
@@ -90,6 +92,71 @@ public class BridgeUtilsTest extends Mockito {
         RequestContext.set(NULL_INSTANCE);
     }
     
+    @Test
+    public void accountHasValidIdentifierValidEmail() {
+        Account account = Account.create();
+        account.setEmail(EMAIL);
+        assertTrue(BridgeUtils.hasValidIdentifier(account));
+    }
+
+    @Test
+    public void accountHasValidIdentifierValiPhone() {
+        Account account = Account.create();
+        account.setPhone(PHONE);
+        assertTrue(BridgeUtils.hasValidIdentifier(account));
+    }
+
+    @Test
+    public void accountHasValidIdentifierValidEnrollment() {
+        Account account = Account.create();
+        Enrollment en1 = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
+        Enrollment en2 = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID, "externalID");
+        account.setEnrollments(ImmutableSet.of(en1, en2));
+
+        assertTrue(BridgeUtils.hasValidIdentifier(account));
+    }
+
+    @Test
+    public void accountHasValidIdentifierValidSynapseUserId() {
+        Account account = Account.create();
+        account.setSynapseUserId(SYNAPSE_USER_ID);
+        assertTrue(BridgeUtils.hasValidIdentifier(account));
+    }
+
+    @Test
+    public void accountHasValidIdentifierInvalid() {
+        Account account = Account.create();
+        account.setEnrollments(null);
+        assertFalse(BridgeUtils.hasValidIdentifier(account));
+
+        account = Account.create();
+        Enrollment en1 = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
+        account.setEnrollments(ImmutableSet.of(en1));
+        assertFalse(BridgeUtils.hasValidIdentifier(account));
+
+        account = Account.create();
+        account.setEnrollments(ImmutableSet.of());
+        assertFalse(BridgeUtils.hasValidIdentifier(account));
+    }
+
+    @Test
+    public void periodInMinutes() {
+        Period period = Period.parse("P3W2DT10H14M"); // 33,734 minutes
+        assertEquals(BridgeUtils.periodInMinutes(period), 33734);
+
+        period = Period.parse("P0W0DT0H0M"); // 0 minutes
+        assertEquals(BridgeUtils.periodInMinutes(period), 0);
+    }
+
+    @Test
+    public void periodInDays() {
+        Period period = Period.parse("P3W2D"); // 23 days
+        assertEquals(BridgeUtils.periodInDays(period), 23);
+
+        period = Period.parse("P0W0DT24H"); // 1 days
+        assertEquals(BridgeUtils.periodInDays(period), 1);
+    }
+
     @Test
     public void generateUUID() {
         // create 20 UUIDs, they should all be unique.

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules/SimpleScheduleStrategyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules/SimpleScheduleStrategyTest.java
@@ -5,20 +5,18 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.springframework.validation.Errors;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
+import org.mockito.Mockito;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoSchedulePlan;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.apps.App;
 import org.sagebionetworks.bridge.time.DateUtils;
-import org.sagebionetworks.bridge.validators.Validate;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
@@ -30,7 +28,7 @@ import nl.jqno.equalsverifier.Warning;
 /**
  * Further tests for these strategy objects are in ScheduleStrategyTest.
  */
-public class SimpleScheduleStrategyTest {
+public class SimpleScheduleStrategyTest extends Mockito {
 
     private static final BridgeObjectMapper MAPPER = BridgeObjectMapper.get();
     private App app;
@@ -78,12 +76,11 @@ public class SimpleScheduleStrategyTest {
         SimpleScheduleStrategy strategy = new SimpleScheduleStrategy();
         strategy.setSchedule(TestUtils.getSchedule("A Schedule"));
         
-        Errors errors = Validate.getErrorsFor(plan);
-        strategy.validate(TestConstants.USER_DATA_GROUPS, TestConstants.USER_STUDY_IDS, taskIdentifiers, errors);
-        Map<String,List<String>> map = Validate.convertErrorsToSimpleMap(errors);
+        Errors mockErrors = mock(Errors.class);
+        strategy.validate(TestConstants.USER_DATA_GROUPS, TestConstants.USER_STUDY_IDS, taskIdentifiers, mockErrors);
         
-        List<String> errorMessages = map.get("schedule.expires");
-        assertEquals(errorMessages.get(0), "schedule.expires must be set if schedule repeats");
+        verify(mockErrors).pushNestedPath("schedule");
+        verify(mockErrors).rejectValue("expires", "must be set if schedule repeats");
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/StudyActivityEventServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/StudyActivityEventServiceTest.java
@@ -20,7 +20,6 @@ import static org.sagebionetworks.bridge.models.activities.ActivityEventUpdateTy
 import static org.sagebionetworks.bridge.services.StudyActivityEventService.CREATED_ON_FIELD;
 import static org.sagebionetworks.bridge.services.StudyActivityEventService.ENROLLMENT_FIELD;
 import static org.sagebionetworks.bridge.services.StudyActivityEventService.INSTALL_LINK_SENT_FIELD;
-import static org.sagebionetworks.bridge.validators.Validate.INVALID_EVENT_ID;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
@@ -157,18 +156,12 @@ public class StudyActivityEventServiceTest extends Mockito {
         verify(mockDao, never()).deleteEvent(any());
     }
     
-    @Test
+    @Test(expectedExceptions = InvalidEntityException.class)
     public void deleteEvent_eventInvalid() {
         // this is not a custom event. Object ID needs to be included or you
         // get (correctly) a validation error for not including an eventId.
         StudyActivityEvent originEvent = makeBuilder().withObjectType(CUSTOM).build();
-        
-        try {
-            service.deleteEvent(originEvent, false);
-            fail("should have thrown exception");
-        } catch(InvalidEntityException e) {
-            assertEquals(e.getErrors().get("eventId").get(0), "eventId " + INVALID_EVENT_ID);
-        }
+        service.deleteEvent(originEvent, false);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/validators/AdherenceRecordListValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/AdherenceRecordListValidatorTest.java
@@ -4,16 +4,16 @@ import static org.sagebionetworks.bridge.TestConstants.GUID;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 import static org.sagebionetworks.bridge.validators.ValidatorUtilsTest.getInvalidStringLengthMessage;
 import static org.sagebionetworks.bridge.validators.ValidatorUtilsTest.getExcessivelyLargeClientData;
+import static org.sagebionetworks.bridge.validators.AdherenceRecordListValidator.CLIENT_TIME_ZONE_FIELD;
+import static org.sagebionetworks.bridge.validators.AdherenceRecordListValidator.EVENT_TIMESTAMP_FIELD;
 import static org.sagebionetworks.bridge.validators.AdherenceRecordListValidator.INSTANCE;
+import static org.sagebionetworks.bridge.validators.AdherenceRecordListValidator.INSTANCE_GUID_FIELD;
+import static org.sagebionetworks.bridge.validators.AdherenceRecordListValidator.STARTED_ON_FIELD;
+import static org.sagebionetworks.bridge.validators.AdherenceRecordListValidator.STUDY_ID_FIELD;
+import static org.sagebionetworks.bridge.validators.AdherenceRecordListValidator.USER_ID_FIELD;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL;
-import static org.sagebionetworks.bridge.validators.Validate.CLIENT_TIME_ZONE_FIELD;
-import static org.sagebionetworks.bridge.validators.Validate.EVENT_TIMESTAMP_FIELD;
-import static org.sagebionetworks.bridge.validators.Validate.INSTANCE_GUID_FIELD;
-import static org.sagebionetworks.bridge.validators.Validate.STARTED_ON_FIELD;
-import static org.sagebionetworks.bridge.validators.Validate.STUDY_ID_FIELD;
-import static org.sagebionetworks.bridge.validators.Validate.TIME_ZONE_ERROR;
-import static org.sagebionetworks.bridge.validators.Validate.USER_ID_FIELD;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_TIME_ZONE;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.TEXT_SIZE;
 
 import com.google.common.collect.ImmutableList;
@@ -95,7 +95,7 @@ public class AdherenceRecordListValidatorTest extends Mockito {
     public void clientTimeZoneInvalid() {
         AdherenceRecord record = new AdherenceRecord();
         record.setClientTimeZone("East Coast/Arkam");
-        assertValidatorMessage(INSTANCE, asList(record), asField(CLIENT_TIME_ZONE_FIELD), TIME_ZONE_ERROR);
+        assertValidatorMessage(INSTANCE, asList(record), asField(CLIENT_TIME_ZONE_FIELD), INVALID_TIME_ZONE);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/validators/AdherenceReportSearchValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/AdherenceReportSearchValidatorTest.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.sagebionetworks.bridge.BridgeConstants.ADHERENCE_RANGE_ERROR;
-import static org.sagebionetworks.bridge.BridgeConstants.ADHERENCE_RANGE_ORDER_ERROR;
-import static org.sagebionetworks.bridge.BridgeConstants.LABEL_FILTER_COUNT_ERROR;
-import static org.sagebionetworks.bridge.BridgeConstants.LABEL_FILTER_LENGTH_ERROR;
 import static org.sagebionetworks.bridge.BridgeConstants.PAGE_SIZE_ERROR;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
+import static org.sagebionetworks.bridge.validators.AdherenceReportSearchValidator.ADHERENCE_RANGE_ERROR;
+import static org.sagebionetworks.bridge.validators.AdherenceReportSearchValidator.ADHERENCE_RANGE_ORDER_ERROR;
+import static org.sagebionetworks.bridge.validators.AdherenceReportSearchValidator.LABEL_FILTER_COUNT_ERROR;
+import static org.sagebionetworks.bridge.validators.AdherenceReportSearchValidator.LABEL_FILTER_LENGTH_ERROR;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NEGATIVE;
 

--- a/src/test/java/org/sagebionetworks/bridge/validators/AppConfigElementValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/AppConfigElementValidatorTest.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.validators;
 
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
+import static org.sagebionetworks.bridge.validators.Validate.BRIDGE_EVENT_ID_ERROR;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.models.appconfig.AppConfigElement;
 
@@ -36,7 +36,7 @@ public class AppConfigElementValidatorTest {
     @Test
     public void idInvalid() {
         element.setId("@bad");
-        assertValidatorMessage(VALIDATOR, element, "id", BridgeConstants.BRIDGE_EVENT_ID_ERROR);
+        assertValidatorMessage(VALIDATOR, element, "id", BRIDGE_EVENT_ID_ERROR);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/validators/AppValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/AppValidatorTest.java
@@ -2,6 +2,9 @@ package org.sagebionetworks.bridge.validators;
 
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventUpdateType.FUTURE_ONLY;
+import static org.sagebionetworks.bridge.validators.AppValidator.APP_LINK_MAX_LENGTH;
+import static org.sagebionetworks.bridge.validators.Validate.BRIDGE_EVENT_ID_ERROR;
+import static org.sagebionetworks.bridge.validators.Validate.BRIDGE_IDENTIFIER_ERROR;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,7 +17,6 @@ import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.TestUtils;
 import org.sagebionetworks.bridge.dynamodb.DynamoApp;
@@ -101,13 +103,13 @@ public class AppValidatorTest {
     @Test
     public void cannotCreateIdentifierWithUppercase() {
         app.setIdentifier("Test");
-        assertValidatorMessage(INSTANCE, app, "identifier", BridgeConstants.BRIDGE_IDENTIFIER_ERROR);
+        assertValidatorMessage(INSTANCE, app, "identifier", BRIDGE_IDENTIFIER_ERROR);
     }
 
     @Test
     public void cannotCreateInvalidIdentifierWithSpaces() {
         app.setIdentifier("test test");
-        assertValidatorMessage(INSTANCE, app, "identifier", BridgeConstants.BRIDGE_IDENTIFIER_ERROR);
+        assertValidatorMessage(INSTANCE, app, "identifier", BRIDGE_IDENTIFIER_ERROR);
     }
 
     @Test
@@ -127,7 +129,7 @@ public class AppValidatorTest {
         app.getCustomEvents().put("a-1", FUTURE_ONLY);
         app.getCustomEvents().put("b:2", FUTURE_ONLY);
         
-        assertValidatorMessage(INSTANCE, app, "customEvents", BridgeConstants.BRIDGE_EVENT_ID_ERROR);
+        assertValidatorMessage(INSTANCE, app, "customEvents", BRIDGE_EVENT_ID_ERROR);
     }
 
     @Test
@@ -135,7 +137,7 @@ public class AppValidatorTest {
         app.getCustomEvents().put("a-1", FUTURE_ONLY);
         app.getCustomEvents().put("b:2", FUTURE_ONLY);
         
-        assertValidatorMessage(INSTANCE, app, "customEvents", BridgeConstants.BRIDGE_EVENT_ID_ERROR);
+        assertValidatorMessage(INSTANCE, app, "customEvents", BRIDGE_EVENT_ID_ERROR);
     }
 
     @Test
@@ -540,13 +542,13 @@ public class AppValidatorTest {
     @Test
     public void installAppLinksCannotExceedSMSLength() {
         String msg = "";
-        for (int i = 0; i < BridgeConstants.APP_LINK_MAX_LENGTH; i++) {
+        for (int i = 0; i < APP_LINK_MAX_LENGTH; i++) {
             msg += "A";
         }
         msg += "A";
         app.getInstallLinks().put("foo", msg);
         assertValidatorMessage(INSTANCE, app, "installLinks", "cannot be longer than " +
-                BridgeConstants.APP_LINK_MAX_LENGTH + " characters");
+                APP_LINK_MAX_LENGTH + " characters");
     }
     
     @Test
@@ -579,7 +581,7 @@ public class AppValidatorTest {
     @Test
     public void invalidAutomaticCustomEventKey() {
         app.setAutomaticCustomEvents(ImmutableMap.of("@not-valid", "activities_retrieved:P-14D"));
-        assertValidatorMessage(INSTANCE, app, "automaticCustomEvents[@not-valid]", BridgeConstants.BRIDGE_EVENT_ID_ERROR);
+        assertValidatorMessage(INSTANCE, app, "automaticCustomEvents[@not-valid]", BRIDGE_EVENT_ID_ERROR);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/validators/AssessmentValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/AssessmentValidatorTest.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_EVENT_ID_ERROR;
 import static org.sagebionetworks.bridge.BridgeConstants.SHARED_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.IDENTIFIER;
 import static org.sagebionetworks.bridge.TestConstants.TEST_OWNER_ID;
@@ -8,6 +7,7 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 import static org.sagebionetworks.bridge.validators.ValidatorUtilsTest.generateStringOfLength;
 import static org.sagebionetworks.bridge.validators.ValidatorUtilsTest.getInvalidStringLengthMessage;
+import static org.sagebionetworks.bridge.validators.Validate.BRIDGE_EVENT_ID_ERROR;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NEGATIVE;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.DUPLICATE_LANG;

--- a/src/test/java/org/sagebionetworks/bridge/validators/OrganizationValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/OrganizationValidatorTest.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_IDENTIFIER_ERROR;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 import static org.sagebionetworks.bridge.validators.ValidatorUtilsTest.generateStringOfLength;
 import static org.sagebionetworks.bridge.validators.ValidatorUtilsTest.getInvalidStringLengthMessage;
 import static org.sagebionetworks.bridge.validators.OrganizationValidator.INSTANCE;
+import static org.sagebionetworks.bridge.validators.Validate.BRIDGE_IDENTIFIER_ERROR;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.TEXT_SIZE;
 

--- a/src/test/java/org/sagebionetworks/bridge/validators/Schedule2ValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/Schedule2ValidatorTest.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_RELAXED_ID_ERROR;
 import static org.sagebionetworks.bridge.TestUtils.assertValidatorMessage;
 import static org.sagebionetworks.bridge.validators.ValidatorUtilsTest.generateStringOfLength;
 import static org.sagebionetworks.bridge.validators.ValidatorUtilsTest.getExcessivelyLargeClientData;
@@ -28,6 +27,7 @@ import static org.sagebionetworks.bridge.validators.Schedule2Validator.OWNER_ID_
 import static org.sagebionetworks.bridge.validators.Schedule2Validator.SESSIONS_FIELD;
 import static org.sagebionetworks.bridge.validators.Schedule2Validator.STUDY_BURSTS_FIELD;
 import static org.sagebionetworks.bridge.validators.Schedule2Validator.UPDATE_TYPE_FIELD;
+import static org.sagebionetworks.bridge.validators.Validate.BRIDGE_RELAXED_ID_ERROR;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_DUPLICATE;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL;

--- a/src/test/java/org/sagebionetworks/bridge/validators/SessionValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/SessionValidatorTest.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_RELAXED_ID_ERROR;
 import static org.sagebionetworks.bridge.models.schedules2.SessionTest.createValidSession;
 import static org.sagebionetworks.bridge.TestConstants.SESSION_GUID_1;
 import static org.sagebionetworks.bridge.TestConstants.SESSION_GUID_2;
@@ -30,6 +29,7 @@ import static org.sagebionetworks.bridge.validators.SessionValidator.STUDY_BURST
 import static org.sagebionetworks.bridge.validators.SessionValidator.WINDOW_EXPIRATION_AFTER_SCHEDULE_DURATION;
 import static org.sagebionetworks.bridge.validators.SessionValidator.WINDOW_OVERLAPS_ERROR;
 import static org.sagebionetworks.bridge.validators.SessionValidator.WINDOW_SHORTER_THAN_DAY_ERROR;
+import static org.sagebionetworks.bridge.validators.Validate.BRIDGE_RELAXED_ID_ERROR;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_DUPLICATE;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL;

--- a/src/test/java/org/sagebionetworks/bridge/validators/StudyActivityEventValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/StudyActivityEventValidatorTest.java
@@ -14,7 +14,7 @@ import static org.sagebionetworks.bridge.validators.StudyActivityEventValidator.
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL;
 import static org.sagebionetworks.bridge.validators.Validate.INVALID_EVENT_ID;
-import static org.sagebionetworks.bridge.validators.Validate.TIME_ZONE_ERROR;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_TIME_ZONE;
 
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
@@ -102,7 +102,7 @@ public class StudyActivityEventValidatorTest extends Mockito {
     public void clientTimeZoneInvalid() {
         StudyActivityEvent.Builder builder = createBuilder();
         builder.withClientTimeZone("America/Europe");
-        assertValidatorMessage(CREATE_INSTANCE, builder.build(), "clientTimeZone", TIME_ZONE_ERROR);
+        assertValidatorMessage(CREATE_INSTANCE, builder.build(), "clientTimeZone", INVALID_TIME_ZONE);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/StudyParticipantValidatorTest.java
@@ -13,7 +13,7 @@ import static org.sagebionetworks.bridge.validators.ValidatorUtilsTest.getExcess
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.INVALID_EMAIL_ERROR;
 import static org.sagebionetworks.bridge.validators.Validate.INVALID_PHONE_ERROR;
-import static org.sagebionetworks.bridge.validators.Validate.TIME_ZONE_ERROR;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_TIME_ZONE;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.TEXT_SIZE;
 import static org.testng.Assert.assertNull;
 import static org.mockito.Mockito.when;
@@ -430,7 +430,7 @@ public class StudyParticipantValidatorTest {
     @Test
     public void validateInvalidClientTimeZoneFails() {
         validator = makeValidator(true);
-        assertValidatorMessage(validator, withClientTimeZone("Invalid/Time_Zone"), "clientTimeZone", TIME_ZONE_ERROR);
+        assertValidatorMessage(validator, withClientTimeZone("Invalid/Time_Zone"), "clientTimeZone", INVALID_TIME_ZONE);
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/StudyValidatorTest.java
@@ -1,7 +1,5 @@
 package org.sagebionetworks.bridge.validators;
 
-import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_EVENT_ID_ERROR;
-import static org.sagebionetworks.bridge.BridgeConstants.BRIDGE_RELAXED_ID_ERROR;
 import static org.sagebionetworks.bridge.TestConstants.EMAIL;
 import static org.sagebionetworks.bridge.TestConstants.PHONE;
 import static org.sagebionetworks.bridge.TestConstants.SCHEDULE_GUID;
@@ -17,11 +15,13 @@ import static org.sagebionetworks.bridge.models.studies.IrbDecisionType.APPROVED
 import static org.sagebionetworks.bridge.models.studies.IrbDecisionType.EXEMPT;
 import static org.sagebionetworks.bridge.models.studies.StudyPhase.DESIGN;
 import static org.sagebionetworks.bridge.validators.StudyValidator.*;
+import static org.sagebionetworks.bridge.validators.Validate.BRIDGE_EVENT_ID_ERROR;
+import static org.sagebionetworks.bridge.validators.Validate.BRIDGE_RELAXED_ID_ERROR;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL;
 import static org.sagebionetworks.bridge.validators.Validate.INVALID_EMAIL_ERROR;
 import static org.sagebionetworks.bridge.validators.Validate.INVALID_PHONE_ERROR;
-import static org.sagebionetworks.bridge.validators.Validate.TIME_ZONE_ERROR;
+import static org.sagebionetworks.bridge.validators.Validate.INVALID_TIME_ZONE;
 import static org.sagebionetworks.bridge.validators.Validate.entityThrowingException;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.TEXT_SIZE;
 
@@ -106,7 +106,7 @@ public class StudyValidatorTest {
     public void studyTimeZoneInvalid() {
         study = createStudy();
         study.setStudyTimeZone("America/Aspen");
-        assertValidatorMessage(validator, study, STUDY_TIME_ZONE_FIELD, TIME_ZONE_ERROR);
+        assertValidatorMessage(validator, study, STUDY_TIME_ZONE_FIELD, INVALID_TIME_ZONE);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/validators/ValidateTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/ValidateTest.java
@@ -7,12 +7,12 @@ import java.util.Map;
 
 import com.google.common.collect.Maps;
 
+import org.mockito.Mockito;
 import org.springframework.validation.Errors;
 import org.springframework.validation.MapBindingResult;
 import org.testng.annotations.Test;
 
-public class ValidateTest {
-    
+public class ValidateTest extends Mockito {
     @Test
     public void rejectValueDifferentFormattedErrorMessages() {
         Errors errors = getErrors();

--- a/src/test/java/org/sagebionetworks/bridge/validators/ValidatorUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/ValidatorUtilsTest.java
@@ -3,24 +3,20 @@ package org.sagebionetworks.bridge.validators;
 import static org.sagebionetworks.bridge.TestConstants.EMAIL;
 import static org.sagebionetworks.bridge.TestConstants.PHONE;
 import static org.sagebionetworks.bridge.TestConstants.SYNAPSE_USER_ID;
-import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
-import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
-import static org.sagebionetworks.bridge.validators.ValidatorUtils.TEXT_SIZE;
 import static org.sagebionetworks.bridge.models.apps.PasswordPolicy.DEFAULT_PASSWORD_POLICY;
-import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.DUPLICATE_LANG;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.INVALID_HEX_TRIPLET;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.INVALID_LANG;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.INVALID_STRING_LENGTH;
+import static org.sagebionetworks.bridge.validators.ValidatorUtils.TEXT_SIZE;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.WRONG_LONG_PERIOD;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.WRONG_PERIOD;
+import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NEGATIVE;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.validateFixedLengthLongPeriod;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.validateFixedLengthPeriod;
-import static org.sagebionetworks.bridge.validators.ValidatorUtils.validatePassword;
-import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -30,7 +26,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -42,12 +37,10 @@ import org.springframework.validation.Errors;
 import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.models.Label;
-import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.apps.PasswordPolicy;
 import org.sagebionetworks.bridge.models.assessments.ColorScheme;
 import org.sagebionetworks.bridge.models.notifications.NotificationMessage;
-import org.sagebionetworks.bridge.models.studies.Enrollment;
 
 public class ValidatorUtilsTest extends Mockito {
     
@@ -97,53 +90,6 @@ public class ValidatorUtilsTest extends Mockito {
 
         participant = new StudyParticipant.Builder().build();
         assertFalse(ValidatorUtils.participantHasValidIdentifier(participant));
-    }
-
-    @Test
-    public void accountHasValidIdentifierValidEmail() {
-        Account account = Account.create();
-        account.setEmail(EMAIL);
-        assertTrue(ValidatorUtils.accountHasValidIdentifier(account));
-    }
-
-    @Test
-    public void accountHasValidIdentifierValiPhone() {
-        Account account = Account.create();
-        account.setPhone(PHONE);
-        assertTrue(ValidatorUtils.accountHasValidIdentifier(account));
-    }
-
-    @Test
-    public void accountHasValidIdentifierValidEnrollment() {
-        Account account = Account.create();
-        Enrollment en1 = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
-        Enrollment en2 = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID, "externalID");
-        account.setEnrollments(ImmutableSet.of(en1, en2));
-
-        assertTrue(ValidatorUtils.accountHasValidIdentifier(account));
-    }
-
-    @Test
-    public void accountHasValidIdentifierValidSynapseUserId() {
-        Account account = Account.create();
-        account.setSynapseUserId(SYNAPSE_USER_ID);
-        assertTrue(ValidatorUtils.accountHasValidIdentifier(account));
-    }
-
-    @Test
-    public void accountHasValidIdentifierInvalid() {
-        Account account = Account.create();
-        account.setEnrollments(null);
-        assertFalse(ValidatorUtils.accountHasValidIdentifier(account));
-
-        account = Account.create();
-        Enrollment en1 = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
-        account.setEnrollments(ImmutableSet.of(en1));
-        assertFalse(ValidatorUtils.accountHasValidIdentifier(account));
-
-        account = Account.create();
-        account.setEnrollments(ImmutableSet.of());
-        assertFalse(ValidatorUtils.accountHasValidIdentifier(account));
     }
 
     @Test
@@ -420,80 +366,6 @@ public class ValidatorUtilsTest extends Mockito {
     }
 
     @Test
-    public void periodInMinutes() {
-        Period period = Period.parse("P3W2DT10H14M"); // 33,734 minutes
-        assertEquals(ValidatorUtils.periodInMinutes(period), 33734);
-
-        period = Period.parse("P0W0DT0H0M"); // 0 minutes
-        assertEquals(ValidatorUtils.periodInMinutes(period), 0);
-    }
-
-    @Test
-    public void periodInDays() {
-        Period period = Period.parse("P3W2D"); // 23 days
-        assertEquals(ValidatorUtils.periodInDays(period), 23);
-
-        period = Period.parse("P0W0DT24H"); // 1 days
-        assertEquals(ValidatorUtils.periodInDays(period), 1);
-    }
-
-    @Test
-    public void validatePassword_isBlank() {
-        Errors errors = mock(Errors.class);
-        validatePassword(errors, DEFAULT_PASSWORD_POLICY, "");
-        verify(errors).rejectValue("password", "is required");
-    }
-
-    @Test
-    public void validatePassword_nothingRequired() {
-        Errors errors = mock(Errors.class);
-        PasswordPolicy policy = new PasswordPolicy(0, false, false, false, false);
-        validatePassword(errors, policy, "m");
-        verify(errors, never()).rejectValue(any(), any());
-    }
-
-    @Test
-    public void validatePassword_minLength() {
-        Errors errors = mock(Errors.class);
-        PasswordPolicy policy = new PasswordPolicy(2, false, false, false, false);
-        validatePassword(errors, policy, "m");
-        verify(errors).rejectValue("password", "must be at least 2 characters");
-    }
-
-    @Test
-    public void validatePassword_numericRequired() {
-        Errors errors = mock(Errors.class);
-        PasswordPolicy policy = new PasswordPolicy(0, true, false, false, false);
-        validatePassword(errors, policy, "m");
-        verify(errors).rejectValue("password", "must contain at least one number (0-9)");
-    }
-
-    @Test
-    public void validatePassword_symbolRequired() {
-        Errors errors = mock(Errors.class);
-        PasswordPolicy policy = new PasswordPolicy(0, false, true, false, false);
-        validatePassword(errors, policy, "m");
-        verify(errors).rejectValue("password",
-                "must contain at least one symbol ( !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~ )");
-    }
-
-    @Test
-    public void validatePassword_lowercaseRequired() {
-        Errors errors = mock(Errors.class);
-        PasswordPolicy policy = new PasswordPolicy(0, false, false, true, false);
-        validatePassword(errors, policy, "M");
-        verify(errors).rejectValue("password", "must contain at least one lowercase letter (a-z)");
-    }
-
-    @Test
-    public void validatePassword_uppercaseRequired() {
-        Errors errors = mock(Errors.class);
-        PasswordPolicy policy = new PasswordPolicy(0, false, false, false, true);
-        validatePassword(errors, policy, "2");
-        verify(errors).rejectValue("password", "must contain at least one uppercase letter (A-Z)");
-    }
-
-    @Test
     public void messagesValid() {
         List<NotificationMessage> messages = ImmutableList.of(
                 new NotificationMessage.Builder().withLang("en").withSubject("subject").withMessage("message").build(),
@@ -722,5 +594,61 @@ public class ValidatorUtilsTest extends Mockito {
         ValidatorUtils.validateJsonLength(errors, TEXT_SIZE, null, "testFieldName");
     
         verify(errors, never()).rejectValue(any(), any());
+    }
+
+    @Test
+    public void validatePassword_isBlank() {
+        Errors errors = mock(Errors.class);
+        ValidatorUtils.password(errors, DEFAULT_PASSWORD_POLICY, "");
+        verify(errors).rejectValue("password", "is required");
+    }
+
+    @Test
+    public void validatePassword_nothingRequired() {
+        Errors errors = mock(Errors.class);
+        PasswordPolicy policy = new PasswordPolicy(0, false, false, false, false);
+        ValidatorUtils.password(errors, policy, "m");
+        verify(errors, never()).rejectValue(any(), any());
+    }
+
+    @Test
+    public void validatePassword_minLength() {
+        Errors errors = mock(Errors.class);
+        PasswordPolicy policy = new PasswordPolicy(2, false, false, false, false);
+        ValidatorUtils.password(errors, policy, "m");
+        verify(errors).rejectValue("password", "must be at least 2 characters");
+    }
+
+    @Test
+    public void validatePassword_numericRequired() {
+        Errors errors = mock(Errors.class);
+        PasswordPolicy policy = new PasswordPolicy(0, true, false, false, false);
+        ValidatorUtils.password(errors, policy, "m");
+        verify(errors).rejectValue("password", "must contain at least one number (0-9)");
+    }
+
+    @Test
+    public void validatePassword_symbolRequired() {
+        Errors errors = mock(Errors.class);
+        PasswordPolicy policy = new PasswordPolicy(0, false, true, false, false);
+        ValidatorUtils.password(errors, policy, "m");
+        verify(errors).rejectValue("password",
+                "must contain at least one symbol ( !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~ )");
+    }
+
+    @Test
+    public void validatePassword_lowercaseRequired() {
+        Errors errors = mock(Errors.class);
+        PasswordPolicy policy = new PasswordPolicy(0, false, false, true, false);
+        ValidatorUtils.password(errors, policy, "M");
+        verify(errors).rejectValue("password", "must contain at least one lowercase letter (a-z)");
+    }
+
+    @Test
+    public void validatePassword_uppercaseRequired() {
+        Errors errors = mock(Errors.class);
+        PasswordPolicy policy = new PasswordPolicy(0, false, false, false, true);
+        ValidatorUtils.password(errors, policy, "2");
+        verify(errors).rejectValue("password", "must contain at least one uppercase letter (A-Z)");
     }
 }


### PR DESCRIPTION
I realized with recent work I was making validator stuff even messier by putting constants into BridgeConstants, and was motivated to do a cleanup.

- **Validate** now only exposes two methods, entityThrowingException and nonEntityThrowingException. Rewrote some older tests so they no longer depend on Validate's internal methods;
- **ValidatorUtils** is now package private and all its utilities are available to validators only. One or two methods were moved to BridgeUtils that were less about validation and more about checking state;
- Moved a lot of constants that had crept into BridgeConstants back to their validators or, if they were used across validators, to Validate which already had some similar constants;
- Removed the presence of "%s" from the errors as the validator utilities don't require it, and removed a lot of places where we were referencing these constants for checkNull() - we don't need the message in these precondition assertions, they are there for developers and it's always clear from the stack trace what is wrong.
- AppAndUsers validation was a bit of a mess so I cleaned it up (this was required to hide Validate's implementation details, and a prime example of why this refactor should help down the road);

None of this changes any API; all unit tests pass and integration tests pass without modification.