### PR TITLE
BRIDGE-3380 - Bootstrap S3 bucket configuration and SNS topics for Antivirus Scanner

### DIFF
--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -6,4 +6,10 @@
     <!-- This generates a false positive on Oracles java compiler, and they cannot be easily 
         eliminated. -->
     <Bug pattern="DLS_DEAD_LOCAL_STORE" />
+
+    <!-- This is a false alarm. -->
+    <Match>
+        <Class name="org.sagebionetworks.bridge.S3Initializer" />
+        <Bug pattern="IC_INIT_CIRCULARITY" />
+    </Match>
 </FindBugsFilter>

--- a/src/main/java/org/sagebionetworks/bridge/DefaultAppBootstrapper.java
+++ b/src/main/java/org/sagebionetworks/bridge/DefaultAppBootstrapper.java
@@ -89,9 +89,11 @@ public class DefaultAppBootstrapper implements ApplicationListener<ContextRefres
     public void onApplicationEvent(ContextRefreshedEvent event) {
         List<TableDescription> tables = annotationBasedTableCreator.getTables("org.sagebionetworks.bridge.dynamodb");
         dynamoInitializer.init(tables);
-        s3Initializer.initBuckets();
+
+        // Order matters. S3 depends on SNS which depends on SQS.
         sqsInitializer.initQueues();
         snsInitializer.initTopics();
+        s3Initializer.initBuckets();
 
         RequestContext.set(new RequestContext.Builder().withCallerAppId(API_APP_ID)
                 .withCallerRoles(ImmutableSet.of(SUPERADMIN))

--- a/src/main/java/org/sagebionetworks/bridge/S3Initializer.java
+++ b/src/main/java/org/sagebionetworks/bridge/S3Initializer.java
@@ -2,18 +2,26 @@ package org.sagebionetworks.bridge;
 
 import static org.sagebionetworks.bridge.BridgeUtils.resolveTemplate;
 
+import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.BucketCrossOriginConfiguration;
+import com.amazonaws.services.s3.model.BucketNotificationConfiguration;
 import com.amazonaws.services.s3.model.BucketWebsiteConfiguration;
 import com.amazonaws.services.s3.model.CORSRule;
 import com.amazonaws.services.s3.model.CreateBucketRequest;
+import com.amazonaws.services.s3.model.NotificationConfiguration;
 import com.amazonaws.services.s3.model.Region;
 import com.amazonaws.services.s3.model.CORSRule.AllowedMethods;
+import com.amazonaws.services.s3.model.S3Event;
+import com.amazonaws.services.s3.model.TopicConfiguration;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,11 +31,33 @@ import org.springframework.stereotype.Component;
 import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.services.AccountService;
 
+/** Initialzes S3 buckets based on config. This requires SnsInitializer to have been run first. */
 @Component
 public class S3Initializer {
     private static final Logger LOG = LoggerFactory.getLogger(AccountService.class);
 
+    static final String BUCKET_NOTIFICATION_CONFIG_NAME_VIRUS_SCAN = "Bridge-Virus-Scan";
     static final String CONFIG_KEY_SYNAPSE_AWS_ACCOUNT_ID = "synapse.aws.account.id";
+    static final String CONFIG_KEY_VIRUS_SCAN_TRIGGER_TOPIC_ARN = "virus.scan.trigger.topic.arn";
+
+    // Buckets can only have one policy. Make the default policy include blocking infected files, and add this snippet
+    // to all other policies as well.
+    private static final String DEFAULT_ACCESS_POLICY = "{"
+            + "    \"Version\": \"2008-10-17\","
+            + "    \"Statement\": ["
+            + "        {"
+            + "            \"Effect\": \"Deny\","
+            + "            \"Principal\": \"*\","
+            + "            \"Action\": \"s3:GetObject\","
+            + "            \"Resource\": \"arn:aws:s3:::${bucketName}/*\","
+            + "            \"Condition\": {"
+            + "                \"StringEquals\": {"
+            + "                    \"s3:ExistingObjectTag/av-status\": \"INFECTED\""
+            + "                }"
+            + "            }"
+            + "        }"
+            + "    ]"
+            + "}";
 
     private static final String SYNAPSE_ACCESS_POLICY = "{"
             + "    \"Version\": \"2008-10-17\","
@@ -53,6 +83,17 @@ public class S3Initializer {
             + "                \"s3:*MultipartUpload*\""
             + "            ],"
             + "            \"Resource\": \"arn:aws:s3:::${bucketName}/*\""
+            + "        },"
+            + "        {"
+            + "            \"Effect\": \"Deny\","
+            + "            \"Principal\": \"*\","
+            + "            \"Action\": \"s3:GetObject\","
+            + "            \"Resource\": \"arn:aws:s3:::${bucketName}/*\","
+            + "            \"Condition\": {"
+            + "                \"StringEquals\": {"
+            + "                    \"s3:ExistingObjectTag/av-status\": \"INFECTED\""
+            + "                }"
+            + "            }"
             + "        }"
             + "    ]"
             + "}";
@@ -67,6 +108,17 @@ public class S3Initializer {
             + "            \"Principal\": \"*\","
             + "            \"Action\": \"s3:GetObject\","
             + "            \"Resource\": \"arn:aws:s3:::${bucketName}/*\""
+            + "        },"
+            + "        {"
+            + "            \"Effect\": \"Deny\","
+            + "            \"Principal\": \"*\","
+            + "            \"Action\": \"s3:GetObject\","
+            + "            \"Resource\": \"arn:aws:s3:::${bucketName}/*\","
+            + "            \"Condition\": {"
+            + "                \"StringEquals\": {"
+            + "                    \"s3:ExistingObjectTag/av-status\": \"INFECTED\""
+            + "                }"
+            + "            }"
             + "        }"
             + "    ]"
             + "}";
@@ -78,15 +130,15 @@ public class S3Initializer {
                     .withAllowedOrigins(ImmutableList.of("*"))
                     .withMaxAgeSeconds(3000));
     
-    public static enum BucketType {
-        INTERNAL(null, null),
-        INTERNAL_UPLOAD_ACCESSIBLE(null, ALLOW_PUT),
+    public enum BucketType {
+        INTERNAL(DEFAULT_ACCESS_POLICY, null),
+        INTERNAL_UPLOAD_ACCESSIBLE(DEFAULT_ACCESS_POLICY, ALLOW_PUT),
         SYNAPSE_ACCESSIBLE(SYNAPSE_ACCESS_POLICY, null),
         PUBLIC_ACCESSIBLE(PUBLIC_ACCESS_POLICY, ALLOW_PUT);
         
         String policy;
         BucketCrossOriginConfiguration corsConfig;
-        private BucketType(String policy, BucketCrossOriginConfiguration corsConfig) {
+        BucketType(String policy, BucketCrossOriginConfiguration corsConfig) {
             this.policy = policy;
             this.corsConfig = corsConfig;
         }
@@ -105,8 +157,17 @@ public class S3Initializer {
     public final void setS3Client(AmazonS3 s3Client) {
         this.s3Client = s3Client;
     }
-    
-    private Map<String, BucketType> S3_BUCKET_PROP_NAMES = new ImmutableMap.Builder<String, BucketType>()
+
+    private static final Set<String> S3_BUCKETS_VIRUS_SCAN_ENABLED = ImmutableSet.of("docs.bucket",
+            "attachment.bucket", "consents.bucket", "health.data.bucket.raw", "participant-file.bucket",
+            "upload.bucket", "usersigned.consents.bucket");
+
+    // Accessor so we can mock this in unit tests.
+    Set<String> getBucketsVirusScanEnabled() {
+        return S3_BUCKETS_VIRUS_SCAN_ENABLED;
+    }
+
+    private static final Map<String, BucketType> S3_BUCKET_PROP_NAMES = new ImmutableMap.Builder<String, BucketType>()
             .put("attachment.bucket", BucketType.SYNAPSE_ACCESSIBLE)
             .put("health.data.bucket.raw", BucketType.SYNAPSE_ACCESSIBLE)
             .put("upload.bucket", BucketType.INTERNAL_UPLOAD_ACCESSIBLE)
@@ -125,7 +186,11 @@ public class S3Initializer {
     }
     
     public void initBuckets() {
+        Set<String> bucketsVirusScanEnabled = getBucketsVirusScanEnabled();
         String synapseAwsAccountId = bridgeConfig.get(CONFIG_KEY_SYNAPSE_AWS_ACCOUNT_ID);
+        String virusScanTriggerTopicArn = bridgeConfig.get(CONFIG_KEY_VIRUS_SCAN_TRIGGER_TOPIC_ARN);
+        TopicConfiguration virusScanNotificationConfig = new TopicConfiguration(virusScanTriggerTopicArn,
+                EnumSet.of(S3Event.ObjectCreated));
 
         for (Map.Entry<String, BucketType> entry : getBucketNames().entrySet()) {
             String propName = entry.getKey();
@@ -139,16 +204,15 @@ public class S3Initializer {
                 LOG.info("Creating bucket " + bucketName + " with policy to be " + type);
                 
                 s3Client.createBucket(new CreateBucketRequest(bucketName, Region.US_Standard));
-                
-                if (type.policy != null) {
-                    Map<String, String> varMap = ImmutableMap.<String, String>builder()
-                            .put("bucketName", bucketName)
-                            .put("synapseAwsAccountId", synapseAwsAccountId)
-                            .build();
-                    String policy = resolveTemplate(type.policy, varMap);
-                    s3Client.setBucketPolicy(bucketName, policy);
-                }
-                // For public buckets to serve for retrieving documents via HTTP, they 
+
+                Map<String, String> varMap = ImmutableMap.<String, String>builder()
+                        .put("bucketName", bucketName)
+                        .put("synapseAwsAccountId", synapseAwsAccountId)
+                        .build();
+                String policy = resolveTemplate(type.policy, varMap);
+                s3Client.setBucketPolicy(bucketName, policy);
+
+                // For public buckets to serve for retrieving documents via HTTP, they
                 // must also be configured as web hosting buckets. index file is required, 
                 // but does not need to exist (and does not exist) 
                 if (type.policy == PUBLIC_ACCESS_POLICY) {
@@ -158,6 +222,39 @@ public class S3Initializer {
                 }
                 if (type.corsConfig != null) {
                     s3Client.setBucketCrossOriginConfiguration(bucketName, type.corsConfig);
+                }
+            }
+
+            // Add SNS notification for virus scan, if needed.
+            if (bucketsVirusScanEnabled.contains(propName)) {
+                // Get old bucket configuration.
+                BucketNotificationConfiguration bucketConfig = s3Client.getBucketNotificationConfiguration(bucketName);
+                boolean updated = false;
+
+                // Bootstrap bucket config, if needed.
+                if (bucketConfig == null) {
+                    bucketConfig = new BucketNotificationConfiguration();
+                    updated = true;
+                }
+                if (bucketConfig.getConfigurations() == null) {
+                    // This should never happen, but just in case...
+                    bucketConfig.setConfigurations(new HashMap<>());
+                    updated = true;
+                }
+
+                // Add virus scan config, if needed.
+                NotificationConfiguration notificationConfig = bucketConfig.getConfigurationByName(
+                        BUCKET_NOTIFICATION_CONFIG_NAME_VIRUS_SCAN);
+                if (notificationConfig == null) {
+                    bucketConfig.addConfiguration(BUCKET_NOTIFICATION_CONFIG_NAME_VIRUS_SCAN,
+                            virusScanNotificationConfig);
+                    updated = true;
+                }
+
+                // Update to S3, if needed.
+                if (updated) {
+                    LOG.info("Creating antivirus SNS notification for bucket " + bucketName);
+                    s3Client.setBucketNotificationConfiguration(bucketName, bucketConfig);
                 }
             }
         }

--- a/src/main/java/org/sagebionetworks/bridge/SqsInitializer.java
+++ b/src/main/java/org/sagebionetworks/bridge/SqsInitializer.java
@@ -52,6 +52,7 @@ public class SqsInitializer {
     // queue.
     private static final Map<String, Boolean> QUEUE_PROPERTIES = ImmutableMap.<String, Boolean>builder()
             .put("exporter.request.sqs.queue", false)
+            .put("virus.scan.result.sqs.queue", true)
             .put("workerPlatform.request.sqs.queue", false)
             .put("integ.test.sqs.queue", true)
             .build();

--- a/src/main/resources/BridgeServer2.conf
+++ b/src/main/resources/BridgeServer2.conf
@@ -7,6 +7,9 @@ dev.bucket.suffix = develop
 uat.bucket.suffix = uat
 prod.bucket.suffix = prod
 
+aws.account.id = 420786776710
+prod.aws.account.id = 649232250620
+
 heartbeat.interval.minutes=30
 
 channel.throttle.max.requests = 1
@@ -29,6 +32,10 @@ exporter.synapse.access.token = your-exporter-synapse-access-token
 exporter.synapse.id = 3336429
 prod.exporter.synapse.id = 3325672
 test.synapse.user.id = 3348228
+
+virus.scan.trigger.topic = virus-scan-trigger-${bucket.suffix}
+virus.scan.result.topic = virus-scan-result-${bucket.suffix}
+virus.scan.result.sqs.queue = virus-scan-result-${bucket.suffix}
 
 # Excludes the original try. For example, if this is set to 1, DDB will try a total of twice (one try, one retry)
 ddb.max.retries = 1

--- a/src/test/java/org/sagebionetworks/bridge/S3InitializerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/S3InitializerTest.java
@@ -1,18 +1,24 @@
 package org.sagebionetworks.bridge;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import java.util.Map;
+import java.util.Set;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.BucketCrossOriginConfiguration;
+import com.amazonaws.services.s3.model.BucketNotificationConfiguration;
 import com.amazonaws.services.s3.model.BucketWebsiteConfiguration;
 import com.amazonaws.services.s3.model.CORSRule;
 import com.amazonaws.services.s3.model.CORSRule.AllowedMethods;
 import com.amazonaws.services.s3.model.CreateBucketRequest;
+import com.amazonaws.services.s3.model.S3Event;
+import com.amazonaws.services.s3.model.TopicConfiguration;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import com.google.common.collect.ImmutableSet;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
@@ -28,6 +34,7 @@ import org.sagebionetworks.bridge.config.BridgeConfig;
 public class S3InitializerTest extends Mockito {
     private static final String BUCKET_NAME = "oneBucketName";
     private static final String SYNAPSE_AWS_ACCOUNT_ID = "1234567890";
+    private static final String VIRUS_SCAN_TRIGGER_TOPIC_ARN = "arn:aws:sns:us-east-1:111111111111:virus-scan-trigger-topic";
 
     @Mock
     BridgeConfig mockBridgeConfig;
@@ -55,6 +62,12 @@ public class S3InitializerTest extends Mockito {
         // Mock config.
         when(mockBridgeConfig.get("bucket.prop")).thenReturn(BUCKET_NAME);
         when(mockBridgeConfig.get(S3Initializer.CONFIG_KEY_SYNAPSE_AWS_ACCOUNT_ID)).thenReturn(SYNAPSE_AWS_ACCOUNT_ID);
+        when(mockBridgeConfig.get(S3Initializer.CONFIG_KEY_VIRUS_SCAN_TRIGGER_TOPIC_ARN)).thenReturn(
+                VIRUS_SCAN_TRIGGER_TOPIC_ARN);
+
+        // Default spy operations so that we don't have to specify these everywhere.
+        doReturn(ImmutableSet.of()).when(initializer).getBucketsVirusScanEnabled();
+        doReturn(ImmutableMap.of()).when(initializer).getBucketNames();
     }
     
     @Test
@@ -69,6 +82,8 @@ public class S3InitializerTest extends Mockito {
         
         verify(mockS3Client, never()).createBucket(any(CreateBucketRequest.class));
         verify(mockS3Client, never()).setBucketPolicy(any(), any());
+        verify(mockS3Client).doesBucketExistV2(BUCKET_NAME);
+        verifyNoMoreInteractions(mockS3Client);
     }
     
     @Test
@@ -89,6 +104,8 @@ public class S3InitializerTest extends Mockito {
         verify(mockS3Client).createBucket(requestCaptor.capture());
         verify(mockS3Client).setBucketPolicy(BUCKET_NAME, resolvedPolicy);
         verify(mockS3Client, never()).setBucketCrossOriginConfiguration(any(), any());
+        verify(mockS3Client).doesBucketExistV2(BUCKET_NAME);
+        verifyNoMoreInteractions(mockS3Client);
 
         assertEquals(requestCaptor.getValue().getBucketName(), BUCKET_NAME);
     }
@@ -111,7 +128,9 @@ public class S3InitializerTest extends Mockito {
         verify(mockS3Client).setBucketPolicy(BUCKET_NAME, resolvedPolicy);
         verify(mockS3Client).setBucketWebsiteConfiguration(eq(BUCKET_NAME), websiteConfigCaptor.capture());
         verify(mockS3Client).setBucketCrossOriginConfiguration(eq(BUCKET_NAME), corsConfigCaptor.capture());
-        
+        verify(mockS3Client).doesBucketExistV2(BUCKET_NAME);
+        verifyNoMoreInteractions(mockS3Client);
+
         assertEquals(requestCaptor.getValue().getBucketName(), BUCKET_NAME);
         
         // Not a lot to check here, but
@@ -134,13 +153,19 @@ public class S3InitializerTest extends Mockito {
         when(mockS3Client.doesBucketExistV2(BUCKET_NAME)).thenReturn(false);
         
         initializer.initBuckets();
-        
+
+        String resolvedPolicy = BridgeUtils.resolveTemplate(
+                S3Initializer.BucketType.INTERNAL.policy,
+                ImmutableMap.of("bucketName", BUCKET_NAME));
+
         verify(mockS3Client).createBucket(requestCaptor.capture());
-        verify(mockS3Client, never()).setBucketPolicy(any(), any());
-        
+        verify(mockS3Client).setBucketPolicy(BUCKET_NAME, resolvedPolicy);
+        verify(mockS3Client).doesBucketExistV2(BUCKET_NAME);
+        verifyNoMoreInteractions(mockS3Client);
+
         assertEquals(requestCaptor.getValue().getBucketName(), BUCKET_NAME);
     }
-    
+
     @Test(expectedExceptions = RuntimeException.class,
             expectedExceptionsMessageRegExp = "Value is missing for bucket property: bucket.prop")
     public void missingBucketConfigThrowsException() {
@@ -163,11 +188,17 @@ public class S3InitializerTest extends Mockito {
         when(mockS3Client.doesBucketExistV2(BUCKET_NAME)).thenReturn(false);
         
         initializer.initBuckets();
-        
+
+        String resolvedPolicy = BridgeUtils.resolveTemplate(
+                S3Initializer.BucketType.INTERNAL_UPLOAD_ACCESSIBLE.policy,
+                ImmutableMap.of("bucketName", BUCKET_NAME));
+
         verify(mockS3Client).createBucket(requestCaptor.capture());
-        verify(mockS3Client, never()).setBucketPolicy(any(), any());
+        verify(mockS3Client).setBucketPolicy(BUCKET_NAME, resolvedPolicy);
+        verify(mockS3Client).doesBucketExistV2(BUCKET_NAME);
         verify(mockS3Client).setBucketCrossOriginConfiguration(eq(BUCKET_NAME), corsConfigCaptor.capture());
-        
+        verifyNoMoreInteractions(mockS3Client);
+
         assertEquals(requestCaptor.getValue().getBucketName(), BUCKET_NAME);
         assertCorsConfig(corsConfigCaptor.getValue());
     }
@@ -178,5 +209,111 @@ public class S3InitializerTest extends Mockito {
         assertEquals(rule.getAllowedOrigins(), ImmutableList.of("*"));
         assertEquals(rule.getAllowedMethods(), ImmutableList.of(AllowedMethods.PUT));
         assertEquals(rule.getMaxAgeSeconds(), 3000);
+    }
+
+    @Test
+    public void virusScanConfig_noBucketConfigObject() {
+        // Spy initializer.
+        doReturn(ImmutableMap.of("bucket.prop", S3Initializer.BucketType.INTERNAL)).when(initializer)
+                .getBucketNames();
+        doReturn(ImmutableSet.of("bucket.prop")).when(initializer).getBucketsVirusScanEnabled();
+
+        // Mock S3.
+        when(mockS3Client.doesBucketExistV2(BUCKET_NAME)).thenReturn(true);
+        when(mockS3Client.getBucketNotificationConfiguration(BUCKET_NAME)).thenReturn(null);
+
+        // Execute and verify.
+        initializer.initBuckets();
+
+        verifyGetBucketNotificationConfiguration();
+        verify(mockS3Client).doesBucketExistV2(BUCKET_NAME);
+        verify(mockS3Client).getBucketNotificationConfiguration(BUCKET_NAME);
+        verifyNoMoreInteractions(mockS3Client);
+    }
+
+    @Test
+    public void virusScanConfig_noBucketConfigMap() {
+        // Spy initializer.
+        doReturn(ImmutableMap.of("bucket.prop", S3Initializer.BucketType.INTERNAL)).when(initializer)
+                .getBucketNames();
+        doReturn(ImmutableSet.of("bucket.prop")).when(initializer).getBucketsVirusScanEnabled();
+
+        // Mock S3.
+        when(mockS3Client.doesBucketExistV2(BUCKET_NAME)).thenReturn(true);
+
+        // BucketNotificationConfiguration constructor creates an empty map. Explicitly set it to null.
+        BucketNotificationConfiguration originalBucketConfig = new BucketNotificationConfiguration();
+        originalBucketConfig.setConfigurations(null);
+        when(mockS3Client.getBucketNotificationConfiguration(BUCKET_NAME)).thenReturn(originalBucketConfig);
+
+        // Execute and verify.
+        initializer.initBuckets();
+
+        verifyGetBucketNotificationConfiguration();
+        verify(mockS3Client).doesBucketExistV2(BUCKET_NAME);
+        verify(mockS3Client).getBucketNotificationConfiguration(BUCKET_NAME);
+        verifyNoMoreInteractions(mockS3Client);
+    }
+
+    @Test
+    public void virusScanConfig_noVirusScanConfig() {
+        // Spy initializer.
+        doReturn(ImmutableMap.of("bucket.prop", S3Initializer.BucketType.INTERNAL)).when(initializer)
+                .getBucketNames();
+        doReturn(ImmutableSet.of("bucket.prop")).when(initializer).getBucketsVirusScanEnabled();
+
+        // Mock S3.
+        when(mockS3Client.doesBucketExistV2(BUCKET_NAME)).thenReturn(true);
+
+        when(mockS3Client.getBucketNotificationConfiguration(BUCKET_NAME)).thenReturn(
+                new BucketNotificationConfiguration());
+
+        // Execute and verify.
+        initializer.initBuckets();
+
+        verifyGetBucketNotificationConfiguration();
+        verify(mockS3Client).doesBucketExistV2(BUCKET_NAME);
+        verify(mockS3Client).getBucketNotificationConfiguration(BUCKET_NAME);
+        verifyNoMoreInteractions(mockS3Client);
+    }
+
+    @Test
+    public void virusScanConfig_alreadyExists() {
+        // Spy initializer.
+        doReturn(ImmutableMap.of("bucket.prop", S3Initializer.BucketType.INTERNAL)).when(initializer)
+                .getBucketNames();
+        doReturn(ImmutableSet.of("bucket.prop")).when(initializer).getBucketsVirusScanEnabled();
+
+        // Mock S3.
+        when(mockS3Client.doesBucketExistV2(BUCKET_NAME)).thenReturn(true);
+
+        // Add a dummy config. Doesn't matter what it contains.
+        BucketNotificationConfiguration originalBucketConfig = new BucketNotificationConfiguration();
+        originalBucketConfig.addConfiguration(S3Initializer.BUCKET_NOTIFICATION_CONFIG_NAME_VIRUS_SCAN,
+                new TopicConfiguration());
+        when(mockS3Client.getBucketNotificationConfiguration(BUCKET_NAME)).thenReturn(originalBucketConfig);
+
+        // Execute and verify.
+        initializer.initBuckets();
+
+        verify(mockS3Client, never()).setBucketNotificationConfiguration(any(), any());
+        verify(mockS3Client).doesBucketExistV2(BUCKET_NAME);
+        verify(mockS3Client).getBucketNotificationConfiguration(BUCKET_NAME);
+        verifyNoMoreInteractions(mockS3Client);
+    }
+
+    private void verifyGetBucketNotificationConfiguration() {
+        ArgumentCaptor<BucketNotificationConfiguration> bucketConfigCaptor = ArgumentCaptor.forClass(
+                BucketNotificationConfiguration.class);
+        verify(mockS3Client).setBucketNotificationConfiguration(eq(BUCKET_NAME), bucketConfigCaptor.capture());
+
+        BucketNotificationConfiguration bucketConfig = bucketConfigCaptor.getValue();
+        TopicConfiguration notificationConfig = (TopicConfiguration) bucketConfig.getConfigurationByName(
+                S3Initializer.BUCKET_NOTIFICATION_CONFIG_NAME_VIRUS_SCAN);
+        assertEquals(notificationConfig.getTopicARN(), VIRUS_SCAN_TRIGGER_TOPIC_ARN);
+
+        Set<String> eventSet = notificationConfig.getEvents();
+        assertEquals(eventSet.size(), 1);
+        assertTrue(eventSet.contains(S3Event.ObjectCreated.toString()));
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/SnsInitializerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/SnsInitializerTest.java
@@ -2,9 +2,12 @@ package org.sagebionetworks.bridge;
 
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.bridge.BridgeUtils.resolveTemplate;
 import static org.testng.Assert.assertEquals;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import com.amazonaws.services.sns.AmazonSNS;
@@ -15,6 +18,7 @@ import com.amazonaws.services.sns.model.Topic;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.GetQueueAttributesResult;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -26,12 +30,18 @@ import org.testng.annotations.Test;
 import org.sagebionetworks.bridge.config.BridgeConfig;
 
 public class SnsInitializerTest {
+    private static final String DUMMY_AWS_ACCOUNT_ID = "111111111111";
     private static final String NEXT_PAGE_TOKEN = "dummy-token";
 
-    private static final String CREATE_THIS_TOPIC_ARN = "arn:aws:sns:us-east-1:111111111111:create-this-topic";
-    private static final String CREATE_THIS_TOPIC_ARN_PROPERTY = "prop.create.this.topic.arn";
-    private static final String CREATE_THIS_TOPIC_NAME = "create-this-topic";
-    private static final String CREATE_THIS_TOPIC_PROPERTY = "prop.create.this.topic";
+    private static final String CREATE_WITH_SQS_SUB_ARN = "arn:aws:sns:us-east-1:111111111111:create-with-sqs-sub";
+    private static final String CREATE_WITH_SQS_SUB_ARN_PROPERTY = "prop.create.with.sqs.sub.arn";
+    private static final String CREATE_WITH_SQS_SUB_NAME = "create-with-sqs-sub";
+    private static final String CREATE_WITH_SQS_SUB_PROPERTY = "prop.create.with.sqs.sub";
+
+    private static final String CREATE_WITH_S3_NOTIFS_ARN = "arn:aws:sns:us-east-1:111111111111:create-with-s3-notifs";
+    private static final String CREATE_WITH_S3_NOTIFS_ARN_PROPERTY = "prop.create.with.s3.notifs.arn";
+    private static final String CREATE_WITH_S3_NOTIFS_NAME = "create-with-s3-notife";
+    private static final String CREATE_WITH_S3_NOTIFS_PROPERTY = "prop.create.with.s3.notifs";
 
     private static final String EXISTING_TOPIC_ARN = "arn:aws:sns:us-east-1:111111111111:existing-topic";
     private static final String EXISTING_TOPIC_ARN_PROPERTY = "prop.existing.topic.arn";
@@ -63,11 +73,15 @@ public class SnsInitializerTest {
     @Test
     public void test() {
         // Test cases.
-        // 1. create-this-topic (We need to create this topic.)
-        // 2. existing-topic (Already exists.)
+        // 1. create-with-sqs-sub (Create a queue and associate it with an SQS queue.)
+        // 2. create-with-s3-notifs (Create a queue and give permissions to receive notifications from S3.)
+        // 3. existing-topic (Configured for both an SQS queue and S3 notifications, but it already exists, so we
+        //   create neither.)
 
         // Mock BridgeConfig.
-        when(mockBridgeConfig.get(CREATE_THIS_TOPIC_PROPERTY)).thenReturn(CREATE_THIS_TOPIC_NAME);
+        when(mockBridgeConfig.get(SnsInitializer.CONFIG_KEY_AWS_ACCOUNT_ID)).thenReturn(DUMMY_AWS_ACCOUNT_ID);
+        when(mockBridgeConfig.get(CREATE_WITH_SQS_SUB_PROPERTY)).thenReturn(CREATE_WITH_SQS_SUB_NAME);
+        when(mockBridgeConfig.get(CREATE_WITH_S3_NOTIFS_PROPERTY)).thenReturn(CREATE_WITH_S3_NOTIFS_NAME);
         when(mockBridgeConfig.get(EXISTING_TOPIC_PROPERTY)).thenReturn(EXISTING_TOPIC_NAME);
         when(mockBridgeConfig.get(SUBSCRIBER_QUEUE_URL_PROPERTY)).thenReturn(SUBSCRIBER_QUEUE_URL);
 
@@ -82,8 +96,10 @@ public class SnsInitializerTest {
         ListTopicsResult listTopicsPage2Result = new ListTopicsResult().withTopics(existingTopic).withNextToken(null);
         when(mockSnsClient.listTopics(NEXT_PAGE_TOKEN)).thenReturn(listTopicsPage2Result);
 
-        when(mockSnsClient.createTopic(CREATE_THIS_TOPIC_NAME)).thenReturn(new CreateTopicResult()
-                .withTopicArn(CREATE_THIS_TOPIC_ARN));
+        when(mockSnsClient.createTopic(CREATE_WITH_SQS_SUB_NAME)).thenReturn(new CreateTopicResult()
+                .withTopicArn(CREATE_WITH_SQS_SUB_ARN));
+        when(mockSnsClient.createTopic(CREATE_WITH_S3_NOTIFS_NAME)).thenReturn(new CreateTopicResult()
+                .withTopicArn(CREATE_WITH_S3_NOTIFS_ARN));
 
         // Mock SQS Client.
         GetQueueAttributesResult getQueueAttributesResult = new GetQueueAttributesResult().addAttributesEntry(
@@ -91,18 +107,22 @@ public class SnsInitializerTest {
         when(mockSqsClient.getQueueAttributes(SUBSCRIBER_QUEUE_URL, SnsInitializer.QUEUE_ATTRIBUTE_LIST))
                 .thenReturn(getQueueAttributesResult);
 
-        // Spy getSnsTopicProperties().
-        Map<String, String> snsTopicProperties = ImmutableMap.<String, String>builder()
-                .put(CREATE_THIS_TOPIC_PROPERTY, SUBSCRIBER_QUEUE_URL_PROPERTY)
-                .put(EXISTING_TOPIC_PROPERTY, SUBSCRIBER_QUEUE_URL_PROPERTY)
-                .build();
+        // Spy getSnsReceiveS3NotificationsEnabled() and getSnsTopicProperties().
+        doReturn(ImmutableSet.of(CREATE_WITH_S3_NOTIFS_PROPERTY)).when(initializer)
+                .getSnsReceiveS3NotificationsEnabled();
+
+        Map<String, String> snsTopicProperties = new HashMap<>();
+        snsTopicProperties.put(CREATE_WITH_SQS_SUB_PROPERTY, SUBSCRIBER_QUEUE_URL_PROPERTY);
+        snsTopicProperties.put(CREATE_WITH_S3_NOTIFS_PROPERTY, null);
+        snsTopicProperties.put(EXISTING_TOPIC_PROPERTY, SUBSCRIBER_QUEUE_URL_PROPERTY);
         doReturn(snsTopicProperties).when(initializer).getSnsTopicProperties();
 
         // Execute.
         initializer.initTopics();
 
-        // Verify 1 topic created.
-        verify(mockSnsClient).createTopic(CREATE_THIS_TOPIC_NAME);
+        // Verify 2 topics created.
+        verify(mockSnsClient).createTopic(CREATE_WITH_SQS_SUB_NAME);
+        verify(mockSnsClient).createTopic(CREATE_WITH_S3_NOTIFS_NAME);
 
         // Verify 1 subscription.
         ArgumentCaptor<SubscribeRequest> subscribeRequestCaptor = ArgumentCaptor.forClass(SubscribeRequest.class);
@@ -111,14 +131,29 @@ public class SnsInitializerTest {
         SubscribeRequest subscribeRequest = subscribeRequestCaptor.getValue();
         assertEquals(subscribeRequest.getEndpoint(), SUBSCRIBER_QUEUE_ARN);
         assertEquals(subscribeRequest.getProtocol(), "sqs");
-        assertEquals(subscribeRequest.getTopicArn(), CREATE_THIS_TOPIC_ARN);
+        assertEquals(subscribeRequest.getTopicArn(), CREATE_WITH_SQS_SUB_ARN);
 
         Map<String, String> subscribeRequestAttrs = subscribeRequest.getAttributes();
         assertEquals(subscribeRequestAttrs.size(), 1);
         assertEquals(subscribeRequestAttrs.get("RawMessageDelivery"), "true");
 
-        // Verify both topics have ARN entries in config.
-        verify(mockBridgeConfig).set(CREATE_THIS_TOPIC_ARN_PROPERTY, CREATE_THIS_TOPIC_ARN);
+        // Verify 1 SNS policy.
+        Map<String, String> varMap = ImmutableMap.<String, String>builder()
+                .put("topicArn", CREATE_WITH_S3_NOTIFS_ARN)
+                .put("awsAccountId", DUMMY_AWS_ACCOUNT_ID)
+                .build();
+        String resolvedPolicy = resolveTemplate(SnsInitializer.S3_NOTIFICATIONS_POLICY, varMap);
+        verify(mockSnsClient).setTopicAttributes(CREATE_WITH_S3_NOTIFS_ARN, SnsInitializer.ATTRIBUTE_NAME_POLICY,
+                resolvedPolicy);
+
+        // For completeness, verify the listTopics calls.
+        verify(mockSnsClient).listTopics();
+        verify(mockSnsClient).listTopics(NEXT_PAGE_TOKEN);
+        verifyNoMoreInteractions(mockSnsClient);
+
+        // Verify all topics have ARN entries in config.
+        verify(mockBridgeConfig).set(CREATE_WITH_SQS_SUB_ARN_PROPERTY, CREATE_WITH_SQS_SUB_ARN);
+        verify(mockBridgeConfig).set(CREATE_WITH_S3_NOTIFS_ARN_PROPERTY, CREATE_WITH_S3_NOTIFS_ARN);
         verify(mockBridgeConfig).set(EXISTING_TOPIC_ARN_PROPERTY, EXISTING_TOPIC_ARN);
     }
 }


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-3380

Miscellaneous infrastructure changes to support the Antivirus Scanner:

* S3 buckets have additional config that deny access to files that the Antivirus Scanner has tagged with "Infected".
* Add S3 notifications for when files are added to buckets that contain user-submitted data.
* Create new SNS topics and SQS queues for triggering the Antivirus Scanner and for receiving results for infected files.
* Add SNS configs to accept notifications from S3.

Testing done:

* mvn clean verify (includes findbugs and Jacoco unit test coverage)
* verify SNS topics and SQS queues are created with the correct configurations
* verify S3 buckets have the notification configs
* deleted some S3 buckets and verified they were created with the correct permissions to deny infected files
* ran selected integ tests (Exporter3Test and UploadTest) as a sanity check

Note that the S3Initializer doesn't apply the Deny Infected permissions to buckets that already exist. We will have to manually add these to existing buckets.