### PR TITLE
BRIDGE-3354 Add SQL index for Timeline.sessionInstanceGuid; re-enable adherence for BiAffect

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/AdherenceService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/AdherenceService.java
@@ -137,12 +137,6 @@ public class AdherenceService {
     public void updateAdherenceRecords(String appId, AdherenceRecordList recordList) {
         checkNotNull(recordList);
 
-        // BRIDGE-3354 - Temporarily disable Biaffect from using this API, since their calls are causing performance
-        // issues that is causing issues globally for Bridge Server.
-        if ("biaffect".equals(appId)) {
-            throw new BadRequestException("Adherence is not available for this app");
-        }
-
         if (recordList.getRecords().isEmpty()) {
             throw new BadRequestException("No adherence records submitted for update.");
         }

--- a/src/main/resources/db/changelog/changelog.sql
+++ b/src/main/resources/db/changelog/changelog.sql
@@ -1030,3 +1030,8 @@ ALTER TABLE `SessionAssessments`
 ADD COLUMN `imageResourceName` varchar(255) DEFAULT NULL,
 ADD COLUMN `imageResourceModule` varchar(255) DEFAULT NULL,
 ADD COLUMN `imageResourceLabels` text DEFAULT NULL;
+
+-- changeset bridge:74
+
+ALTER TABLE `TimelineMetadata`
+ADD INDEX `TimelineMetadata-SessionInstanceGuid` (sessionInstanceGuid);

--- a/src/test/java/org/sagebionetworks/bridge/services/AdherenceServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AdherenceServiceTest.java
@@ -181,15 +181,6 @@ public class AdherenceServiceTest extends Mockito {
     }
 
     @Test(expectedExceptions = BadRequestException.class)
-    public void updateAdherenceRecords_disableBiaffect() {
-        AdherenceRecordList records = mockRecordUpdate(
-                ar(STARTED_ON, null, "AAA", false),
-                ar(null, null, "BBB", false),
-                null);
-        service.updateAdherenceRecords("biaffect", records);
-    }
-
-    @Test(expectedExceptions = BadRequestException.class)
     public void updateAdherenceRecords_noRecords() {
         service.updateAdherenceRecords(TEST_APP_ID, new AdherenceRecordList(ImmutableList.of()));
     }


### PR DESCRIPTION
As part of the call chain, updateAdherenceRecord eventually calls the following query https://github.com/Sage-Bionetworks/BridgeServer2/blob/develop/src/main/java/org/sagebionetworks/bridge/hibernate/HibernateSchedule2Dao.java#L54

`SELECT * FROM TimelineMetadata WHERE sessionInstanceGuid = :instanceGuid AND assessmentInstanceGuid IS NOT NULL`

Table TimelineMetadata does not have an index on sessionInstanceGuid, so this results in a full table scan. Full table scans are incredibly expensive, and the larger the table gets, the more expensive they are. This is almost certainly the cause of the performance issues in Prod.

This change adds an index to TimelineMetadata for sessionInstanceGuid, and it also re-enables adherence for BiAffect.