### PR TITLE
[fix build break] increase FileRevisions.uploadUrl max length to 2048

### DIFF
--- a/src/main/resources/db/changelog/changelog.sql
+++ b/src/main/resources/db/changelog/changelog.sql
@@ -983,3 +983,8 @@ UPDATE Accounts as a SET a.admin = 1 WHERE a.orgMembership IS NOT NULL;
 
 ALTER TABLE `FileRevisions`
 MODIFY COLUMN `uploadURL` VARCHAR(1536) DEFAULT NULL;
+
+-- changeset bridge:71
+
+ALTER TABLE `FileRevisions`
+MODIFY COLUMN `uploadURL` VARCHAR(2048) DEFAULT NULL;


### PR DESCRIPTION
See https://github.com/Sage-Bionetworks/BridgeServer2/pull/587 for context.

I originally increased this from 1024 to 1536. However, as it turns out, in Dev, this is even longer for whatever reason, getting us a URL that is 1735 characters long. So I increased uploadUrl from 1536 to 2048.