### PR TITLE
Fixing integration tests

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantDataService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantDataService.java
@@ -77,13 +77,16 @@ public class ParticipantDataService {
     public void deleteAllParticipantData(String userId) {
         
         ForwardCursorPagedResourceList<ParticipantData> page = null;
+        String offsetKey = null;
         do {
-            page = getAllParticipantData(userId, null, API_MAXIMUM_PAGE_SIZE);
+            page = getAllParticipantData(userId, offsetKey, API_MAXIMUM_PAGE_SIZE);
+            
             for (ParticipantData data : page.getItems()) {
                 CacheKey cacheKey = CacheKey.etag(ParticipantData.class, userId, data.getIdentifier());
                 cacheProvider.removeObject(cacheKey);
             }
-        } while(!page.getItems().isEmpty());
+            offsetKey = page.getNextPageOffsetKey();
+        } while(offsetKey != null);
         
         participantDataDao.deleteAllParticipantData(userId);
     }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyController.java
@@ -180,7 +180,7 @@ public class StudyController extends BaseController {
 
     // This exists because apps want to get rudimentary study data to show participants before they've created their
     // account. For the worker API, see getStudyForWorker() below.
-    @EtagSupport({
+    @EtagSupport(authenticationRequired=false, value = {
         @EtagCacheKey(model=Study.class, keys={"appId", "studyId"})
     })
     @GetMapping(path = "/v1/apps/{appId}/studies/{studyId}", produces = { APPLICATION_JSON_VALUE })

--- a/src/main/java/org/sagebionetworks/bridge/spring/util/EtagContext.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/util/EtagContext.java
@@ -18,6 +18,7 @@ public class EtagContext {
     private final Class<?> model;
     private final List<EtagCacheKey> cacheKeys;
     private final Map<String,Object> argumentValues;
+    private final boolean authenticationRequired; 
 
     public EtagContext(ProceedingJoinPoint joinPoint) {
         MethodSignature method = (MethodSignature)joinPoint.getSignature();
@@ -25,6 +26,7 @@ public class EtagContext {
         
         EtagSupport[] etag = method.getMethod().getAnnotationsByType(EtagSupport.class);
         cacheKeys = Arrays.asList(etag[0].value());
+        authenticationRequired = etag[0].authenticationRequired();
         
         argumentValues = new HashMap<>();
         int len = joinPoint.getArgs().length;
@@ -43,5 +45,8 @@ public class EtagContext {
     }
     public Map<String,Object> getArgValues() {
         return argumentValues;
+    }
+    public boolean isAuthenticationRequired() {
+        return authenticationRequired;
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/spring/util/EtagSupport.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/util/EtagSupport.java
@@ -1,4 +1,4 @@
-    package org.sagebionetworks.bridge.spring.util;
+package org.sagebionetworks.bridge.spring.util;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -9,19 +9,30 @@ import java.lang.annotation.Target;
  * Annotation for a controller method annotation that suspends normal execution and returns a 304 
  * response if all the cache keys specified in this annotation match the caller’s ETag value.
  * 
- * The tag has one or more @EtagCacheKey values that specify the values of a CacheKey.etag key.
- * These are the dependencies that need to be tracked to ensure the etag submitted by the client
- * is up-to-date. If the property name matches a method argument name of the annotated method, 
- * that value will be used. Otherwise, the property name will be used to retrieve the information 
- * from the caller’s session (the supported values here are “appId”, “userId”, and “orgId“). 
- * Currently this tag can only be used on authenticated requests (the presence of the session is 
- * required). 
- * 
  * The values of the etag CacheKeys are Joda DateTime instances, representing the last time that 
- * model was updated.
+ * model was updated. These are used to calculate an etag for the current model retrievable 
+ * through a given controller method.
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface EtagSupport {
+    /**
+     * One or more @EtagCacheKey values that specify the values of a CacheKey.etag key. These are 
+     * the dependencies that need to be tracked to ensure the etag submitted by the client is up-to-
+     * date. If the property name matches a method argument name of the annotated method, that value 
+     * will be used. Otherwise, the property name will be used to retrieve the information from the 
+     * caller’s session (the supported values here are “appId”, “userId”, and “orgId“).
+     * 
+     * The values of the etag CacheKeys are Joda DateTime instances, representing the last time that 
+     * model was updated.
+     */
     EtagCacheKey[] value() default {};
+    /**
+     * Throw a NotAuthenticatedException error if the caller does not have a session. 
+     * If this is false, than all the key values should be retrievable from the controller 
+     * method arguments (query parameters or path parameters). or the tag will throw an 
+     * InvalidArgumentException.
+     * @return authenticationRequired (default: true)
+     */
+    boolean authenticationRequired() default true;
 }

--- a/src/test/java/org/sagebionetworks/bridge/services/ParticipantDataServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ParticipantDataServiceTest.java
@@ -108,7 +108,6 @@ public class ParticipantDataServiceTest extends Mockito {
                 CacheKey.etag(ParticipantData.class, userId, identifier), MODIFIED_ON);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testDeleteAllParticipantData() {
         ParticipantData data1 = ParticipantData.create();
@@ -124,12 +123,12 @@ public class ParticipantDataServiceTest extends Mockito {
         ForwardCursorPagedResourceList<ParticipantData> list1 = 
                 new ForwardCursorPagedResourceList<>(ImmutableList.of(data1, data2), "asdf");
         ForwardCursorPagedResourceList<ParticipantData> list2 = 
-                new ForwardCursorPagedResourceList<>(ImmutableList.of(data3, data4), "efgh");
-        ForwardCursorPagedResourceList<ParticipantData> list3 = 
-                new ForwardCursorPagedResourceList<>(ImmutableList.of(), null);
+                new ForwardCursorPagedResourceList<>(ImmutableList.of(data3, data4), null);
 
         when(mockDao.getAllParticipantData(TEST_USER_ID, null, API_MAXIMUM_PAGE_SIZE))
-            .thenReturn(list1, list2, list3);
+            .thenReturn(list1);
+        when(mockDao.getAllParticipantData(TEST_USER_ID, "asdf", API_MAXIMUM_PAGE_SIZE))
+            .thenReturn(list2);
         
         service.deleteAllParticipantData(TEST_USER_ID);
 


### PR DESCRIPTION
- You can configure an ETag for a public API now, and it will not look for the session (though it'll throw an exception if it cannot find all the cache key values in the controllers query parameters or path parameters);
- Loop to delete participant data was hanging until timeout, restored the original use of a page offset key to iterate through data entries, deleting cache first, then deleting all the data via the dao.