### PR TITLE
Allowing clientTimeZone to be submitted when requesting the participant schedule (BRIDGE-3258)

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/BridgeUtils.java
@@ -22,6 +22,8 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.spec.InvalidKeySpecException;
+import java.time.DateTimeException;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -122,6 +124,18 @@ public class BridgeUtils {
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
     private static final StudyAssociations NO_ASSOCIATIONS = new StudyAssociations(ImmutableSet.of(),
             ImmutableMap.of());
+    
+    public static boolean isValidTimeZoneID(String timeZoneId, boolean required) {
+        if (timeZoneId != null) {
+            try {
+                ZoneId.of(timeZoneId);
+                return true;
+            } catch (DateTimeException e) {
+                return false;
+            }
+        }
+        return !required;
+    }
     
     public static String hashCredential(PasswordAlgorithm algorithm, String type, String value) {
         try {

--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/study/StudyAdherenceReportGenerator.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/study/StudyAdherenceReportGenerator.java
@@ -20,7 +20,6 @@ import java.util.TreeMap;
 import org.joda.time.DateTime;
 import org.joda.time.Days;
 import org.joda.time.LocalDate;
-import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.DateRange;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceState;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceUtils;
@@ -33,7 +32,6 @@ import org.sagebionetworks.bridge.models.schedules2.adherence.eventstream.EventS
 import org.sagebionetworks.bridge.models.schedules2.adherence.weekly.NextActivity;
 import org.sagebionetworks.bridge.models.schedules2.adherence.weekly.WeeklyAdherenceReportRow;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 

--- a/src/main/java/org/sagebionetworks/bridge/services/SessionUpdateService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/SessionUpdateService.java
@@ -47,6 +47,11 @@ public class SessionUpdateService {
         cacheProvider.setUserSession(session);
     }
     
+    public void updateClientTimeZone(UserSession session, String clientTimeZone) {
+        session.setParticipant(builder(session).withClientTimeZone(clientTimeZone).build());
+        cacheProvider.setUserSession(session);
+    }
+    
     public void updateApp(UserSession session, String appId) {
         session.setAppId(appId);
         cacheProvider.setUserSession(session);

--- a/src/main/java/org/sagebionetworks/bridge/services/UserAdminService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/UserAdminService.java
@@ -7,7 +7,8 @@ import static org.sagebionetworks.bridge.models.accounts.SharingScope.NO_SHARING
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
-
+import org.joda.time.DateTimeZone;
+import org.sagebionetworks.bridge.cache.CacheKey;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.time.DateUtils;
@@ -19,6 +20,7 @@ import org.sagebionetworks.bridge.models.accounts.IdentifierHolder;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.activities.StudyActivityEvent;
 import org.sagebionetworks.bridge.models.apps.App;
 import org.sagebionetworks.bridge.models.subpopulations.ConsentSignature;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
@@ -199,8 +201,8 @@ public class UserAdminService {
         if (account != null) {
             // remove this first so if account is partially deleted, re-authenticating will pick
             // up accurate information about the state of the account (as we can recover it)
-            cacheProvider.removeSessionByUserId(account.getId());
-            requestInfoService.removeRequestInfo(account.getId());
+            cacheProvider.removeSessionByUserId(id);
+            requestInfoService.removeRequestInfo(id);
             
             String healthCode = account.getHealthCode();
             healthDataService.deleteRecordsForHealthCode(healthCode);
@@ -212,6 +214,10 @@ public class UserAdminService {
             // AccountSecret records and Enrollment records are are deleted on a 
             // cascading delete from Account
             accountService.deleteAccount(accountId);
+            
+            // Remove known etag cache keys for this user
+            cacheProvider.removeObject( CacheKey.etag(DateTimeZone.class, id) );
+            cacheProvider.removeObject( CacheKey.etag(StudyActivityEvent.class, id) );
         }
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
@@ -156,7 +156,7 @@ public class ParticipantController extends BaseController {
         // usage pattern in prior APIs and it will make refactoring to use this API easier.
         JsonNode node = parseJson(JsonNode.class);
         Set<String> fieldNames = Sets.newHashSet(node.fieldNames());
-
+        
         StudyParticipant participant = parseJson(node, StudyParticipant.class);
         StudyParticipant existing = participantService.getParticipant(app, session.getId(), false);
         StudyParticipant.Builder builder = new StudyParticipant.Builder()

--- a/src/main/java/org/sagebionetworks/bridge/spring/util/EtagCacheKey.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/util/EtagCacheKey.java
@@ -14,4 +14,13 @@ public @interface EtagCacheKey {
      * known in the controller, and what we know when objects are being modified in the service.
      */
     String[] keys();
+    
+    /**
+     * If a query parameter name is given for this attribute, a change in that value from the 
+     * persisted value on the server should invalidate the request (no 304 can be returned, 
+     * although the call should update the value, so a correct etag can be calculated and 
+     * returned to the caller after the controller method returns). The only field currently 
+     * supported in this array is “clientTimeZone”. 
+     */
+    String invalidateCacheOnChange() default "";
 }

--- a/src/main/java/org/sagebionetworks/bridge/spring/util/EtagComponent.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/util/EtagComponent.java
@@ -184,14 +184,14 @@ public class EtagComponent {
                         + ", invalidating cache");
                 cacheProvider.removeObject(cacheKey);
             }
-        }                
+        }
     }
     
     private String getCurrentValue(UserSession session, String fieldName) {
         if (CLIENT_TIME_ZONE_FIELD.equals(fieldName)) {
             return session.getParticipant().getClientTimeZone();
         }
-        return null;
+        throw new IllegalArgumentException(fieldName + " is not a query parameter supported by invalidateCacheOnChange");
     }
     
     private String getValue(EtagContext context, UserSession session, String fieldName) {

--- a/src/main/java/org/sagebionetworks/bridge/spring/util/EtagComponent.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/util/EtagComponent.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
@@ -43,8 +44,10 @@ import com.google.common.net.HttpHeaders;
 @Aspect
 @Component
 public class EtagComponent {
+
     private static final Logger LOG = LoggerFactory.getLogger(EtagComponent.class);
     
+    private static final String CLIENT_TIME_ZONE_FIELD = "clientTimeZone";
     private static final String NO_VALUE_ERROR = "EtagSupport: no value for key: ";
     private static final String ORG_ID_FIELD = "orgId";
     private static final String USER_ID_FIELD = "userId";
@@ -97,10 +100,10 @@ public class EtagComponent {
         if (session == null) {
             throw new NotAuthenticatedException();
         }
-
+        
         // Etag can be null (until all dependent objects have cached their timestamps, 
         // or when a dependent object is deleted).
-        String etag = calculateEtag(context, session);
+        String etag = calculateEtag(context, session, true);
         
         if (requestEtag != null) {
             if (requestEtag.equals(etag)) {
@@ -113,6 +116,8 @@ public class EtagComponent {
             }
         }
         Object retValue = joinPoint.proceed();
+        
+        etag = recalculateEtag(session, context, etag);
         if (etag != null) {
             response.addHeader(HttpHeaders.ETAG, etag);
             if (LOG.isDebugEnabled()) {
@@ -122,20 +127,44 @@ public class EtagComponent {
         return retValue;
     }
 
-    private String calculateEtag(EtagContext context, UserSession session) {
+    /**
+     * Recalculate the etag if any of the cache keys could have updated during the request
+     * itself (invalidateCacheOnChange = a name of a controller method parameter on one of the 
+     * @@EtagCacheKey annotations).
+     */
+    protected String recalculateEtag(UserSession session, EtagContext context, String etag) {
+        for (EtagCacheKey cacheKey : context.getCacheKeys()) {
+            if (cacheKey.invalidateCacheOnChange() != "") {
+                return calculateEtag(context, session, false);
+            }
+        }
+        return etag;
+    }
+
+    private String calculateEtag(EtagContext context, UserSession session, boolean invalidateCache) {
         // Collect timestamps for all the dependencies that determine freshness of etag
         List<DateTime> timestamps = new ArrayList<>();
-        for (EtagCacheKey timestampKey : context.getCacheKeys()) {
-            int len = timestampKey.keys().length;
+        for (EtagCacheKey cacheKeyDef : context.getCacheKeys()) {
+            int len = cacheKeyDef.keys().length;
             String[] resolvedKeyValues = new String[len];
             for (int i=0; i < len; i++) {
                 // given getValue's behavior, this value will not be null;
-                resolvedKeyValues[i] = getValue(context, session, timestampKey.keys()[i]);
+                resolvedKeyValues[i] = getValue(context, session, cacheKeyDef.keys()[i]);
             }
             // Retrieve the timestamp under this key
-            CacheKey cacheKey = CacheKey.etag(timestampKey.model(), resolvedKeyValues);
+            CacheKey cacheKey = CacheKey.etag(cacheKeyDef.model(), resolvedKeyValues);
+            
+            // Check for a request-scoped parameter that differs from the value on the server,
+            // that will necessitate invalidation of the cache (right now the only field that
+            // can do this is clientTimeZone).
+            if (invalidateCache) {
+                invalidateCacheOnChange(session, context, cacheKeyDef.invalidateCacheOnChange(), cacheKey);    
+            }
+            
+            LOG.debug("looking for cache key: " + cacheKey);
             DateTime timestamp = cacheProvider.getObject(cacheKey, DateTime.class);
             if (timestamp == null) {
+                LOG.debug("cache miss (cacheKey has no value: “" + cacheKey + "”)");
                 return null; // this is a cache miss, any miss means there is no etag
             }
             timestamps.add(timestamp.withZone(DateTimeZone.UTC));
@@ -143,6 +172,26 @@ public class EtagComponent {
         String base = BridgeUtils.SPACE_JOINER.join(timestamps);
         byte[] md5 = md5DigestUtils.digest(base.getBytes(Charset.defaultCharset()));
         return Hex.encodeHexString(md5);
+    }
+    
+    private void invalidateCacheOnChange(UserSession session, EtagContext context, String invalidationField,
+            CacheKey cacheKey) {
+        if (!"".equals(invalidationField)) {
+            String pendingChange = (String)context.getArgValues().get(invalidationField);
+            String currentValue = getCurrentValue(session, invalidationField);
+            if (!ObjectUtils.nullSafeEquals(pendingChange, currentValue)) {
+                LOG.debug("Field " + invalidationField + " changed from " + currentValue + " to " + pendingChange
+                        + ", invalidating cache");
+                cacheProvider.removeObject(cacheKey);
+            }
+        }                
+    }
+    
+    private String getCurrentValue(UserSession session, String fieldName) {
+        if (CLIENT_TIME_ZONE_FIELD.equals(fieldName)) {
+            return session.getParticipant().getClientTimeZone();
+        }
+        return null;
     }
     
     private String getValue(EtagContext context, UserSession session, String fieldName) {

--- a/src/main/java/org/sagebionetworks/bridge/validators/AdherenceRecordListValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/AdherenceRecordListValidator.java
@@ -1,16 +1,15 @@
 package org.sagebionetworks.bridge.validators;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.sagebionetworks.bridge.BridgeUtils.isValidTimeZoneID;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL;
 import static org.sagebionetworks.bridge.validators.Validate.INVALID_TIME_ZONE;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.TEXT_SIZE;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.validateJsonLength;
 
-import java.time.ZoneId;
 
 import org.springframework.validation.Errors;
-
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecord;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecordList;
 
@@ -51,12 +50,9 @@ public class AdherenceRecordListValidator extends AbstractValidator {
             if (record.getEventTimestamp() == null) {
                 errors.rejectValue(EVENT_TIMESTAMP_FIELD, CANNOT_BE_NULL);
             }
-            if (record.getClientTimeZone() != null) {
-                try {
-                    ZoneId.of(record.getClientTimeZone());
-                } catch (Exception e) {
-                    errors.rejectValue(CLIENT_TIME_ZONE_FIELD, INVALID_TIME_ZONE);
-                }
+            
+            if (!isValidTimeZoneID(record.getClientTimeZone(), false)) {
+                errors.rejectValue(CLIENT_TIME_ZONE_FIELD, INVALID_TIME_ZONE);
             }
             validateJsonLength(errors, TEXT_SIZE,record.getClientData(), "clientData");
             errors.popNestedPath();

--- a/src/main/java/org/sagebionetworks/bridge/validators/StudyActivityEventValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/StudyActivityEventValidator.java
@@ -1,12 +1,11 @@
 package org.sagebionetworks.bridge.validators;
 
+import static org.sagebionetworks.bridge.BridgeUtils.isValidTimeZoneID;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NULL;
 import static org.sagebionetworks.bridge.validators.Validate.INVALID_EVENT_ID;
 import static org.sagebionetworks.bridge.validators.Validate.INVALID_TIME_ZONE;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.validateStringLength;
-
-import java.time.ZoneId;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.validation.Errors;
@@ -51,12 +50,8 @@ public class StudyActivityEventValidator extends AbstractValidator implements Va
             if (event.getCreatedOn() == null) {
                 errors.rejectValue("createdOn", CANNOT_BE_NULL);
             }
-            if (event.getClientTimeZone() != null) {
-                try {
-                    ZoneId.of(event.getClientTimeZone());
-                } catch (Exception e) {
-                    errors.rejectValue(StudyActivityEventValidator.CLIENT_TIME_ZONE_FIELD, INVALID_TIME_ZONE);
-                }
+            if (!isValidTimeZoneID(event.getClientTimeZone(), false)) {
+                errors.rejectValue(StudyActivityEventValidator.CLIENT_TIME_ZONE_FIELD, INVALID_TIME_ZONE);
             }
         }
     }

--- a/src/main/java/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/StudyParticipantValidator.java
@@ -4,6 +4,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.sagebionetworks.bridge.AuthEvaluatorField.ORG_ID;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_MEMBERS;
+import static org.sagebionetworks.bridge.BridgeUtils.isValidTimeZoneID;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.INVALID_EMAIL_ERROR;
 import static org.sagebionetworks.bridge.validators.Validate.INVALID_PHONE_ERROR;
@@ -12,9 +13,6 @@ import static org.sagebionetworks.bridge.validators.Validate.INVALID_TIME_ZONE;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.TEXT_SIZE;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.validateJsonLength;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.validateStringLength;
-
-import java.time.DateTimeException;
-import java.time.ZoneId;
 
 import java.util.Map;
 import java.util.Optional;
@@ -139,12 +137,8 @@ public class StudyParticipantValidator implements Validator {
                 validateStringLength(errors, 255, attributeValue,"attributes["+attributeName+"]");
             }
         }
-        if (participant.getClientTimeZone() != null) {
-            try {
-                ZoneId.of(participant.getClientTimeZone());
-            } catch (DateTimeException e) {
-                errors.rejectValue("clientTimeZone", INVALID_TIME_ZONE);
-            }
+        if (!isValidTimeZoneID(participant.getClientTimeZone(), false)) {
+            errors.rejectValue("clientTimeZone", INVALID_TIME_ZONE);
         }
         validateStringLength(errors, 255, participant.getEmail(), "email");
         validateStringLength(errors, 255, participant.getFirstName(), "firstName");

--- a/src/main/java/org/sagebionetworks/bridge/validators/StudyValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/StudyValidator.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.validators;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.sagebionetworks.bridge.BridgeUtils.COMMA_SPACE_JOINER;
+import static org.sagebionetworks.bridge.BridgeUtils.isValidTimeZoneID;
 import static org.sagebionetworks.bridge.models.studies.IrbDecisionType.APPROVED;
 import static org.sagebionetworks.bridge.validators.Validate.BRIDGE_EVENT_ID_ERROR;
 import static org.sagebionetworks.bridge.validators.Validate.BRIDGE_EVENT_ID_PATTERN;
@@ -18,8 +19,6 @@ import static org.sagebionetworks.bridge.validators.ValidatorUtils.TEXT_SIZE;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.validateJsonLength;
 import static org.sagebionetworks.bridge.validators.ValidatorUtils.validateStringLength;
 
-import java.time.DateTimeException;
-import java.time.ZoneId;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -130,12 +129,8 @@ public class StudyValidator implements Validator {
                 errors.rejectValue(ADHERENCE_THRESHOLD_PERCENTAGE_FIELD, "must be from 0-100%");
             }
         }
-        if (study.getStudyTimeZone() != null) {
-            try {
-                ZoneId.of(study.getStudyTimeZone());
-            } catch (DateTimeException e) {
-                errors.rejectValue(STUDY_TIME_ZONE_FIELD, INVALID_TIME_ZONE);
-            }
+        if (!isValidTimeZoneID(study.getStudyTimeZone(), false)) {
+            errors.rejectValue(STUDY_TIME_ZONE_FIELD, INVALID_TIME_ZONE);
         }
         
         // If one of these is supplied, all three need to be supplied

--- a/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/BridgeUtilsTest.java
@@ -93,6 +93,22 @@ public class BridgeUtilsTest extends Mockito {
     }
     
     @Test
+    public void isValidTimeZoneID_optional() {
+        assertTrue(BridgeUtils.isValidTimeZoneID(null, false));
+        assertFalse(BridgeUtils.isValidTimeZoneID("", false));
+        assertFalse(BridgeUtils.isValidTimeZoneID("Some value", false));
+        assertTrue(BridgeUtils.isValidTimeZoneID("America/Chicago", false));
+    }
+    
+    @Test
+    public void isValidTimeZoneID_required() {
+        assertFalse(BridgeUtils.isValidTimeZoneID(null, true));
+        assertFalse(BridgeUtils.isValidTimeZoneID("", true));
+        assertFalse(BridgeUtils.isValidTimeZoneID("Some value", true));
+        assertTrue(BridgeUtils.isValidTimeZoneID("America/Chicago", true));
+    }
+    
+    @Test
     public void localDateInRange() {
         LocalDate start = LocalDate.parse("2022-02-10");
         LocalDate end = LocalDate.parse("2022-02-17");

--- a/src/test/java/org/sagebionetworks/bridge/services/SessionUpdateServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/SessionUpdateServiceTest.java
@@ -82,6 +82,16 @@ public class SessionUpdateServiceTest {
     }
     
     @Test
+    public void updateClientTimeZone() {
+        UserSession session = new UserSession();
+        
+        service.updateClientTimeZone(session, "America/Chicago");
+        
+        verify(mockCacheProvider).setUserSession(session);
+        assertEquals(session.getParticipant().getClientTimeZone(), "America/Chicago");
+    }
+    
+    @Test
     public void updateLanguage() {
         // Mock consent service to return dummy consents.
         when(mockConsentService.getConsentStatuses(any())).thenReturn(CONSENT_STATUS_MAP);

--- a/src/test/java/org/sagebionetworks/bridge/services/UserAdminServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/UserAdminServiceTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import org.joda.time.DateTimeZone;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
@@ -32,6 +33,7 @@ import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
+import org.sagebionetworks.bridge.cache.CacheKey;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
@@ -44,6 +46,7 @@ import org.sagebionetworks.bridge.models.accounts.SharingScope;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
+import org.sagebionetworks.bridge.models.activities.StudyActivityEvent;
 import org.sagebionetworks.bridge.models.apps.App;
 import org.sagebionetworks.bridge.models.studies.Enrollment;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
@@ -366,6 +369,8 @@ public class UserAdminServiceTest {
         verify(scheduledActivityService).deleteActivitiesForUser("healthCode");
         verify(activityEventService, atLeastOnce()).deleteActivityEvents(app.getIdentifier(), "healthCode");
         verify(accountService).deleteAccount(accountId);
+        verify(cacheProvider).removeObject(CacheKey.etag(DateTimeZone.class, "userId"));
+        verify(cacheProvider).removeObject(CacheKey.etag(StudyActivityEvent.class, "userId"));
         
         assertEquals(account.getHealthCode(), "healthCode");
     }


### PR DESCRIPTION
This required specifying the property and looking for it in the ETag implementation, busting the cache if the value is going to change. The code assumes the method it is wrapping will update the value, so it recalculates the tag after execution.