### PR TITLE
Api to revert study to design phase (BRIDGE-3339)

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/StudyService.java
@@ -10,6 +10,7 @@ import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.NEGATIVE_OFFSET_ERROR;
 import static org.sagebionetworks.bridge.BridgeConstants.PAGE_SIZE_ERROR;
 import static org.sagebionetworks.bridge.Roles.ADMIN;
+import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
 import static org.sagebionetworks.bridge.models.ResourceList.INCLUDE_DELETED;
 import static org.sagebionetworks.bridge.models.ResourceList.OFFSET_BY;
 import static org.sagebionetworks.bridge.models.ResourceList.PAGE_SIZE;
@@ -39,6 +40,7 @@ import org.sagebionetworks.bridge.dao.StudyDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.EntityAlreadyExistsException;
 import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
+import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.VersionHolder;
 import org.sagebionetworks.bridge.models.activities.StudyActivityEventIdsMap;
@@ -376,6 +378,36 @@ public class StudyService {
                 }
             }
         });
+    }
+    
+    /**
+     * Moves a study to design without regard to the study's current phase.
+     * Only available to SUPERADMIN users.
+     */
+    public Study revertToDesign(String appId, String studyId) {
+        checkNotNull(appId);
+        checkNotNull(studyId);
+        
+        if (!RequestContext.get().isInRole(SUPERADMIN)) {
+            throw new UnauthorizedException("Only superadmins can revert studies to design");
+        }
+    
+        Study study = studyDao.getStudy(appId, studyId);
+        if (study == null) {
+            throw new EntityNotFoundException(Study.class);
+        }
+    
+        study.setPhase(DESIGN);
+        study.setModifiedOn(getDateTime());
+        studyDao.updateStudy(study);
+    
+        CacheKey cacheKey = CacheKey.publicStudy(appId, studyId);
+        cacheProvider.removeObject(cacheKey);
+    
+        cacheKey = CacheKey.etag(Study.class, appId, studyId);
+        cacheProvider.setObject(cacheKey, study.getModifiedOn());
+    
+        return study;
     }
     
     /**

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/StudyController.java
@@ -9,6 +9,7 @@ import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.ORG_ADMIN;
 import static org.sagebionetworks.bridge.Roles.STUDY_COORDINATOR;
 import static org.sagebionetworks.bridge.Roles.STUDY_DESIGNER;
+import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
 import static org.sagebionetworks.bridge.Roles.WORKER;
 import static org.sagebionetworks.bridge.models.files.FileDispositionType.INLINE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -259,5 +260,12 @@ public class StudyController extends BaseController {
         UserSession session = getAdministrativeSession();
        
         return service.transitionToWithdrawn(session.getAppId(), studyId);
+    }
+    
+    @PostMapping("v5/studies/{studyId}/reverttodesign")
+    public Study revertToDesign(@PathVariable String studyId) {
+        UserSession session = getAuthenticatedSession(SUPERADMIN);
+        
+        return  service.revertToDesign(session.getAppId(), studyId);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/StudyControllerTest.java
@@ -8,6 +8,7 @@ import static org.sagebionetworks.bridge.Roles.DEVELOPER;
 import static org.sagebionetworks.bridge.Roles.ORG_ADMIN;
 import static org.sagebionetworks.bridge.Roles.STUDY_COORDINATOR;
 import static org.sagebionetworks.bridge.Roles.STUDY_DESIGNER;
+import static org.sagebionetworks.bridge.Roles.SUPERADMIN;
 import static org.sagebionetworks.bridge.Roles.WORKER;
 import static org.sagebionetworks.bridge.TestConstants.CREATED_ON;
 import static org.sagebionetworks.bridge.TestConstants.GUID;
@@ -153,6 +154,7 @@ public class StudyControllerTest extends Mockito {
         assertPost(StudyController.class, "analysis");
         assertPost(StudyController.class, "completed");
         assertPost(StudyController.class, "withdrawn");
+        assertPost(StudyController.class, "revertToDesign");
     }
 
     @Test
@@ -529,6 +531,20 @@ public class StudyControllerTest extends Mockito {
         controller.withdrawn(TEST_STUDY_ID);
         
         verify(mockStudyService).transitionToWithdrawn(TEST_APP_ID, TEST_STUDY_ID);
+    }
+    
+    @Test
+    public void revertToDesign_superadmin() {
+        UserSession superSession = new UserSession();
+        superSession.setAppId(TEST_APP_ID);
+        superSession.setParticipant(new StudyParticipant.Builder().withRoles(ImmutableSet.of(SUPERADMIN)).build());
+        
+        doReturn(superSession).when(controller).getAuthenticatedSession(SUPERADMIN);
+        
+        controller.revertToDesign(TEST_STUDY_ID);
+        
+        verify(controller).getAuthenticatedSession(SUPERADMIN);
+        verify(mockStudyService).revertToDesign(TEST_APP_ID, TEST_STUDY_ID);
     }
     
     @Test


### PR DESCRIPTION
Adding API allowing superadmins to move a study back to design outside of the typical study lifecycle.