### PR TITLE
Validate MD5 file upload hash

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/validators/UploadValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/UploadValidator.java
@@ -20,8 +20,8 @@ public class UploadValidator implements Validator {
 
     @Override
     public void validate(Object object, Errors errors) {
-        UploadRequest uploadRequest = (UploadRequest)object;
-        
+        UploadRequest uploadRequest = (UploadRequest) object;
+
         final String name = uploadRequest.getName();
         if (name == null || name.isEmpty()) {
             errors.rejectValue("name", CANNOT_BE_BLANK);
@@ -35,11 +35,13 @@ public class UploadValidator implements Validator {
             errors.rejectValue("contentLength", "Invalid content length. Must be > 0.");
         }
         if (length > MAX_UPLOAD_SIZE) {
-            errors.rejectValue("contentLength", "Content length is above the allowed maximum.");   
+            errors.rejectValue("contentLength", "Content length is above the allowed maximum.");
         }
         final String base64md5 = uploadRequest.getContentMd5();
         if (base64md5 == null || base64md5.isEmpty()) {
             errors.rejectValue("contentMd5", "MD5 must not be empty.");
+        } else if (base64md5.length() != 24) {
+            errors.rejectValue("contentMd5", "MD5 must be 24 characters");
         } else {
             try {
                 Base64.decodeBase64(base64md5.getBytes(defaultCharset()));

--- a/src/main/java/org/sagebionetworks/bridge/validators/UploadValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/UploadValidator.java
@@ -12,6 +12,7 @@ public class UploadValidator implements Validator {
     public static final UploadValidator INSTANCE = new UploadValidator();
 
     private static final long MAX_UPLOAD_SIZE = 50L * 1000L * 1000L; // 50 MB
+    private static final int MD5_BYTE_LENGTH = 16; // 16 bytes
 
     @Override
     public boolean supports(Class<?> clazz) {
@@ -40,11 +41,12 @@ public class UploadValidator implements Validator {
         final String base64md5 = uploadRequest.getContentMd5();
         if (base64md5 == null || base64md5.isEmpty()) {
             errors.rejectValue("contentMd5", "MD5 must not be empty.");
-        } else if (base64md5.length() != 24) {
-            errors.rejectValue("contentMd5", "MD5 must be 24 characters");
         } else {
             try {
-                Base64.decodeBase64(base64md5.getBytes(defaultCharset()));
+                final byte[] md5Bytes = Base64.decodeBase64(base64md5.getBytes(defaultCharset()));
+                if (md5Bytes.length != MD5_BYTE_LENGTH) {
+                    errors.rejectValue("contentMd5", "MD5 hash must be 16 bytes.");
+                }
             } catch (Exception e) {
                 errors.rejectValue("contentMd5", "MD5 is not base64 encoded.");
             }

--- a/src/test/java/org/sagebionetworks/bridge/validators/UploadValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/UploadValidatorTest.java
@@ -16,7 +16,7 @@ public class UploadValidatorTest {
     private static final String UPLOAD_CONTENT = "testValidateRequest";
 
     @Test
-    public void testValidateRequest() {
+    public void testValidateRequest() throws IllegalStateException {
         Validator validator = UploadValidator.INSTANCE;
 
         // A valid case

--- a/src/test/java/org/sagebionetworks/bridge/validators/UploadValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/UploadValidatorTest.java
@@ -112,7 +112,7 @@ public class UploadValidatorTest {
             assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "MD5 hash must be 16 bytes.");
         }
 
-        // <24 character MD5 hash
+        // >24 character MD5 hash
         try {
             UploadRequest uploadRequest = makeValidUploadRequestBuilder()
                     .withContentMd5("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")

--- a/src/test/java/org/sagebionetworks/bridge/validators/UploadValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/UploadValidatorTest.java
@@ -10,13 +10,14 @@ import org.sagebionetworks.bridge.models.upload.UploadRequest;
 import org.springframework.validation.Validator;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.fail;
 import static org.testng.Assert.assertEquals;
 
 public class UploadValidatorTest {
     private static final String UPLOAD_CONTENT = "testValidateRequest";
 
     @Test
-    public void testValidateRequest() throws IllegalStateException {
+    public void testValidateRequest() {
         Validator validator = UploadValidator.INSTANCE;
 
         // A valid case
@@ -28,7 +29,7 @@ public class UploadValidatorTest {
         try {
             UploadRequest uploadRequest = makeValidUploadRequestBuilder().withName(null).build();
             Validate.entityThrowingException(validator, uploadRequest);
-            throw new IllegalStateException("Validation should have failed: Name missing");
+            fail("Validation should have failed: Name missing");
         } catch (BridgeServiceException e) {
             assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "Name missing");
         }
@@ -36,7 +37,7 @@ public class UploadValidatorTest {
         try {
             UploadRequest uploadRequest = makeValidUploadRequestBuilder().withContentType(null).build();
             Validate.entityThrowingException(validator, uploadRequest);
-            throw new IllegalStateException("Validation should have failed: Content type missing");
+            fail("Validation should have failed: Content type missing");
         } catch (BridgeServiceException e) {
             assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "Content type missing");
         }
@@ -44,7 +45,7 @@ public class UploadValidatorTest {
         try {
             UploadRequest uploadRequest = makeValidUploadRequestBuilder().withContentLength(null).build();
             Validate.entityThrowingException(validator, uploadRequest);
-            throw new IllegalStateException("Validation should have failed: Content length missing");
+            fail("Validation should have failed: Content length missing");
         } catch (BridgeServiceException e) {
             assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "Content length missing");
         }
@@ -52,7 +53,7 @@ public class UploadValidatorTest {
         try {
             UploadRequest uploadRequest = makeValidUploadRequestBuilder().withContentLength(51000000L).build();
             Validate.entityThrowingException(validator, uploadRequest);
-            throw new IllegalStateException("Validation should have failed: Content length > 10 MB");
+            fail("Validation should have failed: Content length > 10 MB");
         } catch (BridgeServiceException e) {
             assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "Content length > 10 MB");
         }
@@ -60,7 +61,7 @@ public class UploadValidatorTest {
         try {
             UploadRequest uploadRequest = makeValidUploadRequestBuilder().withContentMd5("not-md5").build();
             Validate.entityThrowingException(validator, uploadRequest);
-            throw new IllegalStateException("Validation should have failed: MD5 not base64 encoded");
+            fail("Validation should have failed: MD5 not base64 encoded");
         } catch (BridgeServiceException e) {
             assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "MD5 not base64 encoded");
         }
@@ -68,7 +69,7 @@ public class UploadValidatorTest {
         try {
             UploadRequest uploadRequest = makeValidUploadRequestBuilder().withContentMd5(null).build();
             Validate.entityThrowingException(validator, uploadRequest);
-            throw new IllegalStateException("Validation should have failed: MD5 must not be empty.");
+            fail("Validation should have failed: MD5 must not be empty.");
         } catch (BridgeServiceException e) {
             assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "MD5 must not be empty.");
         }
@@ -76,7 +77,7 @@ public class UploadValidatorTest {
         try {
             UploadRequest uploadRequest = makeValidUploadRequestBuilder().withContentMd5("").build();
             Validate.entityThrowingException(validator, uploadRequest);
-            throw new IllegalStateException("Validation should have failed: MD5 must not be empty.");
+            fail("Validation should have failed: MD5 must not be empty.");
         } catch (BridgeServiceException e) {
             assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "MD5 must not be empty.");
         }
@@ -86,7 +87,7 @@ public class UploadValidatorTest {
             UploadRequest uploadRequest = makeValidUploadRequestBuilder().withContentMd5("AAAAAAAAAAAAAAAAAAAAAAA=")
                     .build();
             Validate.entityThrowingException(validator, uploadRequest);
-            throw new IllegalStateException("Validation should have failed: MD5 hash must be 16 bytes.");
+            fail("Validation should have failed: MD5 hash must be 16 bytes.");
         } catch (BridgeServiceException e) {
             assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "MD5 hash must be 16 bytes.");
         }
@@ -96,7 +97,7 @@ public class UploadValidatorTest {
             UploadRequest uploadRequest = makeValidUploadRequestBuilder().withContentMd5("AAAAAAAAAAAAAAAAAAAAAAAA")
                     .build();
             Validate.entityThrowingException(validator, uploadRequest);
-            throw new IllegalStateException("Validation should have failed: MD5 hash must be 16 bytes.");
+            fail("Validation should have failed: MD5 hash must be 16 bytes.");
         } catch (BridgeServiceException e) {
             assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "MD5 hash must be 16 bytes.");
         }
@@ -106,7 +107,7 @@ public class UploadValidatorTest {
             UploadRequest uploadRequest = makeValidUploadRequestBuilder().withContentMd5("AAAA")
                     .build();
             Validate.entityThrowingException(validator, uploadRequest);
-            throw new IllegalStateException("Validation should have failed: MD5 hash must be 16 bytes.");
+            fail("Validation should have failed: MD5 hash must be 16 bytes.");
         } catch (BridgeServiceException e) {
             assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "MD5 hash must be 16 bytes.");
         }
@@ -117,7 +118,7 @@ public class UploadValidatorTest {
                     .withContentMd5("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
                     .build();
             Validate.entityThrowingException(validator, uploadRequest);
-            throw new IllegalStateException("Validation should have failed: MD5 hash must be 16 bytes.");
+            fail("Validation should have failed: MD5 hash must be 16 bytes.");
         } catch (BridgeServiceException e) {
             assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "MD5 hash must be 16 bytes.");
         }

--- a/src/test/java/org/sagebionetworks/bridge/validators/UploadValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/UploadValidatorTest.java
@@ -28,6 +28,7 @@ public class UploadValidatorTest {
         try {
             UploadRequest uploadRequest = makeValidUploadRequestBuilder().withName(null).build();
             Validate.entityThrowingException(validator, uploadRequest);
+            throw new IllegalStateException("Validation should have failed: Name missing");
         } catch (BridgeServiceException e) {
             assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "Name missing");
         }
@@ -35,6 +36,7 @@ public class UploadValidatorTest {
         try {
             UploadRequest uploadRequest = makeValidUploadRequestBuilder().withContentType(null).build();
             Validate.entityThrowingException(validator, uploadRequest);
+            throw new IllegalStateException("Validation should have failed: Content type missing");
         } catch (BridgeServiceException e) {
             assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "Content type missing");
         }
@@ -42,6 +44,7 @@ public class UploadValidatorTest {
         try {
             UploadRequest uploadRequest = makeValidUploadRequestBuilder().withContentLength(null).build();
             Validate.entityThrowingException(validator, uploadRequest);
+            throw new IllegalStateException("Validation should have failed: Content length missing");
         } catch (BridgeServiceException e) {
             assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "Content length missing");
         }
@@ -49,6 +52,7 @@ public class UploadValidatorTest {
         try {
             UploadRequest uploadRequest = makeValidUploadRequestBuilder().withContentLength(51000000L).build();
             Validate.entityThrowingException(validator, uploadRequest);
+            throw new IllegalStateException("Validation should have failed: Content length > 10 MB");
         } catch (BridgeServiceException e) {
             assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "Content length > 10 MB");
         }
@@ -56,6 +60,7 @@ public class UploadValidatorTest {
         try {
             UploadRequest uploadRequest = makeValidUploadRequestBuilder().withContentMd5("not-md5").build();
             Validate.entityThrowingException(validator, uploadRequest);
+            throw new IllegalStateException("Validation should have failed: MD5 not base64 encoded");
         } catch (BridgeServiceException e) {
             assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "MD5 not base64 encoded");
         }
@@ -63,6 +68,7 @@ public class UploadValidatorTest {
         try {
             UploadRequest uploadRequest = makeValidUploadRequestBuilder().withContentMd5(null).build();
             Validate.entityThrowingException(validator, uploadRequest);
+            throw new IllegalStateException("Validation should have failed: MD5 must not be empty.");
         } catch (BridgeServiceException e) {
             assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "MD5 must not be empty.");
         }
@@ -70,6 +76,7 @@ public class UploadValidatorTest {
         try {
             UploadRequest uploadRequest = makeValidUploadRequestBuilder().withContentMd5("").build();
             Validate.entityThrowingException(validator, uploadRequest);
+            throw new IllegalStateException("Validation should have failed: MD5 must not be empty.");
         } catch (BridgeServiceException e) {
             assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "MD5 must not be empty.");
         }
@@ -79,6 +86,7 @@ public class UploadValidatorTest {
             UploadRequest uploadRequest = makeValidUploadRequestBuilder().withContentMd5("AAAAAAAAAAAAAAAAAAAAAAA=")
                     .build();
             Validate.entityThrowingException(validator, uploadRequest);
+            throw new IllegalStateException("Validation should have failed: MD5 hash must be 16 bytes.");
         } catch (BridgeServiceException e) {
             assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "MD5 hash must be 16 bytes.");
         }
@@ -88,6 +96,7 @@ public class UploadValidatorTest {
             UploadRequest uploadRequest = makeValidUploadRequestBuilder().withContentMd5("AAAAAAAAAAAAAAAAAAAAAAAA")
                     .build();
             Validate.entityThrowingException(validator, uploadRequest);
+            throw new IllegalStateException("Validation should have failed: MD5 hash must be 16 bytes.");
         } catch (BridgeServiceException e) {
             assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "MD5 hash must be 16 bytes.");
         }
@@ -97,6 +106,7 @@ public class UploadValidatorTest {
             UploadRequest uploadRequest = makeValidUploadRequestBuilder().withContentMd5("AAAA")
                     .build();
             Validate.entityThrowingException(validator, uploadRequest);
+            throw new IllegalStateException("Validation should have failed: MD5 hash must be 16 bytes.");
         } catch (BridgeServiceException e) {
             assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "MD5 hash must be 16 bytes.");
         }
@@ -107,6 +117,7 @@ public class UploadValidatorTest {
                     .withContentMd5("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
                     .build();
             Validate.entityThrowingException(validator, uploadRequest);
+            throw new IllegalStateException("Validation should have failed: MD5 hash must be 16 bytes.");
         } catch (BridgeServiceException e) {
             assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "MD5 hash must be 16 bytes.");
         }

--- a/src/test/java/org/sagebionetworks/bridge/validators/UploadValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/UploadValidatorTest.java
@@ -18,7 +18,7 @@ public class UploadValidatorTest {
     @Test
     public void testValidateRequest() {
         Validator validator = UploadValidator.INSTANCE;
-        
+
         // A valid case
         {
             UploadRequest uploadRequest = makeValidUploadRequestBuilder().build();
@@ -58,6 +58,57 @@ public class UploadValidatorTest {
             Validate.entityThrowingException(validator, uploadRequest);
         } catch (BridgeServiceException e) {
             assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "MD5 not base64 encoded");
+        }
+
+        try {
+            UploadRequest uploadRequest = makeValidUploadRequestBuilder().withContentMd5(null).build();
+            Validate.entityThrowingException(validator, uploadRequest);
+        } catch (BridgeServiceException e) {
+            assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "MD5 must not be empty.");
+        }
+
+        try {
+            UploadRequest uploadRequest = makeValidUploadRequestBuilder().withContentMd5("").build();
+            Validate.entityThrowingException(validator, uploadRequest);
+        } catch (BridgeServiceException e) {
+            assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "MD5 must not be empty.");
+        }
+
+        // 17 byte MD5 hash (still 24 characters)
+        try {
+            UploadRequest uploadRequest = makeValidUploadRequestBuilder().withContentMd5("AAAAAAAAAAAAAAAAAAAAAAA=")
+                    .build();
+            Validate.entityThrowingException(validator, uploadRequest);
+        } catch (BridgeServiceException e) {
+            assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "MD5 hash must be 16 bytes.");
+        }
+
+        // 18 byte MD5 hash (still 24 characters)
+        try {
+            UploadRequest uploadRequest = makeValidUploadRequestBuilder().withContentMd5("AAAAAAAAAAAAAAAAAAAAAAAA")
+                    .build();
+            Validate.entityThrowingException(validator, uploadRequest);
+        } catch (BridgeServiceException e) {
+            assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "MD5 hash must be 16 bytes.");
+        }
+
+        // <24 character MD5 hash
+        try {
+            UploadRequest uploadRequest = makeValidUploadRequestBuilder().withContentMd5("AAAA")
+                    .build();
+            Validate.entityThrowingException(validator, uploadRequest);
+        } catch (BridgeServiceException e) {
+            assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "MD5 hash must be 16 bytes.");
+        }
+
+        // <24 character MD5 hash
+        try {
+            UploadRequest uploadRequest = makeValidUploadRequestBuilder()
+                    .withContentMd5("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+                    .build();
+            Validate.entityThrowingException(validator, uploadRequest);
+        } catch (BridgeServiceException e) {
+            assertEquals(e.getStatusCode(), HttpStatus.SC_BAD_REQUEST, "MD5 hash must be 16 bytes.");
         }
     }
 


### PR DESCRIPTION
[https://sagebionetworks.jira.com/browse/BRIDGE-1897](https://sagebionetworks.jira.com/browse/BRIDGE-1897)

- Ensures that MD5 hashes associated with file uploads are valid (not that the hash necessarily matches the file) by checking base64 decoded byte length

Also included:

- Adds missing tests for cases where the MD5 hash is missing
- Adds failing for all tests when the validator fails to recognize invalid uploads (previously, all tests would pass silently even if the validator incorrectly failed to detect anything)