### PR TITLE
BRIDGE-3268: consolidate account deletion methods

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
@@ -13,7 +13,6 @@ import static org.sagebionetworks.bridge.BridgeUtils.collectStudyIds;
 import static org.sagebionetworks.bridge.dao.AccountDao.MIGRATION_VERSION;
 import static org.sagebionetworks.bridge.models.activities.ActivityEventObjectType.ENROLLMENT;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -21,7 +20,6 @@ import java.util.function.Function;
 
 import com.google.common.collect.Sets;
 
-import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.sagebionetworks.bridge.RequestContext;
@@ -32,7 +30,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.ObjectUtils;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.AccountDao;
-import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.AccountSummarySearch;
@@ -78,17 +75,6 @@ public class AccountService {
     // Provided to override in tests
     protected String generateGUID() {
         return BridgeUtils.generateGuid();
-    }
-    
-    /**
-     * Search for all accounts across apps that have the same Synapse user ID in common, 
-     * and return a list of the app IDs where these accounts are found.
-     */
-    public List<String> getAppIdsForUser2(String synapseUserId) {
-        if (StringUtils.isBlank(synapseUserId)) {
-            throw new BadRequestException("Account does not have a Synapse user");
-        }
-        return accountDao.getAppIdForUser(synapseUserId);
     }
     
     /**

--- a/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
@@ -48,42 +48,32 @@ import org.sagebionetworks.bridge.time.DateUtils;
 
 @Component
 public class AccountService {
+    @Autowired
     private AccountDao accountDao;
+    @Autowired
     private AppService appService;
+    @Autowired
     private ActivityEventService activityEventService;
+    @Autowired
     private ParticipantVersionService participantVersionService;
+    @Autowired
     private StudyActivityEventService studyActivityEventService;
+    @Autowired
     private CacheProvider cacheProvider;
-
-    @Autowired
-    final void setAccountDao(AccountDao accountDao) {
-        this.accountDao = accountDao;
-    }
     
+    // For cleaning up when deleting a user
     @Autowired
-    final void setAppService(AppService appService) {
-        this.appService = appService;
-    }
-    
+    private NotificationsService notificationsService;
     @Autowired
-    final void setActivityEventService(ActivityEventService activityEventService) {
-        this.activityEventService = activityEventService;
-    }
-
+    private HealthDataService healthDataService;
     @Autowired
-    final void setParticipantVersionService(ParticipantVersionService participantVersionService) {
-        this.participantVersionService = participantVersionService;
-    }
-
+    private HealthDataEx3Service healthDataEx3Service;
     @Autowired
-    final void setStudyActivityEventService(StudyActivityEventService studyActivityEventService) {
-        this.studyActivityEventService = studyActivityEventService;
-    }
-    
+    private ScheduledActivityService scheduledActivityService;
     @Autowired
-    final void setCacheProvider(CacheProvider cacheProvider) {
-        this.cacheProvider = cacheProvider;
-    }
+    private UploadService uploadService;
+    @Autowired
+    private RequestInfoService requestInfoService;
     
     // Provided to override in tests
     protected String generateGUID() {
@@ -94,7 +84,7 @@ public class AccountService {
      * Search for all accounts across apps that have the same Synapse user ID in common, 
      * and return a list of the app IDs where these accounts are found.
      */
-    public List<String> getAppIdsForUser(String synapseUserId) {
+    public List<String> getAppIdsForUser2(String synapseUserId) {
         if (StringUtils.isBlank(synapseUserId)) {
             throw new BadRequestException("Account does not have a Synapse user");
         }
@@ -287,10 +277,26 @@ public class AccountService {
         Optional<Account> opt = accountDao.getAccount(accountId);
         if (opt.isPresent()) {
             Account account = opt.get();
+            
+            // remove this first so if account is partially deleted, re-authenticating will pick
+            // up accurate information about the state of the account (as we can recover it)
+            cacheProvider.removeSessionByUserId(account.getId());
+            requestInfoService.removeRequestInfo(account.getId());
+            
+            String healthCode = account.getHealthCode();
+            healthDataService.deleteRecordsForHealthCode(healthCode);
+            healthDataEx3Service.deleteRecordsForHealthCode(healthCode);
+            notificationsService.deleteAllRegistrations(account.getAppId(), healthCode);
+            uploadService.deleteUploadsForHealthCode(healthCode);
+            scheduledActivityService.deleteActivitiesForUser(healthCode);
+            activityEventService.deleteActivityEvents(account.getAppId(), healthCode);
+            // AccountSecret records and Enrollment records are are deleted on a 
+            // cascading delete from Account
             accountDao.deleteAccount(account.getId());
             
-            CacheKey cacheKey = CacheKey.etag(DateTimeZone.class, account.getId());
-            cacheProvider.removeObject(cacheKey);
+            // Remove known etag cache keys for this user
+            cacheProvider.removeObject( CacheKey.etag(DateTimeZone.class, account.getId()) );
+            cacheProvider.removeObject( CacheKey.etag(StudyActivityEvent.class, account.getId()) );
         }
     }
     

--- a/src/main/java/org/sagebionetworks/bridge/services/AdminAccountService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AdminAccountService.java
@@ -231,23 +231,7 @@ public class AdminAccountService {
         
         return account;
     }
-    
-    /*
-    public void deleteAccount(String appId, String userId) {
-        checkNotNull(appId);
-        checkNotNull(userId);
-        
-        AccountId accountId = AccountId.forId(appId,  userId);
-        Optional<Account> opt = accountDao.getAccount(accountId);
-        if (opt.isPresent()) {
-            Account account = opt.get();
-            accountDao.deleteAccount(account.getId());
-            
-            cacheProvider.removeSessionByUserId(account.getId());
-            requestInfoService.removeRequestInfo(account.getId());
-        }
-    }
-    */
+
     protected void sendVerificationMessages(App app, Account original, Account update) {
         if (!nullSafeEquals(original.getEmail(), update.getEmail())) {
             update.setEmailVerified(FALSE);

--- a/src/main/java/org/sagebionetworks/bridge/services/AdminAccountService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AdminAccountService.java
@@ -55,37 +55,16 @@ import com.google.common.collect.Sets;
 
 @Component
 public class AdminAccountService {
+    @Autowired
     private AppService appService;
+    @Autowired
     private AccountWorkflowService accountWorkflowService;
+    @Autowired
     private SmsService smsService;
+    @Autowired
     private AccountDao accountDao;
+    @Autowired
     private CacheProvider cacheProvider;
-    private RequestInfoService requestInfoService;
-    
-    @Autowired
-    final void setAppService(AppService appService) {
-        this.appService = appService;
-    }
-    @Autowired
-    final void setAccountWorkflowService(AccountWorkflowService accountWorkflowService) {
-        this.accountWorkflowService = accountWorkflowService;
-    }
-    @Autowired
-    final void setSmsService(SmsService smsService) {
-        this.smsService = smsService;
-    }
-    @Autowired
-    final void setAccountDao(AccountDao accountDao) {
-        this.accountDao = accountDao;
-    }
-    @Autowired
-    final void setCacheProvider(CacheProvider cacheProvider) {
-        this.cacheProvider = cacheProvider;
-    }
-    @Autowired
-    final void setRequestInfoService(RequestInfoService requestInfoService) {
-        this.requestInfoService = requestInfoService;
-    }
     
     // accessor for mocking in tests
     protected DateTime getCreatedOn() {
@@ -253,6 +232,7 @@ public class AdminAccountService {
         return account;
     }
     
+    /*
     public void deleteAccount(String appId, String userId) {
         checkNotNull(appId);
         checkNotNull(userId);
@@ -267,7 +247,7 @@ public class AdminAccountService {
             requestInfoService.removeRequestInfo(account.getId());
         }
     }
-    
+    */
     protected void sendVerificationMessages(App app, Account original, Account update) {
         if (!nullSafeEquals(original.getEmail(), update.getEmail())) {
             update.setEmailVerified(FALSE);

--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -122,133 +122,43 @@ public class ParticipantService {
     static final String DOWNLOAD_ROSTER_SERVICE_TITLE = "DownloadParticipantRosterWorker";
     static final String APP_INSTALL_URL_KEY = "appInstallUrl";
 
+    @Autowired
     private AccountService accountService;
-
+    @Autowired
     private SmsService smsService;
-
+    @Autowired
     private SubpopulationService subpopService;
-
+    @Autowired
     private ConsentService consentService;
-    
+    @Autowired
     private RequestInfoService requestInfoService;
-
+    @Autowired
     private ScheduledActivityDao activityDao;
-
+    @Autowired
     private UploadService uploadService;
-
+    @Autowired
     private NotificationsService notificationsService;
-
+    @Autowired
     private ScheduledActivityService scheduledActivityService;
-
+    @Autowired
     private ActivityEventService activityEventService;
-
+    @Autowired
     private AccountWorkflowService accountWorkflowService;
-    
+    @Autowired
     private StudyService studyService;
-    
+    @Autowired
     private OrganizationService organizationService;
-    
+    @Autowired
     private EnrollmentService enrollmentService;
-
+    @Autowired
     private BridgeConfig bridgeConfig;
-
+    @Autowired
     private AmazonSQS sqsClient;
-    
+    @Autowired
     private TemplateService templateService;
-    
+    @Autowired
     private SendMailService sendMailService;
 
-    @Autowired
-    final void setAccountWorkflowService(AccountWorkflowService accountWorkflowService) {
-        this.accountWorkflowService = accountWorkflowService;
-    }
-    
-    @Autowired
-    void setAccountService(AccountService accountService) {
-        this.accountService = accountService;
-    }
-
-    /** SMS Service, used to send text messages to participants. */
-    @Autowired
-    void setSmsService(SmsService smsService) {
-        this.smsService = smsService;
-    }
-
-    @Autowired
-    void setSubpopulationService(SubpopulationService subpopService) {
-        this.subpopService = subpopService;
-    }
-
-    @Autowired
-    void setUserConsent(ConsentService consentService) {
-        this.consentService = consentService;
-    }
-
-    @Autowired
-    void setScheduledActivityDao(ScheduledActivityDao activityDao) {
-        this.activityDao = activityDao;
-    }
-
-    @Autowired
-    void setUploadService(UploadService uploadService) {
-        this.uploadService = uploadService;
-    }
-
-    @Autowired
-    void setNotificationsService(NotificationsService notificationsService) {
-        this.notificationsService = notificationsService;
-    }
-
-    @Autowired
-    void setScheduledActivityService(ScheduledActivityService scheduledActivityService) {
-        this.scheduledActivityService = scheduledActivityService;
-    }
-
-    @Autowired
-    final void setActivityEventService(ActivityEventService activityEventService) {
-        this.activityEventService = activityEventService;
-    }
-
-    @Autowired
-    final void setStudyService(StudyService studyService) {
-        this.studyService = studyService;
-    }
-    
-    @Autowired
-    final void setRequestInfoService(RequestInfoService requestInfoService) {
-        this.requestInfoService = requestInfoService;
-    }
-    
-    @Autowired
-    final void setOrganizationService(OrganizationService organizationService) {
-        this.organizationService = organizationService;
-    }
-    
-    @Autowired
-    final void setEnrollmentService(EnrollmentService enrollmentService) {
-        this.enrollmentService = enrollmentService;
-    }
-
-    @Autowired
-    final void setBridgeConfig(BridgeConfig bridgeConfig) {
-        this.bridgeConfig = bridgeConfig;
-    }
-
-    @Autowired
-    final void setSqsClient(AmazonSQS sqsClient) {
-        this.sqsClient = sqsClient;
-    }
-    
-    @Autowired
-    final void setTemplateService(TemplateService templateService) {
-        this.templateService = templateService;
-    }
-
-    @Autowired
-    final void setSendMailService(SendMailService sendMailService) {
-        this.sendMailService = sendMailService;
-    }
-    
     // Accessor so we can mock the value
     protected DateTime getInstallDateTime() {
         return new DateTime();

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AccountsController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AccountsController.java
@@ -127,9 +127,9 @@ public class AccountsController extends BaseController  {
     public StatusMessage deleteAccount(@PathVariable String userId) {
         UserSession session = getAuthenticatedSession(ORG_ADMIN);
         
-        verifyOrgAdminIsActingOnOrgMember(session, userId);
+        Account account = verifyOrgAdminIsActingOnOrgMember(session, userId);
         
-        adminAccountService.deleteAccount(session.getAppId(), userId);
+        accountService.deleteAccount(AccountId.forId(session.getAppId(), account.getId()));
         
         return DELETED_MSG;
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AppController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AppController.java
@@ -50,6 +50,7 @@ import org.sagebionetworks.bridge.models.apps.SynapseProjectIdTeamIdHolder;
 import org.sagebionetworks.bridge.models.upload.UploadView;
 import org.sagebionetworks.bridge.services.EmailVerificationService;
 import org.sagebionetworks.bridge.services.EmailVerificationStatus;
+import org.sagebionetworks.bridge.services.AdminAccountService;
 import org.sagebionetworks.bridge.services.AppEmailType;
 import org.sagebionetworks.bridge.services.UploadCertificateService;
 import org.sagebionetworks.bridge.services.UploadService;
@@ -74,27 +75,18 @@ public class AppController extends BaseController {
     private final Set<String> appWhitelist = Collections
             .unmodifiableSet(new HashSet<>(BridgeConfigFactory.getConfig().getPropertyAsList("app.whitelist")));
 
+    @Autowired
     private UploadCertificateService uploadCertificateService;
 
+    @Autowired
     private EmailVerificationService emailVerificationService;
 
+    @Autowired
     private UploadService uploadService;
-
-    @Autowired
-    final void setUploadCertificateService(UploadCertificateService uploadCertificateService) {
-        this.uploadCertificateService = uploadCertificateService;
-    }
-
-    @Autowired
-    final void setEmailVerificationService(EmailVerificationService emailVerificationService) {
-        this.emailVerificationService = emailVerificationService;
-    }
-
-    @Autowired
-    final void setUploadService(UploadService uploadService) {
-        this.uploadService = uploadService;
-    }
     
+    @Autowired
+    private AdminAccountService adminAccountService;
+
     // To enable mocking of values.
     Set<String> getAppWhitelist() {
         return appWhitelist;
@@ -185,7 +177,7 @@ public class AppController extends BaseController {
             stream = appService.getApps().stream().filter(s -> s.isActive());
         } else {
             // Otherwise, apps are linked by Synapse user ID.
-            List<String> appIds = accountService
+            List<String> appIds = adminAccountService
                     .getAppIdsForUser(session.getParticipant().getSynapseUserId());
             stream = appIds.stream()
                 .map(id -> appService.getApp(id))

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/IntegrationTestUserController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/IntegrationTestUserController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import org.sagebionetworks.bridge.json.JsonUtils;
 import org.sagebionetworks.bridge.models.StatusMessage;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
 import org.sagebionetworks.bridge.models.accounts.UserSessionInfo;
@@ -62,10 +63,8 @@ public class IntegrationTestUserController extends BaseController {
     @DeleteMapping("/v3/users/{userId}")
     public StatusMessage deleteUser(@PathVariable String userId) {
         UserSession session = getAuthenticatedSession(ADMIN);
-        App app = appService.getApp(session.getAppId());
         
-        testUserService.deleteUser(app, userId);
-        
+        accountService.deleteAccount(AccountId.forId(session.getAppId(), userId));
         return DELETED_MSG;
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
@@ -80,7 +80,6 @@ import org.sagebionetworks.bridge.models.studies.EnrollmentDetail;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.models.upload.UploadView;
 import org.sagebionetworks.bridge.services.ParticipantService;
-import org.sagebionetworks.bridge.services.IntegrationTestUserService;
 import org.sagebionetworks.bridge.services.AccountWorkflowService;
 import org.sagebionetworks.bridge.services.AuthenticationService.ChannelType;
 import org.sagebionetworks.bridge.services.EnrollmentService;
@@ -94,8 +93,6 @@ public class ParticipantController extends BaseController {
 
     private ParticipantService participantService;
     
-    private IntegrationTestUserService testUserService;
-    
     private EnrollmentService enrollmentService;
     
     private AccountWorkflowService accountWorkflowService;
@@ -103,11 +100,6 @@ public class ParticipantController extends BaseController {
     @Autowired
     final void setParticipantService(ParticipantService participantService) {
         this.participantService = participantService;
-    }
-    
-    @Autowired
-    final void setIntegrationTestUserService(IntegrationTestUserService testUserService) {
-        this.testUserService = testUserService;
     }
     
     @Autowired
@@ -219,8 +211,7 @@ public class ParticipantController extends BaseController {
         if (!participantEligibleForDeletion(requestInfoService, account)) {
             throw new UnauthorizedException(CANNOT_DELETE_ACCOUNT_ERROR);
         }
-        App app = appService.getApp(session.getAppId());
-        testUserService.deleteUser(app, account.getId());
+        accountService.deleteAccount(AccountId.forId(session.getAppId(), account.getId()));
         return new StatusMessage("User deleted.");
     }
 

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantController.java
@@ -86,7 +86,6 @@ import org.sagebionetworks.bridge.services.ReportService;
 import org.sagebionetworks.bridge.services.Schedule2Service;
 import org.sagebionetworks.bridge.services.StudyActivityEventService;
 import org.sagebionetworks.bridge.services.StudyService;
-import org.sagebionetworks.bridge.services.IntegrationTestUserService;
 import org.sagebionetworks.bridge.spring.util.EtagSupport;
 import org.sagebionetworks.bridge.spring.util.EtagCacheKey;
 import org.sagebionetworks.bridge.services.AccountWorkflowService;
@@ -119,8 +118,6 @@ public class StudyParticipantController extends BaseController {
 
     private ParticipantService participantService;
     
-    private IntegrationTestUserService testUserService;
-    
     private EnrollmentService enrollmentService;
     
     private StudyActivityEventService studyActivityEventService;
@@ -138,11 +135,6 @@ public class StudyParticipantController extends BaseController {
         this.participantService = participantService;
     }
     
-    @Autowired
-    final void setIntegrationTestUserService(IntegrationTestUserService testUserService) {
-        this.testUserService = testUserService;
-    }
-
     @Autowired
     final void setEnrollmentService(EnrollmentService enrollmentService) {
         this.enrollmentService = enrollmentService;
@@ -578,8 +570,7 @@ public class StudyParticipantController extends BaseController {
         if (!participantEligibleForDeletion(requestInfoService, account)) {
             throw new UnauthorizedException("Account is not a test account or it is already in use.");
         }
-        App app = appService.getApp(session.getAppId());
-        testUserService.deleteUser(app, account.getId());
+        accountService.deleteAccount(AccountId.forId(session.getAppId(), account.getId()));
         return DELETE_MSG;
     }    
     

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
@@ -15,7 +15,6 @@ import static org.sagebionetworks.bridge.TestConstants.ACCOUNT_ID;
 import static org.sagebionetworks.bridge.TestConstants.EMAIL;
 import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
 import static org.sagebionetworks.bridge.TestConstants.PHONE;
-import static org.sagebionetworks.bridge.TestConstants.SYNAPSE_USER_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_ORG_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
@@ -34,7 +33,6 @@ import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -63,7 +61,6 @@ import org.sagebionetworks.bridge.cache.CacheKey;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.dao.AccountDao;
 import org.sagebionetworks.bridge.dao.AccountSecretDao;
-import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.PagedResourceList;
@@ -99,14 +96,11 @@ public class AccountServiceTest extends Mockito {
     AccountSecretDao mockAccountSecretDao;
     
     @Mock
-    AppService appService;
+    AppService mockAppService;
     
     @Mock
-    StudyActivityEventService studyActivityEventService;
+    StudyActivityEventService mockStudyActivityEventService;
 
-    @Mock
-    ActivityEventService activityEventService;
-    
     @Mock
     PagedResourceList<AccountSummary> mockAccountSummaries;
     
@@ -121,6 +115,30 @@ public class AccountServiceTest extends Mockito {
 
     @Mock
     ParticipantVersionService mockParticipantVersionService;
+    
+    @Mock
+    RequestInfoService mockRequestInfoService;
+
+    @Mock
+    HealthDataService mockHealthDataService;
+    
+    @Mock
+    HealthDataEx3Service mockHealthDataEx3Service;
+    
+    @Mock
+    NotificationsService mockNotificationsService;
+    
+    @Mock
+    UploadService mockUploadService;
+    
+    @Mock
+    ScheduledActivityService mockScheduledActivityService;
+    
+    @Mock
+    ActivityEventService mockActivityEventService;
+    
+    @Mock
+    AccountService mockAccountService;
 
     @InjectMocks
     @Spy
@@ -153,35 +171,7 @@ public class AccountServiceTest extends Mockito {
     public void afterMethod() {
         RequestContext.set(NULL_INSTANCE);
     }
-
-    @Test
-    public void getAppIdsForUser() {
-        List<String> apps = ImmutableList.of("app1", "app2");
-        when(mockAccountDao.getAppIdForUser(SYNAPSE_USER_ID)).thenReturn(apps);
-
-        List<String> returnVal = service.getAppIdsForUser(SYNAPSE_USER_ID);
-        assertEquals(returnVal, apps);
-        verify(mockAccountDao).getAppIdForUser(SYNAPSE_USER_ID);
-    }
-
-    @Test(expectedExceptions = BadRequestException.class, expectedExceptionsMessageRegExp =
-            "Account does not have a Synapse user")
-    public void getAppIdsForUser_NullSynapseUserId() {
-        service.getAppIdsForUser(null);
-    }
-
-    @Test(expectedExceptions = BadRequestException.class, expectedExceptionsMessageRegExp =
-            "Account does not have a Synapse user")
-    public void getAppIdsForUser_EmptySynapseUserId() {
-        service.getAppIdsForUser("");
-    }
-
-    @Test(expectedExceptions = BadRequestException.class, expectedExceptionsMessageRegExp =
-            "Account does not have a Synapse user")
-    public void getAppIdsForUser_BlankSynapseUserId() {
-        service.getAppIdsForUser("   ");
-    }
-
+    
     @Test
     public void createAccount() {
         App app = App.create();
@@ -467,23 +457,6 @@ public class AccountServiceTest extends Mockito {
     }
 
     @Test
-    public void deleteAccount() throws Exception {
-        mockGetAccountById(ACCOUNT_ID, false);
-
-        service.deleteAccount(ACCOUNT_ID);
-        
-        verify(mockAccountDao).deleteAccount(TEST_USER_ID);
-        verify(mockCacheProvider).removeObject(CacheKey.etag(DateTimeZone.class, TEST_USER_ID));
-    }
-    
-    @Test
-    public void deleteAccountNotFound() {
-        service.deleteAccount(ACCOUNT_ID);
-        verify(mockAccountDao, never()).deleteAccount(any());
-        verify(mockCacheProvider, never()).removeObject(any());
-    }
-
-    @Test
     public void getPagedAccountSummaries() {
         when(mockAccountDao.getPagedAccountSummaries(TEST_APP_ID, EMPTY_SEARCH)).thenReturn(mockAccountSummaries);
 
@@ -562,8 +535,8 @@ public class AccountServiceTest extends Mockito {
         assertEquals(createdAccount.getPasswordModifiedOn().getMillis(), MOCK_DATETIME.getMillis());
         assertEquals(createdAccount.getMigrationVersion(), MIGRATION_VERSION);
         
-        verify(activityEventService, never()).publishEnrollmentEvent(any(), any(), any());
-        verify(studyActivityEventService, never()).publishEvent(any(), anyBoolean(), anyBoolean());
+        verify(mockActivityEventService, never()).publishEnrollmentEvent(any(), any(), any());
+        verify(mockStudyActivityEventService, never()).publishEvent(any(), anyBoolean(), anyBoolean());
     }
     
     @Test
@@ -583,8 +556,8 @@ public class AccountServiceTest extends Mockito {
         service.createAccount(app, account);
 
         verify(mockAccountDao).createAccount(account);
-        verify(activityEventService).publishEnrollmentEvent(any(), any(), any());
-        verify(studyActivityEventService, times(2)).publishEvent(eventCaptor.capture(), eq(false), eq(true));
+        verify(mockActivityEventService).publishEnrollmentEvent(any(), any(), any());
+        verify(mockStudyActivityEventService, times(2)).publishEvent(eventCaptor.capture(), eq(false), eq(true));
 
         StudyActivityEvent event1 = getElement(
                 eventCaptor.getAllValues(), StudyActivityEvent::getStudyId, STUDY_A).orElse(null);
@@ -663,8 +636,8 @@ public class AccountServiceTest extends Mockito {
         assertEquals(updatedAccount.getModifiedOn().getMillis(), MOCK_DATETIME.getMillis());
         assertEquals(updatedAccount.getClientTimeZone(), OTHER_CLIENT_TIME_ZONE);
         
-        verify(activityEventService, never()).publishEnrollmentEvent(any(), any(), any());
-        verify(studyActivityEventService, never()).publishEvent(any(), anyBoolean(), anyBoolean());
+        verify(mockActivityEventService, never()).publishEnrollmentEvent(any(), any(), any());
+        verify(mockStudyActivityEventService, never()).publishEvent(any(), anyBoolean(), anyBoolean());
     }
 
     @Test
@@ -692,14 +665,14 @@ public class AccountServiceTest extends Mockito {
         
         App app = App.create();
         app.setIdentifier(TEST_APP_ID);
-        when(appService.getApp(TEST_APP_ID)).thenReturn(app);
+        when(mockAppService.getApp(TEST_APP_ID)).thenReturn(app);
 
         // Execute. Identifiers not allows to change.
         service.updateAccount(account);
         
-        verify(activityEventService).publishEnrollmentEvent(
+        verify(mockActivityEventService).publishEnrollmentEvent(
                 eq(app), eq(HEALTH_CODE), any(DateTime.class));
-        verify(studyActivityEventService).publishEvent(eventCaptor.capture(), eq(false), eq(true));
+        verify(mockStudyActivityEventService).publishEvent(eventCaptor.capture(), eq(false), eq(true));
         StudyActivityEvent event = eventCaptor.getValue();
         assertEquals(event.getAppId(), TEST_APP_ID);
         assertEquals(event.getStudyId(), STUDY_B);
@@ -922,6 +895,56 @@ public class AccountServiceTest extends Mockito {
         service.updateAccount(account);
         
         assertTrue(account.isAdmin());
+    }
+
+    @Test
+    public void deleteAccount() {
+        Account account = Account.create();
+        account.setAppId(TEST_APP_ID);
+        account.setId(TEST_USER_ID);
+        account.setHealthCode(HEALTH_CODE);
+        AccountId accountId = AccountId.forId(TEST_APP_ID,  TEST_USER_ID);
+
+        Enrollment en1 = Enrollment.create(TEST_APP_ID, "studyA", TEST_USER_ID, "subAextId");
+        Enrollment en2 = Enrollment.create(TEST_APP_ID, "studyB", TEST_USER_ID, "subBextId");
+        Set<Enrollment> enrollments = ImmutableSet.of(en1, en2);
+        account.setEnrollments(enrollments);
+        
+        when(mockAccountDao.getAccount(accountId)).thenReturn(Optional.of(account));
+        
+        service.deleteAccount(accountId);
+        
+        verify(service).deleteAccount(accountId);
+        
+        // Verify a lot of stuff is deleted or removed
+        verify(mockCacheProvider).removeSessionByUserId(TEST_USER_ID);
+        verify(mockRequestInfoService).removeRequestInfo(TEST_USER_ID);
+        verify(mockHealthDataService).deleteRecordsForHealthCode(HEALTH_CODE);
+        verify(mockHealthDataEx3Service).deleteRecordsForHealthCode(HEALTH_CODE);
+        verify(mockNotificationsService).deleteAllRegistrations(TEST_APP_ID, HEALTH_CODE);
+        verify(mockUploadService).deleteUploadsForHealthCode(HEALTH_CODE);
+        verify(mockScheduledActivityService).deleteActivitiesForUser(HEALTH_CODE);
+        verify(mockActivityEventService, atLeastOnce()).deleteActivityEvents(TEST_APP_ID, HEALTH_CODE);
+        verify(mockAccountDao).deleteAccount(TEST_USER_ID);
+        verify(mockCacheProvider).removeObject(CacheKey.etag(DateTimeZone.class, TEST_USER_ID));
+        verify(mockCacheProvider).removeObject(CacheKey.etag(StudyActivityEvent.class, TEST_USER_ID));
+    }
+    
+    @Test
+    public void deleteAccount_notFound() {
+        service.deleteAccount(AccountId.forId(TEST_APP_ID, TEST_USER_ID));
+        
+        // (it very quietly does nothing)
+        verify(mockCacheProvider, never()).removeSessionByUserId(any());
+        verify(mockRequestInfoService, never()).removeRequestInfo(any());
+        verify(mockHealthDataService, never()).deleteRecordsForHealthCode(any());
+        verify(mockHealthDataEx3Service, never()).deleteRecordsForHealthCode(any());
+        verify(mockNotificationsService, never()).deleteAllRegistrations(any(), any());
+        verify(mockUploadService, never()).deleteUploadsForHealthCode(any());
+        verify(mockScheduledActivityService, never()).deleteActivitiesForUser(any());
+        verify(mockActivityEventService, never()).deleteActivityEvents(any(), any());
+        verify(mockAccountDao, never()).deleteAccount(any());
+        verify(mockCacheProvider, never()).removeObject(any());
     }
 
     private Account mockGetAccountById(AccountId accountId, boolean generatePasswordHash) throws Exception {

--- a/src/test/java/org/sagebionetworks/bridge/services/IntegrationTestUserServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/IntegrationTestUserServiceTest.java
@@ -15,9 +15,7 @@ import static org.testng.Assert.fail;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
-import org.joda.time.DateTimeZone;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
@@ -32,7 +30,6 @@ import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.Roles;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.TestUtils;
-import org.sagebionetworks.bridge.cache.CacheKey;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.exceptions.ConsentRequiredException;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
@@ -45,9 +42,7 @@ import org.sagebionetworks.bridge.models.accounts.SharingScope;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
-import org.sagebionetworks.bridge.models.activities.StudyActivityEvent;
 import org.sagebionetworks.bridge.models.apps.App;
-import org.sagebionetworks.bridge.models.studies.Enrollment;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 
 import com.google.common.collect.ImmutableMap;
@@ -453,56 +448,5 @@ public class IntegrationTestUserServiceTest extends Mockito {
         } catch(IllegalStateException e) {
             verify(accountService).deleteAccount(accountId);
         }
-    }
-    
-    @Test
-    public void deleteUser() {
-        App app = TestUtils.getValidApp(IntegrationTestUserServiceTest.class);
-        
-        AccountId accountId = AccountId.forId(app.getIdentifier(),  "userId");
-
-        Enrollment en1 = Enrollment.create(TEST_APP_ID, "studyA", "userId", "subAextId");
-        Enrollment en2 = Enrollment.create(TEST_APP_ID, "studyB", "userId", "subBextId");
-        Set<Enrollment> enrollments = ImmutableSet.of(en1, en2);
-        
-        doReturn("userId").when(account).getId();
-        doReturn("healthCode").when(account).getHealthCode();
-        doReturn(enrollments).when(account).getActiveEnrollments();
-        doReturn(enrollments).when(account).getEnrollments();
-        doReturn(Optional.of(account)).when(accountService).getAccount(accountId);
-        
-        service.deleteUser(app, "userId");
-        
-        // Verify a lot of stuff is deleted or removed
-        verify(cacheProvider).removeSessionByUserId("userId");
-        verify(requestInfoService).removeRequestInfo("userId");
-        verify(healthDataService).deleteRecordsForHealthCode("healthCode");
-        verify(healthDataEx3Service).deleteRecordsForHealthCode("healthCode");
-        verify(notificationsService).deleteAllRegistrations(app.getIdentifier(), "healthCode");
-        verify(uploadService).deleteUploadsForHealthCode("healthCode");
-        verify(scheduledActivityService).deleteActivitiesForUser("healthCode");
-        verify(activityEventService, atLeastOnce()).deleteActivityEvents(app.getIdentifier(), "healthCode");
-        verify(accountService).deleteAccount(accountId);
-        verify(cacheProvider).removeObject(CacheKey.etag(DateTimeZone.class, "userId"));
-        verify(cacheProvider).removeObject(CacheKey.etag(StudyActivityEvent.class, "userId"));
-        
-        assertEquals(account.getHealthCode(), "healthCode");
-    }
-    
-    @Test
-    public void deleteUser_notFound() {
-        App app = TestUtils.getValidApp(IntegrationTestUserServiceTest.class);
-        
-        service.deleteUser(app, "userId");
-        
-        // (it very quietly does nothing)
-        verify(cacheProvider, never()).removeSessionByUserId(any());
-        verify(requestInfoService, never()).removeRequestInfo(any());
-        verify(healthDataService, never()).deleteRecordsForHealthCode(any());
-        verify(notificationsService, never()).deleteAllRegistrations(any(), any());
-        verify(uploadService, never()).deleteUploadsForHealthCode(any());
-        verify(scheduledActivityService, never()).deleteActivitiesForUser(any());
-        verify(activityEventService, never()).deleteActivityEvents(any(), any());
-        verify(accountService, never()).deleteAccount(any());
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AccountsControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AccountsControllerTest.java
@@ -300,11 +300,8 @@ public class AccountsControllerTest extends Mockito {
         doReturn(session).when(controller).getAuthenticatedSession(ORG_ADMIN);
         
         account.setOrgMembership(TEST_ORG_ID);
+        account.setId(TEST_USER_ID);
         when(mockAccountService.getAccount(ACCOUNT_ID)).thenReturn(Optional.of(account));
-        
-        Account existing = Account.create();
-        existing.setOrgMembership(TEST_ORG_ID);
-        when(mockAdminAccountService.getAccount(TEST_APP_ID, TEST_USER_ID)).thenReturn(Optional.of(existing));
 
         StatusMessage retValue = controller.deleteAccount(TEST_USER_ID);
         assertEquals(retValue.getMessage(), "Member account deleted.");

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AccountsControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AccountsControllerTest.java
@@ -309,7 +309,7 @@ public class AccountsControllerTest extends Mockito {
         StatusMessage retValue = controller.deleteAccount(TEST_USER_ID);
         assertEquals(retValue.getMessage(), "Member account deleted.");
         
-        verify(mockAdminAccountService).deleteAccount(TEST_APP_ID, TEST_USER_ID);
+        verify(mockAccountService).deleteAccount(ACCOUNT_ID);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AppControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AppControllerTest.java
@@ -80,6 +80,7 @@ import org.sagebionetworks.bridge.models.apps.SynapseProjectIdTeamIdHolder;
 import org.sagebionetworks.bridge.models.upload.Upload;
 import org.sagebionetworks.bridge.models.upload.UploadView;
 import org.sagebionetworks.bridge.services.AccountService;
+import org.sagebionetworks.bridge.services.AdminAccountService;
 import org.sagebionetworks.bridge.services.EmailVerificationService;
 import org.sagebionetworks.bridge.services.AppService;
 import org.sagebionetworks.bridge.services.UploadCertificateService;
@@ -123,6 +124,9 @@ public class AppControllerTest extends Mockito {
     
     @Mock
     AccountService mockAccountService;
+    
+    @Mock
+    AdminAccountService mockAdminAccountService;
     
     @Mock
     BridgeConfig mockBridgeConfig;
@@ -820,7 +824,7 @@ public class AppControllerTest extends Mockito {
         mockApp("App A", "appA", false);
         
         List<String> list = ImmutableList.of("appA", "appB", "appC");
-        when(mockAccountService.getAppIdsForUser(SYNAPSE_USER_ID)).thenReturn(list);
+        when(mockAdminAccountService.getAppIdsForUser(SYNAPSE_USER_ID)).thenReturn(list);
         
         String jsonString = controller.getAppMemberships();
         JsonNode node = BridgeObjectMapper.get().readTree(jsonString).get("items");
@@ -847,7 +851,7 @@ public class AppControllerTest extends Mockito {
         JsonNode node = BridgeObjectMapper.get().readTree(jsonString).get("items");
         
         assertEquals(node.size(), 0);
-        verify(mockAccountService, never()).getAppIdsForUser(SYNAPSE_USER_ID);
+        verify(mockAdminAccountService, never()).getAppIdsForUser(SYNAPSE_USER_ID);
     }
     
     @Test
@@ -869,7 +873,7 @@ public class AppControllerTest extends Mockito {
         
         // This user is only associated to the API app, but they are an admin
         List<String> list = ImmutableList.of(TEST_APP_ID);
-        when(mockAccountService.getAppIdsForUser(SYNAPSE_USER_ID)).thenReturn(list);
+        when(mockAdminAccountService.getAppIdsForUser(SYNAPSE_USER_ID)).thenReturn(list);
         
         String jsonString = controller.getAppMemberships();
         JsonNode node = BridgeObjectMapper.get().readTree(jsonString).get("items");

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationControllerTest.java
@@ -96,6 +96,7 @@ import org.sagebionetworks.bridge.models.oauth.OAuthAuthorizationToken;
 import org.sagebionetworks.bridge.models.subpopulations.SubpopulationGuid;
 import org.sagebionetworks.bridge.services.AccountService;
 import org.sagebionetworks.bridge.services.AccountWorkflowService;
+import org.sagebionetworks.bridge.services.AdminAccountService;
 import org.sagebionetworks.bridge.services.AuthenticationService;
 import org.sagebionetworks.bridge.services.AppService;
 import org.sagebionetworks.bridge.services.AuthenticationService.ChannelType;
@@ -136,6 +137,9 @@ public class AuthenticationControllerTest extends Mockito {
     
     @Mock
     AccountService mockAccountService;
+    
+    @Mock
+    AdminAccountService mockAdminAccountService;
     
     @Mock
     AppService mockAppService;
@@ -1386,7 +1390,7 @@ public class AuthenticationControllerTest extends Mockito {
         userSession.setSynapseAuthenticated(true);
         doReturn(userSession).when(controller).getAuthenticatedSession();
         
-        when(mockAccountService.getAppIdsForUser(SYNAPSE_USER_ID))
+        when(mockAdminAccountService.getAppIdsForUser(SYNAPSE_USER_ID))
             .thenReturn(ImmutableList.of(TEST_APP_ID));
         
         App newApp = App.create();

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/IntegrationTestUserControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/IntegrationTestUserControllerTest.java
@@ -33,6 +33,7 @@ import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.exceptions.InvalidEntityException;
 import org.sagebionetworks.bridge.models.StatusMessage;
+import org.sagebionetworks.bridge.models.accounts.AccountId;
 import org.sagebionetworks.bridge.models.accounts.SignIn;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.accounts.UserSession;
@@ -150,6 +151,6 @@ public class IntegrationTestUserControllerTest extends Mockito {
         StatusMessage result = controller.deleteUser(TEST_USER_ID);
         assertEquals(result, IntegrationTestUserController.DELETED_MSG);
 
-        verify(mockUserManagementService).deleteUser(mockApp, TEST_USER_ID);
+        verify(mockAccountService).deleteAccount(AccountId.forId(TEST_APP_ID, TEST_USER_ID));
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
@@ -1509,7 +1509,7 @@ public class ParticipantControllerTest extends Mockito {
         when(mockParticipantService.getParticipant(app, TEST_USER_ID, false)).thenReturn(participant);
         controller.deleteTestOrUnusedParticipant(TEST_USER_ID);
 
-        verify(mockUserManagementService).deleteUser(app, TEST_USER_ID);
+        verify(mockAccountService).deleteAccount(AccountId.forId(TEST_APP_ID, TEST_USER_ID));
     }
 
     @Test(expectedExceptions = UnauthorizedException.class)

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyParticipantControllerTest.java
@@ -1217,7 +1217,7 @@ public class StudyParticipantControllerTest extends Mockito {
         StatusMessage retValue = controller.deleteTestOrUnusedParticipant(TEST_STUDY_ID, TEST_USER_ID);
         assertEquals(retValue.getMessage(), "User deleted.");
         
-        verify(mockUserManagementService).deleteUser(app, TEST_USER_ID);
+        verify(mockAccountService).deleteAccount(AccountId.forId(TEST_APP_ID, TEST_USER_ID));
     }    
     
     @Test(expectedExceptions = EntityNotFoundException.class)


### PR DESCRIPTION
There is now one canonical delete method in AccountService that handles clearing all the caches, the non-transactional DynamoDB tables, etc.