### PR TITLE
BRIDGE-3389 Upload Status API for EX3

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/AuthUtils.java
@@ -266,7 +266,16 @@ public class AuthUtils {
             .isSelf().isEnrolledInStudy().or()
             .canAccessStudy().hasAnyRole(STUDY_DESIGNER, STUDY_COORDINATOR).or()
             .hasAnyRole(DEVELOPER, RESEARCHER, WORKER, ADMIN);
-    
+
+    /**
+     * Can the caller read uploads? Users can read their own uploads. Study designers and study coordinators can read
+     * any upload in their study. Developers, researchers, workers, and admins can read any upload in the app.
+     */
+    public static final AuthEvaluator CAN_READ_UPLOADS = new AuthEvaluator()
+            .isSelf().or()
+            .canAccessStudy().hasAnyRole(STUDY_DESIGNER, STUDY_COORDINATOR).or()
+            .hasAnyRole(DEVELOPER, RESEARCHER, WORKER, ADMIN);
+
     /**
      * Does the caller have the required role? Note that a few roles pass for other roles.
      */

--- a/src/main/java/org/sagebionetworks/bridge/dao/UploadDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dao/UploadDao.java
@@ -37,7 +37,10 @@ public interface UploadDao {
      * @return upload metadata
      */
     Upload getUpload(@Nonnull String uploadId);
-    
+
+    /** Get upload. Returns null if the upload doesn't exist. */
+    Upload getUploadNoThrow(String uploadId);
+
     /**
      * Get the uploads for an indicated time range.
      */

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataRecordEx3.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataRecordEx3.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.sagebionetworks.bridge.json.DateTimeToLongDeserializer;
 import org.sagebionetworks.bridge.json.DateTimeToLongSerializer;
 import org.sagebionetworks.bridge.models.accounts.SharingScope;
+import org.sagebionetworks.bridge.models.exporter.ExportedRecordInfo;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecordEx3;
 
 @DynamoDBTable(tableName = "HealthDataRecordEx3")
@@ -35,6 +36,8 @@ public class DynamoHealthDataRecordEx3 implements HealthDataRecordEx3 {
     private String clientInfo;
     private boolean exported;
     private Long exportedOn;
+    private ExportedRecordInfo exportedRecord;
+    private Map<String, ExportedRecordInfo> exportedStudyRecords;
     private Map<String, String> metadata;
     private SharingScope sharingScope;
     private Long version;
@@ -171,6 +174,30 @@ public class DynamoHealthDataRecordEx3 implements HealthDataRecordEx3 {
     @Override
     public void setExportedOn(Long exportedOn) {
         this.exportedOn = exportedOn;
+    }
+
+    @DynamoDBTypeConverted(converter = ExportedRecordInfoMarshaller.class)
+    @Override
+    public ExportedRecordInfo getExportedRecord() {
+        return exportedRecord;
+    }
+
+    @Override
+    public void setExportedRecord(ExportedRecordInfo exportedRecord) {
+        this.exportedRecord = exportedRecord;
+    }
+
+    @DynamoDBTypeConverted(converter = ExportedRecordInfoMapMarshaller.class)
+    @Override
+    public Map<String, ExportedRecordInfo> getExportedStudyRecords() {
+        return exportedStudyRecords;
+    }
+
+    @Override
+    public void setExportedStudyRecords(Map<String, ExportedRecordInfo> exportedStudyRecords) {
+        // Dynamo DB doesn't support empty maps.
+        this.exportedStudyRecords = exportedStudyRecords != null && !exportedStudyRecords.isEmpty() ?
+                exportedStudyRecords : null;
     }
 
     @Override

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadDao.java
@@ -33,6 +33,8 @@ import com.google.common.collect.Iterables;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -56,6 +58,8 @@ import org.sagebionetworks.bridge.models.upload.UploadStatus;
 
 @Component
 public class DynamoUploadDao implements UploadDao {
+    private static final Logger LOG = LoggerFactory.getLogger(DynamoUploadDao.class);
+
     static final String PAGE_SIZE_ERROR = "pageSize must be from 1-"+API_MAXIMUM_PAGE_SIZE+" records";
 
     private DynamoDBMapper mapper;
@@ -118,26 +122,34 @@ public class DynamoUploadDao implements UploadDao {
     /** {@inheritDoc} */
     @Override
     public Upload getUpload(@Nonnull String uploadId) {
+        Upload upload = getUploadNoThrow(uploadId);
+        if (upload == null) {
+            throw new NotFoundException(String.format("Upload ID %s not found", uploadId));
+        }
+        return upload;
+    }
+
+    @Override
+    public Upload getUploadNoThrow(String uploadId) {
         // Fetch upload from DynamoUpload2
         DynamoUpload2 key = new DynamoUpload2();
         key.setUploadId(uploadId);
         DynamoUpload2 upload = mapper.load(key);
         if (upload != null) {
-            // Very old uploads (2+ years ago) did not have appId set; for these we must do 
+            // Very old uploads (2+ years ago) did not have appId set; for these we must do
             // a lookup in the legacy DynamoHealthCode table.
-            if (upload.getAppId() == null) { 
+            if (upload.getAppId() == null) {
                 String appId = healthCodeDao.getAppId(upload.getHealthCode());
                 if (appId == null) {
-                    throw new EntityNotFoundException(DynamoApp.class,
-                            "App not found for upload. User may have been deleted from system.");
+                    LOG.error("App not found for upload " + uploadId + ". User may have been deleted from system.");
+                    return null;
                 }
                 upload.setAppId(appId);
             }
-            return upload;
         }
-        throw new NotFoundException(String.format("Upload ID %s not found", uploadId));
+        return upload;
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public ForwardCursorPagedResourceList<Upload> getUploads(String healthCode, DateTime startTime, DateTime endTime,

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/ExportedRecordInfoMapMarshaller.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/ExportedRecordInfoMapMarshaller.java
@@ -1,0 +1,16 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import org.sagebionetworks.bridge.models.exporter.ExportedRecordInfo;
+
+public class ExportedRecordInfoMapMarshaller extends StringKeyMapMarshaller<ExportedRecordInfo> {
+    private static final TypeReference<Map<String, ExportedRecordInfo>> REF = new TypeReference<Map<String, ExportedRecordInfo>>() {
+    };
+
+    @Override public TypeReference<Map<String, ExportedRecordInfo>> getTypeReference() {
+        return REF;
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/ExportedRecordInfoMarshaller.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/ExportedRecordInfoMarshaller.java
@@ -1,0 +1,10 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import org.sagebionetworks.bridge.models.exporter.ExportedRecordInfo;
+
+public class ExportedRecordInfoMarshaller extends JsonMarshaller<ExportedRecordInfo> {
+    @Override
+    public Class<ExportedRecordInfo> getConvertedClass() {
+        return ExportedRecordInfo.class;
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/JsonMarshaller.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/JsonMarshaller.java
@@ -1,0 +1,45 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import java.io.IOException;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMappingException;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTypeConverter;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+/**
+ * Generic JSON marshaller for DynamoDB. This converts the object into JSON for marshalling to DynamoDB. Because
+ * DynamoDB annotations don't work with generics, you'll need to subclass this and fill in getConvertedClass().
+ */
+public abstract class JsonMarshaller<T> implements DynamoDBTypeConverter<String, T> {
+    /**
+     * Returns the class for Jackson to deserialize the value from DynamoDB, because Java can't infer generic types at
+     * runtime.
+     */
+    public abstract Class<T> getConvertedClass();
+
+    @Override
+    public String convert(T t) {
+        if (t == null) {
+            return null;
+        }
+        try {
+            return BridgeObjectMapper.get().writerWithDefaultPrettyPrinter().writeValueAsString(t);
+        } catch (JsonProcessingException ex) {
+            throw new DynamoDBMappingException(ex);
+        }
+    }
+
+    @Override
+    public T unconvert(String json) {
+        if (json == null) {
+            return null;
+        }
+        try {
+            return BridgeObjectMapper.get().readValue(json, getConvertedClass());
+        } catch (IOException ex) {
+            throw new DynamoDBMappingException(ex);
+        }
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/models/exporter/ExportToAppNotification.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/exporter/ExportToAppNotification.java
@@ -10,63 +10,10 @@ import org.sagebionetworks.bridge.models.BridgeEntity;
  * by the worker to trigger notifications and generate study-specific notifications.
  */
 public class ExportToAppNotification implements BridgeEntity {
-    public static class RecordInfo {
-        private String parentProjectId;
-        private String rawFolderId;
-        private String fileEntityId;
-        private String s3Bucket;
-        private String s3Key;
-
-        /** Synapse project that the health data is exported to. */
-        public String getParentProjectId() {
-            return parentProjectId;
-        }
-
-        public void setParentProjectId(String parentProjectId) {
-            this.parentProjectId = parentProjectId;
-        }
-
-        /** Synapse folder that the health data is exported to. */
-        public String getRawFolderId() {
-            return rawFolderId;
-        }
-
-        public void setRawFolderId(String rawFolderId) {
-            this.rawFolderId = rawFolderId;
-        }
-
-        /** Synapse file entity of the health data that is exported. */
-        public String getFileEntityId() {
-            return fileEntityId;
-        }
-
-        public void setFileEntityId(String fileEntityId) {
-            this.fileEntityId = fileEntityId;
-        }
-
-        /** S3 bucket that contains the exported health data. */
-        public String getS3Bucket() {
-            return s3Bucket;
-        }
-
-        public void setS3Bucket(String s3Bucket) {
-            this.s3Bucket = s3Bucket;
-        }
-
-        /** S3 key that of the exported health data. */
-        public String getS3Key() {
-            return s3Key;
-        }
-
-        public void setS3Key(String s3Key) {
-            this.s3Key = s3Key;
-        }
-    }
-
     private String appId;
     private String recordId;
-    private RecordInfo record;
-    private Map<String, RecordInfo> studyRecords = new HashMap<>();
+    private ExportedRecordInfo record;
+    private Map<String, ExportedRecordInfo> studyRecords = new HashMap<>();
 
     /** App that the health data is exported for. */
     public String getAppId() {
@@ -90,11 +37,11 @@ public class ExportToAppNotification implements BridgeEntity {
      * Record that is exported to the app-wide Synapse project. May be null if there is no app-wide Synapse project
      * configured.
      */
-    public RecordInfo getRecord() {
+    public ExportedRecordInfo getRecord() {
         return record;
     }
 
-    public void setRecord(RecordInfo record) {
+    public void setRecord(ExportedRecordInfo record) {
         this.record = record;
     }
 
@@ -102,11 +49,11 @@ public class ExportToAppNotification implements BridgeEntity {
      * Records that are exported to the study-specific Synapse project, keyed by study ID. May be empty if there are no
      * study-specific Synapse projects configured.
      */
-    public Map<String, RecordInfo> getStudyRecords() {
+    public Map<String, ExportedRecordInfo> getStudyRecords() {
         return studyRecords;
     }
 
-    public void setStudyRecords(Map<String, RecordInfo> studyRecords) {
+    public void setStudyRecords(Map<String, ExportedRecordInfo> studyRecords) {
         this.studyRecords = studyRecords != null ? studyRecords : new HashMap<>();
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/models/exporter/ExportedRecordInfo.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/exporter/ExportedRecordInfo.java
@@ -1,0 +1,55 @@
+package org.sagebionetworks.bridge.models.exporter;
+
+/** Info about a health data record that was exported to Synapse. */
+public class ExportedRecordInfo {
+    private String parentProjectId;
+    private String rawFolderId;
+    private String fileEntityId;
+    private String s3Bucket;
+    private String s3Key;
+
+    /** Synapse project that the health data is exported to. */
+    public String getParentProjectId() {
+        return parentProjectId;
+    }
+
+    public void setParentProjectId(String parentProjectId) {
+        this.parentProjectId = parentProjectId;
+    }
+
+    /** Synapse folder that the health data is exported to. */
+    public String getRawFolderId() {
+        return rawFolderId;
+    }
+
+    public void setRawFolderId(String rawFolderId) {
+        this.rawFolderId = rawFolderId;
+    }
+
+    /** Synapse file entity of the health data that is exported. */
+    public String getFileEntityId() {
+        return fileEntityId;
+    }
+
+    public void setFileEntityId(String fileEntityId) {
+        this.fileEntityId = fileEntityId;
+    }
+
+    /** S3 bucket that contains the exported health data. */
+    public String getS3Bucket() {
+        return s3Bucket;
+    }
+
+    public void setS3Bucket(String s3Bucket) {
+        this.s3Bucket = s3Bucket;
+    }
+
+    /** S3 key that of the exported health data. */
+    public String getS3Key() {
+        return s3Key;
+    }
+
+    public void setS3Key(String s3Key) {
+        this.s3Key = s3Key;
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordEx3.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordEx3.java
@@ -12,6 +12,7 @@ import org.sagebionetworks.bridge.dynamodb.DynamoHealthDataRecordEx3;
 import org.sagebionetworks.bridge.json.BridgeTypeName;
 import org.sagebionetworks.bridge.models.BridgeEntity;
 import org.sagebionetworks.bridge.models.accounts.SharingScope;
+import org.sagebionetworks.bridge.models.exporter.ExportedRecordInfo;
 import org.sagebionetworks.bridge.models.upload.Upload;
 
 /**
@@ -102,6 +103,20 @@ public interface HealthDataRecordEx3 extends BridgeEntity {
      */
     Long getExportedOn();
     void setExportedOn(Long exportedOn);
+
+    /**
+     * Record that is exported to the app-wide Synapse project. May be null if there is no app-wide Synapse project
+     * configured.
+     */
+    ExportedRecordInfo getExportedRecord();
+    void setExportedRecord(ExportedRecordInfo exportedRecord);
+
+    /**
+     * Records that are exported to the study-specific Synapse project, keyed by study ID. May be empty if there are no
+     * study-specific Synapse projects configured.
+     */
+    Map<String, ExportedRecordInfo> getExportedStudyRecords();
+    void setExportedStudyRecords(Map<String, ExportedRecordInfo> exportedStudyRecords);
 
     /** Client-submitted metadata, as a map of key-value pairs. */
     Map<String, String> getMetadata();

--- a/src/main/java/org/sagebionetworks/bridge/models/upload/UploadViewEx3.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/upload/UploadViewEx3.java
@@ -1,0 +1,89 @@
+package org.sagebionetworks.bridge.models.upload;
+
+import java.util.List;
+
+import org.sagebionetworks.bridge.models.BridgeEntity;
+import org.sagebionetworks.bridge.models.healthdata.HealthDataRecordEx3;
+import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecord;
+import org.sagebionetworks.bridge.models.schedules2.timelines.TimelineMetadata;
+
+/**
+ * This helpful data structure includes the upload, health data record, adherence records, and timeline metadata for
+ * a given upload/record ID, if they exist.
+ */
+public class UploadViewEx3 implements BridgeEntity {
+    private String id;
+    private String healthCode;
+    private String userId;
+    private List<AdherenceRecord> adherenceRecords;
+    private HealthDataRecordEx3 record;
+    private TimelineMetadata timelineMetadata;
+    private Upload upload;
+
+    /**
+     * Upload ID. This is the same as Record ID. Provided here for convenience, since the upload or record might not
+     * always exist.
+     */
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /** Health code of the user that submitted the upload or record. */
+    public String getHealthCode() {
+        return healthCode;
+    }
+
+    public void setHealthCode(String healthCode) {
+        this.healthCode = healthCode;
+    }
+
+    /** ID of the user that submitted the upload or record. */
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    /** Adherence records associated with this upload/record. */
+    public List<AdherenceRecord> getAdherenceRecords() {
+        return adherenceRecords;
+    }
+
+    public void setAdherenceRecords(
+            List<AdherenceRecord> adherenceRecords) {
+        this.adherenceRecords = adherenceRecords;
+    }
+
+    /** Health data record corresponding to this upload, if it exists. */
+    public HealthDataRecordEx3 getRecord() {
+        return record;
+    }
+
+    public void setRecord(HealthDataRecordEx3 record) {
+        this.record = record;
+    }
+
+    /** Timeline metadata associated with this upload/record. */
+    public TimelineMetadata getTimelineMetadata() {
+        return timelineMetadata;
+    }
+
+    public void setTimelineMetadata(TimelineMetadata timelineMetadata) {
+        this.timelineMetadata = timelineMetadata;
+    }
+
+    /** Upload corresponding to the health data record, if it exists. */
+    public Upload getUpload() {
+        return upload;
+    }
+
+    public void setUpload(Upload upload) {
+        this.upload = upload;
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/models/upload/UploadViewEx3.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/upload/UploadViewEx3.java
@@ -5,7 +5,7 @@ import java.util.List;
 import org.sagebionetworks.bridge.models.BridgeEntity;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecordEx3;
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecord;
-import org.sagebionetworks.bridge.models.schedules2.timelines.TimelineMetadata;
+import org.sagebionetworks.bridge.models.schedules2.timelines.TimelineMetadataView;
 
 /**
  * This helpful data structure includes the upload, health data record, adherence records, and timeline metadata for
@@ -17,7 +17,7 @@ public class UploadViewEx3 implements BridgeEntity {
     private String userId;
     private List<AdherenceRecord> adherenceRecords;
     private HealthDataRecordEx3 record;
-    private TimelineMetadata timelineMetadata;
+    private TimelineMetadataView timelineMetadata;
     private Upload upload;
 
     /**
@@ -55,8 +55,7 @@ public class UploadViewEx3 implements BridgeEntity {
         return adherenceRecords;
     }
 
-    public void setAdherenceRecords(
-            List<AdherenceRecord> adherenceRecords) {
+    public void setAdherenceRecords(List<AdherenceRecord> adherenceRecords) {
         this.adherenceRecords = adherenceRecords;
     }
 
@@ -70,11 +69,11 @@ public class UploadViewEx3 implements BridgeEntity {
     }
 
     /** Timeline metadata associated with this upload/record. */
-    public TimelineMetadata getTimelineMetadata() {
+    public TimelineMetadataView getTimelineMetadata() {
         return timelineMetadata;
     }
 
-    public void setTimelineMetadata(TimelineMetadata timelineMetadata) {
+    public void setTimelineMetadata(TimelineMetadataView timelineMetadata) {
         this.timelineMetadata = timelineMetadata;
     }
 

--- a/src/main/java/org/sagebionetworks/bridge/services/Exporter3Service.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/Exporter3Service.java
@@ -61,6 +61,7 @@ import org.sagebionetworks.bridge.models.apps.App;
 import org.sagebionetworks.bridge.models.apps.Exporter3Configuration;
 import org.sagebionetworks.bridge.models.exporter.ExportToAppNotification;
 import org.sagebionetworks.bridge.models.exporter.ExportToStudyNotification;
+import org.sagebionetworks.bridge.models.exporter.ExportedRecordInfo;
 import org.sagebionetworks.bridge.models.exporter.ExporterCreateStudyNotification;
 import org.sagebionetworks.bridge.models.exporter.ExporterSubscriptionRequest;
 import org.sagebionetworks.bridge.models.exporter.ExporterSubscriptionResult;
@@ -650,8 +651,8 @@ public class Exporter3Service {
         }
 
         // Send study-specific notifications. Note that getStudyRecords() is never null.
-        Map<String, ExportToAppNotification.RecordInfo> studyRecordMap = exportToAppNotification.getStudyRecords();
-        for (Map.Entry<String, ExportToAppNotification.RecordInfo> entry : studyRecordMap.entrySet()) {
+        Map<String, ExportedRecordInfo> studyRecordMap = exportToAppNotification.getStudyRecords();
+        for (Map.Entry<String, ExportedRecordInfo> entry : studyRecordMap.entrySet()) {
             String studyId = entry.getKey();
 
             try {
@@ -669,7 +670,7 @@ public class Exporter3Service {
                     continue;
                 }
 
-                ExportToAppNotification.RecordInfo recordInfo = entry.getValue();
+                ExportedRecordInfo recordInfo = entry.getValue();
                 ExportToStudyNotification exportToStudyNotification = new ExportToStudyNotification();
                 exportToStudyNotification.setAppId(appId);
                 exportToStudyNotification.setStudyId(studyId);

--- a/src/main/java/org/sagebionetworks/bridge/services/UploadService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/UploadService.java
@@ -4,7 +4,11 @@ import static com.amazonaws.services.s3.Headers.SERVER_SIDE_ENCRYPTION;
 import static com.amazonaws.services.s3.model.ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.STUDY_ID;
+import static org.sagebionetworks.bridge.AuthEvaluatorField.USER_ID;
+import static org.sagebionetworks.bridge.AuthUtils.CAN_READ_UPLOADS;
 import static org.sagebionetworks.bridge.BridgeConstants.API_APP_ID;
 import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.CANNOT_BE_BLANK;
@@ -25,8 +29,11 @@ import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
@@ -34,6 +41,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import org.sagebionetworks.bridge.AuthEvaluatorField;
 import org.sagebionetworks.bridge.RequestContext;
 import org.sagebionetworks.bridge.config.BridgeConfig;
 import org.sagebionetworks.bridge.dao.UploadDao;
@@ -41,10 +49,16 @@ import org.sagebionetworks.bridge.dao.UploadDedupeDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
+import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.NotFoundException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.apps.App;
+import org.sagebionetworks.bridge.models.healthdata.HealthDataRecordEx3;
+import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecord;
+import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecordsSearch;
+import org.sagebionetworks.bridge.models.schedules2.timelines.TimelineMetadata;
+import org.sagebionetworks.bridge.models.upload.UploadViewEx3;
 import org.sagebionetworks.bridge.time.DateUtils;
 import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
@@ -56,6 +70,7 @@ import org.sagebionetworks.bridge.models.upload.UploadSession;
 import org.sagebionetworks.bridge.models.upload.UploadStatus;
 import org.sagebionetworks.bridge.models.upload.UploadValidationStatus;
 import org.sagebionetworks.bridge.models.upload.UploadView;
+import org.sagebionetworks.bridge.validators.AdherenceRecordsSearchValidator;
 import org.sagebionetworks.bridge.validators.UploadValidator;
 import org.sagebionetworks.bridge.validators.Validate;
 
@@ -68,12 +83,17 @@ public class UploadService {
     
     // package-scoped to be available in unit tests
     static final String CONFIG_KEY_UPLOAD_BUCKET = "upload.bucket";
+    static final String METADATA_KEY_INSTANCE_GUID = "instanceGuid";
 
+    private AccountService accountService;
+    private AdherenceService adherenceService;
     private AppService appService;
     private Exporter3Service exporter3Service;
     private HealthDataService healthDataService;
+    private HealthDataEx3Service healthDataEx3Service;
     private AmazonS3 s3UploadClient;
     private AmazonS3 s3Client;
+    private Schedule2Service schedule2Service;
     private String uploadBucket;
     private UploadDao uploadDao;
     private UploadDedupeDao uploadDedupeDao;
@@ -84,6 +104,16 @@ public class UploadService {
     // 30 seconds will have passed.
     private int pollValidationStatusMaxIterations = 7;
     private long pollValidationStatusSleepMillis = 5000;
+
+    @Autowired
+    public final void setAccountService(AccountService accountService) {
+        this.accountService = accountService;
+    }
+
+    @Autowired
+    public final void setAdherenceService(AdherenceService adherenceService) {
+        this.adherenceService = adherenceService;
+    }
 
     @Autowired
     public final void setAppService(AppService appService) {
@@ -106,20 +136,31 @@ public class UploadService {
      * validation status.
      */
     @Autowired
-    public void setHealthDataService(HealthDataService healthDataService) {
+    public final void setHealthDataService(HealthDataService healthDataService) {
         this.healthDataService = healthDataService;
     }
 
+    @Autowired
+    public final void setHealthDataEx3Service(HealthDataEx3Service healthDataEx3Service) {
+        this.healthDataEx3Service = healthDataEx3Service;
+    }
+
     @Resource(name = "s3Client")
-    public void setS3UploadClient(AmazonS3 s3UploadClient) {
+    public final void setS3UploadClient(AmazonS3 s3UploadClient) {
         this.s3UploadClient = s3UploadClient;
     }
     @Resource(name = "s3Client")
-    public void setS3Client(AmazonS3 s3Client) {
+    public final void setS3Client(AmazonS3 s3Client) {
         this.s3Client = s3Client;
     }
+
     @Autowired
-    public void setUploadDao(UploadDao uploadDao) {
+    public final void setSchedule2Service(Schedule2Service schedule2Service) {
+        this.schedule2Service = schedule2Service;
+    }
+
+    @Autowired
+    public final void setUploadDao(UploadDao uploadDao) {
         this.uploadDao = uploadDao;
     }
 
@@ -475,6 +516,126 @@ public class UploadService {
         for (String uploadId : uploadIdList) {
             s3Client.deleteObject(uploadBucket, uploadId);
         }
+    }
+
+    //todo doc
+    public UploadViewEx3 getUploadViewForExporter3(String appId, String studyId, String id, boolean fetchTimeline,
+            boolean fetchAdherence) {
+        checkNotNull(appId);
+        checkNotNull(id);
+
+        if (fetchAdherence && isBlank(studyId)) {
+            throw new BadRequestException("Adherence requires study ID");
+        }
+
+        // Get upload, if it exists. This can be null if the record was created through the synchronous health data
+        // submission API.
+        Upload upload = uploadDao.getUploadNoThrow(id);
+        if (upload != null && !appId.equals(upload.getAppId())) {
+            // Upload is from a different app.
+            throw new EntityNotFoundException(UploadViewEx3.class);
+        }
+
+        // Get record, if it exists. This can be null if the upload complete API was never called.
+        HealthDataRecordEx3 record = healthDataEx3Service.getRecord(id, false).orElse(null);
+        if (record != null && !appId.equals(record.getAppId())) {
+            // Record is from a different app.
+            throw new EntityNotFoundException(UploadViewEx3.class);
+        }
+
+        // If neither upload nor record exist, then throw a 404.
+        if (upload == null && record == null) {
+            throw new EntityNotFoundException(UploadViewEx3.class);
+        }
+
+        // Uploads and Records only store health codes. We need the health code to get the User ID.
+        String healthCode = null;
+        if (upload != null) {
+            healthCode = upload.getHealthCode();
+        }
+        if (healthCode == null) {
+            // Fall back to record.
+            if (record != null) {
+                healthCode = record.getHealthCode();
+            }
+        }
+
+        // Get the user ID. We need this to check permissions.
+        String userId = accountService.getAccountId(appId, "healthcode:" + healthCode)
+                .orElseThrow(() -> new EntityNotFoundException(UploadViewEx3.class));
+        CAN_READ_UPLOADS.checkAndThrow(STUDY_ID, studyId, USER_ID, userId);
+
+        UploadViewEx3 view = new UploadViewEx3();
+        view.setId(id);
+        view.setHealthCode(healthCode);
+        view.setRecord(record);
+        view.setUpload(upload);
+        view.setUserId(userId);
+
+        if (fetchTimeline || fetchAdherence) {
+            // Get the instanceGuid from upload/record metadata. This is needed for both timeline and adherence.
+            // instanceGuid in metadata instead of being a top-level attribute for legacy reasons.
+            String instanceGuid = null;
+            if (upload != null) {
+                ObjectNode metadataNode = upload.getMetadata();
+                if (metadataNode != null) {
+                    JsonNode instanceGuidNode = metadataNode.get(METADATA_KEY_INSTANCE_GUID);
+                    if (instanceGuidNode != null && instanceGuidNode.isTextual()) {
+                        instanceGuid = instanceGuidNode.textValue();
+                    }
+                }
+            }
+            if (instanceGuid == null) {
+                // Fall back to record.
+                if (record != null) {
+                    Map<String, String> metadataMap = record.getMetadata();
+                    if (metadataMap != null) {
+                        instanceGuid = metadataMap.get(METADATA_KEY_INSTANCE_GUID);
+                    }
+                }
+            }
+
+            if (instanceGuid != null) {
+                if (fetchTimeline) {
+                    // Fetch timeline metadata.
+                    TimelineMetadata timelineMetadata;
+                    timelineMetadata = schedule2Service.getTimelineMetadata(instanceGuid).orElse(null);
+                    if (timelineMetadata != null) {
+                        if (!appId.equals(timelineMetadata.getAppId())) {
+                            // This should never happen, but if it does, log an error and move on.
+                            // In this case, we log instead of throwing because there's still useful information in the
+                            // upload and/or record.
+                            logger.error(
+                                    "Timeline metadata associated with upload is from a different app, uploadId=" +
+                                            id + ", upload appId=" + appId + ", timeline instanceGuid=" +
+                                            instanceGuid + ", timeline appId=" + timelineMetadata.getAppId());
+
+                            // Null out the metadata to mitigate cross-app data leaks.
+                            timelineMetadata = null;
+                        }
+
+                        view.setTimelineMetadata(timelineMetadata);
+                    }
+                }
+
+                if (fetchAdherence) {
+                    // Fetch the adherence record(s). MAX_PAGE_SIZE is 500. It is very unlikely that a single
+                    // instanceGuid will map to more than 500 adherence records. If it somehow does, that's a problem
+                    // we can solve in the future.
+                    AdherenceRecordsSearch adherenceSearch = new AdherenceRecordsSearch.Builder()
+                            .withInstanceGuids(ImmutableSet.of(instanceGuid))
+                            .withPageSize(AdherenceRecordsSearchValidator.MAX_PAGE_SIZE)
+                            .withStudyId(studyId)
+                            .withUserId(userId)
+                            .build();
+                    List<AdherenceRecord> adherenceRecords = adherenceService.getAdherenceRecords(appId,
+                            adherenceSearch).getItems();
+                    view.setAdherenceRecords(adherenceRecords);
+                }
+            }
+        }
+
+        return view;
     }
 
     @FunctionalInterface

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/UploadController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/UploadController.java
@@ -8,6 +8,7 @@ import static org.sagebionetworks.bridge.Roles.WORKER;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.EnumSet;
+import java.util.Optional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableSet;
@@ -33,6 +34,7 @@ import org.sagebionetworks.bridge.models.upload.UploadRequest;
 import org.sagebionetworks.bridge.models.upload.UploadSession;
 import org.sagebionetworks.bridge.models.upload.UploadValidationStatus;
 import org.sagebionetworks.bridge.models.upload.UploadView;
+import org.sagebionetworks.bridge.models.upload.UploadViewEx3;
 import org.sagebionetworks.bridge.services.HealthDataService;
 import org.sagebionetworks.bridge.services.UploadService;
 import org.sagebionetworks.bridge.time.DateUtils;
@@ -199,5 +201,28 @@ public class UploadController extends BaseController {
             return uploadView;
         }
         throw new UnauthorizedException("Caller does not have permission to access upload.");
+    }
+
+    @GetMapping({"/v3/uploads/{uploadId}/exporter3",
+            "/v5/studies/{studyId}/uploads/{uploadId}/exporter3"})
+    public UploadViewEx3 getUploadViewForExporter3(@PathVariable(required = false) Optional<String> studyId,
+            @PathVariable String uploadId, @RequestParam(defaultValue = "false") boolean fetchTimeline,
+            @RequestParam(defaultValue = "false") boolean fetchAdherence) {
+        // UploadService handles fine-grained permissions checks. For the Controller, just check that we're
+        // authenticated.
+        UserSession session = getAuthenticatedSession();
+        return uploadService.getUploadViewForExporter3(session.getAppId(), studyId.orElse(null), uploadId,
+                fetchTimeline, fetchAdherence);
+    }
+
+    @GetMapping({"/v1/apps/{appId}/uploads/{uploadId}/exporter3",
+            "/v1/apps/{appId}/studies/{studyId}/uploads/{uploadId}/exporter3"})
+    public UploadViewEx3 getUploadEx3ForWorker(@PathVariable String appId,
+            @PathVariable(required = false) Optional<String> studyId, @PathVariable String uploadId,
+            @RequestParam(defaultValue = "false") boolean fetchTimeline,
+            @RequestParam(defaultValue = "false") boolean fetchAdherence) {
+        getAuthenticatedSession(WORKER);
+        return uploadService.getUploadViewForExporter3(appId, studyId.orElse(null), uploadId, fetchTimeline,
+                fetchAdherence);
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/UploadController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/UploadController.java
@@ -203,6 +203,15 @@ public class UploadController extends BaseController {
         throw new UnauthorizedException("Caller does not have permission to access upload.");
     }
 
+    /**
+     * This method gets a view that includes both the upload and the record (if they exist) for a given upload ID.
+     * Optionally includes getting the timeline metadata and the adherence records, if they exist.
+     *
+     * App ID and upload ID are required. Study ID is only required if we are fetching adherence.
+     *
+     * Can only be called for your own uploads, for study coordinators and study designers that have access to the
+     * study (study ID is required), and for developers, researchers, and admins.
+     */
     @GetMapping({"/v3/uploads/{uploadId}/exporter3",
             "/v5/studies/{studyId}/uploads/{uploadId}/exporter3"})
     public UploadViewEx3 getUploadViewForExporter3(@PathVariable(required = false) Optional<String> studyId,
@@ -215,6 +224,7 @@ public class UploadController extends BaseController {
                 fetchTimeline, fetchAdherence);
     }
 
+    /** Worker equivalent to getUploadViewForExporter3. */
     @GetMapping({"/v1/apps/{appId}/uploads/{uploadId}/exporter3",
             "/v1/apps/{appId}/studies/{studyId}/uploads/{uploadId}/exporter3"})
     public UploadViewEx3 getUploadEx3ForWorker(@PathVariable String appId,

--- a/src/main/java/org/sagebionetworks/bridge/validators/ExportToAppNotificationValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/ExportToAppNotificationValidator.java
@@ -7,6 +7,7 @@ import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
 import org.sagebionetworks.bridge.models.exporter.ExportToAppNotification;
+import org.sagebionetworks.bridge.models.exporter.ExportedRecordInfo;
 
 /** Validator for notifications for exporting a health data record to Synapse for Exporter 3.0. */
 public class ExportToAppNotificationValidator implements Validator {
@@ -43,7 +44,7 @@ public class ExportToAppNotificationValidator implements Validator {
             }
 
             // Note that getStudyRecords() is never null.
-            for (Map.Entry<String, ExportToAppNotification.RecordInfo> studyRecordEntry :
+            for (Map.Entry<String, ExportedRecordInfo> studyRecordEntry :
                     notification.getStudyRecords().entrySet()) {
                 errors.pushNestedPath("studyRecords{" + studyRecordEntry.getKey() + "}");
                 validateRecordInfo(studyRecordEntry.getValue(), errors);
@@ -52,7 +53,7 @@ public class ExportToAppNotificationValidator implements Validator {
         }
     }
 
-    private static void validateRecordInfo(ExportToAppNotification.RecordInfo recordInfo, Errors errors) {
+    private static void validateRecordInfo(ExportedRecordInfo recordInfo, Errors errors) {
         if (StringUtils.isBlank(recordInfo.getParentProjectId())) {
             errors.rejectValue("parentProjectId", "is required");
         }

--- a/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/AuthUtilsTest.java
@@ -15,6 +15,7 @@ import static org.sagebionetworks.bridge.AuthUtils.CAN_EDIT_OTHER_ENROLLMENTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_EXPORT_PARTICIPANTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_READ_PARTICIPANT_REPORTS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_READ_STUDY_ASSOCIATIONS;
+import static org.sagebionetworks.bridge.AuthUtils.CAN_READ_UPLOADS;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_TRANSITION_STUDY;
 import static org.sagebionetworks.bridge.BridgeConstants.TEST_USER_GROUP;
 import static org.sagebionetworks.bridge.AuthUtils.CAN_READ_EXTERNAL_IDS;
@@ -1403,5 +1404,126 @@ public class AuthUtilsTest extends Mockito {
                 .withCallerRoles(ImmutableSet.of(ADMIN)).build());
         
         assertTrue(CAN_ACCESS_ADHERENCE_DATA.check(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID));
+    }
+
+    @Test
+    public void canReadUploads_selfSucceeds() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId(TEST_USER_ID).build());
+
+        assertTrue(CAN_READ_UPLOADS.check(USER_ID, TEST_USER_ID));
+    }
+
+    @Test
+    public void canReadUploads_otherParticipantFails() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("other-id").build());
+
+        assertFalse(CAN_READ_UPLOADS.check(USER_ID, TEST_USER_ID));
+    }
+
+    @Test
+    public void canReadUploads_studyDesignerSucceeds() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("other-id")
+                .withCallerRoles(ImmutableSet.of(STUDY_DESIGNER))
+                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID)).build());
+
+        assertTrue(CAN_READ_UPLOADS.check(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID));
+    }
+
+    @Test
+    public void canReadUploads_studyDesignerWrongStudy() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("other-id")
+                .withCallerRoles(ImmutableSet.of(STUDY_DESIGNER))
+                .withOrgSponsoredStudies(ImmutableSet.of("wrong-study")).build());
+
+        assertFalse(CAN_READ_UPLOADS.check(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID));
+    }
+
+    @Test
+    public void canReadUploads_studyDesignerNoStudy() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("other-id")
+                .withCallerRoles(ImmutableSet.of(STUDY_DESIGNER))
+                .withOrgSponsoredStudies(ImmutableSet.of("wrong-study")).build());
+
+        assertFalse(CAN_READ_UPLOADS.check(USER_ID, TEST_USER_ID));
+    }
+
+    @Test
+    public void canReadUploads_studyCoordinatorSucceeds() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("other-id")
+                .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR))
+                .withOrgSponsoredStudies(ImmutableSet.of(TEST_STUDY_ID)).build());
+
+        assertTrue(CAN_READ_UPLOADS.check(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID));
+    }
+
+    @Test
+    public void canReadUploads_studyCoordinatorWrongStudy() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("other-id")
+                .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR))
+                .withOrgSponsoredStudies(ImmutableSet.of("wrong-study")).build());
+
+        assertFalse(CAN_READ_UPLOADS.check(STUDY_ID, TEST_STUDY_ID, USER_ID, TEST_USER_ID));
+    }
+
+    @Test
+    public void canReadUploads_studyCoordinatorNoStudy() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("other-id")
+                .withCallerRoles(ImmutableSet.of(STUDY_COORDINATOR))
+                .withOrgSponsoredStudies(ImmutableSet.of("wrong-study")).build());
+
+        assertFalse(CAN_READ_UPLOADS.check(USER_ID, TEST_USER_ID));
+    }
+
+    @Test
+    public void canReadUploads_developerSucceeds() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("other-id")
+                .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
+
+        assertTrue(CAN_READ_UPLOADS.check(USER_ID, TEST_USER_ID));
+    }
+
+    @Test
+    public void canReadUploads_researcherSucceeds() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("other-id")
+                .withCallerRoles(ImmutableSet.of(RESEARCHER)).build());
+
+        assertTrue(CAN_READ_UPLOADS.check(USER_ID, TEST_USER_ID));
+    }
+
+    @Test
+    public void canReadUploads_workerSucceeds() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("other-id")
+                .withCallerRoles(ImmutableSet.of(WORKER)).build());
+
+        assertTrue(CAN_READ_UPLOADS.check(USER_ID, TEST_USER_ID));
+    }
+
+    @Test
+    public void canReadUploads_adminSucceeds() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("other-id")
+                .withCallerRoles(ImmutableSet.of(ADMIN)).build());
+
+        assertTrue(CAN_READ_UPLOADS.check(USER_ID, TEST_USER_ID));
+    }
+
+    @Test
+    public void canReadUploads_orgAdminFails() {
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("other-id")
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
+
+        assertFalse(CAN_READ_UPLOADS.check(USER_ID, TEST_USER_ID));
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataRecordEx3Test.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataRecordEx3Test.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.bridge.dynamodb;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
@@ -14,6 +15,7 @@ import org.testng.annotations.Test;
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.accounts.SharingScope;
+import org.sagebionetworks.bridge.models.exporter.ExportedRecordInfo;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecordEx3;
 import org.sagebionetworks.bridge.models.upload.Upload;
 
@@ -25,6 +27,8 @@ public class DynamoHealthDataRecordEx3Test {
     private static final long VERSION = 3L;
 
     private static final String APP_STUDY_KEY = TestConstants.TEST_APP_ID + ':' + STUDY_ID;
+    private static final Map<String, ExportedRecordInfo> STUDY_RECORD_INFO_MAP =
+            ImmutableMap.of(STUDY_ID, new ExportedRecordInfo());
 
     @Test
     public void createFromUpload() throws Exception {
@@ -116,6 +120,28 @@ public class DynamoHealthDataRecordEx3Test {
     }
 
     @Test
+    public void getSetExportedStudyRecords() {
+        // Initially null.
+        DynamoHealthDataRecordEx3 record = new DynamoHealthDataRecordEx3();
+        assertNull(record.getExportedStudyRecords());
+
+        // Set non-empty.
+        record.setExportedStudyRecords(STUDY_RECORD_INFO_MAP);
+        assertEquals(record.getExportedStudyRecords(), STUDY_RECORD_INFO_MAP);
+
+        // Set empty, gets changed to null.
+        record.setExportedStudyRecords(ImmutableMap.of());
+        assertNull(record.getExportedStudyRecords());
+
+        // Set non-empty, then set null. Null is null.
+        record.setExportedStudyRecords(STUDY_RECORD_INFO_MAP);
+        assertEquals(record.getExportedStudyRecords(), STUDY_RECORD_INFO_MAP);
+
+        record.setExportedStudyRecords(null);
+        assertNull(record.getExportedStudyRecords());
+    }
+
+    @Test
     public void getSetMetadata() {
         // Initially null.
         DynamoHealthDataRecordEx3 record = new DynamoHealthDataRecordEx3();
@@ -150,13 +176,15 @@ public class DynamoHealthDataRecordEx3Test {
         record.setClientInfo("dummy client info");
         record.setExported(true);
         record.setExportedOn(TestConstants.EXPORTED_ON.getMillis());
+        record.setExportedRecord(new ExportedRecordInfo());
+        record.setExportedStudyRecords(STUDY_RECORD_INFO_MAP);
         record.setMetadata(METADATA_MAP);
         record.setSharingScope(SharingScope.SPONSORS_AND_PARTNERS);
         record.setVersion(VERSION);
 
         // Convert to JsonNode.
         JsonNode jsonNode = BridgeObjectMapper.get().convertValue(record, JsonNode.class);
-        assertEquals(jsonNode.size(), 14);
+        assertEquals(jsonNode.size(), 16);
         assertEquals(jsonNode.get("id").textValue(), RECORD_ID);
         assertEquals(jsonNode.get("appId").textValue(), TestConstants.TEST_APP_ID);
         assertEquals(jsonNode.get("studyId").textValue(), STUDY_ID);
@@ -174,6 +202,12 @@ public class DynamoHealthDataRecordEx3Test {
         assertEquals(metadataMapNode.size(), 1);
         assertEquals(metadataMapNode.get("foo").textValue(), "bar");
 
+        // Just check that the record infos exist. The actual JSON serialization is tested elsewhere.
+        assertTrue(jsonNode.hasNonNull("exportedRecord"));
+        JsonNode exportedStudyRecordsNode = jsonNode.get("exportedStudyRecords");
+        assertEquals(exportedStudyRecordsNode.size(), 1);
+        assertTrue(exportedStudyRecordsNode.hasNonNull(STUDY_ID));
+
         // Convert back to POJO.
         record = BridgeObjectMapper.get().treeToValue(jsonNode, HealthDataRecordEx3.class);
         assertEquals(record.getId(), RECORD_ID);
@@ -185,8 +219,13 @@ public class DynamoHealthDataRecordEx3Test {
         assertEquals(record.getClientInfo(), "dummy client info");
         assertTrue(record.isExported());
         assertEquals(record.getExportedOn().longValue(), TestConstants.EXPORTED_ON.getMillis());
+        assertNotNull(record.getExportedRecord());
         assertEquals(record.getSharingScope(), SharingScope.SPONSORS_AND_PARTNERS);
         assertEquals(record.getMetadata(), METADATA_MAP);
         assertEquals(record.getVersion().longValue(), VERSION);
+
+        Map<String, ExportedRecordInfo> exportedStudyRecordMap = record.getExportedStudyRecords();
+        assertEquals(exportedStudyRecordMap.size(), 1);
+        assertNotNull(exportedStudyRecordMap.get(STUDY_ID));
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadDaoTest.java
@@ -35,7 +35,6 @@ import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.dao.HealthCodeDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
-import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.NotFoundException;
 import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
 import org.sagebionetworks.bridge.models.upload.Upload;
@@ -197,7 +196,7 @@ public class DynamoUploadDaoTest {
         assertEquals(retVal.getAppId(), TEST_APP_ID);
     }
 
-    @Test(expectedExceptions = EntityNotFoundException.class)
+    @Test(expectedExceptions = NotFoundException.class)
     public void getUploadWithoutAppIdAndNoHealthCodeRecord() {
         DynamoUpload2 upload = new DynamoUpload2();
         upload.setHealthCode("healthCode");
@@ -224,6 +223,25 @@ public class DynamoUploadDaoTest {
 
         // validate we passed in the expected key
         assertEquals(uploadCaptor.getValue().getUploadId(), "test-get-404");
+    }
+
+    @Test
+    public void getUploadNoThrow_WithoutAppIdAndNoHealthCodeRecord() {
+        DynamoUpload2 upload = new DynamoUpload2();
+        upload.setHealthCode("healthCode");
+        when(mockMapper.load(any())).thenReturn(upload);
+
+        when(healthCodeDao.getAppId(upload.getHealthCode())).thenReturn(null);
+
+        Upload result = dao.getUploadNoThrow("test-get-upload");
+        assertNull(result);
+    }
+
+    @Test
+    public void getUploadNoThrow_NotFound() {
+        when(mockMapper.load(any())).thenReturn(null);
+        Upload result = dao.getUploadNoThrow("test-get-upload");
+        assertNull(result);
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/ExportedRecordInfoMapMarshallerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/ExportedRecordInfoMapMarshallerTest.java
@@ -1,0 +1,38 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static org.testng.Assert.assertEquals;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.exporter.ExportedRecordInfo;
+
+public class ExportedRecordInfoMapMarshallerTest {
+    private static final String FILE_ENTITY_ID = "dummy-file-id";
+    private static final ExportedRecordInfoMapMarshaller MARSHALLER = new ExportedRecordInfoMapMarshaller();
+
+
+    @Test
+    public void testConvert() throws Exception {
+        // Make a simple record info with just one field. The full JSON serialization is tested elsewhere.
+        ExportedRecordInfo recordInfo = new ExportedRecordInfo();
+        recordInfo.setFileEntityId(FILE_ENTITY_ID);
+        Map<String, ExportedRecordInfo> recordInfoMap = ImmutableMap.of(TEST_STUDY_ID, recordInfo);
+
+        // Serialize. Use Jackson to verify.
+        String serialized = MARSHALLER.convert(recordInfoMap);
+        JsonNode jsonNode = BridgeObjectMapper.get().readTree(serialized);
+        assertEquals(jsonNode.size(), 1);
+        assertEquals(jsonNode.get(TEST_STUDY_ID).get("fileEntityId").textValue(), FILE_ENTITY_ID);
+
+        // Deserialize and verify fields.
+        Map<String, ExportedRecordInfo> deserialized = MARSHALLER.unconvert(serialized);
+        assertEquals(deserialized.size(), 1);
+        assertEquals(deserialized.get(TEST_STUDY_ID).getFileEntityId(), FILE_ENTITY_ID);
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/ExportedRecordInfoMarshallerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/ExportedRecordInfoMarshallerTest.java
@@ -1,0 +1,31 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static org.testng.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.exporter.ExportedRecordInfo;
+
+public class ExportedRecordInfoMarshallerTest {
+    private static final String FILE_ENTITY_ID = "dummy-file-id";
+    private static final ExportedRecordInfoMarshaller MARSHALLER = new ExportedRecordInfoMarshaller();
+
+
+    @Test
+    public void testConvert() throws Exception {
+        // Make a simple record info with just one field. The full JSON serialization is tested elsewhere.
+        ExportedRecordInfo recordInfo = new ExportedRecordInfo();
+        recordInfo.setFileEntityId(FILE_ENTITY_ID);
+
+        // Serialize. Use Jackson to verify.
+        String serialized = MARSHALLER.convert(recordInfo);
+        JsonNode jsonNode = BridgeObjectMapper.get().readTree(serialized);
+        assertEquals(jsonNode.get("fileEntityId").textValue(), FILE_ENTITY_ID);
+
+        // Deserialize and verify fields.
+        ExportedRecordInfo deserialized = MARSHALLER.unconvert(serialized);
+        assertEquals(deserialized.getFileEntityId(), FILE_ENTITY_ID);
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/JsonMarshallerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/JsonMarshallerTest.java
@@ -1,0 +1,74 @@
+package org.sagebionetworks.bridge.dynamodb;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+public class JsonMarshallerTest {
+    // Test class that we marshal to JSON.
+    private static class TestClass {
+        private String value;
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    // Test marshaller for the test.
+    private static class TestMarshaller extends JsonMarshaller<TestClass> {
+        @Override
+        public Class<TestClass> getConvertedClass() {
+            return TestClass.class;
+        }
+    }
+
+    private static final TestMarshaller MARSHALLER = new TestMarshaller();
+    private static final String TEST_VALUE = "test value";
+
+    @Test
+    public void normalCase() throws Exception {
+        // Create test object.
+        TestClass testObject = new TestClass();
+        testObject.setValue(TEST_VALUE);
+
+        // Convert to JSON.
+        String json = MARSHALLER.convert(testObject);
+
+        // Validate JSON using Jackson.
+        JsonNode jsonNode = BridgeObjectMapper.get().readTree(json);
+        assertEquals(jsonNode.get("value").textValue(), TEST_VALUE);
+
+        // Convert back to object and validate.
+        TestClass unmarshalledObject = MARSHALLER.unconvert(json);
+        assertEquals(unmarshalledObject.getValue(), TEST_VALUE);
+    }
+
+    @Test
+    public void convertNull() {
+        // Convert null to JSON.
+        String json = MARSHALLER.convert(null);
+        assertNull(json);
+    }
+
+    @Test
+    public void unconvertNull() {
+        // Convert JSON back to object.
+        TestClass unmarshalledObject = MARSHALLER.unconvert(null);
+        assertNull(unmarshalledObject);
+    }
+
+    @Test(expectedExceptions = DynamoDBMappingException.class)
+    public void unconvertInvalidJson() {
+        // Convert invalid JSON back to object.
+        MARSHALLER.unconvert("invalid json");
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/models/exporter/ExportToAppNotificationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/exporter/ExportToAppNotificationTest.java
@@ -42,7 +42,7 @@ public class ExportToAppNotificationTest {
         assertTrue(notification.getStudyRecords().isEmpty());
 
         // Set to non-empty.
-        notification.setStudyRecords(ImmutableMap.of(STUDY_1_ID, new ExportToAppNotification.RecordInfo()));
+        notification.setStudyRecords(ImmutableMap.of(STUDY_1_ID, new ExportedRecordInfo()));
         assertEquals(notification.getStudyRecords().size(), 1);
 
         // Set to null. It's empty again.
@@ -57,7 +57,7 @@ public class ExportToAppNotificationTest {
         notification.setAppId(TestConstants.TEST_APP_ID);
         notification.setRecordId(RECORD_ID);
 
-        ExportToAppNotification.RecordInfo appRecordInfo = new ExportToAppNotification.RecordInfo();
+        ExportedRecordInfo appRecordInfo = new ExportedRecordInfo();
         appRecordInfo.setParentProjectId(APP_PARENT_PROJECT_ID);
         appRecordInfo.setRawFolderId(APP_RAW_FOLDER_ID);
         appRecordInfo.setFileEntityId(APP_FILE_ENTITY_ID);
@@ -65,22 +65,22 @@ public class ExportToAppNotificationTest {
         appRecordInfo.setS3Key(APP_S3_KEY);
         notification.setRecord(appRecordInfo);
 
-        ExportToAppNotification.RecordInfo study1RecordInfo = new ExportToAppNotification.RecordInfo();
+        ExportedRecordInfo study1RecordInfo = new ExportedRecordInfo();
         study1RecordInfo.setParentProjectId(STUDY_1_PARENT_PROJECT_ID);
         study1RecordInfo.setRawFolderId(STUDY_1_RAW_FOLDER_ID);
         study1RecordInfo.setFileEntityId(STUDY_1_FILE_ENTITY_ID);
         study1RecordInfo.setS3Bucket(STUDY_1_S3_BUCKET);
         study1RecordInfo.setS3Key(STUDY_1_S3_KEY);
 
-        ExportToAppNotification.RecordInfo study2RecordInfo = new ExportToAppNotification.RecordInfo();
+        ExportedRecordInfo study2RecordInfo = new ExportedRecordInfo();
         study2RecordInfo.setParentProjectId(STUDY_2_PARENT_PROJECT_ID);
         study2RecordInfo.setRawFolderId(STUDY_2_RAW_FOLDER_ID);
         study2RecordInfo.setFileEntityId(STUDY_2_FILE_ENTITY_ID);
         study2RecordInfo.setS3Bucket(STUDY_2_S3_BUCKET);
         study2RecordInfo.setS3Key(STUDY_2_S3_KEY);
 
-        Map<String, ExportToAppNotification.RecordInfo> studyRecordMap =
-                new ImmutableMap.Builder<String, ExportToAppNotification.RecordInfo>()
+        Map<String, ExportedRecordInfo> studyRecordMap =
+                new ImmutableMap.Builder<String, ExportedRecordInfo>()
                         .put(STUDY_1_ID, study1RecordInfo)
                         .put(STUDY_2_ID, study2RecordInfo)
                         .build();

--- a/src/test/java/org/sagebionetworks/bridge/models/exporter/ExportToAppNotificationTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/exporter/ExportToAppNotificationTest.java
@@ -100,7 +100,7 @@ public class ExportToAppNotificationTest {
         assertEquals(appRecordInfoNode.get("fileEntityId").textValue(), APP_FILE_ENTITY_ID);
         assertEquals(appRecordInfoNode.get("s3Bucket").textValue(), APP_S3_BUCKET);
         assertEquals(appRecordInfoNode.get("s3Key").textValue(), APP_S3_KEY);
-        assertEquals(appRecordInfoNode.get("type").textValue(), "RecordInfo");
+        assertEquals(appRecordInfoNode.get("type").textValue(), "ExportedRecordInfo");
 
         JsonNode studyRecordsObjectNode = jsonNode.get("studyRecords");
         assertEquals(studyRecordsObjectNode.size(), 2);
@@ -112,7 +112,7 @@ public class ExportToAppNotificationTest {
         assertEquals(study1RecordInfoNode.get("fileEntityId").textValue(), STUDY_1_FILE_ENTITY_ID);
         assertEquals(study1RecordInfoNode.get("s3Bucket").textValue(), STUDY_1_S3_BUCKET);
         assertEquals(study1RecordInfoNode.get("s3Key").textValue(), STUDY_1_S3_KEY);
-        assertEquals(study1RecordInfoNode.get("type").textValue(), "RecordInfo");
+        assertEquals(study1RecordInfoNode.get("type").textValue(), "ExportedRecordInfo");
 
         JsonNode study2RecordInfoNode = studyRecordsObjectNode.get(STUDY_2_ID);
         assertEquals(study2RecordInfoNode.size(), 6);
@@ -121,7 +121,7 @@ public class ExportToAppNotificationTest {
         assertEquals(study2RecordInfoNode.get("fileEntityId").textValue(), STUDY_2_FILE_ENTITY_ID);
         assertEquals(study2RecordInfoNode.get("s3Bucket").textValue(), STUDY_2_S3_BUCKET);
         assertEquals(study2RecordInfoNode.get("s3Key").textValue(), STUDY_2_S3_KEY);
-        assertEquals(study2RecordInfoNode.get("type").textValue(), "RecordInfo");
+        assertEquals(study2RecordInfoNode.get("type").textValue(), "ExportedRecordInfo");
 
         // Convert back to POJO.
         notification = BridgeObjectMapper.get().treeToValue(jsonNode, ExportToAppNotification.class);

--- a/src/test/java/org/sagebionetworks/bridge/models/exporter/ExportedRecordInfoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/exporter/ExportedRecordInfoTest.java
@@ -1,0 +1,45 @@
+package org.sagebionetworks.bridge.models.exporter;
+
+import static org.testng.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+
+public class ExportedRecordInfoTest {
+    private static final String FILE_ENTITY_ID = "syn1111";
+    private static final String PARENT_PROJECT_ID = "syn1222";
+    private static final String RAW_FOLDER_ID = "syn1333";
+    private static final String S3_BUCKET = "test-bucket";
+    private static final String S3_KEY = "test-record-key";
+
+    @Test
+    public void serialize() throws Exception {
+        // Start with POJO.
+        ExportedRecordInfo recordInfo = new ExportedRecordInfo();
+        recordInfo.setFileEntityId(FILE_ENTITY_ID);
+        recordInfo.setParentProjectId(PARENT_PROJECT_ID);
+        recordInfo.setRawFolderId(RAW_FOLDER_ID);
+        recordInfo.setS3Bucket(S3_BUCKET);
+        recordInfo.setS3Key(S3_KEY);
+
+        // Convert to JsonNode.
+        JsonNode jsonNode = BridgeObjectMapper.get().convertValue(recordInfo, JsonNode.class);
+        assertEquals(jsonNode.size(), 6);
+        assertEquals(jsonNode.get("parentProjectId").textValue(), PARENT_PROJECT_ID);
+        assertEquals(jsonNode.get("rawFolderId").textValue(), RAW_FOLDER_ID);
+        assertEquals(jsonNode.get("fileEntityId").textValue(), FILE_ENTITY_ID);
+        assertEquals(jsonNode.get("s3Bucket").textValue(), S3_BUCKET);
+        assertEquals(jsonNode.get("s3Key").textValue(), S3_KEY);
+        assertEquals(jsonNode.get("type").textValue(), "ExportedRecordInfo");
+
+        // Convert back to POJO.
+        recordInfo = BridgeObjectMapper.get().treeToValue(jsonNode, ExportedRecordInfo.class);
+        assertEquals(recordInfo.getParentProjectId(), PARENT_PROJECT_ID);
+        assertEquals(recordInfo.getRawFolderId(), RAW_FOLDER_ID);
+        assertEquals(recordInfo.getFileEntityId(), FILE_ENTITY_ID);
+        assertEquals(recordInfo.getS3Bucket(), S3_BUCKET);
+        assertEquals(recordInfo.getS3Key(), S3_KEY);
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/models/upload/UploadViewEx3Test.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/upload/UploadViewEx3Test.java
@@ -1,0 +1,62 @@
+package org.sagebionetworks.bridge.models.upload;
+
+import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
+import static org.testng.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import org.sagebionetworks.bridge.json.BridgeObjectMapper;
+import org.sagebionetworks.bridge.models.healthdata.HealthDataRecordEx3;
+import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecord;
+import org.sagebionetworks.bridge.models.schedules2.timelines.TimelineMetadata;
+import org.sagebionetworks.bridge.models.schedules2.timelines.TimelineMetadataView;
+
+public class UploadViewEx3Test {
+    private static final String INSTANCE_GUID = "dummy-instance-guid";
+    private static final String UPLOAD_ID = "dummy-upload-id";
+
+    @Test
+    public void serialize() throws Exception {
+        // Make simple AdherenceRecord, HealthDataRecordEx3, TimelineMetadata, and Upload. Just choose a small set of
+        // attributes. Full JSON serialization of these classes is tested elsewhere.
+        AdherenceRecord adherenceRecord = new AdherenceRecord();
+        adherenceRecord.setInstanceGuid(INSTANCE_GUID);
+
+        HealthDataRecordEx3 healthDataRecord = HealthDataRecordEx3.create();
+        healthDataRecord.setId(UPLOAD_ID);
+
+        TimelineMetadata timelineMetadata = new TimelineMetadata();
+        timelineMetadata.setAssessmentInstanceGuid(INSTANCE_GUID);
+        TimelineMetadataView timelineMetadataView = new TimelineMetadataView(timelineMetadata);
+
+        Upload upload = Upload.create();
+        upload.setUploadId(UPLOAD_ID);
+
+        // Make UploadViewEx3.
+        UploadViewEx3 uploadView = new UploadViewEx3();
+        uploadView.setId(UPLOAD_ID);
+        uploadView.setHealthCode(HEALTH_CODE);
+        uploadView.setUserId(TEST_USER_ID);
+        uploadView.setAdherenceRecords(ImmutableList.of(adherenceRecord));
+        uploadView.setRecord(healthDataRecord);
+        uploadView.setTimelineMetadata(timelineMetadataView);
+        uploadView.setUpload(upload);
+
+        // Convert to JsonNode.
+        JsonNode jsonNode = BridgeObjectMapper.get().convertValue(uploadView, JsonNode.class);
+        assertEquals(jsonNode.size(), 8);
+        assertEquals(jsonNode.get("id").textValue(), UPLOAD_ID);
+        assertEquals(jsonNode.get("healthCode").textValue(), HEALTH_CODE);
+        assertEquals(jsonNode.get("userId").textValue(), TEST_USER_ID);
+        assertEquals(jsonNode.get("adherenceRecords").get(0).get("instanceGuid").textValue(), INSTANCE_GUID);
+        assertEquals(jsonNode.get("record").get("id").textValue(), UPLOAD_ID);
+        assertEquals(jsonNode.get("timelineMetadata").get("metadata").get("assessmentInstanceGuid").textValue(),
+                INSTANCE_GUID);
+        assertEquals(jsonNode.get("upload").get("uploadId").textValue(), UPLOAD_ID);
+
+        // We can skip deserialization. We never read this from anywhere.
+    }
+}

--- a/src/test/java/org/sagebionetworks/bridge/services/Exporter3ServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/Exporter3ServiceTest.java
@@ -83,6 +83,7 @@ import org.sagebionetworks.bridge.models.apps.App;
 import org.sagebionetworks.bridge.models.apps.Exporter3Configuration;
 import org.sagebionetworks.bridge.models.exporter.ExportToAppNotification;
 import org.sagebionetworks.bridge.models.exporter.ExportToStudyNotification;
+import org.sagebionetworks.bridge.models.exporter.ExportedRecordInfo;
 import org.sagebionetworks.bridge.models.exporter.ExporterCreateStudyNotification;
 import org.sagebionetworks.bridge.models.exporter.ExporterSubscriptionRequest;
 import org.sagebionetworks.bridge.models.exporter.ExporterSubscriptionResult;
@@ -901,7 +902,7 @@ public class Exporter3ServiceTest {
         notification.setAppId(TestConstants.TEST_APP_ID);
         notification.setRecordId(RECORD_ID);
 
-        ExportToAppNotification.RecordInfo appRecordInfo = new ExportToAppNotification.RecordInfo();
+        ExportedRecordInfo appRecordInfo = new ExportedRecordInfo();
         appRecordInfo.setParentProjectId(APP_PARENT_PROJECT_ID);
         appRecordInfo.setRawFolderId(APP_RAW_FOLDER_ID);
         appRecordInfo.setFileEntityId(APP_FILE_ENTITY_ID);
@@ -909,22 +910,22 @@ public class Exporter3ServiceTest {
         appRecordInfo.setS3Key(APP_S3_KEY);
         notification.setRecord(appRecordInfo);
 
-        ExportToAppNotification.RecordInfo study1RecordInfo = new ExportToAppNotification.RecordInfo();
+        ExportedRecordInfo study1RecordInfo = new ExportedRecordInfo();
         study1RecordInfo.setParentProjectId(STUDY_1_PARENT_PROJECT_ID);
         study1RecordInfo.setRawFolderId(STUDY_1_RAW_FOLDER_ID);
         study1RecordInfo.setFileEntityId(STUDY_1_FILE_ENTITY_ID);
         study1RecordInfo.setS3Bucket(STUDY_1_S3_BUCKET);
         study1RecordInfo.setS3Key(STUDY_1_S3_KEY);
 
-        ExportToAppNotification.RecordInfo study2RecordInfo = new ExportToAppNotification.RecordInfo();
+        ExportedRecordInfo study2RecordInfo = new ExportedRecordInfo();
         study2RecordInfo.setParentProjectId(STUDY_2_PARENT_PROJECT_ID);
         study2RecordInfo.setRawFolderId(STUDY_2_RAW_FOLDER_ID);
         study2RecordInfo.setFileEntityId(STUDY_2_FILE_ENTITY_ID);
         study2RecordInfo.setS3Bucket(STUDY_2_S3_BUCKET);
         study2RecordInfo.setS3Key(STUDY_2_S3_KEY);
 
-        Map<String, ExportToAppNotification.RecordInfo> studyRecordMap =
-                new ImmutableMap.Builder<String, ExportToAppNotification.RecordInfo>()
+        Map<String, ExportedRecordInfo> studyRecordMap =
+                new ImmutableMap.Builder<String, ExportedRecordInfo>()
                         .put(STUDY_1_ID, study1RecordInfo)
                         .put(STUDY_2_ID, study2RecordInfo)
                         .build();
@@ -942,23 +943,23 @@ public class Exporter3ServiceTest {
         assertEquals(appNotification.getAppId(), TEST_APP_ID);
         assertEquals(appNotification.getRecordId(), RECORD_ID);
 
-        ExportToAppNotification.RecordInfo appRecordInfo = appNotification.getRecord();
+        ExportedRecordInfo appRecordInfo = appNotification.getRecord();
         assertEquals(appRecordInfo.getParentProjectId(), APP_PARENT_PROJECT_ID);
         assertEquals(appRecordInfo.getRawFolderId(), APP_RAW_FOLDER_ID);
         assertEquals(appRecordInfo.getFileEntityId(), APP_FILE_ENTITY_ID);
         assertEquals(appRecordInfo.getS3Bucket(), APP_S3_BUCKET);
         assertEquals(appRecordInfo.getS3Key(), APP_S3_KEY);
 
-        Map<String, ExportToAppNotification.RecordInfo> studyRecordMap = appNotification.getStudyRecords();
+        Map<String, ExportedRecordInfo> studyRecordMap = appNotification.getStudyRecords();
 
-        ExportToAppNotification.RecordInfo study1RecordInfo = studyRecordMap.get(STUDY_1_ID);
+        ExportedRecordInfo study1RecordInfo = studyRecordMap.get(STUDY_1_ID);
         assertEquals(study1RecordInfo.getParentProjectId(), STUDY_1_PARENT_PROJECT_ID);
         assertEquals(study1RecordInfo.getRawFolderId(), STUDY_1_RAW_FOLDER_ID);
         assertEquals(study1RecordInfo.getFileEntityId(), STUDY_1_FILE_ENTITY_ID);
         assertEquals(study1RecordInfo.getS3Bucket(), STUDY_1_S3_BUCKET);
         assertEquals(study1RecordInfo.getS3Key(), STUDY_1_S3_KEY);
 
-        ExportToAppNotification.RecordInfo study2RecordInfo = studyRecordMap.get(STUDY_2_ID);
+        ExportedRecordInfo study2RecordInfo = studyRecordMap.get(STUDY_2_ID);
         assertEquals(study2RecordInfo.getParentProjectId(), STUDY_2_PARENT_PROJECT_ID);
         assertEquals(study2RecordInfo.getRawFolderId(), STUDY_2_RAW_FOLDER_ID);
         assertEquals(study2RecordInfo.getFileEntityId(), STUDY_2_FILE_ENTITY_ID);

--- a/src/test/java/org/sagebionetworks/bridge/services/UploadServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/UploadServiceTest.java
@@ -10,30 +10,43 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.bridge.BridgeConstants.API_APP_ID;
 import static org.sagebionetworks.bridge.BridgeConstants.API_DEFAULT_PAGE_SIZE;
 import static org.sagebionetworks.bridge.BridgeConstants.API_MAXIMUM_PAGE_SIZE;
+import static org.sagebionetworks.bridge.Roles.DEVELOPER;
+import static org.sagebionetworks.bridge.Roles.ORG_ADMIN;
 import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.models.upload.UploadCompletionClient.S3_WORKER;
 import static org.sagebionetworks.bridge.models.upload.UploadStatus.SUCCEEDED;
 import static org.sagebionetworks.bridge.models.upload.UploadStatus.VALIDATION_IN_PROGRESS;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import java.net.URL;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.mockito.ArgumentCaptor;
@@ -41,6 +54,7 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -55,20 +69,29 @@ import org.sagebionetworks.bridge.dynamodb.DynamoUpload2;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
+import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.NotFoundException;
+import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.ForwardCursorPagedResourceList;
+import org.sagebionetworks.bridge.models.PagedResourceList;
 import org.sagebionetworks.bridge.models.ResourceList;
 import org.sagebionetworks.bridge.models.accounts.StudyParticipant;
 import org.sagebionetworks.bridge.models.apps.App;
 import org.sagebionetworks.bridge.models.healthdata.HealthDataRecord;
+import org.sagebionetworks.bridge.models.healthdata.HealthDataRecordEx3;
+import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecord;
+import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecordsSearch;
+import org.sagebionetworks.bridge.models.schedules2.timelines.TimelineMetadata;
 import org.sagebionetworks.bridge.models.upload.Upload;
 import org.sagebionetworks.bridge.models.upload.UploadRequest;
 import org.sagebionetworks.bridge.models.upload.UploadSession;
 import org.sagebionetworks.bridge.models.upload.UploadStatus;
 import org.sagebionetworks.bridge.models.upload.UploadValidationStatus;
 import org.sagebionetworks.bridge.models.upload.UploadView;
+import org.sagebionetworks.bridge.models.upload.UploadViewEx3;
+import org.sagebionetworks.bridge.validators.AdherenceRecordsSearchValidator;
 
 @SuppressWarnings("ConstantConditions")
 public class UploadServiceTest {
@@ -76,6 +99,7 @@ public class UploadServiceTest {
 
     private static final DateTime START_TIME = DateTime.parse("2016-04-02T10:00:00.000Z");
     private static final DateTime END_TIME = DateTime.parse("2016-04-03T10:00:00.000Z");
+    private static final String INSTANCE_GUID = "dummy-instance-guid";
     private static final String MOCK_OFFSET_KEY = "mock-offset-key";
     private static final String UPLOAD_BUCKET_NAME = "upload-bucket";
     final static DateTime TIMESTAMP = DateTime.now();
@@ -87,11 +111,20 @@ public class UploadServiceTest {
     final static StudyParticipant PARTICIPANT = new StudyParticipant.Builder().withHealthCode(HEALTH_CODE).build();
 
     @Mock
+    private AccountService mockAccountService;
+
+    @Mock
+    private AdherenceService mockAdherenceService;
+
+    @Mock
     private AppService mockAppService;
 
     @Mock
     HealthDataService mockHealthDataService;
-    
+
+    @Mock
+    private HealthDataEx3Service mockHealthDataEx3Service;
+
     @Mock
     Upload mockUpload;
 
@@ -106,7 +139,10 @@ public class UploadServiceTest {
     
     @Mock
     AmazonS3 mockS3Client;
-    
+
+    @Mock
+    private Schedule2Service mockSchedule2Service;
+
     @Mock
     UploadValidationService mockUploadValidationService;
 
@@ -667,5 +703,523 @@ public class UploadServiceTest {
         return new UploadRequest.Builder().withName("oneUpload").withContentLength(1048L)
                 .withContentMd5("AAAAAAAAAAAAAAAAAAAAAA==")
                 .withContentType("application/binary").build();
+    }
+
+    @Test(expectedExceptions = BadRequestException.class,
+            expectedExceptionsMessageRegExp = "Adherence requires study ID")
+    public void getUploadViewForExporter3_FetchAdherenceWithNoStudyId() {
+        svc.getUploadViewForExporter3(TEST_APP_ID, null, UPLOAD_ID_1, false, true);
+    }
+
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void getUploadViewForExporter3_UploadFromWrongApp() {
+        Upload upload = makeUploadForEx3Test();
+        upload.setAppId("wrong-app");
+        setupGetUploadViewForExporter3Test(upload, makeRecordForEx3Test());
+
+        svc.getUploadViewForExporter3(TEST_APP_ID, null, UPLOAD_ID_1, false, false);
+    }
+
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void getUploadViewForExporter3_RecordFromWrongApp() {
+        HealthDataRecordEx3 healthDataRecord = makeRecordForEx3Test();
+        healthDataRecord.setAppId("wrong-app");
+        setupGetUploadViewForExporter3Test(makeUploadForEx3Test(), healthDataRecord);
+
+        svc.getUploadViewForExporter3(TEST_APP_ID, null, UPLOAD_ID_1, false, false);
+    }
+
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void getUploadViewForExporter3_NoUploadNoRecord() {
+        setupGetUploadViewForExporter3Test(null, null);
+        svc.getUploadViewForExporter3(TEST_APP_ID, null, UPLOAD_ID_1, false, false);
+    }
+
+    @Test(expectedExceptions = EntityNotFoundException.class)
+    public void getUploadViewForExporter3_AccountNotFound() {
+        setupGetUploadViewForExporter3Test(makeUploadForEx3Test(), makeRecordForEx3Test());
+
+        // Override mock to return no account ID.
+        when(mockAccountService.getAccountId(TEST_APP_ID, "healthcode:" + HEALTH_CODE)).thenReturn(
+                Optional.empty());
+
+        svc.getUploadViewForExporter3(TEST_APP_ID, null, UPLOAD_ID_1, false, false);
+    }
+
+    @Test(expectedExceptions = UnauthorizedException.class)
+    public void getUploadViewForExporter3_NotPermitted() {
+        setupGetUploadViewForExporter3Test(makeUploadForEx3Test(), makeRecordForEx3Test());
+
+        // Just test one case where we don't have permissions. The full permissions test is tested in AuthUtilsTest.
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("other-id")
+                .withCallerRoles(ImmutableSet.of(ORG_ADMIN)).build());
+
+        svc.getUploadViewForExporter3(TEST_APP_ID, null, UPLOAD_ID_1, false, false);
+    }
+
+    @Test
+    public void getUploadViewForExporter3_NormalCase_NoTimelineNoAdherence() {
+        // Set up test.
+        Upload upload = makeUploadForEx3Test();
+        HealthDataRecordEx3 record = makeRecordForEx3Test();
+        setupGetUploadViewForExporter3Test(upload, record);
+
+        // Execute and validate.
+        UploadViewEx3 uploadView = svc.getUploadViewForExporter3(TEST_APP_ID, null, UPLOAD_ID_1,
+                false, false);
+        assertEquals(uploadView.getId(), UPLOAD_ID_1);
+        assertEquals(uploadView.getHealthCode(), HEALTH_CODE);
+        assertEquals(uploadView.getUserId(), TEST_USER_ID);
+        assertNull(uploadView.getAdherenceRecords());
+        assertSame(uploadView.getRecord(), record);
+        assertNull(uploadView.getTimelineMetadata());
+        assertSame(uploadView.getUpload(), upload);
+
+        // Verify back-end calls.
+        verify(mockUploadDao).getUploadNoThrow(UPLOAD_ID_1);
+        verify(mockHealthDataEx3Service).getRecord(UPLOAD_ID_1, false);
+        verify(mockAccountService).getAccountId(TEST_APP_ID, "healthcode:" + HEALTH_CODE);
+        verifyZeroInteractions(mockSchedule2Service, mockAdherenceService);
+    }
+
+    @Test
+    public void getUploadViewForExporter3_NormalCase_WithTimeline() {
+        // Setup test.
+        Upload upload = makeUploadForEx3Test();
+        HealthDataRecordEx3 record = makeRecordForEx3Test();
+        setupGetUploadViewForExporter3Test(upload, record);
+
+        mockTimelineMetadataForExporter3Test();
+
+        // Execute and validate.
+        UploadViewEx3 uploadView = svc.getUploadViewForExporter3(TEST_APP_ID, null, UPLOAD_ID_1,
+                true, false);
+        assertEquals(uploadView.getId(), UPLOAD_ID_1);
+        assertEquals(uploadView.getHealthCode(), HEALTH_CODE);
+        assertEquals(uploadView.getUserId(), TEST_USER_ID);
+        assertNull(uploadView.getAdherenceRecords());
+        assertSame(uploadView.getRecord(), record);
+        assertEquals(uploadView.getTimelineMetadata().getMetadata().get("assessmentInstanceGuid"), INSTANCE_GUID);
+        assertSame(uploadView.getUpload(), upload);
+
+        // Verify timeline call, but no adherence call.
+        verify(mockSchedule2Service).getTimelineMetadata(INSTANCE_GUID);
+        verifyZeroInteractions(mockAdherenceService);
+    }
+
+    @Test
+    public void getUploadViewForExporter3_NormalCase_WithAdherence() {
+        // Setup test.
+        Upload upload = makeUploadForEx3Test();
+        HealthDataRecordEx3 record = makeRecordForEx3Test();
+        setupGetUploadViewForExporter3Test(upload, record);
+
+        List<AdherenceRecord> adherenceRecordList = mockAdherenceForExporter3Test();
+
+        // Execute and validate.
+        UploadViewEx3 uploadView = svc.getUploadViewForExporter3(TEST_APP_ID, TEST_STUDY_ID, UPLOAD_ID_1,
+                false, true);
+        assertEquals(uploadView.getId(), UPLOAD_ID_1);
+        assertEquals(uploadView.getHealthCode(), HEALTH_CODE);
+        assertEquals(uploadView.getUserId(), TEST_USER_ID);
+        assertSame(uploadView.getAdherenceRecords(), adherenceRecordList);
+        assertSame(uploadView.getRecord(), record);
+        assertNull(uploadView.getTimelineMetadata());
+        assertSame(uploadView.getUpload(), upload);
+
+        // Verify adherence call, but no timeline call.
+        verifyZeroInteractions(mockSchedule2Service);
+
+        ArgumentCaptor<AdherenceRecordsSearch> searchCaptor = ArgumentCaptor.forClass(AdherenceRecordsSearch.class);
+        verify(mockAdherenceService).getAdherenceRecords(eq(TEST_APP_ID), searchCaptor.capture());
+        AdherenceRecordsSearch search = searchCaptor.getValue();
+        assertEquals(search.getInstanceGuids(), ImmutableSet.of(INSTANCE_GUID));
+        assertEquals(search.getPageSize().intValue(), AdherenceRecordsSearchValidator.MAX_PAGE_SIZE);
+        assertEquals(search.getStudyId(), TEST_STUDY_ID);
+        assertEquals(search.getUserId(), TEST_USER_ID);
+    }
+
+    @Test
+    public void getUploadViewForExporter3_NormalCase_WithBothTimelineAndAdherence() {
+        // Setup test.
+        Upload upload = makeUploadForEx3Test();
+        HealthDataRecordEx3 record = makeRecordForEx3Test();
+        setupGetUploadViewForExporter3Test(upload, record);
+
+        mockTimelineMetadataForExporter3Test();
+
+        List<AdherenceRecord> adherenceRecordList = mockAdherenceForExporter3Test();
+
+        // Execute and validate.
+        UploadViewEx3 uploadView = svc.getUploadViewForExporter3(TEST_APP_ID, TEST_STUDY_ID, UPLOAD_ID_1,
+                true, true);
+        assertEquals(uploadView.getId(), UPLOAD_ID_1);
+        assertEquals(uploadView.getHealthCode(), HEALTH_CODE);
+        assertEquals(uploadView.getUserId(), TEST_USER_ID);
+        assertSame(uploadView.getAdherenceRecords(), adherenceRecordList);
+        assertSame(uploadView.getRecord(), record);
+        assertEquals(uploadView.getTimelineMetadata().getMetadata().get("assessmentInstanceGuid"), INSTANCE_GUID);
+        assertSame(uploadView.getUpload(), upload);
+
+        // Verify both timeline and adherence calls. (Don't worry about search parameters.)
+        verify(mockSchedule2Service).getTimelineMetadata(INSTANCE_GUID);
+        verify(mockAdherenceService).getAdherenceRecords(eq(TEST_APP_ID), any());
+    }
+
+    @Test
+    public void getUploadViewForExporter3_UploadWithoutRecord() {
+        // Setup test.
+        Upload upload = makeUploadForEx3Test();
+        setupGetUploadViewForExporter3Test(upload, null);
+
+        mockTimelineMetadataForExporter3Test();
+
+        List<AdherenceRecord> adherenceRecordList = mockAdherenceForExporter3Test();
+
+        // Execute and validate.
+        UploadViewEx3 uploadView = svc.getUploadViewForExporter3(TEST_APP_ID, TEST_STUDY_ID, UPLOAD_ID_1,
+                true, true);
+        assertEquals(uploadView.getId(), UPLOAD_ID_1);
+        assertEquals(uploadView.getHealthCode(), HEALTH_CODE);
+        assertEquals(uploadView.getUserId(), TEST_USER_ID);
+        assertSame(uploadView.getAdherenceRecords(), adherenceRecordList);
+        assertNotNull(uploadView.getTimelineMetadata());
+        assertNull(uploadView.getRecord());
+        assertSame(uploadView.getUpload(), upload);
+
+        // Verify both timeline and adherence calls. (Don't worry about search parameters.)
+        verify(mockSchedule2Service).getTimelineMetadata(INSTANCE_GUID);
+        verify(mockAdherenceService).getAdherenceRecords(eq(TEST_APP_ID), any());
+    }
+
+    @Test
+    public void getUploadViewForExporter3_NormalCase_RecordWithoutUpload() {
+        // Setup test.
+        HealthDataRecordEx3 record = makeRecordForEx3Test();
+        setupGetUploadViewForExporter3Test(null, record);
+
+        mockTimelineMetadataForExporter3Test();
+
+        List<AdherenceRecord> adherenceRecordList = mockAdherenceForExporter3Test();
+
+        // Execute and validate.
+        UploadViewEx3 uploadView = svc.getUploadViewForExporter3(TEST_APP_ID, TEST_STUDY_ID, UPLOAD_ID_1,
+                true, true);
+        assertEquals(uploadView.getId(), UPLOAD_ID_1);
+        assertEquals(uploadView.getHealthCode(), HEALTH_CODE);
+        assertEquals(uploadView.getUserId(), TEST_USER_ID);
+        assertSame(uploadView.getAdherenceRecords(), adherenceRecordList);
+        assertSame(uploadView.getRecord(), record);
+        assertNotNull(uploadView.getTimelineMetadata());
+        assertNull(uploadView.getUpload());
+
+        // Verify both timeline and adherence calls. (Don't worry about search parameters.)
+        verify(mockSchedule2Service).getTimelineMetadata(INSTANCE_GUID);
+        verify(mockAdherenceService).getAdherenceRecords(eq(TEST_APP_ID), any());
+    }
+
+    @Test
+    public void getUploadViewForExporter3_NormalCase_UploadWithoutMetadata() {
+        // Setup test.
+        Upload upload = makeUploadForEx3Test();
+        upload.setMetadata(null);
+
+        HealthDataRecordEx3 record = makeRecordForEx3Test();
+        setupGetUploadViewForExporter3Test(upload, record);
+
+        mockTimelineMetadataForExporter3Test();
+
+        List<AdherenceRecord> adherenceRecordList = mockAdherenceForExporter3Test();
+
+        // Execute and validate.
+        UploadViewEx3 uploadView = svc.getUploadViewForExporter3(TEST_APP_ID, TEST_STUDY_ID, UPLOAD_ID_1,
+                true, true);
+        assertEquals(uploadView.getId(), UPLOAD_ID_1);
+        assertEquals(uploadView.getHealthCode(), HEALTH_CODE);
+        assertEquals(uploadView.getUserId(), TEST_USER_ID);
+        assertSame(uploadView.getAdherenceRecords(), adherenceRecordList);
+        assertSame(uploadView.getRecord(), record);
+        assertNotNull(uploadView.getTimelineMetadata());
+        assertSame(uploadView.getUpload(), upload);
+
+        // We can still call timeline and adherence because we fallback to the record metadata.
+        verify(mockSchedule2Service).getTimelineMetadata(INSTANCE_GUID);
+        verify(mockAdherenceService).getAdherenceRecords(eq(TEST_APP_ID), any());
+    }
+
+    @Test
+    public void getUploadViewForExporter3_NormalCase_UploadWithoutInstanceGuid() {
+        // Setup test.
+        Upload upload = makeUploadForEx3Test();
+        upload.getMetadata().remove(UploadService.METADATA_KEY_INSTANCE_GUID);
+
+        HealthDataRecordEx3 record = makeRecordForEx3Test();
+        setupGetUploadViewForExporter3Test(upload, record);
+
+        mockTimelineMetadataForExporter3Test();
+
+        List<AdherenceRecord> adherenceRecordList = mockAdherenceForExporter3Test();
+
+        // Execute and validate.
+        UploadViewEx3 uploadView = svc.getUploadViewForExporter3(TEST_APP_ID, TEST_STUDY_ID, UPLOAD_ID_1,
+                true, true);
+        assertEquals(uploadView.getId(), UPLOAD_ID_1);
+        assertEquals(uploadView.getHealthCode(), HEALTH_CODE);
+        assertEquals(uploadView.getUserId(), TEST_USER_ID);
+        assertSame(uploadView.getAdherenceRecords(), adherenceRecordList);
+        assertSame(uploadView.getRecord(), record);
+        assertNotNull(uploadView.getTimelineMetadata());
+        assertSame(uploadView.getUpload(), upload);
+
+        // We can still call timeline and adherence because we fallback to the record metadata.
+        verify(mockSchedule2Service).getTimelineMetadata(INSTANCE_GUID);
+        verify(mockAdherenceService).getAdherenceRecords(eq(TEST_APP_ID), any());
+    }
+
+    @Test
+    public void getUploadViewForExporter3_NormalCase_UploadInstanceGuidJsonNull() {
+        // Setup test.
+        Upload upload = makeUploadForEx3Test();
+        upload.getMetadata().set(UploadService.METADATA_KEY_INSTANCE_GUID, NullNode.getInstance());
+
+        HealthDataRecordEx3 record = makeRecordForEx3Test();
+        setupGetUploadViewForExporter3Test(upload, record);
+
+        mockTimelineMetadataForExporter3Test();
+
+        List<AdherenceRecord> adherenceRecordList = mockAdherenceForExporter3Test();
+
+        // Execute and validate.
+        UploadViewEx3 uploadView = svc.getUploadViewForExporter3(TEST_APP_ID, TEST_STUDY_ID, UPLOAD_ID_1,
+                true, true);
+        assertEquals(uploadView.getId(), UPLOAD_ID_1);
+        assertEquals(uploadView.getHealthCode(), HEALTH_CODE);
+        assertEquals(uploadView.getUserId(), TEST_USER_ID);
+        assertSame(uploadView.getAdherenceRecords(), adherenceRecordList);
+        assertSame(uploadView.getRecord(), record);
+        assertNotNull(uploadView.getTimelineMetadata());
+        assertSame(uploadView.getUpload(), upload);
+
+        // We can still call timeline and adherence because we fallback to the record metadata.
+        verify(mockSchedule2Service).getTimelineMetadata(INSTANCE_GUID);
+        verify(mockAdherenceService).getAdherenceRecords(eq(TEST_APP_ID), any());
+    }
+
+    @Test
+    public void getUploadViewForExporter3_NormalCase_UploadInstanceGuidWrongType() {
+        // Setup test.
+        Upload upload = makeUploadForEx3Test();
+        upload.getMetadata().put(UploadService.METADATA_KEY_INSTANCE_GUID, 123);
+
+        HealthDataRecordEx3 record = makeRecordForEx3Test();
+        setupGetUploadViewForExporter3Test(upload, record);
+
+        mockTimelineMetadataForExporter3Test();
+
+        List<AdherenceRecord> adherenceRecordList = mockAdherenceForExporter3Test();
+
+        // Execute and validate.
+        UploadViewEx3 uploadView = svc.getUploadViewForExporter3(TEST_APP_ID, TEST_STUDY_ID, UPLOAD_ID_1,
+                true, true);
+        assertEquals(uploadView.getId(), UPLOAD_ID_1);
+        assertEquals(uploadView.getHealthCode(), HEALTH_CODE);
+        assertEquals(uploadView.getUserId(), TEST_USER_ID);
+        assertSame(uploadView.getAdherenceRecords(), adherenceRecordList);
+        assertSame(uploadView.getRecord(), record);
+        assertNotNull(uploadView.getTimelineMetadata());
+        assertSame(uploadView.getUpload(), upload);
+
+        // We can still call timeline and adherence because we fallback to the record metadata.
+        verify(mockSchedule2Service).getTimelineMetadata(INSTANCE_GUID);
+        verify(mockAdherenceService).getAdherenceRecords(eq(TEST_APP_ID), any());
+    }
+
+    @Test
+    public void getUploadViewForExporter3_NormalCase_RecordWithoutMetadata() {
+        // Setup test.
+        Upload upload = makeUploadForEx3Test();
+        upload.setMetadata(null);
+
+        HealthDataRecordEx3 record = makeRecordForEx3Test();
+        record.setMetadata(null);
+
+        setupGetUploadViewForExporter3Test(upload, record);
+
+        // Execute and validate.
+        UploadViewEx3 uploadView = svc.getUploadViewForExporter3(TEST_APP_ID, TEST_STUDY_ID, UPLOAD_ID_1,
+                true, true);
+        assertEquals(uploadView.getId(), UPLOAD_ID_1);
+        assertEquals(uploadView.getHealthCode(), HEALTH_CODE);
+        assertEquals(uploadView.getUserId(), TEST_USER_ID);
+        assertNull(uploadView.getAdherenceRecords());
+        assertSame(uploadView.getRecord(), record);
+        assertNull(uploadView.getTimelineMetadata());
+        assertSame(uploadView.getUpload(), upload);
+
+        // Without metadata, we can't call timeline or adherence.
+        verifyZeroInteractions(mockSchedule2Service, mockAdherenceService);
+    }
+
+    @Test
+    public void getUploadViewForExporter3_NormalCase_RecordWithoutInstanceGuid() {
+        // Setup test.
+        Upload upload = makeUploadForEx3Test();
+        upload.setMetadata(null);
+
+        HealthDataRecordEx3 record = makeRecordForEx3Test();
+        record.getMetadata().remove(UploadService.METADATA_KEY_INSTANCE_GUID);
+
+        setupGetUploadViewForExporter3Test(upload, record);
+
+        // Execute and validate.
+        UploadViewEx3 uploadView = svc.getUploadViewForExporter3(TEST_APP_ID, TEST_STUDY_ID, UPLOAD_ID_1,
+                true, true);
+        assertEquals(uploadView.getId(), UPLOAD_ID_1);
+        assertEquals(uploadView.getHealthCode(), HEALTH_CODE);
+        assertEquals(uploadView.getUserId(), TEST_USER_ID);
+        assertNull(uploadView.getAdherenceRecords());
+        assertSame(uploadView.getRecord(), record);
+        assertNull(uploadView.getTimelineMetadata());
+        assertSame(uploadView.getUpload(), upload);
+
+        // Without metadata, we can't call timeline or adherence.
+        verifyZeroInteractions(mockSchedule2Service, mockAdherenceService);
+    }
+
+    @Test
+    public void getUploadViewForExporter3_TimelineNotPresent() {
+        // Setup test.
+        Upload upload = makeUploadForEx3Test();
+        HealthDataRecordEx3 record = makeRecordForEx3Test();
+        setupGetUploadViewForExporter3Test(upload, record);
+
+        when(mockSchedule2Service.getTimelineMetadata(INSTANCE_GUID)).thenReturn(Optional.empty());
+
+        // Execute and validate.
+        UploadViewEx3 uploadView = svc.getUploadViewForExporter3(TEST_APP_ID, null, UPLOAD_ID_1,
+                true, false);
+        assertEquals(uploadView.getId(), UPLOAD_ID_1);
+        assertEquals(uploadView.getHealthCode(), HEALTH_CODE);
+        assertEquals(uploadView.getUserId(), TEST_USER_ID);
+        assertNull(uploadView.getAdherenceRecords());
+        assertSame(uploadView.getRecord(), record);
+        assertNull(uploadView.getTimelineMetadata());
+        assertSame(uploadView.getUpload(), upload);
+
+        // Verify timeline call, but no adherence call.
+        verify(mockSchedule2Service).getTimelineMetadata(INSTANCE_GUID);
+        verifyZeroInteractions(mockAdherenceService);
+    }
+
+    @Test
+    public void getUploadViewForExporter3_TimelineFromWrongApp() {
+        // Setup test.
+        Upload upload = makeUploadForEx3Test();
+        HealthDataRecordEx3 record = makeRecordForEx3Test();
+        setupGetUploadViewForExporter3Test(upload, record);
+
+        TimelineMetadata timelineMetadata = new TimelineMetadata();
+        timelineMetadata.setAppId("wrong-app");
+        timelineMetadata.setAssessmentInstanceGuid(INSTANCE_GUID);
+        when(mockSchedule2Service.getTimelineMetadata(INSTANCE_GUID)).thenReturn(Optional.of(timelineMetadata));
+
+        // Execute and validate.
+        UploadViewEx3 uploadView = svc.getUploadViewForExporter3(TEST_APP_ID, null, UPLOAD_ID_1,
+                true, false);
+        assertEquals(uploadView.getId(), UPLOAD_ID_1);
+        assertEquals(uploadView.getHealthCode(), HEALTH_CODE);
+        assertEquals(uploadView.getUserId(), TEST_USER_ID);
+        assertNull(uploadView.getAdherenceRecords());
+        assertSame(uploadView.getRecord(), record);
+        assertNull(uploadView.getTimelineMetadata());
+        assertSame(uploadView.getUpload(), upload);
+
+        // Verify timeline call, but no adherence call.
+        verify(mockSchedule2Service).getTimelineMetadata(INSTANCE_GUID);
+        verifyZeroInteractions(mockAdherenceService);
+    }
+
+    @Test
+    public void getUploadViewForExporter3_NormalCase_EmptyAdherenceRecords() {
+        // Setup test.
+        Upload upload = makeUploadForEx3Test();
+        HealthDataRecordEx3 record = makeRecordForEx3Test();
+        setupGetUploadViewForExporter3Test(upload, record);
+
+        PagedResourceList<AdherenceRecord> pagedResourceList = new PagedResourceList<>(ImmutableList.of(), 0);
+        when(mockAdherenceService.getAdherenceRecords(eq(TEST_APP_ID), any())).thenReturn(pagedResourceList);
+
+        // Execute and validate.
+        UploadViewEx3 uploadView = svc.getUploadViewForExporter3(TEST_APP_ID, TEST_STUDY_ID, UPLOAD_ID_1,
+                false, true);
+        assertEquals(uploadView.getId(), UPLOAD_ID_1);
+        assertEquals(uploadView.getHealthCode(), HEALTH_CODE);
+        assertEquals(uploadView.getUserId(), TEST_USER_ID);
+        assertTrue(uploadView.getAdherenceRecords().isEmpty());
+        assertSame(uploadView.getRecord(), record);
+        assertNull(uploadView.getTimelineMetadata());
+        assertSame(uploadView.getUpload(), upload);
+
+        // Verify adherence call, but no timeline call.
+        verifyZeroInteractions(mockSchedule2Service);
+        verify(mockAdherenceService).getAdherenceRecords(eq(TEST_APP_ID), any());
+    }
+
+    private void setupGetUploadViewForExporter3Test(Upload upload, HealthDataRecordEx3 record) {
+        // Set request context. Developer has access to everything.
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("other-id")
+                .withCallerRoles(ImmutableSet.of(DEVELOPER)).build());
+
+        // Mock upload and record.
+        when(mockUploadDao.getUploadNoThrow(UPLOAD_ID_1)).thenReturn(upload);
+        when(mockHealthDataEx3Service.getRecord(UPLOAD_ID_1, false)).thenReturn(Optional.ofNullable(record));
+
+        // Mock account service.
+        when(mockAccountService.getAccountId(TEST_APP_ID, "healthcode:" + HEALTH_CODE)).thenReturn(
+                Optional.of(TEST_USER_ID));
+    }
+
+    private static Upload makeUploadForEx3Test() {
+        Upload upload = Upload.create();
+        upload.setAppId(TEST_APP_ID);
+        upload.setUploadId(UPLOAD_ID_1);
+        upload.setHealthCode(HEALTH_CODE);
+
+        ObjectNode metadataNode = BridgeObjectMapper.get().createObjectNode();
+        metadataNode.put(UploadService.METADATA_KEY_INSTANCE_GUID, INSTANCE_GUID);
+        upload.setMetadata(metadataNode);
+
+        return upload;
+    }
+
+    private static HealthDataRecordEx3 makeRecordForEx3Test() {
+        HealthDataRecordEx3 record = HealthDataRecordEx3.create();
+        record.setAppId(TEST_APP_ID);
+        record.setHealthCode(HEALTH_CODE);
+        record.setId(UPLOAD_ID_1);
+
+        Map<String, String> metadataMap = new HashMap<>();
+        metadataMap.put(UploadService.METADATA_KEY_INSTANCE_GUID, INSTANCE_GUID);
+        record.setMetadata(metadataMap);
+
+        return record;
+    }
+
+    private void mockTimelineMetadataForExporter3Test() {
+        TimelineMetadata timelineMetadata = new TimelineMetadata();
+        timelineMetadata.setAppId(TEST_APP_ID);
+        timelineMetadata.setAssessmentInstanceGuid(INSTANCE_GUID);
+
+        when(mockSchedule2Service.getTimelineMetadata(INSTANCE_GUID)).thenReturn(Optional.of(timelineMetadata));
+    }
+
+    private List<AdherenceRecord> mockAdherenceForExporter3Test() {
+        // We don't actually need any of the data in the adherence record, just the fact that it exists.
+        List<AdherenceRecord> adherenceRecordList = ImmutableList.of(new AdherenceRecord());
+        PagedResourceList<AdherenceRecord> pagedResourceList = new PagedResourceList<>(adherenceRecordList, 1);
+        when(mockAdherenceService.getAdherenceRecords(eq(TEST_APP_ID), any())).thenReturn(pagedResourceList);
+        return adherenceRecordList;
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/Schedule2ControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/Schedule2ControllerTest.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -259,6 +258,7 @@ public class Schedule2ControllerTest extends Mockito {
         doReturn(session).when(controller).getAuthenticatedSession(WORKER);
         
         TimelineMetadata meta = TimelineMetadataTest.createTimelineMetadata();
+        meta.setAppId(TEST_APP_ID);
         when(mockService.getTimelineMetadata("instanceGuid")).thenReturn(Optional.of(meta));
         
         TimelineMetadataView view = controller.getTimelineMetadataForWorker(TEST_APP_ID, "instanceGuid");
@@ -267,7 +267,22 @@ public class Schedule2ControllerTest extends Mockito {
     }
 
     @Test
-    public void getTimelineMetadataForWorker_noData() throws JsonProcessingException { 
+    public void getTimelineMetadataForWorker_wrongApp() {
+        doReturn(session).when(controller).getAuthenticatedSession(WORKER);
+
+        TimelineMetadata meta = TimelineMetadataTest.createTimelineMetadata();
+        meta.setAppId("wrongAppId");
+        when(mockService.getTimelineMetadata("instanceGuid")).thenReturn(Optional.of(meta));
+
+        TimelineMetadataView view = controller.getTimelineMetadataForWorker(TEST_APP_ID, "instanceGuid");
+        // Map is populated but empty. It serializes to an empty map.
+        for (Map.Entry<String, String> entry : view.getMetadata().entrySet()) {
+            assertNull(entry.getValue());
+        }
+    }
+
+    @Test
+    public void getTimelineMetadataForWorker_noData() {
         doReturn(session).when(controller).getAuthenticatedSession(WORKER);
         
         when(mockService.getTimelineMetadata("instanceGuid")).thenReturn(Optional.empty());

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/UploadControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/UploadControllerTest.java
@@ -7,12 +7,14 @@ import static org.sagebionetworks.bridge.Roles.WORKER;
 import static org.sagebionetworks.bridge.TestConstants.ACCOUNT_ID;
 import static org.sagebionetworks.bridge.TestConstants.HEALTH_CODE;
 import static org.sagebionetworks.bridge.TestConstants.TEST_APP_ID;
+import static org.sagebionetworks.bridge.TestConstants.TEST_STUDY_ID;
 import static org.sagebionetworks.bridge.TestConstants.TEST_USER_ID;
 import static org.sagebionetworks.bridge.TestUtils.createJson;
 import static org.sagebionetworks.bridge.TestUtils.mockRequestBody;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.fail;
 
 import java.net.URL;
@@ -54,6 +56,7 @@ import org.sagebionetworks.bridge.models.upload.UploadSession;
 import org.sagebionetworks.bridge.models.upload.UploadStatus;
 import org.sagebionetworks.bridge.models.upload.UploadValidationStatus;
 import org.sagebionetworks.bridge.models.upload.UploadView;
+import org.sagebionetworks.bridge.models.upload.UploadViewEx3;
 import org.sagebionetworks.bridge.services.AccountService;
 import org.sagebionetworks.bridge.services.HealthDataService;
 import org.sagebionetworks.bridge.services.RequestInfoService;
@@ -495,5 +498,89 @@ public class UploadControllerTest extends Mockito {
 
         // Health code is filtered out of the record.
         assertNull(recordNode.get("healthCode"));
+    }
+
+    @Test
+    public void getUploadViewForExporter3() {
+        // Mock session.
+        doReturn(mockResearcherSession).when(controller).getAuthenticatedSession();
+        when(mockResearcherSession.getAppId()).thenReturn(TEST_APP_ID);
+
+        // Mock service.
+        UploadViewEx3 uploadView = new UploadViewEx3();
+        when(mockUploadService.getUploadViewForExporter3(any(), any(), any(), anyBoolean(), anyBoolean()))
+                .thenReturn(uploadView);
+
+        // Execute and validate.
+        UploadViewEx3 result = controller.getUploadViewForExporter3(Optional.empty(), UPLOAD_ID,
+                true, true);
+        assertSame(uploadView, result);
+
+        // Verify service call.
+        verify(mockUploadService).getUploadViewForExporter3(TEST_APP_ID, null, UPLOAD_ID, true,
+                true);
+    }
+
+    @Test
+    public void getUploadViewForExporter3_WithStudyId() {
+        // Mock session.
+        doReturn(mockResearcherSession).when(controller).getAuthenticatedSession();
+        when(mockResearcherSession.getAppId()).thenReturn(TEST_APP_ID);
+
+        // Mock service.
+        UploadViewEx3 uploadView = new UploadViewEx3();
+        when(mockUploadService.getUploadViewForExporter3(any(), any(), any(), anyBoolean(), anyBoolean()))
+                .thenReturn(uploadView);
+
+        // Execute and validate.
+        UploadViewEx3 result = controller.getUploadViewForExporter3(Optional.of(TEST_STUDY_ID), UPLOAD_ID,
+                false, false);
+        assertSame(uploadView, result);
+
+        // Verify service call.
+        verify(mockUploadService).getUploadViewForExporter3(TEST_APP_ID, TEST_STUDY_ID, UPLOAD_ID, false,
+                false);
+    }
+
+    @Test
+    public void getUploadEx3ForWorker() {
+        // Mock session.
+        doReturn(mockWorkerSession).when(controller).getAuthenticatedSession(WORKER);
+        when(mockWorkerSession.getAppId()).thenReturn("other-app-id");
+
+        // Mock service.
+        UploadViewEx3 uploadView = new UploadViewEx3();
+        when(mockUploadService.getUploadViewForExporter3(any(), any(), any(), anyBoolean(), anyBoolean()))
+                .thenReturn(uploadView);
+
+        // Execute and validate.
+        UploadViewEx3 result = controller.getUploadEx3ForWorker(TEST_APP_ID, Optional.empty(), UPLOAD_ID,
+                true, true);
+        assertSame(uploadView, result);
+
+        // Verify service call.
+        verify(mockUploadService).getUploadViewForExporter3(TEST_APP_ID, null, UPLOAD_ID, true,
+                true);
+    }
+
+    @Test
+    public void getUploadEx3ForWorker_WithStudyId() {
+        // Mock session.
+        doReturn(mockWorkerSession).when(controller).getAuthenticatedSession(WORKER);
+        when(mockWorkerSession.getAppId()).thenReturn("other-app-id");
+
+        // Mock service.
+        UploadViewEx3 uploadView = new UploadViewEx3();
+        when(mockUploadService.getUploadViewForExporter3(any(), any(), any(), anyBoolean(), anyBoolean()))
+                .thenReturn(uploadView);
+
+        // Execute and validate.
+        UploadViewEx3 result = controller.getUploadEx3ForWorker(TEST_APP_ID, Optional.of(TEST_STUDY_ID), UPLOAD_ID,
+                false, false);
+        assertSame(uploadView, result);
+
+        // Verify service call.
+        verify(mockUploadService).getUploadViewForExporter3(TEST_APP_ID, TEST_STUDY_ID, UPLOAD_ID, false,
+                false);
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/validators/ExportToAppNotificationValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/validators/ExportToAppNotificationValidatorTest.java
@@ -7,6 +7,7 @@ import org.testng.annotations.Test;
 
 import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.models.exporter.ExportToAppNotification;
+import org.sagebionetworks.bridge.models.exporter.ExportedRecordInfo;
 
 public class ExportToAppNotificationValidatorTest {
     private static final String FILE_ENTITY_ID = "syn1111";
@@ -87,7 +88,7 @@ public class ExportToAppNotificationValidatorTest {
     @Test
     public void nullParentProjectId() {
         ExportToAppNotification notification = makeValidNotification();
-        ExportToAppNotification.RecordInfo recordInfo = makeValidRecordInfo();
+        ExportedRecordInfo recordInfo = makeValidRecordInfo();
         recordInfo.setParentProjectId(null);
         notification.setRecord(recordInfo);
         assertValidatorMessage(ExportToAppNotificationValidator.INSTANCE, notification,
@@ -97,7 +98,7 @@ public class ExportToAppNotificationValidatorTest {
     @Test
     public void emptyParentProjectId() {
         ExportToAppNotification notification = makeValidNotification();
-        ExportToAppNotification.RecordInfo recordInfo = makeValidRecordInfo();
+        ExportedRecordInfo recordInfo = makeValidRecordInfo();
         recordInfo.setParentProjectId("");
         notification.setRecord(recordInfo);
         assertValidatorMessage(ExportToAppNotificationValidator.INSTANCE, notification,
@@ -107,7 +108,7 @@ public class ExportToAppNotificationValidatorTest {
     @Test
     public void blankParentProjectId() {
         ExportToAppNotification notification = makeValidNotification();
-        ExportToAppNotification.RecordInfo recordInfo = makeValidRecordInfo();
+        ExportedRecordInfo recordInfo = makeValidRecordInfo();
         recordInfo.setParentProjectId("   ");
         notification.setRecord(recordInfo);
         assertValidatorMessage(ExportToAppNotificationValidator.INSTANCE, notification,
@@ -117,7 +118,7 @@ public class ExportToAppNotificationValidatorTest {
     @Test
     public void nullRawFolderId() {
         ExportToAppNotification notification = makeValidNotification();
-        ExportToAppNotification.RecordInfo recordInfo = makeValidRecordInfo();
+        ExportedRecordInfo recordInfo = makeValidRecordInfo();
         recordInfo.setRawFolderId(null);
         notification.setRecord(recordInfo);
         assertValidatorMessage(ExportToAppNotificationValidator.INSTANCE, notification,
@@ -127,7 +128,7 @@ public class ExportToAppNotificationValidatorTest {
     @Test
     public void emptyRawFolderId() {
         ExportToAppNotification notification = makeValidNotification();
-        ExportToAppNotification.RecordInfo recordInfo = makeValidRecordInfo();
+        ExportedRecordInfo recordInfo = makeValidRecordInfo();
         recordInfo.setRawFolderId("");
         notification.setRecord(recordInfo);
         assertValidatorMessage(ExportToAppNotificationValidator.INSTANCE, notification,
@@ -137,7 +138,7 @@ public class ExportToAppNotificationValidatorTest {
     @Test
     public void blankRawFolderId() {
         ExportToAppNotification notification = makeValidNotification();
-        ExportToAppNotification.RecordInfo recordInfo = makeValidRecordInfo();
+        ExportedRecordInfo recordInfo = makeValidRecordInfo();
         recordInfo.setRawFolderId("   ");
         notification.setRecord(recordInfo);
         assertValidatorMessage(ExportToAppNotificationValidator.INSTANCE, notification,
@@ -147,7 +148,7 @@ public class ExportToAppNotificationValidatorTest {
     @Test
     public void nullFileEntityId() {
         ExportToAppNotification notification = makeValidNotification();
-        ExportToAppNotification.RecordInfo recordInfo = makeValidRecordInfo();
+        ExportedRecordInfo recordInfo = makeValidRecordInfo();
         recordInfo.setFileEntityId(null);
         notification.setRecord(recordInfo);
         assertValidatorMessage(ExportToAppNotificationValidator.INSTANCE, notification,
@@ -157,7 +158,7 @@ public class ExportToAppNotificationValidatorTest {
     @Test
     public void emptyFileEntityId() {
         ExportToAppNotification notification = makeValidNotification();
-        ExportToAppNotification.RecordInfo recordInfo = makeValidRecordInfo();
+        ExportedRecordInfo recordInfo = makeValidRecordInfo();
         recordInfo.setFileEntityId("");
         notification.setRecord(recordInfo);
         assertValidatorMessage(ExportToAppNotificationValidator.INSTANCE, notification,
@@ -167,7 +168,7 @@ public class ExportToAppNotificationValidatorTest {
     @Test
     public void blankFileEntityId() {
         ExportToAppNotification notification = makeValidNotification();
-        ExportToAppNotification.RecordInfo recordInfo = makeValidRecordInfo();
+        ExportedRecordInfo recordInfo = makeValidRecordInfo();
         recordInfo.setFileEntityId("   ");
         notification.setRecord(recordInfo);
         assertValidatorMessage(ExportToAppNotificationValidator.INSTANCE, notification,
@@ -177,7 +178,7 @@ public class ExportToAppNotificationValidatorTest {
     @Test
     public void nullS3Bucket() {
         ExportToAppNotification notification = makeValidNotification();
-        ExportToAppNotification.RecordInfo recordInfo = makeValidRecordInfo();
+        ExportedRecordInfo recordInfo = makeValidRecordInfo();
         recordInfo.setS3Bucket(null);
         notification.setRecord(recordInfo);
         assertValidatorMessage(ExportToAppNotificationValidator.INSTANCE, notification,
@@ -187,7 +188,7 @@ public class ExportToAppNotificationValidatorTest {
     @Test
     public void emptyS3Bucket() {
         ExportToAppNotification notification = makeValidNotification();
-        ExportToAppNotification.RecordInfo recordInfo = makeValidRecordInfo();
+        ExportedRecordInfo recordInfo = makeValidRecordInfo();
         recordInfo.setS3Bucket("");
         notification.setRecord(recordInfo);
         assertValidatorMessage(ExportToAppNotificationValidator.INSTANCE, notification,
@@ -197,7 +198,7 @@ public class ExportToAppNotificationValidatorTest {
     @Test
     public void blankS3Bucket() {
         ExportToAppNotification notification = makeValidNotification();
-        ExportToAppNotification.RecordInfo recordInfo = makeValidRecordInfo();
+        ExportedRecordInfo recordInfo = makeValidRecordInfo();
         recordInfo.setS3Bucket("   ");
         notification.setRecord(recordInfo);
         assertValidatorMessage(ExportToAppNotificationValidator.INSTANCE, notification,
@@ -207,7 +208,7 @@ public class ExportToAppNotificationValidatorTest {
     @Test
     public void nullS3Key() {
         ExportToAppNotification notification = makeValidNotification();
-        ExportToAppNotification.RecordInfo recordInfo = makeValidRecordInfo();
+        ExportedRecordInfo recordInfo = makeValidRecordInfo();
         recordInfo.setS3Key(null);
         notification.setRecord(recordInfo);
         assertValidatorMessage(ExportToAppNotificationValidator.INSTANCE, notification,
@@ -217,7 +218,7 @@ public class ExportToAppNotificationValidatorTest {
     @Test
     public void emptyS3Key() {
         ExportToAppNotification notification = makeValidNotification();
-        ExportToAppNotification.RecordInfo recordInfo = makeValidRecordInfo();
+        ExportedRecordInfo recordInfo = makeValidRecordInfo();
         recordInfo.setS3Key("");
         notification.setRecord(recordInfo);
         assertValidatorMessage(ExportToAppNotificationValidator.INSTANCE, notification,
@@ -227,7 +228,7 @@ public class ExportToAppNotificationValidatorTest {
     @Test
     public void blankS3Key() {
         ExportToAppNotification notification = makeValidNotification();
-        ExportToAppNotification.RecordInfo recordInfo = makeValidRecordInfo();
+        ExportedRecordInfo recordInfo = makeValidRecordInfo();
         recordInfo.setS3Key("   ");
         notification.setRecord(recordInfo);
         assertValidatorMessage(ExportToAppNotificationValidator.INSTANCE, notification,
@@ -237,7 +238,7 @@ public class ExportToAppNotificationValidatorTest {
     @Test
     public void invalidStudyRecord() {
         ExportToAppNotification notification = makeValidNotification();
-        ExportToAppNotification.RecordInfo recordInfo = makeValidRecordInfo();
+        ExportedRecordInfo recordInfo = makeValidRecordInfo();
         recordInfo.setParentProjectId(null);
         notification.setStudyRecords(ImmutableMap.of(TestConstants.TEST_STUDY_ID, recordInfo));
         assertValidatorMessage(ExportToAppNotificationValidator.INSTANCE, notification,
@@ -251,8 +252,8 @@ public class ExportToAppNotificationValidatorTest {
         return notification;
     }
 
-    private static ExportToAppNotification.RecordInfo makeValidRecordInfo() {
-        ExportToAppNotification.RecordInfo recordInfo = new ExportToAppNotification.RecordInfo();
+    private static ExportedRecordInfo makeValidRecordInfo() {
+        ExportedRecordInfo recordInfo = new ExportedRecordInfo();
         recordInfo.setParentProjectId(PARENT_PROJECT_ID);
         recordInfo.setRawFolderId(RAW_FOLDER_ID);
         recordInfo.setFileEntityId(FILE_ENTITY_ID);


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-3389

New API to get an upload for Exporter 3.0, with optional flags to also get adherence and timeline. This will be used by deveopers to investigate upload issues.

Also includes changes to add Synapse export information to health data record (which is also returned by the Upload Status API.