### PR TITLE
Fix demographics dao issues with null studyId

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateDemographicDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateDemographicDao.java
@@ -87,7 +87,11 @@ public class HibernateDemographicDao implements DemographicDao {
         builder.append("SELECT du.id FROM DemographicUser du");
         WhereClauseBuilder where = builder.startWhere(SearchTermPredicate.AND);
         where.append("du.appId = :appId", "appId", appId);
-        where.append("du.studyId = :studyId", "studyId", studyId);
+        if (studyId == null) {
+            where.append("du.studyId IS NULL");
+        } else {
+            where.append("du.studyId = :studyId", "studyId", studyId);
+        }
         where.append("du.userId = :userId", "userId", userId);
         Optional<String> existingDemographicUserId = hibernateHelper.queryGetOne(builder.getQuery(),
                 builder.getParameters(), String.class);
@@ -134,7 +138,11 @@ public class HibernateDemographicDao implements DemographicDao {
         builder.append("FROM DemographicUser du");
         WhereClauseBuilder where = builder.startWhere(SearchTermPredicate.AND);
         where.append("du.appId = :appId", "appId", appId);
-        where.append("du.studyId = :studyId", "studyId", studyId);
+        if (studyId == null) {
+            where.append("du.studyId IS NULL");
+        } else {
+            where.append("du.studyId = :studyId", "studyId", studyId);
+        }
         where.append("du.userId = :userId", "userId", userId);
         Optional<DemographicUser> existingDemographicUser = hibernateHelper.queryGetOne(builder.getQuery(),
                 builder.getParameters(), DemographicUser.class);
@@ -162,7 +170,11 @@ public class HibernateDemographicDao implements DemographicDao {
         builder.append("FROM DemographicUser du");
         WhereClauseBuilder where = builder.startWhere(SearchTermPredicate.AND);
         where.append("du.appId = :appId", "appId", appId);
-        where.append("du.studyId = :studyId", "studyId", studyId);
+        if (studyId == null) {
+            where.append("du.studyId IS NULL");
+        } else {
+            where.append("du.studyId = :studyId", "studyId", studyId);
+        }
         int count = hibernateHelper.queryCount("SELECT COUNT(*) " + builder.getQuery(), builder.getParameters());
         List<DemographicUser> existingDemographicUsers = hibernateHelper.queryGet(builder.getQuery(),
                 builder.getParameters(), offsetBy, pageSize, DemographicUser.class);

--- a/src/main/java/org/sagebionetworks/bridge/services/DemographicService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/DemographicService.java
@@ -4,6 +4,8 @@ import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MINIMUM_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.PAGE_SIZE_ERROR;
 
+import java.util.Optional;
+
 import org.sagebionetworks.bridge.BridgeUtils;
 import org.sagebionetworks.bridge.dao.DemographicDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
@@ -98,15 +100,9 @@ public class DemographicService {
      *                fetch. Can be null if the demographics are app-level.
      * @param userId  The userId of the user to fetch demographics for.
      * @return The fetched DemographicUser.
-     * @throws EntityNotFoundException if the DemographicUser to fetch does not
-     *                                 exist based on the provided appId, studyId,
-     *                                 and userId.
      */
-    public DemographicUser getDemographicUser(String appId, String studyId, String userId)
-            throws EntityNotFoundException {
-        DemographicUser existingDemographicUser = demographicDao.getDemographicUser(appId, studyId, userId)
-                .orElseThrow(() -> new EntityNotFoundException(DemographicUser.class));
-        return existingDemographicUser;
+    public Optional<DemographicUser> getDemographicUser(String appId, String studyId, String userId) {
+        return demographicDao.getDemographicUser(appId, studyId, userId);
     }
 
     /**

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/DemographicController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/DemographicController.java
@@ -296,7 +296,8 @@ public class DemographicController extends BaseController {
         }
         participantService.getAccountInStudy(session.getAppId(), studyIdNull, userId);
 
-        return demographicService.getDemographicUser(session.getAppId(), studyIdNull, userId);
+        return demographicService.getDemographicUser(session.getAppId(), studyIdNull, userId)
+                .orElseThrow(() -> new EntityNotFoundException(DemographicUser.class));
     }
 
     /**

--- a/src/test/java/org/sagebionetworks/bridge/services/DemographicServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/DemographicServiceTest.java
@@ -11,6 +11,7 @@ import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import java.util.HashMap;
@@ -176,24 +177,26 @@ public class DemographicServiceTest {
         when(demographicDao.getDemographicUser(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID))
                 .thenReturn(Optional.of(demographicUser));
 
-        DemographicUser returnedDemographicUser = demographicService.getDemographicUser(TEST_APP_ID,
+        Optional<DemographicUser> returnedDemographicUser = demographicService.getDemographicUser(TEST_APP_ID,
                 TEST_STUDY_ID,
                 TEST_USER_ID);
 
         verify(demographicDao).getDemographicUser(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
-        assertSame(returnedDemographicUser, demographicUser);
+        assertSame(returnedDemographicUser.get(), demographicUser);
     }
 
     /**
      * Tests that attempting to fetch a DemographicUser that does not exist results
-     * in an error.
+     * in an Optional.empty.
      */
-    @Test(expectedExceptions = EntityNotFoundException.class)
+    @Test
     public void getDemographicUserNotFound() {
         when(demographicDao.getDemographicUser(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID))
                 .thenReturn(Optional.empty());
 
-        demographicService.getDemographicUser(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
+        Optional<DemographicUser> returnedDemographicUser = demographicService.getDemographicUser(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
+        verify(demographicDao).getDemographicUser(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
+        assertTrue(!returnedDemographicUser.isPresent());
     }
 
     /**

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/DemographicControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/DemographicControllerTest.java
@@ -14,6 +14,7 @@ import static org.sagebionetworks.bridge.TestUtils.assertDelete;
 import static org.sagebionetworks.bridge.TestUtils.assertGet;
 import static org.sagebionetworks.bridge.TestUtils.assertPost;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.fail;
 
 import java.util.Optional;
@@ -459,12 +460,15 @@ public class DemographicControllerTest {
      */
     @Test
     public void getDemographicUser() {
+        DemographicUser demographicUser = new DemographicUser();
+        doReturn(Optional.of(demographicUser)).when(demographicService).getDemographicUser(any(), any(), any());
 
-        controller.getDemographicUser(Optional.of(TEST_STUDY_ID), TEST_USER_ID);
+        DemographicUser returnedDemographicUser = controller.getDemographicUser(Optional.of(TEST_STUDY_ID), TEST_USER_ID);
 
         verify(controller).getAuthenticatedSession(Roles.RESEARCHER, Roles.STUDY_COORDINATOR);
         verify(participantService).getAccountInStudy(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         verify(demographicService).getDemographicUser(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
+        assertSame(returnedDemographicUser, demographicUser);
     }
 
     /**
@@ -496,12 +500,15 @@ public class DemographicControllerTest {
      */
     @Test
     public void getDemographicUserAppLevel() {
+        DemographicUser demographicUser = new DemographicUser();
+        doReturn(Optional.of(demographicUser)).when(demographicService).getDemographicUser(any(), any(), any());
 
-        controller.getDemographicUser(Optional.empty(), TEST_USER_ID);
+        DemographicUser returnedDemographicUser = controller.getDemographicUser(Optional.empty(), TEST_USER_ID);
 
         verify(controller).getAuthenticatedSession(Roles.ADMIN);
         verify(participantService).getAccountInStudy(TEST_APP_ID, null, TEST_USER_ID);
         verify(demographicService).getDemographicUser(TEST_APP_ID, null, TEST_USER_ID);
+        assertSame(returnedDemographicUser, demographicUser);
     }
 
     /**

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/DemographicControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/DemographicControllerTest.java
@@ -485,7 +485,7 @@ public class DemographicControllerTest {
      */
     @Test(expectedExceptions = { EntityNotFoundException.class })
     public void getDemographicUserNotFound() {
-        doThrow(new EntityNotFoundException(Demographic.class)).when(demographicService).getDemographicUser(any(),
+        doReturn(Optional.empty()).when(demographicService).getDemographicUser(any(),
                 any(), any());
 
         controller.getDemographicUser(Optional.of(TEST_STUDY_ID), TEST_USER_ID);


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-2964

Forgot to include this fix in #622 

1. Fixes issue where null studyId is not queried correctly
2. Adds tests for that case
3. Changes DemographicService.getDemographicUser to return Optional<DemographicUser> instead of throwing an exception when it doesn't exist. The exception is now thrown in the controller instead.