### PR TITLE
BRIDGE-3174 Update Server2 to Corretto

### DIFF
--- a/ebextensions/ignore-4xx.config
+++ b/ebextensions/ignore-4xx.config
@@ -1,5 +1,0 @@
-container_commands:
-  01-patch-healthd:
-    command: "sudo /bin/sed -i 's/\\# normalize units to seconds with millisecond resolution/if status \\&\\& status.index(\"4\") == 0 then next end/g' /opt/elasticbeanstalk/lib/ruby/lib/ruby/gems/2.2.0/gems/healthd-appstat-1.0.1/lib/healthd-appstat/plugin.rb"
-  02-restart-healthd:
-    command: "sudo /bin/kill $(sudo /bin/ps aux | /bin/grep -e '/bin/bash -c healthd' | /bin/grep -v 'grep' | /usr/bin/awk '{ print $2 }')"

--- a/ebextensions/newrelic-server.config
+++ b/ebextensions/newrelic-server.config
@@ -9,9 +9,9 @@ container_commands:
   "02SetNRServerInstanceId":
     command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo hostname=$INSTANCE_ID && echo hostname=$INSTANCE_ID >> /etc/newrelic/nrsysmond.cfg"
   "03CopyNRApmAgent":
-    command: "/bin/mkdir -p /usr/local/lib/newrelic && cp -rf /tmp/deployment/application/ROOT/WEB-INF/lib/newrelic-agent-4.8.0.jar /usr/local/lib/newrelic/newrelic-agent.jar"
+    command: "/bin/mkdir -p /usr/local/lib/newrelic && cp -rf /var/app/staging/WEB-INF/lib/newrelic-agent-4.8.0.jar /usr/local/lib/newrelic/newrelic-agent.jar"
   "04CopyNRConfig":
-    command: "cp -rf /tmp/deployment/application/ROOT/WEB-INF/classes/newrelic.yml /etc/newrelic.yml"
+    command: "cp -rf /var/app/staging/WEB-INF/classes/newrelic.yml /etc/newrelic.yml"
   "05SetNRLicenseKey":
     command: "echo -e \"\n  license_key: $NEW_RELIC_LICENSE_KEY\" >> /etc/newrelic.yml"
   "06SetNRAppName":
@@ -22,7 +22,7 @@ container_commands:
     command: "/etc/init.d/newrelic-sysmond start"
 # Setup NR infrastructure agent config
   "10CopyNRInfraConfig":
-    command: "cp -rf /tmp/deployment/application/ROOT/WEB-INF/classes/newrelic-infra.yml /etc/newrelic-infra.yml"
+    command: "cp -rf /var/app/staging/WEB-INF/classes/newrelic-infra.yml /etc/newrelic-infra.yml"
   "11SetNRInfraLicenseKey":
     command: "echo -e \"license_key: $NEW_RELIC_LICENSE_KEY\" >> /etc/newrelic-infra.yml"
   "12SetNRInfraDisplayName":

--- a/ebextensions/tomcatlogs.config
+++ b/ebextensions/tomcatlogs.config
@@ -29,8 +29,8 @@ files:
       log_stream_name={instance_id}
       file=/var/log/eb-activity.log*
 
-      [/var/log/tomcat/catalina.out]
-      log_group_name=`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/log/tomcat/catalina.out"]]}`
+      [/var/log/tomcat8/catalina.out]
+      log_group_name=`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/log/tomcat8/catalina.out"]]}`
       log_stream_name={instance_id}
       file=/var/log/tomcat/catalina.out*
 

--- a/ebextensions/tomcatlogs.config
+++ b/ebextensions/tomcatlogs.config
@@ -3,7 +3,7 @@
 #### the Log Stream name as the instance id. The following files are examples of logs that will be
 #### streamed to CloudWatch Logs in near real time:
 ####
-#### /var/log/tomcat8/catalina.out
+#### /var/log/tomcat/catalina.out
 ####
 #### You can then access the CloudWatch Logs by accessing the AWS CloudWatch Console and clicking
 #### the "Logs" link on the left. The Log Group name will follow this format:
@@ -13,6 +13,10 @@
 #### Please note this configuration can be used additionally to the "Log Streaming" feature:
 #### http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.cloudwatchlogs.html
 ###################################################################################################
+
+packages:
+  yum:
+    awslogs: []
 
 files:
   "/etc/awslogs/config/beanstalklogs.conf" :
@@ -25,10 +29,23 @@ files:
       log_stream_name={instance_id}
       file=/var/log/eb-activity.log*
 
-      [/var/log/tomcat8/catalina.out]
-      log_group_name=`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/log/tomcat8/catalina.out"]]}`
+      [/var/log/tomcat/catalina.out]
+      log_group_name=`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/log/tomcat/catalina.out"]]}`
       log_stream_name={instance_id}
-      file=/var/log/tomcat8/catalina.out*
+      file=/var/log/tomcat/catalina.out*
+
+  "/etc/rsyslog.d/catalina.conf":
+    mode: "0644"
+    owner: root
+    group: root
+    content: |
+      #redirect tomcat logs to /var/log/tomcat/catalina.out discarding timestamps since the messages already have them
+      template(name="catalinalog" type="string"
+          string="%msg%\n")
+      if $programname  == 'server' then {
+        *.=warning;*.=err;*.=crit;*.=alert;*.=emerg /var/log/tomcat/catalina.out;catalinalog
+        *.=info;*.=notice /var/log/tomcat/catalina.out;catalinalog
+       }
 
 commands:
   "01_rm_old_confs":
@@ -36,5 +53,16 @@ commands:
     cwd: "/etc/awslogs/config"
     ignoreErrors: true
 
-  "02_restart_awslogs":
-    command: service awslogs restart
+  "02a_systemctl_start_awslogsd":
+    command: systemctl start awslogsd
+    ignoreErrors: true
+
+  "02b_systemctl_enable_awslogsd_service":
+    command: systemctl enable awslogsd.service
+    ignoreErrors: true
+
+  "02c_restart_awslogs":
+    command: service awslogsd restart
+
+  "03_restart_rsyslog":
+    command: systemctl restart rsyslog


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-3174

Updating the Elastic Beanstalk stack from Java 8 to Corretto 8 as Java 8 is no longer being supported by Elastic Beanstalk. This also updates to Amazon Linux 2, which requires a few changes with our configs and ebextensions.

For Server2, the configs for Elastic Beanstalk to ignore 4XX errors in the health checks was moved from ebextensions to an Elastic Beanstalk environment attribute. Also, I needed to change some file paths and change some logging configs to get catalina.out to show up in CloudWatch and SumoLogic.

This was tested on the Development stack.

Note: This requires infra changes (see also https://github.com/Sage-Bionetworks/BridgeServer2-infra/pull/52) or else Bridge will fail to boot. Given this, I want to deploy this as a separate deployment Thursday night, after our regular deployment, in order to minimize risk.