### PR TITLE
Fix for BRIDGE-3283

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudy.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateStudy.java
@@ -86,7 +86,7 @@ public class HibernateStudy implements Study {
     private String logoGuid;
     private String keywords;
     @Version
-    private Long version;
+    private long version;
     
     // the subselect annotations below reduce the number of SQL queries that
     // hibernate makes to retrieve the full study object. Tables are being used
@@ -217,12 +217,12 @@ public class HibernateStudy implements Study {
     }
     
     @Override
-    public Long getVersion() {
+    public long getVersion() {
         return version;
     }
     
     @Override
-    public void setVersion(Long version) {
+    public void setVersion(long version) {
         this.version = version;
     }
 

--- a/src/main/java/org/sagebionetworks/bridge/models/organizations/HibernateOrganization.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/organizations/HibernateOrganization.java
@@ -32,7 +32,7 @@ public class HibernateOrganization implements Organization {
     @Convert(converter = DateTimeToLongAttributeConverter.class)
     private DateTime modifiedOn;
     @Version
-    private Long version;
+    private long version;
     
     public HibernateOrganization() {
     }
@@ -107,12 +107,12 @@ public class HibernateOrganization implements Organization {
     }
 
     @Override
-    public Long getVersion() {
+    public long getVersion() {
         return version;
     }
 
     @Override
-    public void setVersion(Long version) {
+    public void setVersion(long version) {
         this.version = version;
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/models/organizations/Organization.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/organizations/Organization.java
@@ -31,6 +31,6 @@ public interface Organization extends BridgeEntity {
     DateTime getModifiedOn();
     void setModifiedOn(DateTime modifiedOn);
     
-    Long getVersion();
-    void setVersion(Long version);
+    long getVersion();
+    void setVersion(long version);
 }

--- a/src/main/java/org/sagebionetworks/bridge/models/studies/Study.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/studies/Study.java
@@ -139,6 +139,6 @@ public interface Study extends BridgeEntity {
     Integer getAdherenceThresholdPercentage();
     void setAdherenceThresholdPercentage(Integer adherenceThresholdPercentage);
 
-    Long getVersion();
-    void setVersion(Long version);
+    long getVersion();
+    void setVersion(long version);
 }

--- a/src/main/java/org/sagebionetworks/bridge/services/OrganizationService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/OrganizationService.java
@@ -129,7 +129,7 @@ public class OrganizationService {
         DateTime timestamp = getCreatedOn();
         organization.setCreatedOn(timestamp);
         organization.setModifiedOn(timestamp);
-        organization.setVersion(null);
+        organization.setVersion(0L);
         return orgDao.createOrganization(organization);
     }
     

--- a/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
@@ -191,7 +191,7 @@ public class StudyService {
                 scheduleService, sponsorService);
         Validate.entityThrowingException(validator, study);
         
-        study.setVersion(null);
+        study.setVersion(0);
         study.setDeleted(false);
         DateTime timestamp = DateTime.now();
         study.setCreatedOn(timestamp);

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateStudyDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateStudyDaoTest.java
@@ -185,7 +185,7 @@ public class HibernateStudyDaoTest extends Mockito {
         verify(hibernateHelper).create(studyCaptor.capture());
         
         Study persisted = studyCaptor.getValue();
-        assertEquals(persisted.getVersion(), new Long(2));
+        assertEquals(persisted.getVersion(), 2L);
     }
 
     @Test
@@ -199,7 +199,7 @@ public class HibernateStudyDaoTest extends Mockito {
         verify(hibernateHelper).update(studyCaptor.capture());
         
         Study persisted = studyCaptor.getValue();
-        assertEquals(persisted.getVersion(), new Long(2));
+        assertEquals(persisted.getVersion(), 2L);
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateStudyTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/hibernate/HibernateStudyTest.java
@@ -82,7 +82,7 @@ public class HibernateStudyTest {
         assertTrue(study.isDeleted());
         assertEquals(study.getPhase(), DESIGN);
         assertEquals(study.getStudyLogoUrl(), TEST_LINK);
-        assertEquals(study.getVersion(), Long.valueOf(10L));
+        assertEquals(study.getVersion(), 10L);
         assertEquals(study.getScheduleGuid(), "scheduleGuid");
     }
     
@@ -181,7 +181,7 @@ public class HibernateStudyTest {
         assertEquals(deser.getLogoGuid(), GUID);
         assertEquals(deser.getStudyTimeZone(), "America/Los_Angeles");
         assertEquals(deser.getAdherenceThresholdPercentage(), Integer.valueOf(80));
-        assertEquals(deser.getVersion(), new Long(3));
+        assertEquals(deser.getVersion(), 3L);
         assertEquals(deser.getCustomEvents().get(0).getEventId(), "event1");
         assertEquals(deser.getCustomEvents().get(0).getUpdateType(), IMMUTABLE);
         

--- a/src/test/java/org/sagebionetworks/bridge/models/organizations/OrganizationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/organizations/OrganizationTest.java
@@ -44,7 +44,7 @@ public class OrganizationTest {
         assertEquals(deser.getDescription(), "aDescription");
         assertEquals(deser.getCreatedOn(), CREATED_ON);
         assertEquals(deser.getModifiedOn(), MODIFIED_ON);
-        assertEquals(deser.getVersion(), Long.valueOf(3L));
+        assertEquals(deser.getVersion(), 3L);
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/OrganizationServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/OrganizationServiceTest.java
@@ -187,7 +187,7 @@ public class OrganizationServiceTest extends Mockito {
         Organization retValue = service.createOrganization(org);
         assertEquals(retValue.getCreatedOn(), CREATED_ON);
         assertEquals(retValue.getModifiedOn(), CREATED_ON);
-        assertNull(retValue.getVersion());
+        assertEquals(retValue.getVersion(), 0L);
         
         verify(mockOrgDao).createOrganization(org);
     }

--- a/src/test/java/org/sagebionetworks/bridge/services/StudyServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/StudyServiceTest.java
@@ -287,7 +287,7 @@ public class StudyServiceTest {
         assertEquals(persisted.getName(), "oneName");
         assertEquals(persisted.getAppId(), TEST_APP_ID);
         assertEquals(persisted.getPhase(), DESIGN);
-        assertNull(persisted.getVersion());
+        assertEquals(persisted.getVersion(), 0L);
         assertFalse(persisted.isDeleted());
         assertNotEquals(persisted.getCreatedOn(), timestamp);
         assertNotEquals(persisted.getModifiedOn(), timestamp);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyControllerTest.java
@@ -22,7 +22,6 @@ import static org.sagebionetworks.bridge.TestUtils.assertPost;
 import static org.sagebionetworks.bridge.TestUtils.mockRequestBody;
 import static org.sagebionetworks.bridge.models.files.FileDispositionType.INLINE;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 
 import java.util.Optional;
@@ -430,7 +429,7 @@ public class StudyControllerTest extends Mockito {
         Study deser = BridgeObjectMapper.get().readValue(retValue, Study.class);
         assertEquals(deser.getName(), "Name1");
         assertEquals(deser.getIdentifier(), "id1");
-        assertNull(deser.getVersion());
+        assertEquals(deser.getVersion(), 0L);
         
         CacheKey key = CacheKey.publicStudy(TEST_APP_ID, TEST_STUDY_ID);
         String json = Study.STUDY_SUMMARY_WRITER.writeValueAsString(study);
@@ -454,7 +453,7 @@ public class StudyControllerTest extends Mockito {
         Study deser = BridgeObjectMapper.get().readValue(retValue, Study.class);
         assertEquals(deser.getName(), "Name1");
         assertEquals(deser.getIdentifier(), "id1");
-        assertNull(deser.getVersion());
+        assertEquals(deser.getVersion(), 0L);
         
         verify(mockCacheProvider, never()).setObject(any(), any(), anyInt());
         verify(mockStudyService, never()).getStudy(any(), any(), anyBoolean());
@@ -473,7 +472,7 @@ public class StudyControllerTest extends Mockito {
         Study retValue = controller.getStudyForWorker(TEST_APP_ID, TEST_STUDY_ID);
         assertEquals(retValue.getName(), "Name1");
         assertEquals(retValue.getIdentifier(), "id1");
-        assertEquals(retValue.getVersion().intValue(), 10);
+        assertEquals(retValue.getVersion(), 10L);
 
         verify(mockStudyService).getStudy(TEST_APP_ID, TEST_STUDY_ID, true);
     }


### PR DESCRIPTION
Version attributes that use the Long object will accept null values via the API, which lead to null pointer errors in Hibernate code. Primitive long values at least deserialize to 0L when this occurs, and that correctly throws a concurrent modification exception. Switching these fields to use primitives (this issue does not seem to exist for DynamoDB, only for Hibernate-backed SQL entities).