### PR TITLE
Fix permissions for emailRoster for study

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
@@ -173,11 +173,12 @@ public class AuthUtils {
 
     public static final AuthEvaluator CAN_DELETE_PARTICIPANTS = new AuthEvaluator()
             .canAccessStudy().hasAnyRole(STUDY_COORDINATOR).or()
-            .hasAnyRole(RESEARCHER, ADMIN); 
-    
+            .hasAnyRole(RESEARCHER, ADMIN);
+
     public static final AuthEvaluator CAN_EXPORT_PARTICIPANTS = new AuthEvaluator()
-            .canAccessStudy().hasAnyRole(STUDY_COORDINATOR);        
-    
+            .canAccessStudy().hasAnyRole(STUDY_COORDINATOR).or()
+            .hasAnyRole(ADMIN);
+
     /**
      * Can the caller view external IDs? Must be a study coordinator, developer, or researcher
      * (external IDs are pretty lax because in theory, they are not identifying).

--- a/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
@@ -12,6 +12,7 @@ import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_ASSESSMENTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_SHARED_ASSESSMENTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_ENROLLMENTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_OTHER_ENROLLMENTS;
+import static org.sagebionetworks.bridge.AuthUtils.CAN_EXPORT_PARTICIPANTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_READ_STUDY_ASSOCIATIONS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_TRANSITION_STUDY;
 import static org.sagebionetworks.bridge.BridgeConstants.TEST_USER_GROUP;
@@ -1196,6 +1197,39 @@ public class AuthUtilsTest extends Mockito {
                 .build());
 
         assertFalse(CAN_DOWNLOAD_PARTICIPANT_ROSTER.check(STUDY_ID, TEST_STUDY_ID));
+    }
+
+    @Test
+    public void canExporterParticipants_adminSucceeds() {
+        RequestContext.set(new RequestContext.Builder().withCallerRoles(ImmutableSet.of(ADMIN)).build());
+        assertTrue(CAN_EXPORT_PARTICIPANTS.check(STUDY_ID, TEST_STUDY_ID));
+    }
+
+    @Test
+    public void canExporterParticipants_developerFails() {
+        RequestContext.set(new RequestContext.Builder().withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
+        assertFalse(CAN_EXPORT_PARTICIPANTS.check(STUDY_ID, TEST_STUDY_ID));
+    }
+
+    @Test
+    public void canExporterParticipants_studyCoordinatorSucceeds() {
+        RequestContext.set(new RequestContext.Builder().withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR))
+                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID)).build());
+        assertTrue(CAN_EXPORT_PARTICIPANTS.check(STUDY_ID, TEST_STUDY_ID));
+    }
+
+    @Test
+    public void canExporterParticipants_studyDesignerFails() {
+        RequestContext.set(new RequestContext.Builder().withCallerRoles(ImmutableSet.of(STUDY_DESIGNER))
+                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID)).build());
+        assertFalse(CAN_EXPORT_PARTICIPANTS.check(STUDY_ID, TEST_STUDY_ID));
+    }
+
+    @Test
+    public void canExporterParticipants_studyCoordinatorWrongStudyFails() {
+        RequestContext.set(new RequestContext.Builder().withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR))
+                .withOrgSponsoredStudies(ImmutableSet.of("wrong-study")).build());
+        assertFalse(CAN_EXPORT_PARTICIPANTS.check(STUDY_ID, TEST_STUDY_ID));
     }
 
     @Test


### PR DESCRIPTION
Bridge Study Manager only uses /v5/studies/{studyId}/participants/emailRoster. However, there is a bug in the permissions check that app-scoped accounts (even superadmins) cannot get the participant roster through this API.

This change adds ADMIN to CAN_EXPORT_PARTICIPANTS, so app admins (and superadmins) can get the participant roster. There is a subsequent check CAN_DOWNLOAD_PARTICIPANT_ROSTER, which was coded correctly.

Workaround is to log in using HTTP and call /v3/participants/emailRoster directly, which does not use CAN_EXPORT_PARTICIPANTS and uses CAN_DOWNLOAD_PARTICIPANT_ROSTER.