### PR TITLE
Fix new enrollment alerts

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/EnrollmentService.java
@@ -42,6 +42,7 @@ import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
+import org.sagebionetworks.bridge.models.studies.Alert;
 import org.sagebionetworks.bridge.models.studies.Enrollment;
 import org.sagebionetworks.bridge.models.studies.EnrollmentDetail;
 import org.sagebionetworks.bridge.models.studies.EnrollmentFilter;
@@ -194,6 +195,10 @@ public class EnrollmentService {
         }
         editEnrollment(account, newEnrollment, newEnrollment);
         account.getEnrollments().add(newEnrollment);
+
+        // trigger alert for new enrollment
+        alertService.createAlert(
+                Alert.newEnrollment(newEnrollment.getStudyId(), newEnrollment.getAppId(), account.getId()));
 
         return newEnrollment;
     }

--- a/src/test/java/org/sagebionetworks/bridge/services/AlertServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/AlertServiceTest.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.bridge.services;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_EXTERNAL_ID;
@@ -68,6 +69,7 @@ public class AlertServiceTest {
 
     @Test
     public void createAlert() {
+        when(accountService.getAccount(any())).thenReturn(Optional.of(Account.create()));
         when(alertDao.getAlert(TEST_STUDY_ID, TEST_APP_ID, TEST_USER_ID, AlertCategory.NEW_ENROLLMENT)).thenReturn(Optional.empty());
 
         alertService.createAlert(alert);
@@ -80,7 +82,8 @@ public class AlertServiceTest {
     }
 
     @Test
-    public void createAlert_alreadyExists() {
+    public void createAlert_alertAlreadyExists() {
+        when(accountService.getAccount(any())).thenReturn(Optional.of(Account.create()));
         Alert existingAlert = new Alert();
         when(alertDao.getAlert(TEST_STUDY_ID, TEST_APP_ID, TEST_USER_ID, AlertCategory.NEW_ENROLLMENT))
                 .thenReturn(Optional.of(existingAlert));
@@ -93,6 +96,15 @@ public class AlertServiceTest {
         assertSame(alertCaptor.getValue(), alert);
         assertNotNull(alert.getId());
         assertNotNull(alert.getCreatedOn());
+    }
+
+    @Test
+    public void createAlert_accountDoesNotExist() {
+        when(accountService.getAccount(any())).thenReturn(Optional.empty());
+
+        alertService.createAlert(alert);
+
+        verifyZeroInteractions(alertDao);
     }
 
     @Test(expectedExceptions = NullPointerException.class)

--- a/src/test/java/org/sagebionetworks/bridge/services/EnrollmentServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/EnrollmentServiceTest.java
@@ -60,10 +60,12 @@ import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.Account;
 import org.sagebionetworks.bridge.models.accounts.AccountId;
+import org.sagebionetworks.bridge.models.studies.Alert;
 import org.sagebionetworks.bridge.models.studies.Enrollment;
 import org.sagebionetworks.bridge.models.studies.EnrollmentDetail;
 import org.sagebionetworks.bridge.models.studies.EnrollmentFilter;
 import org.sagebionetworks.bridge.models.studies.Study;
+import org.sagebionetworks.bridge.models.studies.Alert.AlertCategory;
 
 public class EnrollmentServiceTest extends Mockito {
 
@@ -88,6 +90,9 @@ public class EnrollmentServiceTest extends Mockito {
     
     @Captor
     ArgumentCaptor<Account> accountCaptor;
+
+    @Captor
+    ArgumentCaptor<Alert> alertCaptor;
 
     @BeforeMethod
     public void beforeMethod() {
@@ -230,6 +235,10 @@ public class EnrollmentServiceTest extends Mockito {
         assertEquals(retValue.getNote(), TEST_NOTE);
         
         assertTrue(account.getEnrollments().contains(retValue));
+
+        // verify new enrollment alert created
+        verify(alertService).createAlert(alertCaptor.capture());
+        assertNewEnrollmentAlert(alertCaptor.getValue());
     }
     
     @Test
@@ -253,6 +262,10 @@ public class EnrollmentServiceTest extends Mockito {
         assertEquals(retValue.getAccountId(), TEST_USER_ID);
         assertEquals(retValue.getEnrolledBy(), "adminUser");
         assertEquals(retValue.getNote(), TEST_NOTE);
+
+        // verify new enrollment alert created
+        verify(alertService).createAlert(alertCaptor.capture());
+        assertNewEnrollmentAlert(alertCaptor.getValue());
     }
     
     @Test
@@ -278,6 +291,10 @@ public class EnrollmentServiceTest extends Mockito {
         assertEquals(retValue.getAccountId(), TEST_USER_ID);
         assertEquals(retValue.getEnrolledBy(), "adminUser");
         assertEquals(retValue.getNote(), TEST_NOTE);
+
+        // verify new enrollment alert created
+        verify(alertService).createAlert(alertCaptor.capture());
+        assertNewEnrollmentAlert(alertCaptor.getValue());
     }
     
     @Test
@@ -300,6 +317,10 @@ public class EnrollmentServiceTest extends Mockito {
         Enrollment retValue = service.enroll(enrollment);
         assertEquals(retValue.getAccountId(), TEST_USER_ID);
         assertEquals(retValue.getNote(), TEST_NOTE);
+
+        // verify new enrollment alert created
+        verify(alertService).createAlert(alertCaptor.capture());
+        assertNewEnrollmentAlert(alertCaptor.getValue());
     }
     
     @Test
@@ -325,6 +346,9 @@ public class EnrollmentServiceTest extends Mockito {
         
         Enrollment enrollment = Enrollment.create(TEST_APP_ID, TEST_STUDY_ID, TEST_USER_ID);
         service.enroll(enrollment);
+
+        // verify no new enrollment alert created
+        verifyZeroInteractions(alertService);
     }
     
     @Test(expectedExceptions = EntityNotFoundException.class, 
@@ -381,6 +405,9 @@ public class EnrollmentServiceTest extends Mockito {
         assertNull(retValue.getWithdrawnBy());
         assertNull(retValue.getWithdrawalNote());
         assertFalse(retValue.isConsentRequired());
+
+        // verify new enrollment alert created
+        verifyZeroInteractions(alertService);
     }
     
     @Test(expectedExceptions = UnauthorizedException.class)
@@ -902,5 +929,13 @@ public class EnrollmentServiceTest extends Mockito {
                 capturedEnrollments, Enrollment::getStudyId, TEST_STUDY_ID).orElse(null);
         assertNotNull(captured);
         assertEquals(captured.getNote(), TEST_NOTE);
+    }
+
+    private void assertNewEnrollmentAlert(Alert alert) {
+        assertNotNull(alert);
+        assertEquals(alert.getAppId(), TEST_APP_ID);
+        assertEquals(alert.getStudyId(), TEST_STUDY_ID);
+        assertEquals(alert.getUserId(), TEST_USER_ID);
+        assertEquals(alert.getCategory(), AlertCategory.NEW_ENROLLMENT);
     }
 }


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/MTB-651

New enrollment alerts caused a build break, so they were removed. This re-enables them.

New enrollment alerts were triggered only in the method to add enrollments. I missed a case where enrollments could be added before the account was created. This meant that, since alerts reference accounts, a constraint violation occurred when there was an attempt to create an alert referencing an account that did not exist.

Now, there is a check to make sure the account exists before creating a new enrollment alert, and if it does not, the alert is not created. However, this change alone would mean that adding an enrollment before creating the account would cause the enrollment alert to never be created, even if the account was created later. Therefore, additional new enrollment alert triggers are added when accounts are created and when accounts are updated with new enrollments.