### PR TITLE
Fix database

### DIFF
--- a/src/main/resources/db/changelog/changelog.sql
+++ b/src/main/resources/db/changelog/changelog.sql
@@ -1005,7 +1005,7 @@ CREATE TABLE `DemographicsUsers` (
 CREATE TABLE `Demographics` (
     `id` varchar(60) NOT NULL,
     `demographicUserId` varchar(60) NOT NULL,
-    `categoryName` varchar(768) NOT NULL,
+    `categoryName` varchar(255) NOT NULL,
     `multipleSelect` boolean NOT NULL,
     `units` varchar(512) NULL,
     PRIMARY KEY (`id`),


### PR DESCRIPTION
Dev failed because of the following error

```
2022-09-08T18:18:43.453-07:00	Caused by: liquibase.exception.MigrationFailedException: Migration failed for change set classpath:db/changelog/changelog.sql::72::bridge:
	2022-09-08T18:18:43.453-07:00	Reason: liquibase.exception.DatabaseException: Specified key was too long; max key length is 767 bytes [Failed SQL: (1071) CREATE TABLE `Demographics` (
	2022-09-08T18:18:43.453-07:00	`id` varchar(60) NOT NULL,
	2022-09-08T18:18:43.453-07:00	`demographicUserId` varchar(60) NOT NULL,
	2022-09-08T18:18:43.453-07:00	`categoryName` varchar(768) NOT NULL,
	2022-09-08T18:18:43.453-07:00	`multipleSelect` boolean NOT NULL,
	2022-09-08T18:18:43.453-07:00	`units` varchar(512) NULL,
	2022-09-08T18:18:43.453-07:00	PRIMARY KEY (`id`),
	2022-09-08T18:18:43.454-07:00	UNIQUE KEY (`demographicUserId`, `categoryName`),
	2022-09-08T18:18:43.454-07:00	CONSTRAINT `Demographic-DemographicUser-Constraint` FOREIGN KEY (`demographicUserId`) REFERENCES `DemographicsUsers` (`id`) ON DELETE CASCADE
	2022-09-08T18:18:43.454-07:00	) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci]
```

See https://stackoverflow.com/questions/1814532/mysql-error-1071-specified-key-was-too-long-max-key-length-is-767-bytes

Short version is, the maximum length for a varchar in a database key is 767 bytes. Since we use utf8, which is 3 bytes, this means the longest varchar we can use is 255 characters.

This succeeds in local but not in dev, because local uses MySQL 5.7 while dev uses MySQL 5.6, and apparently, this behavior changed in 5.7. (The bootstrap wiki has since been updated.)

Since Liquibase failed to create this table, I had to modify the Liquibase entry itself instead of creating a new entry. You *may* be able to fix this locally by dropping your Demographics, DemographicsUsers, and DemographicsValues tables.

If that doesn't work, you may need to drop all your database tables in MySQL, delete all entries in your local-*-Study, local-*-StudyConsent1, and local-*-Subpopulation tables in DynamoDB, and flush Redis (`redis-cli flushall`, while Redis is running locally).