### PR TITLE
Fix for BRIDGE-3290

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/models/schedules2/adherence/study/StudyAdherenceReportGeneratorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/schedules2/adherence/study/StudyAdherenceReportGeneratorTest.java
@@ -28,7 +28,6 @@ import org.joda.time.LocalTime;
 import org.joda.time.Period;
 import org.mockito.Mockito;
 import org.sagebionetworks.bridge.BridgeUtils;
-import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.models.activities.ActivityEventObjectType;
 import org.sagebionetworks.bridge.models.activities.StudyActivityEvent;
 import org.sagebionetworks.bridge.models.schedules2.AssessmentReference;
@@ -42,7 +41,6 @@ import org.sagebionetworks.bridge.models.schedules2.adherence.ParticipantStudyPr
 import org.sagebionetworks.bridge.models.schedules2.adherence.SessionCompletionState;
 import org.sagebionetworks.bridge.models.schedules2.adherence.eventstream.EventStreamDay;
 import org.sagebionetworks.bridge.models.schedules2.adherence.eventstream.EventStreamWindow;
-import org.sagebionetworks.bridge.models.schedules2.adherence.weekly.WeeklyAdherenceReport;
 import org.sagebionetworks.bridge.models.schedules2.adherence.weekly.WeeklyAdherenceReportRow;
 import org.sagebionetworks.bridge.models.schedules2.timelines.Scheduler;
 import org.sagebionetworks.bridge.models.schedules2.timelines.Timeline;

--- a/src/test/java/org/sagebionetworks/bridge/services/AdminAccountServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AdminAccountServiceTest.java
@@ -889,6 +889,75 @@ public class AdminAccountServiceTest extends Mockito {
     }
     
     @Test
+    public void updateAccount_noChangeToSynapseUserId() {
+        App app = App.create();
+        when(mockAppService.getApp(TEST_APP_ID)).thenReturn(app);
+        
+        Account persistedAccount = Account.create();
+        persistedAccount.setAdmin(TRUE);
+        persistedAccount.setId(TEST_USER_ID);
+        persistedAccount.setAppId(TEST_APP_ID);
+        persistedAccount.setSynapseUserId(SYNAPSE_USER_ID);
+
+        when(mockAccountDao.getAccount(any())).thenReturn(Optional.of(persistedAccount));
+
+        Account account = Account.create();
+        account.setId(TEST_USER_ID);
+        account.setSynapseUserId("67890");
+        
+        Account retValue = service.updateAccount(TEST_APP_ID, account);
+        assertEquals(retValue.getSynapseUserId(), "67890");
+        
+        verify(mockCacheProvider).removeSessionByUserId(TEST_USER_ID);
+    }
+    
+    @Test
+    public void updateAccount_nullSynapseUserId() {
+        App app = App.create();
+        when(mockAppService.getApp(TEST_APP_ID)).thenReturn(app);
+        
+        Account persistedAccount = Account.create();
+        persistedAccount.setEmail(EMAIL);
+        persistedAccount.setAdmin(TRUE);
+        persistedAccount.setId(TEST_USER_ID);
+        persistedAccount.setAppId(TEST_APP_ID);
+
+        when(mockAccountDao.getAccount(any())).thenReturn(Optional.of(persistedAccount));
+
+        Account account = Account.create();
+        account.setId(TEST_USER_ID);
+        account.setEmail(EMAIL);
+        
+        Account retValue = service.updateAccount(TEST_APP_ID, account);
+        assertNull(retValue.getSynapseUserId());
+        
+        verify(mockCacheProvider, never()).removeSessionByUserId(TEST_USER_ID);
+    }
+    
+    @Test
+    public void updateAccount_changeSynapseUserIdSignsOutUser() {
+        App app = App.create();
+        when(mockAppService.getApp(TEST_APP_ID)).thenReturn(app);
+        
+        Account persistedAccount = Account.create();
+        persistedAccount.setAdmin(TRUE);
+        persistedAccount.setId(TEST_USER_ID);
+        persistedAccount.setAppId(TEST_APP_ID);
+        persistedAccount.setSynapseUserId(SYNAPSE_USER_ID);
+
+        when(mockAccountDao.getAccount(any())).thenReturn(Optional.of(persistedAccount));
+
+        Account account = Account.create();
+        account.setId(TEST_USER_ID);
+        account.setSynapseUserId(SYNAPSE_USER_ID);
+        
+        Account retValue = service.updateAccount(TEST_APP_ID, account);
+        assertEquals(retValue.getSynapseUserId(), SYNAPSE_USER_ID);
+        
+        verify(mockCacheProvider, never()).removeSessionByUserId(TEST_USER_ID);
+    }
+    
+    @Test
     public void deleteAccount() {
         Account account = Account.create();
         account.setId(TEST_USER_ID);

--- a/src/test/java/org/sagebionetworks/bridge/services/AdminAccountServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AdminAccountServiceTest.java
@@ -889,7 +889,7 @@ public class AdminAccountServiceTest extends Mockito {
     }
     
     @Test
-    public void updateAccount_noChangeToSynapseUserId() {
+    public void updateAccount_changeToSynapseUserIdSignsOutUser() {
         App app = App.create();
         when(mockAppService.getApp(TEST_APP_ID)).thenReturn(app);
         
@@ -935,7 +935,7 @@ public class AdminAccountServiceTest extends Mockito {
     }
     
     @Test
-    public void updateAccount_changeSynapseUserIdSignsOutUser() {
+    public void updateAccount_noChangeToSynapseUserId() {
         App app = App.create();
         when(mockAppService.getApp(TEST_APP_ID)).thenReturn(app);
         


### PR DESCRIPTION
Sign out accounts on a change of the synapse user ID. When an ID is changed, we want that user to authenticate so we know they control that account.