### PR TITLE
Create queues and subscriptions for S3EventNotificationCallback

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/SnsInitializer.java
+++ b/src/main/java/org/sagebionetworks/bridge/SnsInitializer.java
@@ -94,7 +94,7 @@ public class SnsInitializer {
         // These aren't mapped to SQS queues, and ImmuntableMap doesn't allow null values. So make a HashMap and wrap
         // it in an unmodifiableMap().
         HashMap<String, String> snsToSqsMap = new HashMap<>();
-        snsToSqsMap.put("virus.scan.trigger.topic", null);
+        snsToSqsMap.put("virus.scan.trigger.topic", "s3.notification.sqs.queue.url");
         snsToSqsMap.put("virus.scan.result.topic", "virus.scan.result.sqs.queue.url");
         SNS_TOPIC_PROPERTIES = Collections.unmodifiableMap(snsToSqsMap);
     }

--- a/src/main/java/org/sagebionetworks/bridge/SqsInitializer.java
+++ b/src/main/java/org/sagebionetworks/bridge/SqsInitializer.java
@@ -52,6 +52,7 @@ public class SqsInitializer {
     // queue.
     private static final Map<String, Boolean> QUEUE_PROPERTIES = ImmutableMap.<String, Boolean>builder()
             .put("exporter.request.sqs.queue", false)
+            .put("s3.notification.sqs.queue", true)
             .put("virus.scan.result.sqs.queue", true)
             .put("workerPlatform.request.sqs.queue", false)
             .put("integ.test.sqs.queue", true)

--- a/src/main/resources/BridgeServer2.conf
+++ b/src/main/resources/BridgeServer2.conf
@@ -141,6 +141,12 @@ dev.exporter.request.sqs.queue=Bridge-EX-Request-develop
 uat.exporter.request.sqs.queue=Bridge-EX-Request-staging
 prod.exporter.request.sqs.queue=Bridge-EX-Request-prod
 
+# S3 Event Notification Callback (Upload Auto-Complete)
+local.s3.notification.sqs.queue=Bridge-UploadComplete-Notification-${bucket.suffix}
+dev.s3.notification.sqs.queue=Bridge-UploadComplete-Notification-develop
+uat.s3.notification.sqs.queue=Bridge-UploadComplete-Notification-staging
+prod.s3.notification.sqs.queue=Bridge-UploadComplete-Notification-prod
+
 #Bridge Participant Roster Download Worker SQS queues
 local.workerPlatform.request.sqs.queue=Bridge-WorkerPlatform-Request-${bucket.suffix}
 dev.workerPlatform.request.sqs.queue=Bridge-WorkerPlatform-Request-develop


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-2225

The S3EventNotificationCallback uses its own queue because the message format is distinct. We add this queue to our SqsInitializer for consistency.

It's subscribed to the Virus Scan SNS topic because an S3 bucket can only have one notification attached to it, so we need to share.