### PR TITLE
BRIDGE-3259 EX3 Permissions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>bridge-base</artifactId>
-            <version>2.7.33</version>
+            <version>2.7.34</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/resources/BridgeServer2.conf
+++ b/src/main/resources/BridgeServer2.conf
@@ -81,6 +81,12 @@ local.webservices.url = http://localhost:9000
 
 route53.zone = ZP0HNVK1V670D
 
+# Synapse accounts, used by Bridge when creating Synapse projects.
+admin.synapse.id =
+downstream.etl.synapse.id =
+prod.admin.synapse.id = 3323830
+prod.downstream.etl.synapse.id = 3432808
+
 # Synapse Team IDs, used by the BridgeStudyCreator when creating Synapse projects.
 team.bridge.admin = 3336438
 team.bridge.staff = 3336437


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-3259

Requires https://github.com/Sage-Bionetworks/bridge-base/pull/80

Note that we are currently unable to create additional test accounts in Synapse Dev, so we're unable to actually test these changes. I did test that dev doesn't break with these changes, but we won't be able to test the functionality except in Prod.

Will discuss whether we should push forward with these changes to unblock Downstream ETL, or if we should block until Synapse Team helps us create test accounts in Dev.