### PR TITLE
BRIDGE-3150 Backfill Participant Versions

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AccountService.java
@@ -120,7 +120,7 @@ public class AccountService {
         cacheProvider.setObject(cacheKey, account.getCreatedOn());
 
         // Create the corresponding Participant Version.
-        participantVersionService.createParticipantVersionFromAccount(account);
+        participantVersionService.createParticipantVersionFromAccount(app, account);
     }
     
     /**
@@ -168,10 +168,10 @@ public class AccountService {
         // reflect the enrollments.
         Set<String> newStudies = Sets.newHashSet(collectStudyIds(account));
         newStudies.removeAll(collectStudyIds(persistedAccount));
-        
+
+        App app = appService.getApp(account.getAppId());
         if (!newStudies.isEmpty()) {
-            App app = appService.getApp(account.getAppId());
-            activityEventService.publishEnrollmentEvent(app, 
+            activityEventService.publishEnrollmentEvent(app,
                     account.getHealthCode(), account.getModifiedOn());
             
             StudyActivityEvent.Builder builder = new StudyActivityEvent.Builder()
@@ -190,7 +190,7 @@ public class AccountService {
             cacheProvider.setObject(cacheKey, account.getModifiedOn());
         }
         // Create the corresponding Participant Version.
-        participantVersionService.createParticipantVersionFromAccount(account);
+        participantVersionService.createParticipantVersionFromAccount(app, account);
     }
     
     /**

--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -125,6 +125,8 @@ public class ParticipantService {
     @Autowired
     private AccountService accountService;
     @Autowired
+    private ParticipantVersionService participantVersionService;
+    @Autowired
     private SmsService smsService;
     @Autowired
     private SubpopulationService subpopService;
@@ -161,7 +163,19 @@ public class ParticipantService {
     protected DateTime getInstallDateTime() {
         return new DateTime();
     }
-    
+
+    /**
+     * Backfills the participant version for a user in a given app. Note that if the participant version already
+     * exists, participantVersionService will do nothing.
+     */
+    public void backfillParticipantVersion(App app, String userIdToken) {
+        checkNotNull(app);
+        checkNotNull(userIdToken);
+
+        Account account = getAccountThrowingException(app.getIdentifier(), userIdToken);
+        participantVersionService.createParticipantVersionFromAccount(app, account);
+    }
+
     /**
      * This is a researcher API to backfill SMS notification registrations for a user. We generally prefer the app
      * register notifications, but sometimes the work can't be done on time, so we want study developers to have the

--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantVersionService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantVersionService.java
@@ -67,6 +67,14 @@ public class ParticipantVersionService {
     public void createParticipantVersionFromAccount(Account account) {
         String appId = account.getAppId();
         App app = appService.getApp(appId);
+        createParticipantVersionFromAccount(app, account);
+    }
+
+    /**
+     * Creates a participant version from an account. Takes in an app, if you already have it, so that we don't
+     * needlessly call appService.getApp() twice.
+     */
+    public void createParticipantVersionFromAccount(App app, Account account) {
         if (!app.isExporter3Enabled()) {
             // If Exporter 3.0 isn't enabled, there's no point in creating a Participant Version.
             return;

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/ParticipantController.java
@@ -111,7 +111,20 @@ public class ParticipantController extends BaseController {
     final void setAccountWorkflowService(AccountWorkflowService accountWorkflowService) {
         this.accountWorkflowService = accountWorkflowService; 
     }
-    
+
+    /**
+     * Backfills the participant version for a user in a given app. Note that if the participant version already
+     * exists, participantVersionService will do nothing.
+     */
+    @PostMapping("/v1/apps/{appId}/participants/{userId}/exporter3/versions/backfill")
+    @ResponseStatus(HttpStatus.CREATED)
+    public StatusMessage backfillParticipantVersion(@PathVariable String appId, @PathVariable String userId) {
+        getAuthenticatedSession(WORKER);
+        App app = appService.getApp(appId);
+        participantService.backfillParticipantVersion(app, userId);
+        return new StatusMessage("Participant version backfilled");
+    }
+
     /** Researcher API to allow backfill of SMS notification registrations. */
     @PostMapping("/v3/participants/{userId}/notifications/sms")
     @ResponseStatus(HttpStatus.CREATED)

--- a/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AccountServiceTest.java
@@ -210,7 +210,7 @@ public class AccountServiceTest extends Mockito {
         verify(mockCacheProvider).setObject(CacheKey.etag(DateTimeZone.class, TEST_USER_ID), MOCK_DATETIME);
 
         // Verify we also create a participant version.
-        verify(mockParticipantVersionService).createParticipantVersionFromAccount(same(createdAccount));
+        verify(mockParticipantVersionService).createParticipantVersionFromAccount(same(app), same(createdAccount));
     }
     
     @Test
@@ -252,7 +252,11 @@ public class AccountServiceTest extends Mockito {
     @Test
     public void updateAccount() throws Exception {
         mockGetAccountById(ACCOUNT_ID, false);
-        
+
+        App app = App.create();
+        app.setIdentifier(TEST_APP_ID);
+        when(mockAppService.getApp(TEST_APP_ID)).thenReturn(app);
+
         Account updated = Account.create();
         updated.setAppId(TEST_APP_ID);
         updated.setId(TEST_USER_ID);
@@ -265,7 +269,7 @@ public class AccountServiceTest extends Mockito {
         verify(mockCacheProvider).setObject(CacheKey.etag(DateTimeZone.class, TEST_USER_ID), MOCK_DATETIME);
 
         // Verify we also create a participant version.
-        verify(mockParticipantVersionService).createParticipantVersionFromAccount(same(updated));
+        verify(mockParticipantVersionService).createParticipantVersionFromAccount(same(app), same(updated));
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -193,6 +193,9 @@ public class ParticipantServiceTest extends Mockito {
     private ScheduledActivityDao activityDao;
 
     @Mock
+    private ParticipantVersionService participantVersionService;
+
+    @Mock
     private SmsService smsService;
 
     @Mock
@@ -326,7 +329,19 @@ public class ParticipantServiceTest extends Mockito {
         when(accountService.getAccount(ACCOUNT_ID)).thenReturn(Optional.of(account));
         when(studyService.getStudy(TEST_APP_ID, STUDY_ID, false)).thenReturn(Study.create());
     }
-    
+
+    @Test
+    public void backfillParticipantVersion() {
+        // Mock account.
+        account.setId(ID);
+        AccountId accountId = AccountId.forId(TEST_APP_ID, ID);
+        when(accountService.getAccount(accountId)).thenReturn(Optional.of(account));
+
+        // Execute and validate.
+        participantService.backfillParticipantVersion(APP, ID);
+        verify(participantVersionService).createParticipantVersionFromAccount(same(APP), same(account));
+    }
+
     @Test
     public void createParticipant() {
         APP.setEmailVerificationEnabled(true);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/Exporter3ControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/Exporter3ControllerTest.java
@@ -66,6 +66,7 @@ public class Exporter3ControllerTest {
     public void verifyAnnotations() throws Exception {
         assertCrossOrigin(Exporter3Controller.class);
         assertPost(Exporter3Controller.class, "initExporter3");
+        assertPost(Exporter3Controller.class, "subscribeToCreateStudyNotifications");
         assertPost(Exporter3Controller.class, "initExporter3ForStudy");
     }
 

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ParticipantControllerTest.java
@@ -312,6 +312,7 @@ public class ParticipantControllerTest extends Mockito {
     @Test
     public void verifyAnnotations() throws Exception {
         assertCrossOrigin(ParticipantController.class);
+        assertPost(ParticipantController.class, "backfillParticipantVersion");
         assertPost(ParticipantController.class, "requestParticipantRoster");
         assertCreate(ParticipantController.class, "createSmsRegistration");
         assertGet(ParticipantController.class, "getSelfParticipant");
@@ -347,6 +348,14 @@ public class ParticipantControllerTest extends Mockito {
         assertGet(ParticipantController.class, "getActivityEvents");
         assertAccept(ParticipantController.class, "sendSmsMessageForWorker");
         assertPost(ParticipantController.class, "createCustomActivityEvent");
+    }
+
+    @Test
+    public void backfillParticipantVersion() {
+        doReturn(session).when(controller).getAuthenticatedSession(WORKER);
+        StatusMessage result = controller.backfillParticipantVersion(TEST_APP_ID, TEST_USER_ID);
+        assertEquals(result.getMessage(), "Participant version backfilled");
+        verify(mockParticipantService).backfillParticipantVersion(same(app), eq(TEST_USER_ID));
     }
 
     @Test


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-3150

Create API to backfill a participant version. If a participant version doesn't exist, but should, this API forces the creation of a participant version. (Does nothing if the participant version already exists, or if Exporter 3.0 is not enabled.)