### PR TITLE
Get queue URLs from configs dynamically

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/ExportViaSqsService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ExportViaSqsService.java
@@ -31,12 +31,12 @@ public class ExportViaSqsService implements ExportService {
     static final String REQUEST_KEY_USE_LAST_EXPORT_TIME = "useLastExportTime";
 
     private AmazonSQS sqsClient;
-    private String sqsQueueUrl;
+    private BridgeConfig config;
 
     /** Bridge config, used to get the SQS queue URL. */
     @Autowired
     public final void setBridgeConfig(BridgeConfig bridgeConfig) {
-        this.sqsQueueUrl = bridgeConfig.getProperty(CONFIG_KEY_EXPORTER_SQS_QUEUE_URL);
+        this.config = bridgeConfig;
     }
 
     /** SQS client. */
@@ -67,6 +67,9 @@ public class ExportViaSqsService implements ExportService {
         requestNode.put(REQUEST_KEY_USE_LAST_EXPORT_TIME, true);
 
         String requestJsonText = JSON_OBJECT_MAPPER.writeValueAsString(requestNode);
+
+        // Note: SqsInitializer runs after Spring, so we need to grab the queue URL dynamically.
+        String sqsQueueUrl = config.getProperty(CONFIG_KEY_EXPORTER_SQS_QUEUE_URL);
 
         // send to SQS
         SendMessageResult sqsResult = sqsClient.sendMessage(sqsQueueUrl, requestJsonText);

--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantVersionService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantVersionService.java
@@ -39,9 +39,9 @@ public class ParticipantVersionService {
     static final String WORKER_NAME_EX_3_PARTICIPANT_VERSION = "Ex3ParticipantVersionWorker";
 
     private AppService appService;
+    private BridgeConfig config;
     private ParticipantVersionDao participantVersionDao;
     private AmazonSQS sqsClient;
-    private String workerQueueUrl;
 
     @Autowired
     public final void setAppService(AppService appService) {
@@ -50,7 +50,7 @@ public class ParticipantVersionService {
 
     @Autowired
     public final void setConfig(BridgeConfig config) {
-        workerQueueUrl = config.getProperty(BridgeConstants.CONFIG_KEY_WORKER_SQS_URL);
+        this.config = config;
     }
 
     @Autowired
@@ -197,6 +197,9 @@ public class ParticipantVersionService {
             throw new BridgeServiceException("Error creating export participant version request for app " + appId +
                     " healthcode " + healthCode + " version " + versionNum, ex);
         }
+
+        // Note: SqsInitializer runs after Spring, so we need to grab the queue URL dynamically.
+        String workerQueueUrl = config.getProperty(BridgeConstants.CONFIG_KEY_WORKER_SQS_URL);
 
         // Sent to SQS.
         SendMessageResult sqsResult = sqsClient.sendMessage(workerQueueUrl, requestJson);


### PR DESCRIPTION
Build break due to https://github.com/Sage-Bionetworks/BridgeServer2/pull/599

We changed how we initialize SQS queues. However, SqsInitializer runs after Spring, which caused some classes to pull the queue URL from the configs before SqsInitializer initialized those configs.

The fix is to pull SQS Queue URLs dynamically.