### PR TITLE
[FIX BUILD BREAK] Remove alert from EnrollmentService.addEnrollment()

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
@@ -42,7 +42,6 @@ import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
-import org.sagebionetworks.bridge.models.studies.Alert;
 import org.sagebionetworks.bridge.models.studies.Enrollment;
 import org.sagebionetworks.bridge.models.studies.EnrollmentDetail;
 import org.sagebionetworks.bridge.models.studies.EnrollmentFilter;
@@ -195,10 +194,6 @@ public class EnrollmentService {
         }
         editEnrollment(account, newEnrollment, newEnrollment);
         account.getEnrollments().add(newEnrollment);
-
-        // trigger alert for new enrollment
-        alertService.createAlert(
-                Alert.newEnrollment(newEnrollment.getStudyId(), newEnrollment.getAppId(), account.getId()));
 
         return newEnrollment;
     }

--- a/src/test/java/org/sagebionetworks/bridge/services/EnrollmentServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/EnrollmentServiceTest.java
@@ -60,12 +60,10 @@ import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
-import org.sagebionetworks.bridge.models.studies.Alert;
 import org.sagebionetworks.bridge.models.studies.Enrollment;
 import org.sagebionetworks.bridge.models.studies.EnrollmentDetail;
 import org.sagebionetworks.bridge.models.studies.EnrollmentFilter;
 import org.sagebionetworks.bridge.models.studies.Study;
-import org.sagebionetworks.bridge.models.studies.Alert.AlertCategory;
 
 public class EnrollmentServiceTest extends Mockito {
 
@@ -90,9 +88,6 @@ public class EnrollmentServiceTest extends Mockito {
     
     @Captor
     ArgumentCaptor<Account> accountCaptor;
-
-    @Captor
-    ArgumentCaptor<Alert> alertCaptor;
 
     @BeforeMethod
     public void beforeMethod() {
@@ -235,10 +230,6 @@ public class EnrollmentServiceTest extends Mockito {
         assertEquals(retValue.getNote(), TEST_NOTE);
         
         assertTrue(account.getEnrollments().contains(retValue));
-
-        // verify new enrollment alert created
-        verify(alertService).createAlert(alertCaptor.capture());
-        assertNewEnrollmentAlert(alertCaptor.getValue());
     }
     
     @Test
@@ -262,10 +253,6 @@ public class EnrollmentServiceTest extends Mockito {
         assertEquals(retValue.getAccountId(), TEST_USER_ID);
         assertEquals(retValue.getEnrolledBy(), "adminUser");
         assertEquals(retValue.getNote(), TEST_NOTE);
-
-        // verify new enrollment alert created
-        verify(alertService).createAlert(alertCaptor.capture());
-        assertNewEnrollmentAlert(alertCaptor.getValue());
     }
     
     @Test
@@ -291,10 +278,6 @@ public class EnrollmentServiceTest extends Mockito {
         assertEquals(retValue.getAccountId(), TEST_USER_ID);
         assertEquals(retValue.getEnrolledBy(), "adminUser");
         assertEquals(retValue.getNote(), TEST_NOTE);
-
-        // verify new enrollment alert created
-        verify(alertService).createAlert(alertCaptor.capture());
-        assertNewEnrollmentAlert(alertCaptor.getValue());
     }
     
     @Test
@@ -317,10 +300,6 @@ public class EnrollmentServiceTest extends Mockito {
         Enrollment retValue = service.enroll(enrollment);
         assertEquals(retValue.getAccountId(), TEST_USER_ID);
         assertEquals(retValue.getNote(), TEST_NOTE);
-
-        // verify new enrollment alert created
-        verify(alertService).createAlert(alertCaptor.capture());
-        assertNewEnrollmentAlert(alertCaptor.getValue());
     }
     
     @Test
@@ -346,9 +325,6 @@ public class EnrollmentServiceTest extends Mockito {
         
         Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         service.enroll(enrollment);
-
-        // verify no new enrollment alert created
-        verifyZeroInteractions(alertService);
     }
     
     @Test(expectedExceptions = EntityNotFoundException.class, 
@@ -405,9 +381,6 @@ public class EnrollmentServiceTest extends Mockito {
         assertNull(retValue.getWithdrawnBy());
         assertNull(retValue.getWithdrawalNote());
         assertFalse(retValue.isConsentRequired());
-
-        // verify new enrollment alert created
-        verifyZeroInteractions(alertService);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -929,13 +902,5 @@ public class EnrollmentServiceTest extends Mockito {
                 capturedEnrollments, Enrollment::getStudyId, TEST_STUDY_ID).orElse(null);
         assertNotNull(captured);
         assertEquals(captured.getNote(), TEST_NOTE);
-    }
-
-    private void assertNewEnrollmentAlert(Alert alert) {
-        assertNotNull(alert);
-        assertEquals(alert.getAppId(), TEST_APP_ID);
-        assertEquals(alert.getStudyId(), TEST_STUDY_ID);
-        assertEquals(alert.getUserId(), TEST_USER_ID);
-        assertEquals(alert.getCategory(), AlertCategory.NEW_ENROLLMENT);
     }
 }


### PR DESCRIPTION
ParticipantService.createParticipant() will enroll the participant *before* creating the account. This means that EnrollmentService.addEnrollment() will fail to create the alert because the participant doesn't exist yet. This results in createParticipant() failing, which causes a lot of issues.

See https://sagebionetworks.jira.com/browse/MTB-651