### PR TITLE
Use personal access token (BRIDGE-3189)

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/config/SpringConfig.java
+++ b/src/main/java/org/sagebionetworks/bridge/config/SpringConfig.java
@@ -749,8 +749,7 @@ public class SpringConfig {
         Config config = bridgeConfig();
 
         SynapseClient synapseClient = new SynapseAdminClientImpl();
-        synapseClient.setUsername(config.get("synapse.user"));
-        synapseClient.setApiKey(config.get("synapse.api.key"));
+        synapseClient.setBearerAuthorizationToken(config.get("synapse.access.token"));
         setSynapseEndpoint(synapseClient, config);
         return synapseClient;
     }
@@ -760,8 +759,7 @@ public class SpringConfig {
         Config config = bridgeConfig();
 
         SynapseClient synapseClient = new SynapseAdminClientImpl();
-        synapseClient.setUsername(config.get("exporter.synapse.user"));
-        synapseClient.setApiKey(config.get("exporter.synapse.api.key"));
+        synapseClient.setBearerAuthorizationToken(config.get("exporter.synapse.access.token"));
         setSynapseEndpoint(synapseClient, config);
         return synapseClient;
     }

--- a/src/main/resources/BridgeServer2.conf
+++ b/src/main/resources/BridgeServer2.conf
@@ -19,7 +19,7 @@ channel.throttle.timeout.seconds = 300
 ses.notification.topic.arn = arn:aws:sns:us-east-1:649232250620:SNSBounces
 
 synapse.user = yours-synapse-user
-synapse.api.key = yours-synapse-api-key
+synapse.access.token = your-synapse-access-token
 
 synapse.aws.account.id = 449435941126
 prod.synapse.aws.account.id = 325565585839
@@ -28,7 +28,7 @@ synapse.endpoint = https://repo-dev.dev.sagebase.org/
 prod.synapse.endpoint = https://repo-prod.prod.sagebase.org/
 
 exporter.synapse.user = your-exporter-synapse-user
-exporter.synapse.api.key = your-exporter-synapse-api-key
+exporter.synapse.access.token = your-exporter-synapse-access-token
 
 exporter.synapse.id = 3336429
 prod.exporter.synapse.id = 3325672


### PR DESCRIPTION
Before this can be deployed, the Jenkins configuration and the AWS parameter store must be updated with the personal access token value (in each environment before this is deployed there).