### PR TITLE
Fixing duplicate key error (BRIDGE-3179)

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/StudyActivityEventService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyActivityEventService.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.bridge.services;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static java.util.stream.Collectors.toSet;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.NEGATIVE_OFFSET_ERROR;
@@ -21,8 +20,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -313,18 +310,23 @@ public class StudyActivityEventService {
     }
     
     private void addIfPresent(List<StudyActivityEvent> events, Map<String, DateTime> map, String field, boolean addCount) {
-        Set<String> existingFields = events.stream().map(StudyActivityEvent::getEventId).collect(toSet());
-        if (map.containsKey(field) && !existingFields.contains(field)) {
-            DateTime ts = map.get(field);
-            StudyActivityEvent.Builder builder = new StudyActivityEvent.Builder()
-                    .withEventId(field)
-                    .withTimestamp(ts)
-                    .withCreatedOn(ts);
-            if (addCount) {
-                builder.withRecordCount(ONE);
-            }
-            events.add(builder.build());
+        if (!map.containsKey(field)) {
+            return;
         }
+        boolean inEventList = events.stream().map(StudyActivityEvent::getEventId)
+                .anyMatch(eventId -> eventId.equals(field));
+        if (inEventList) {
+            return;
+        }
+        DateTime ts = map.get(field);
+        StudyActivityEvent.Builder builder = new StudyActivityEvent.Builder()
+                .withEventId(field)
+                .withTimestamp(ts)
+                .withCreatedOn(ts);
+        if (addCount) {
+            builder.withRecordCount(ONE);
+        }
+        events.add(builder.build());
     }
     
     /**

--- a/src/main/java/org/sagebionetworks/bridge/services/StudyActivityEventService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyActivityEventService.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.services;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.stream.Collectors.toSet;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.NEGATIVE_OFFSET_ERROR;
@@ -20,6 +21,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -310,7 +313,8 @@ public class StudyActivityEventService {
     }
     
     private void addIfPresent(List<StudyActivityEvent> events, Map<String, DateTime> map, String field, boolean addCount) {
-        if (map.containsKey(field)) {
+        Set<String> existingFields = events.stream().map(StudyActivityEvent::getEventId).collect(toSet());
+        if (map.containsKey(field) && !existingFields.contains(field)) {
             DateTime ts = map.get(field);
             StudyActivityEvent.Builder builder = new StudyActivityEvent.Builder()
                     .withEventId(field)

--- a/src/test/java/org/sagebionetworks/bridge/models/ClientInfoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/ClientInfoTest.java
@@ -159,6 +159,10 @@ public class ClientInfoTest {
                 "PsorcastValidation", 20, "iPhone SE", "iPhone OS", "13.4", "BridgeSDK", 69);
         assertClientInfo("BiAffect/18 (Unknown iPhone [iPhone12,1]; iOS/13.4.1) BridgeSDK/71",
                 "BiAffect", 18, "Unknown iPhone [iPhone12,1]", "iPhone OS", "13.4.1", "BridgeSDK", 71);
+        assertClientInfo("Mobile Toolbox/14 (Samsung SM-G960U; Android/10) BridgeClientKMM",
+                "Mobile Toolbox", 14, "Samsung SM-G960U", "Android", "10", "BridgeClientKMM", null);
+        assertClientInfo("Mobile Toolbox/14 (Samsung SM-G960U; Android/10)",
+                "Mobile Toolbox", 14, "Samsung SM-G960U", "Android", "10", null, null);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/StudyActivityEventServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/StudyActivityEventServiceTest.java
@@ -1047,7 +1047,7 @@ public class StudyActivityEventServiceTest extends Mockito {
     
     // BRIDGE-3179
     @Test
-    public void getRecentStudyActivityEvents_noDuplicateErrors() {
+    public void getRecentStudyActivityEvents_noDuplicationError() {
         Account account = Account.create();
         account.setAppId(TEST_APP_ID);
         account.setHealthCode(HEALTH_CODE);


### PR DESCRIPTION
The duplication of keys in this list, was causing a Collector to throw an exception elsewhere in the code due to duplicate keys. The CREATED_ON timestamp can be persisted in the study-specific events table and when that happens, we can ignore the value in the app-scoped table. The service should not return two entries for this value.

Also I added a couple of real-world UA strings to that test to double-check that some proposed UA strings from the mobile team will be parsed correctly (they will). 