### PR TITLE
Preview accounts (BRIDGE-3255)

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/BridgeConstants.java
+++ b/src/main/java/org/sagebionetworks/bridge/BridgeConstants.java
@@ -115,6 +115,12 @@ public class BridgeConstants {
     
     public static final String TEST_USER_GROUP = "test_user";
     
+    /** 
+     * This kind of test user is deleted when a study is moved from design to recruitment. Once tagged
+     * with this tag, the account cannot remove it, and the account cannot be enrolled in a second study.
+     */
+    public static final String PREVIEW_USER_GROUP = "preview_user";
+    
     public static final String EXPIRATION_PERIOD_KEY = "expirationPeriod";
     
     public static final String CONSENT_URL = "consentUrl";

--- a/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
@@ -7,6 +7,8 @@ import static org.sagebionetworks.bridge.AuthEvaluatorField.USER_ID;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_READ_PARTICIPANTS;
 import static org.sagebionetworks.bridge.AuthUtils.CANNOT_ACCESS_PARTICIPANTS;
 import static org.sagebionetworks.bridge.AuthUtils.canAccessAccount;
+import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
+import static org.sagebionetworks.bridge.BridgeConstants.PREVIEW_USER_GROUP;
 import static org.sagebionetworks.bridge.BridgeConstants.TEST_USER_GROUP;
 import static org.sagebionetworks.bridge.BridgeUtils.addToSet;
 import static org.sagebionetworks.bridge.BridgeUtils.collectStudyIds;
@@ -18,6 +20,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
 import org.joda.time.DateTime;
@@ -286,6 +289,34 @@ public class AccountService {
         }
     }
     
