### PR TITLE
[fix build break] increase FileRevisions.uploadUrl max length to 1536

### DIFF
--- a/src/main/resources/db/changelog/changelog.sql
+++ b/src/main/resources/db/changelog/changelog.sql
@@ -978,3 +978,8 @@ ALTER TABLE `Accounts`
 ADD COLUMN `admin` tinyint(1) DEFAULT '0';
 UPDATE Accounts as a JOIN AccountRoles as r ON a.id = r.accountId SET a.admin = 1;
 UPDATE Accounts as a SET a.admin = 1 WHERE a.orgMembership IS NOT NULL;
+
+-- changeset bridge:70
+
+ALTER TABLE `FileRevisions`
+MODIFY COLUMN `uploadURL` VARCHAR(1536) DEFAULT NULL;


### PR DESCRIPTION
Fixing https://sagebionetworks.jira.com/browse/BRIDGE-3188 had an unusual side effect. Apparently, pre-signed URLs generated from Roles instead of Users increase from ~500 chars to ~1200 chars. FileRevisions.uploadUrl was a varchar(1024). Integ Tests AppConfigTest, FileTest, and StudyTest all use FileRevisions, and these would regularly get SQL exceptions because the uploadUrl exceeded 1024 chars.

This was not caught during the development of https://sagebionetworks.jira.com/browse/BRIDGE-3188 because locally we still use Users, and the VPN was down at the time, so I didn't try running a full integ test suite.

This was fixed locally by calling Get-Session-Token with my local AWS user, repro'ing the issue with the temporary credentials, and then verifying the fix after I updated uploadUrl from varchar(1024) to varchar(1536).