### PR TITLE
[BUILD BREAK] Give Org Admin permissions to delete participant reports

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
@@ -139,12 +139,10 @@ public class AuthUtils {
     public static final AuthEvaluator CAN_DOWNLOAD_PARTICIPANT_ROSTER = new AuthEvaluator()
             .canAccessStudy().hasAnyRole(STUDY_COORDINATOR).or()
             .hasAnyRole(RESEARCHER, ADMIN);
-    
-    /**
-     * Can the caller read participant reports? 
-     */
+
+    /** Can the caller read/write/delete participant reports? */
     public static final AuthEvaluator CAN_READ_PARTICIPANT_REPORTS = new AuthEvaluator().isSelf().or()
-            .canAccessStudy().hasAnyRole(STUDY_DESIGNER, STUDY_COORDINATOR).or()
+            .canAccessStudy().hasAnyRole(STUDY_DESIGNER, STUDY_COORDINATOR, ORG_ADMIN).or()
             .hasAnyRole(DEVELOPER, RESEARCHER, WORKER, ADMIN);
     
     /**


### PR DESCRIPTION
This fixes a build break.

Apparently, org admins have permission to delete participants, but not participant reports. Since we added Participant Reports to be deleted when accounts are deleted (see https://github.com/Sage-Bionetworks/BridgeServer2/pull/624), this caused a build break in Dev.

Currently, only Study Coordinators and Study Designers can read/write/delete Participant Reports. Since Org Admins can grant the Study Coordinator and Study Designer roles (including to themselves), this doesn't add anything Org Admins can't already do.