+    /**
+     * Delete all accounts that are preview users in this study. We check and throw an exception 
+     * if someone attempts to enroll a preview user in more than one study, so it's safe to 
+     * just delete here.
+     */
+    public void deleteAllPreviewAccounts(String appId, String studyId) {
+        checkNotNull(appId);
+        checkNotNull(studyId);
+        
+        Set<String> allOfGroups = ImmutableSet.of(PREVIEW_USER_GROUP);
+        AccountSummarySearch.Builder searchBuilder = new AccountSummarySearch.Builder()
+                .withPageSize(API_MAXIMUM_PAGE_SIZE)
+                .withAllOfGroups(allOfGroups)
+                .withEnrolledInStudyId(studyId);
+        PagedResourceList<AccountSummary> page = null;
+        int offset = 0;
+        do {
+            searchBuilder.withOffsetBy(offset);
+            page = getPagedAccountSummaries(appId, searchBuilder.build());
+            for (AccountSummary summary : page.getItems()) {
+                // It is too slow to use deleteAccount because it cleans up a ton of
+                // DynamoDB resources. So... we leave all the non-relational data behind.
+                accountDao.deleteAccount(summary.getId());
+            }
+            offset += API_MAXIMUM_PAGE_SIZE;
+        } while(offset < page.getTotal());
+    }
+
     /**
      * Get a page of lightweight account summaries (most importantly, the email addresses of 
      * participants which are required for the rest of the participant APIs). 

--- a/src/main/java/org/sagebionetworks/bridge/services/AdminAccountService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AdminAccountService.java
@@ -200,7 +200,7 @@ public class AdminAccountService {
         // None of these values should be changeable by the user.
         account.setAppId(persistedAccount.getAppId());
         account.setAdmin(persistedAccount.isAdmin());
-        account.setDataGroups(persistedAccount.getDataGroups());
+        account.setDataGroups(addToSet(persistedAccount.getDataGroups(), TEST_USER_GROUP));
         account.setCreatedOn(persistedAccount.getCreatedOn());
         account.setHealthCode(persistedAccount.getHealthCode());
         account.setPasswordAlgorithm(persistedAccount.getPasswordAlgorithm());
@@ -208,7 +208,6 @@ public class AdminAccountService {
         account.setPasswordModifiedOn(persistedAccount.getPasswordModifiedOn());
         account.setOrgMembership(persistedAccount.getOrgMembership());
         account.setMigrationVersion(persistedAccount.getMigrationVersion());
-        account.setDataGroups(addToSet(account.getDataGroups(), TEST_USER_GROUP));
         account.setModifiedOn(getModifiedOn());
         account.setPhoneVerified(persistedAccount.getPhoneVerified());
         account.setEmailVerified(persistedAccount.getEmailVerified());

--- a/src/main/java/org/sagebionetworks/bridge/services/AppService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AppService.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.sagebionetworks.bridge.BridgeConstants.TEST_USER_GROUP;
 import static org.sagebionetworks.bridge.models.apps.MimeType.HTML;
 
 import java.io.IOException;
@@ -50,7 +51,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Component;
 
-import org.sagebionetworks.bridge.BridgeConstants;
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.SecureTokenGenerator;
 import org.sagebionetworks.bridge.cache.CacheProvider;
@@ -252,7 +252,7 @@ public class AppService {
         app.setAppIdExcludedInExport(true);
         app.setVerifyChannelOnSignInEnabled(true);
         app.setEmailVerificationEnabled(true);
-        app.getDataGroups().add(BridgeConstants.TEST_USER_GROUP);
+        app.getDataGroups().add(TEST_USER_GROUP);
         if (app.getPasswordPolicy() == null) {
             app.setPasswordPolicy(PasswordPolicy.DEFAULT_PASSWORD_POLICY);
         }

--- a/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
@@ -55,33 +55,16 @@ import com.google.common.collect.ImmutableMap;
 @Component
 public class StudyService {
     
+    @Autowired
     private StudyDao studyDao;
-    
+    @Autowired
     private SponsorService sponsorService;
-    
+    @Autowired
     private CacheProvider cacheProvider;
-    
+    @Autowired
     private Schedule2Service scheduleService;
-    
     @Autowired
-    final void setStudyDao(StudyDao studyDao) {
-        this.studyDao = studyDao;
-    }
-    
-    @Autowired
-    final void setSponsorService(SponsorService sponsorService) {
-        this.sponsorService = sponsorService;
-    }
-    
-    @Autowired
-    final void setCacheProvider(CacheProvider cacheProvider) {
-        this.cacheProvider = cacheProvider;
-    }
-    
-    @Autowired
-    final void setSchedule2Service(Schedule2Service scheduleService) {
-        this.scheduleService = scheduleService;
-    }
+    private AccountService accountService;
     
     public void removeStudyEtags(String appId, String scheduleGuid) {
         checkNotNull(appId);
@@ -306,6 +289,7 @@ public class StudyService {
      */
     public Study transitionToRecruitment(String appId, String studyId) {
         return phaseTransition(appId, studyId, RECRUITMENT, (study) -> {
+            accountService.deleteAllPreviewAccounts(appId, studyId);
             if (study.getScheduleGuid() != null) {
                 Schedule2 schedule = scheduleService.getSchedule(appId, study.getScheduleGuid());
                 if (!schedule.isPublished()) {

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
@@ -845,21 +845,20 @@ public class AccountServiceTest extends Mockito {
                 ImmutableList.of(summary1, summary2, summary3), API_MAXIMUM_PAGE_SIZE+1);
         PagedResourceList<AccountSummary> page2 = new PagedResourceList<>(
                 ImmutableList.of(summary4, summary5, summary6), API_MAXIMUM_PAGE_SIZE+1);
-        when(mockAccountDao.getPagedAccountSummaries(eq(TEST_APP_ID), any())).thenReturn(page1, page2);
+        PagedResourceList<AccountSummary> page3 = new PagedResourceList<>(
+                ImmutableList.of(), API_MAXIMUM_PAGE_SIZE+1);
+        when(mockAccountDao.getPagedAccountSummaries(eq(TEST_APP_ID), any())).thenReturn(page1, page2, page3);
         
         service.deleteAllPreviewAccounts(TEST_APP_ID, TEST_STUDY_ID);
         
-        verify(mockAccountDao, times(2)).getPagedAccountSummaries(eq(TEST_APP_ID), searchCaptor.capture());
+        verify(mockAccountDao, times(3)).getPagedAccountSummaries(eq(TEST_APP_ID), searchCaptor.capture());
         
         AccountSummarySearch capturedSearch = searchCaptor.getAllValues().get(0);
         assertEquals(capturedSearch.getPageSize(), API_MAXIMUM_PAGE_SIZE);
         assertEquals(capturedSearch.getAllOfGroups(), ImmutableSet.of(PREVIEW_USER_GROUP));
         assertEquals(capturedSearch.getEnrolledInStudyId(), TEST_STUDY_ID);
         assertEquals(capturedSearch.getOffsetBy(), 0);
-        
-        capturedSearch = searchCaptor.getAllValues().get(1);
-        assertEquals(capturedSearch.getOffsetBy(), 100);
-        
+
         verify(mockAccountDao).deleteAccount("user1");
         verify(mockAccountDao).deleteAccount("user2");
         verify(mockAccountDao).deleteAccount("user3");

--- a/src/test/java/org/sagebionetworks/bridge/services/StudyServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/StudyServiceTest.java
@@ -90,6 +90,9 @@ public class StudyServiceTest {
     @Mock
     private Schedule2Service mockScheduleService;
     
+    @Mock
+    private AccountService mockAccountService;
+    
     @Captor
     private ArgumentCaptor<Study> studyCaptor;
     
@@ -703,6 +706,8 @@ public class StudyServiceTest {
 
         service.transitionToRecruitment(TEST_APP_ID, TEST_STUDY_ID);
         
+        verify(mockAccountService).deleteAllPreviewAccounts(TEST_APP_ID, TEST_STUDY_ID);
+        
         verify(mockStudyDao).updateStudy(study);
         assertEquals(study.getPhase(), RECRUITMENT);
         
@@ -724,6 +729,8 @@ public class StudyServiceTest {
 
         service.transitionToRecruitment(TEST_APP_ID, TEST_STUDY_ID);
         
+        verify(mockAccountService).deleteAllPreviewAccounts(TEST_APP_ID, TEST_STUDY_ID);
+        
         verify(mockStudyDao).updateStudy(study);
         assertEquals(study.getPhase(), RECRUITMENT);
         
@@ -741,6 +748,8 @@ public class StudyServiceTest {
         when(mockStudyDao.getStudy(TEST_APP_ID, TEST_STUDY_ID)).thenReturn(study);
         
         service.transitionToRecruitment(TEST_APP_ID, TEST_STUDY_ID);
+        
+        verify(mockAccountService).deleteAllPreviewAccounts(TEST_APP_ID, TEST_STUDY_ID);
         
         verify(mockStudyDao).updateStudy(study);
         assertEquals(study.getPhase(), RECRUITMENT);


### PR DESCRIPTION
1) Accounts can be tagged with "preview_user" data group (if you want to use this, it needs to be added to the app's configuration where it will be used);
2) These accounts will be deleted if the study transitions from design to recruitment (no other transition, and you aren't prevented from creating these when the study is in other states);
3) An account marked with "preview_user" can only be enrolled in one study (so when it is deleted, it doesn't disappear from another study).