### PR TITLE
Fix for BRIDGE-3288

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/study/StudyAdherenceReportGenerator.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/study/StudyAdherenceReportGenerator.java
@@ -60,7 +60,7 @@ public class StudyAdherenceReportGenerator {
         // calculations are correct.
         LocalDate earliestDate = getDate(state, eventReport.getEarliestEventId());
         // Get the start date of the report. If the schedule was not set up correctly, this can be after
-        // the earliest date. The timeline is calculated the same, but we’ll shor weeks before the start
+        // the earliest date. The timeline is calculated the same, but we’ll show weeks before the start
         // of the study as “Week 0”, “Week -1”, and so forth.
         LocalDate studyStartDate = getDate(state, state.getStudyStartEventId());
 
@@ -139,11 +139,14 @@ public class StudyAdherenceReportGenerator {
             adherence = calculateAdherencePercentage(ImmutableList.of(studyStream));
         }
         // If the earliest date is before the study start date, we're going to offset the weekInStudy 
-        // field to show there are scheduled activities occurring earlier in the study design.
+        // field to show there are scheduled activities occurring earlier in the study design. Up to 7
+        // days difference, earliestDate and studyStartDate are in the same week (so the offset is, 
+        // correctly, still 0). Above seven days, earliestDate and studyStartDate will start to be in 
+        // different weeks.
         int weekOffset = 0;
         if (earliestDate != null && studyStartDate != null && earliestDate.isBefore(studyStartDate)) {
             int days = Days.daysBetween(earliestDate, studyStartDate).getDays();
-            weekOffset = days/7;
+            weekOffset = (days/7);
         }
 
         List<StudyReportWeek> weeks = Lists.newArrayList(weekMap.values());

--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/adherence/study/StudyAdherenceReportGeneratorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/adherence/study/StudyAdherenceReportGeneratorTest.java
@@ -3,8 +3,14 @@ package org.sagebionetworks.bridge.models.schedules2.adherence.study;
 import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
 import static org.sagebionetworks.bridge.TestConstants.MODIFIED_ON;
 import static org.sagebionetworks.bridge.TestConstants.SCHEDULE_GUID;
+import static org.sagebionetworks.bridge.TestConstants.SESSION_GUID_1;
+import static org.sagebionetworks.bridge.TestConstants.SESSION_GUID_2;
+import static org.sagebionetworks.bridge.TestConstants.SESSION_GUID_3;
+import static org.sagebionetworks.bridge.TestConstants.SESSION_GUID_4;
+import static org.sagebionetworks.bridge.TestConstants.SESSION_WINDOW_GUID_2;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventUpdateType.IMMUTABLE;
+import static org.sagebionetworks.bridge.models.activities.ActivityEventUpdateType.MUTABLE;
 import static org.sagebionetworks.bridge.models.schedules2.PerformanceOrder.SEQUENTIAL;
 import static org.sagebionetworks.bridge.models.schedules2.adherence.SessionCompletionState.COMPLETED;
 import static org.sagebionetworks.bridge.models.schedules2.adherence.SessionCompletionState.EXPIRED;
@@ -26,6 +32,7 @@ import org.joda.time.LocalTime;
 import org.joda.time.Period;
 import org.mockito.Mockito;
 import org.sagebionetworks.bridge.BridgeUtils;
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.models.activities.ActivityEventObjectType;
 import org.sagebionetworks.bridge.models.activities.StudyActivityEvent;
 import org.sagebionetworks.bridge.models.schedules2.AssessmentReference;
@@ -45,6 +52,7 @@ import org.sagebionetworks.bridge.models.schedules2.timelines.Timeline;
 import org.sagebionetworks.bridge.models.schedules2.timelines.TimelineMetadata;
 import org.testng.annotations.Test;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -1306,7 +1314,6 @@ public class StudyAdherenceReportGeneratorTest extends Mockito {
     
     @Test
     public void dateRangeErrorDefaultsToStreamDateRange() {
-        // survey
         AssessmentReference ref1 = new AssessmentReference();
         ref1.setGuid("survey");
         ref1.setAppId(TEST_APP_ID);
@@ -1364,5 +1371,118 @@ public class StudyAdherenceReportGeneratorTest extends Mockito {
         // start of the study...it's not specified.
         StudyAdherenceReport report = INSTANCE.generate(state);
         assertNull(report.getDateRange());
+    }
+    
+    // BRIDGE-3288
+    @Test
+    public void negativeDaysDoNotBreakSchedule() throws JsonProcessingException {
+        AssessmentReference ref1 = new AssessmentReference();
+        ref1.setGuid("survey");
+        ref1.setAppId(TEST_APP_ID);
+        ref1.setIdentifier("survey");
+        
+        TimeWindow win1 = new TimeWindow();
+        win1.setGuid(TestConstants.SESSION_WINDOW_GUID_1);
+        win1.setStartTime(LocalTime.parse("08:00"));
+        win1.setExpiration(Period.parse("PT24H"));
+        
+        Session session1 = new Session();
+        session1.setGuid(SESSION_GUID_1);
+        session1.setName("session1");
+        session1.setOccurrences(1);
+        session1.setAssessments(ImmutableList.of(ref1));
+        session1.setTimeWindows(ImmutableList.of(win1));
+        session1.setStartEventIds(ImmutableList.of("custom:First Clinic visit"));
+        
+        TimeWindow win2 = new TimeWindow();
+        win2.setGuid(SESSION_WINDOW_GUID_2);
+        win2.setStartTime(LocalTime.parse("08:30"));
+        win2.setExpiration(Period.parse("PT2H"));
+        
+        TimeWindow win3 = new TimeWindow();
+        win3.setGuid(TestConstants.SESSION_WINDOW_GUID_3);
+        win3.setStartTime(LocalTime.parse("20:30"));
+        win3.setExpiration(Period.parse("PT2H"));
+
+        Session session2 = new Session();
+        session2.setGuid(SESSION_GUID_2);
+        session2.setName("session2");
+        session2.setAssessments(ImmutableList.of(ref1));
+        session2.setDelay(Period.parse("P2D"));
+        session2.setOccurrences(14);
+        session2.setInterval(Period.parse("P1D"));
+        session2.setAssessments(ImmutableList.of(ref1));
+        session2.setTimeWindows(ImmutableList.of(win2, win3));
+        session2.setStudyBurstIds(ImmutableList.of("custom_RemoteActivities_burst"));
+
+        TimeWindow win4 = new TimeWindow();
+        win4.setGuid(SESSION_GUID_4);
+        win4.setStartTime(LocalTime.parse("08:00"));
+        win4.setExpiration(Period.parse("P20D"));
+        
+        Session session3 = new Session();
+        session3.setGuid(SESSION_GUID_3);
+        session3.setName("session3");
+        session3.setDelay(Period.parse("P4W"));
+        session3.setOccurrences(10);
+        session3.setInterval(Period.parse("P4W"));
+        session3.setAssessments(ImmutableList.of(ref1));
+        session3.setTimeWindows(ImmutableList.of(win4));
+        session3.setStartEventIds(ImmutableList.of("custom:First Clinic visit"));
+        
+        StudyBurst burst = new StudyBurst();
+        burst.setIdentifier("custom_RemoteActivities_burst");
+        burst.setOriginEventId("custom:RemoteActivities");
+        burst.setInterval(Period.parse("P2W"));
+        burst.setOccurrences(3);
+        burst.setUpdateType(MUTABLE);
+        
+        Schedule2 schedule = new Schedule2();
+        schedule.setGuid(SCHEDULE_GUID);
+        schedule.setDuration(Period.parse("P2W"));
+        schedule.setStudyBursts(ImmutableList.of(burst));
+        schedule.setSessions(ImmutableList.of(session1, session2, session3));
+        
+        Timeline timeline = Scheduler.INSTANCE.calculateTimeline(schedule);
+        
+        StudyActivityEvent event0 = new StudyActivityEvent.Builder()
+                .withEventId("custom:First Clinic visit")
+                .withTimestamp(DateTime.parse("2022-04-05T19:05:43.000Z")).build();
+        StudyActivityEvent event1 = new StudyActivityEvent.Builder()
+                .withEventId("custom:RemoteActivities")
+                .withTimestamp(DateTime.parse("2022-04-01T19:05:46.000Z")).build();
+        StudyActivityEvent event2 = new StudyActivityEvent.Builder()
+                .withEventId("study_burst:custom_RemoteActivities_burst:01")
+                .withTimestamp(DateTime.parse("2022-04-01T19:05:46.000Z")).build();
+        StudyActivityEvent event3 = new StudyActivityEvent.Builder()
+                .withEventId("study_burst:custom_RemoteActivities_burst:02")
+                .withTimestamp(DateTime.parse("2022-04-15T19:05:46.000Z")).build();
+        StudyActivityEvent event4 = new StudyActivityEvent.Builder()
+                .withEventId("study_burst:custom_RemoteActivities_burst:03")
+                .withTimestamp(DateTime.parse("2022-04-29T19:05:46.000Z")).build();
+        
+        AdherenceState state = new AdherenceState.Builder()
+                .withMetadata(timeline.getMetadata())
+                .withEvents(ImmutableList.of(event0, event1, event2, event3, event4))
+                .withNow(DateTime.parse("2022-04-08T12:53:31.385-08:00"))
+                .withStudyStartEventId("custom:First Clinic visit")
+                .build();
+            
+        StudyAdherenceReport report = StudyAdherenceReportGenerator.INSTANCE.generate(state);
+        StudyReportWeek weeklyReport = report.getWeekReport();
+
+        assertStartDate(weeklyReport, 0, LocalDate.parse("2022-04-05"));
+        assertStartDate(weeklyReport, 1, LocalDate.parse("2022-04-06"));
+        assertStartDate(weeklyReport, 2, LocalDate.parse("2022-04-07"));
+        assertStartDate(weeklyReport, 3, LocalDate.parse("2022-04-08"));
+        assertStartDate(weeklyReport, 4, LocalDate.parse("2022-04-09"));
+        assertStartDate(weeklyReport, 5, LocalDate.parse("2022-04-10"));
+        assertStartDate(weeklyReport, 6, LocalDate.parse("2022-04-11"));
+    }
+    
+    private void assertStartDate(StudyReportWeek weeklyReport, int dayOfWeek, LocalDate startDate) {
+        for (EventStreamDay day : weeklyReport.getByDayEntries().get(dayOfWeek)) {
+            assertEquals(day.getStartDate(), startDate);
+        }
     }
 }


### PR DESCRIPTION
Once users start creating events before the start of the study, we're in uncharted territory. The fix here is to use negative weeks, and recognize that the day count is running the other direction week after week (because it's negative).