### PR TITLE
BRIDGE-3390 ClientInfo Fixes

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/dao/UploadDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dao/UploadDao.java
@@ -88,4 +88,7 @@ public interface UploadDao {
      * @return a list of upload IDs to be deleted
      */
     List<String> deleteUploadsForHealthCode(@Nonnull String healthCode);
+
+    /** Update an upload record. */
+    void updateUpload(Upload upload);
 }

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataRecordEx3.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataRecordEx3.java
@@ -40,6 +40,7 @@ public class DynamoHealthDataRecordEx3 implements HealthDataRecordEx3 {
     private Map<String, ExportedRecordInfo> exportedStudyRecords;
     private Map<String, String> metadata;
     private SharingScope sharingScope;
+    private String userAgent;
     private Long version;
     private String downloadUrl;
     private long downloadExpiration;
@@ -220,6 +221,16 @@ public class DynamoHealthDataRecordEx3 implements HealthDataRecordEx3 {
     @Override
     public void setSharingScope(SharingScope sharingScope) {
         this.sharingScope = sharingScope;
+    }
+
+    @Override
+    public String getUserAgent() {
+        return userAgent;
+    }
+
+    @Override
+    public void setUserAgent(String userAgent) {
+        this.userAgent = userAgent;
     }
 
     @DynamoDBVersionAttribute

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoUpload2.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoUpload2.java
@@ -50,6 +50,7 @@ public class DynamoUpload2 implements Upload {
     private UploadCompletionClient completedBy;
     private LocalDate uploadDate;
     private String uploadId;
+    private String userAgent;
     private final List<String> validationMessageList = new ArrayList<>();
     private Long version;
     private Boolean zipped;
@@ -307,6 +308,16 @@ public class DynamoUpload2 implements Upload {
     @Override
     public void setUploadId(String uploadId) {
         this.uploadId = uploadId;
+    }
+
+    @Override
+    public String getUserAgent() {
+        return userAgent;
+    }
+
+    @Override
+    public void setUserAgent(String userAgent) {
+        this.userAgent = userAgent;
     }
 
     /**

--- a/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadDao.java
+++ b/src/main/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadDao.java
@@ -45,7 +45,6 @@ import org.sagebionetworks.bridge.dao.UploadDao;
 import org.sagebionetworks.bridge.exceptions.BadRequestException;
 import org.sagebionetworks.bridge.exceptions.BridgeServiceException;
 import org.sagebionetworks.bridge.exceptions.ConcurrentModificationException;
-import org.sagebionetworks.bridge.exceptions.EntityNotFoundException;
 import org.sagebionetworks.bridge.exceptions.NotFoundException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.time.DateUtils;
@@ -333,5 +332,9 @@ public class DynamoUploadDao implements UploadDao {
 
         return uploadIdList;
     }
-}
 
+    @Override
+    public void updateUpload(Upload upload) {
+        mapper.save(upload);
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordEx3.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/healthdata/HealthDataRecordEx3.java
@@ -129,6 +129,10 @@ public interface HealthDataRecordEx3 extends BridgeEntity {
     SharingScope getSharingScope();
     void setSharingScope(SharingScope sharingScope);
 
+    /** Participant's User-Agent header. */
+    String getUserAgent();
+    void setUserAgent(String userAgent);
+
     /**
      * Record version. This is used to detect concurrency conflicts. For creating new health data records, this field
      * should be left unspecified. For updating records, this field should match the version of the most recent GET

--- a/src/main/java/org/sagebionetworks/bridge/models/upload/Upload.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/upload/Upload.java
@@ -120,6 +120,10 @@ public interface Upload {
     /** @see #getUploadId */
     void setUploadId(String uploadId);
 
+    /** Participant's User-Agent header. */
+    String getUserAgent();
+    void setUserAgent(String userAgent);
+
     /** True if the upload is zipped. False if it is a single file. */
     boolean isZipped();
     void setZipped(boolean zipped);

--- a/src/main/java/org/sagebionetworks/bridge/services/Exporter3Service.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/Exporter3Service.java
@@ -844,23 +844,30 @@ public class Exporter3Service {
         SharingScope sharingScope = account.getSharingScope();
         record.setSharingScope(sharingScope);
 
-        // Handle Client Info.
+        // Handle Client Info and User Agent.
         String clientInfoJsonText;
-        if (upload.getClientInfo() != null) {
+        String userAgent;
+        if (upload.getUserAgent() != null) {
             clientInfoJsonText = upload.getClientInfo();
+            userAgent = upload.getUserAgent();
         } else {
-            ClientInfo clientInfo = ClientInfo.UNKNOWN_CLIENT;
+            ClientInfo clientInfo;
             RequestContext requestContext = RequestContext.get();
             String calledUserId = requestContext.getCallerUserId();
             String uploaderUserId = account.getId();
             if (Objects.equals(calledUserId, uploaderUserId)) {
                 // The caller is the uploader. Get the Client Info from the RequestContext.
                 clientInfo = requestContext.getCallerClientInfo();
+                userAgent = requestContext.getUserAgent();
             } else {
                 // The caller is _not_ the uploader. Get the Client Info from the RequestInfoService.
                 RequestInfo requestInfo = requestInfoService.getRequestInfo(uploaderUserId);
                 if (requestInfo != null && requestInfo.getClientInfo() != null) {
                     clientInfo = requestInfo.getClientInfo();
+                    userAgent = requestInfo.getUserAgent();
+                } else {
+                    clientInfo = ClientInfo.UNKNOWN_CLIENT;
+                    userAgent = null;
                 }
             }
 
@@ -868,6 +875,7 @@ public class Exporter3Service {
                     .writeValueAsString(clientInfo);
         }
         record.setClientInfo(clientInfoJsonText);
+        record.setUserAgent(userAgent);
 
         // Also mark with the latest participant version.
         Optional<ParticipantVersion> participantVersion = participantVersionService

--- a/src/main/java/org/sagebionetworks/bridge/services/UploadService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/UploadService.java
@@ -230,7 +230,8 @@ public class UploadService {
             uploadId = upload.getUploadId();
 
             // Get client info from Request Context, write it to the upload as JSON.
-            ClientInfo clientInfo = RequestContext.get().getCallerClientInfo();
+            RequestContext requestContext = RequestContext.get();
+            ClientInfo clientInfo = requestContext.getCallerClientInfo();
             try {
                 String clientInfoJsonText = BridgeObjectMapper.get().writerWithDefaultPrettyPrinter()
                         .writeValueAsString(clientInfo);
@@ -240,6 +241,13 @@ public class UploadService {
                 logger.error("Error serializing client info to JSON for app " + appId + " healthcode " +
                         participant.getHealthCode(), ex);
             }
+
+            // Also, get the User Agent.
+            String userAgent = requestContext.getUserAgent();
+            upload.setUserAgent(userAgent);
+
+            // Write the upload back to the upload table with the user agent and client info.
+            uploadDao.updateUpload(upload);
 
             if (originalUploadId != null) {
                 // We had a dupe of a previous completed upload. Log this for future analysis.

--- a/src/main/java/org/sagebionetworks/bridge/spring/filters/RequestFilter.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/filters/RequestFilter.java
@@ -104,7 +104,7 @@ public class RequestFilter implements Filter {
         RequestContext.Builder builder = new RequestContext.Builder()
                 .withRequestId(requestId)
                 .withCallerIpAddress(parseIpAddress(getRemoteAddress(request)))
-                .withCallerClientInfo(getClientInfoFromUserAgentHeader(request, response))
+                .withUserAgent(getUserAgentHeader(request, response))
                 .withCallerLanguages(getLanguagesFromAcceptLanguageHeader(request, response));
         setRequestContext(builder.build());
 
@@ -172,17 +172,19 @@ public class RequestFilter implements Filter {
         return ImmutableList.of();
     }
     
-    static ClientInfo getClientInfoFromUserAgentHeader(HttpServletRequest request, HttpServletResponse response) {
+    static String getUserAgentHeader(HttpServletRequest request, HttpServletResponse response) {
         String userAgentHeader = request.getHeader(USER_AGENT);
-        ClientInfo info = ClientInfo.fromUserAgentCache(userAgentHeader);
 
         // if the user agent cannot be parsed (probably due to missing user agent string or unrecognizable user agent),
         // should set an extra header to http response as warning - we should have an user agent info for filtering to work
+        ClientInfo info = ClientInfo.fromUserAgentCache(userAgentHeader);
         if (info.equals(UNKNOWN_CLIENT)) {
             addWarningMessage(response, WARN_NO_USER_AGENT);
         }
         LOG.debug("User-Agent: '"+userAgentHeader+"' converted to " + info);    
-        return info;
+
+        // Return the User-Agent header value.
+        return userAgentHeader;
     }
     
     /**

--- a/src/test/java/org/sagebionetworks/bridge/RequestContextTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/RequestContextTest.java
@@ -63,7 +63,7 @@ public class RequestContextTest extends Mockito {
         // code that executes.
         RequestContext nullContext = new RequestContext.Builder().withRequestId(null).withCallerAppId(null)
                 .withOrgSponsoredStudies(null).withCallerEnrolledStudies(null).withCallerRoles(null).withCallerUserId(null)
-                .withCallerLanguages(null).withCallerClientInfo(null).withCallerOrgMembership(null).build();
+                .withCallerLanguages(null).withCallerOrgMembership(null).withUserAgent(null).build();
         
         assertNotNull(nullContext.getId());
         assertTrue(nullContext.getCallerEnrolledStudies().isEmpty());
@@ -75,6 +75,7 @@ public class RequestContextTest extends Mockito {
         assertEquals(nullContext.getCallerClientInfo(), UNKNOWN_CLIENT);
         assertNull(nullContext.getCallerOrgMembership());
         assertTrue(nullContext.getOrgSponsoredStudies().isEmpty());
+        assertNull(nullContext.getUserAgent());
         
         ObjectNode node = nullContext.getMetrics().getJson();
         assertTrue(node.has("request_id"));
@@ -97,19 +98,20 @@ public class RequestContextTest extends Mockito {
         assertNull(NULL_INSTANCE.getCallerOrgMembership());
         assertTrue(NULL_INSTANCE.getOrgSponsoredStudies().isEmpty());
         assertEquals(NULL_INSTANCE.getCallerClientInfo(), UNKNOWN_CLIENT);
+        assertNull(NULL_INSTANCE.getUserAgent());
     }
 
     @Test
     public void test() {
         // An existing metrics object
         Metrics metrics = new Metrics(REQUEST_ID);
-        
-        ClientInfo clientInfo = ClientInfo.fromUserAgentCache("Asthma/26 (Unknown iPhone; iPhone OS/9.1) BridgeSDK/4");
+        String userAgent = "Asthma/26 (Unknown iPhone; iPhone OS/9.1) BridgeSDK/4";
+        ClientInfo clientInfo = ClientInfo.fromUserAgentCache(userAgent);
         
         RequestContext context = new RequestContext.Builder().withRequestId(REQUEST_ID).withCallerEnrolledStudies(STUDIES)
                 .withCallerAppId(TEST_APP_ID).withMetrics(metrics).withCallerRoles(ROLES).withCallerUserId(TEST_USER_ID)
-                .withCallerLanguages(LANGUAGES).withCallerClientInfo(clientInfo).withCallerOrgMembership(TEST_ORG_ID)
-                .withOrgSponsoredStudies(USER_STUDY_IDS).build();
+                .withCallerLanguages(LANGUAGES).withCallerOrgMembership(TEST_ORG_ID)
+                .withOrgSponsoredStudies(USER_STUDY_IDS).withUserAgent(userAgent).build();
 
         assertEquals(context.getId(), REQUEST_ID);
         assertEquals(context.getCallerAppId(), TEST_APP_ID);
@@ -121,19 +123,20 @@ public class RequestContextTest extends Mockito {
         assertEquals(context.getMetrics(), metrics);
         assertEquals(context.getCallerOrgMembership(), TEST_ORG_ID);
         assertEquals(context.getOrgSponsoredStudies(), USER_STUDY_IDS);
+        assertEquals(context.getUserAgent(), userAgent);
     }
     
     @Test
     public void toBuilder() { 
         // An existing metrics object
         Metrics metrics = new Metrics(REQUEST_ID);
-        
-        ClientInfo clientInfo = ClientInfo.fromUserAgentCache("Asthma/26 (Unknown iPhone; iPhone OS/9.1) BridgeSDK/4");
+        String userAgent = "Asthma/26 (Unknown iPhone; iPhone OS/9.1) BridgeSDK/4";
+        ClientInfo clientInfo = ClientInfo.fromUserAgentCache(userAgent);
         
         RequestContext context = new RequestContext.Builder().withRequestId(REQUEST_ID).withCallerAppId(TEST_APP_ID)
                 .withCallerEnrolledStudies(STUDIES).withMetrics(metrics).withCallerRoles(ROLES).withCallerUserId(TEST_USER_ID)
-                .withCallerLanguages(LANGUAGES).withCallerClientInfo(clientInfo).withCallerOrgMembership(TEST_ORG_ID)
-                .withOrgSponsoredStudies(USER_STUDY_IDS).build();
+                .withCallerLanguages(LANGUAGES).withCallerOrgMembership(TEST_ORG_ID)
+                .withOrgSponsoredStudies(USER_STUDY_IDS).withUserAgent(userAgent).build();
         
         RequestContext copy = context.toBuilder().withRequestId("did-change-this").build();
         
@@ -147,6 +150,7 @@ public class RequestContextTest extends Mockito {
         assertEquals(copy.getMetrics(), metrics);
         assertEquals(copy.getCallerOrgMembership(), TEST_ORG_ID);
         assertEquals(copy.getOrgSponsoredStudies(), USER_STUDY_IDS);
+        assertEquals(copy.getUserAgent(), userAgent);
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataRecordEx3Test.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoHealthDataRecordEx3Test.java
@@ -180,11 +180,12 @@ public class DynamoHealthDataRecordEx3Test {
         record.setExportedStudyRecords(STUDY_RECORD_INFO_MAP);
         record.setMetadata(METADATA_MAP);
         record.setSharingScope(SharingScope.SPONSORS_AND_PARTNERS);
+        record.setUserAgent(TestConstants.UA);
         record.setVersion(VERSION);
 
         // Convert to JsonNode.
         JsonNode jsonNode = BridgeObjectMapper.get().convertValue(record, JsonNode.class);
-        assertEquals(jsonNode.size(), 16);
+        assertEquals(jsonNode.size(), 17);
         assertEquals(jsonNode.get("id").textValue(), RECORD_ID);
         assertEquals(jsonNode.get("appId").textValue(), TestConstants.TEST_APP_ID);
         assertEquals(jsonNode.get("studyId").textValue(), STUDY_ID);
@@ -195,6 +196,7 @@ public class DynamoHealthDataRecordEx3Test {
         assertTrue(jsonNode.get("exported").booleanValue());
         assertEquals(jsonNode.get("exportedOn").textValue(), TestConstants.EXPORTED_ON.toString());
         assertEquals(jsonNode.get("sharingScope").textValue(), "sponsors_and_partners");
+        assertEquals(jsonNode.get("userAgent").textValue(), TestConstants.UA);
         assertEquals(jsonNode.get("version").longValue(), VERSION);
         assertEquals(jsonNode.get("type").textValue(), "HealthDataRecordEx3");
 
@@ -222,6 +224,7 @@ public class DynamoHealthDataRecordEx3Test {
         assertNotNull(record.getExportedRecord());
         assertEquals(record.getSharingScope(), SharingScope.SPONSORS_AND_PARTNERS);
         assertEquals(record.getMetadata(), METADATA_MAP);
+        assertEquals(record.getUserAgent(), TestConstants.UA);
         assertEquals(record.getVersion().longValue(), VERSION);
 
         Map<String, ExportedRecordInfo> exportedStudyRecordMap = record.getExportedStudyRecords();

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoUpload2Test.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoUpload2Test.java
@@ -19,6 +19,7 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 import org.testng.annotations.Test;
 
+import org.sagebionetworks.bridge.TestConstants;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
 import org.sagebionetworks.bridge.models.upload.UploadCompletionClient;
 import org.sagebionetworks.bridge.models.upload.UploadStatus;
@@ -55,6 +56,7 @@ public class DynamoUpload2Test {
         upload.setAppId(TEST_APP_ID);
         upload.setUploadDate(LocalDate.parse("2016-10-10"));
         upload.setUploadId("DEF");
+        upload.setUserAgent(TestConstants.UA);
         upload.setValidationMessageList(Lists.newArrayList("message 1", "message 2"));
         upload.setVersion(2L);
         upload.setZipped(false);
@@ -77,6 +79,7 @@ public class DynamoUpload2Test {
         assertEquals(node.get("filename").textValue(), "filename.zip");
         assertEquals(node.get("appId").textValue(), TEST_APP_ID);
         assertEquals(node.get("studyId").textValue(), TEST_APP_ID);
+        assertEquals(node.get("userAgent").textValue(), TestConstants.UA);
         assertEquals(node.get("version").longValue(), 2L);
         assertEquals(node.get("healthCode").textValue(), "healthCode");
         assertFalse(node.get("zipped").booleanValue());

--- a/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadDaoTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/dynamodb/DynamoUploadDaoTest.java
@@ -538,6 +538,13 @@ public class DynamoUploadDaoTest {
         dao.uploadComplete(APP, upload);
     }
 
+    @Test
+    public void updateUpload() {
+        Upload upload = Upload.create();
+        dao.updateUpload(upload);
+        verify(mockMapper).save(upload);
+    }
+
     private static UploadRequest createUploadRequest() {
         final String text = "test upload dao";
         return new UploadRequest.Builder().withName("test-upload-dao-filename").withContentType("text/plain")

--- a/src/test/java/org/sagebionetworks/bridge/services/Exporter3ServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/Exporter3ServiceTest.java
@@ -1277,7 +1277,7 @@ public class Exporter3ServiceTest {
 
         // Ensure there is no client info in the Request Context.
         RequestContext requestContext = new RequestContext.Builder().withCallerUserId(USER_ID)
-                .withCallerClientInfo(null).build();
+                .withUserAgent(null).build();
         RequestContext.set(requestContext);
 
         // Mock HealthDataEx3Service.
@@ -1313,7 +1313,7 @@ public class Exporter3ServiceTest {
 
         // Set RequestContext.
         RequestContext requestContext = new RequestContext.Builder().withCallerUserId(USER_ID)
-                .withCallerClientInfo(null).build();
+                .withUserAgent(null).build();
         RequestContext.set(requestContext);
 
         // Mock HealthDataEx3Service.
@@ -1351,7 +1351,7 @@ public class Exporter3ServiceTest {
 
         // Set RequestContext.
         RequestContext requestContext = new RequestContext.Builder().withCallerUserId(USER_ID)
-                .withCallerClientInfo(CLIENT_INFO).build();
+                .withUserAgent(TestConstants.UA).build();
         RequestContext.set(requestContext);
 
         // Mock HealthDataEx3Service.

--- a/src/test/java/org/sagebionetworks/bridge/services/Exporter3ServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/Exporter3ServiceTest.java
@@ -1269,6 +1269,7 @@ public class Exporter3ServiceTest {
         upload.setClientInfo("dummy upload client info string");
         upload.setHealthCode(TestConstants.HEALTH_CODE);
         upload.setUploadId(RECORD_ID);
+        upload.setUserAgent(TestConstants.UA);
 
         // Mock AccountService.
         Account account = Account.create();
@@ -1297,6 +1298,7 @@ public class Exporter3ServiceTest {
 
         HealthDataRecordEx3 recordToCreate = recordToCreateCaptor.getValue();
         assertEquals(recordToCreate.getClientInfo(), "dummy upload client info string");
+        assertEquals(recordToCreate.getUserAgent(), TestConstants.UA);
     }
 
     @Test
@@ -1335,6 +1337,7 @@ public class Exporter3ServiceTest {
         String clientInfoJsonText = recordToCreate.getClientInfo();
         ClientInfo deser = BridgeObjectMapper.get().readValue(clientInfoJsonText, ClientInfo.class);
         assertEquals(deser, ClientInfo.UNKNOWN_CLIENT);
+        assertNull(recordToCreate.getUserAgent());
     }
 
     @Test
@@ -1373,6 +1376,7 @@ public class Exporter3ServiceTest {
         String clientInfoJsonText = recordToCreate.getClientInfo();
         ClientInfo deser = BridgeObjectMapper.get().readValue(clientInfoJsonText, ClientInfo.class);
         assertEquals(deser, CLIENT_INFO);
+        assertEquals(recordToCreate.getUserAgent(), TestConstants.UA);
     }
 
     @Test
@@ -1410,6 +1414,7 @@ public class Exporter3ServiceTest {
         String clientInfoJsonText = recordToCreate.getClientInfo();
         ClientInfo deser = BridgeObjectMapper.get().readValue(clientInfoJsonText, ClientInfo.class);
         assertEquals(deser, ClientInfo.UNKNOWN_CLIENT);
+        assertNull(recordToCreate.getUserAgent());
     }
 
     @Test
@@ -1450,6 +1455,7 @@ public class Exporter3ServiceTest {
         String clientInfoJsonText = recordToCreate.getClientInfo();
         ClientInfo deser = BridgeObjectMapper.get().readValue(clientInfoJsonText, ClientInfo.class);
         assertEquals(deser, ClientInfo.UNKNOWN_CLIENT);
+        assertNull(recordToCreate.getUserAgent());
     }
 
     @Test
@@ -1474,7 +1480,8 @@ public class Exporter3ServiceTest {
         when(mockHealthDataEx3Service.createOrUpdateRecord(any())).thenReturn(createdRecord);
 
         // Mock RequestInfoService.
-        RequestInfo requestInfo = new RequestInfo.Builder().withClientInfo(CLIENT_INFO).build();
+        RequestInfo requestInfo = new RequestInfo.Builder().withClientInfo(CLIENT_INFO).withUserAgent(TestConstants.UA)
+                .build();
         when(mockRequestInfoService.getRequestInfo(USER_ID)).thenReturn(requestInfo);
 
         // Mock SQS. Return type doesn't actually matter except for logs, but we don't want it to be null.
@@ -1491,6 +1498,7 @@ public class Exporter3ServiceTest {
         String clientInfoJsonText = recordToCreate.getClientInfo();
         ClientInfo deser = BridgeObjectMapper.get().readValue(clientInfoJsonText, ClientInfo.class);
         assertEquals(deser, CLIENT_INFO);
+        assertEquals(recordToCreate.getUserAgent(), TestConstants.UA);
     }
 
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/services/TemplateServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/TemplateServiceTest.java
@@ -632,7 +632,7 @@ public class TemplateServiceTest extends Mockito {
     public void getRevisionForUser() throws Exception {
         ClientInfo clientInfo = ClientInfo.fromUserAgentCache(UA);
         RequestContext.set(new RequestContext.Builder()
-                .withCallerClientInfo(clientInfo).withCallerLanguages(LANGUAGES).build());
+                .withCallerLanguages(LANGUAGES).withUserAgent(UA).build());
         
         DateTime createdOn = DateTime.now();
         Template t1 = makeTemplate(GUID1, "de");
@@ -661,9 +661,8 @@ public class TemplateServiceTest extends Mockito {
     @Test(expectedExceptions = EntityNotFoundException.class, 
             expectedExceptionsMessageRegExp = "TemplateRevision not found.")
     public void getRevisionForUserWhenTemplateExistsButRevisionMissing() throws Exception {
-        ClientInfo clientInfo = ClientInfo.fromUserAgentCache(UA);
         RequestContext.set(new RequestContext.Builder()
-                .withCallerClientInfo(clientInfo).withCallerLanguages(LANGUAGES).build());
+                .withCallerLanguages(LANGUAGES).withUserAgent(UA).build());
         
         DateTime createdOn = DateTime.now();
         Template t1 = makeTemplate(GUID1, "en");

--- a/src/test/java/org/sagebionetworks/bridge/services/UploadServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/UploadServiceTest.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bridge.services;
 
 import static com.amazonaws.services.s3.Headers.SERVER_SIDE_ENCRYPTION;
 import static com.amazonaws.services.s3.model.ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -475,7 +476,7 @@ public class UploadServiceTest {
     @Test
     public void createUpload() throws Exception {
         // Set up RequestContext.
-        RequestContext.set(new RequestContext.Builder().withCallerClientInfo(CLIENT_INFO).build());
+        RequestContext.set(new RequestContext.Builder().withUserAgent(TestConstants.UA).build());
 
         // Create input.
         UploadRequest uploadRequest = constructUploadRequest();
@@ -502,9 +503,15 @@ public class UploadServiceTest {
         assertEquals(request.getMethod(), HttpMethod.PUT);
         assertEquals(request.getRequestParameters().get(SERVER_SIDE_ENCRYPTION), AES_256_SERVER_SIDE_ENCRYPTION);
 
+        // Verify client info and user agent.
         String clientInfoJsonText = upload.getClientInfo();
         ClientInfo deser = BridgeObjectMapper.get().readValue(clientInfoJsonText, ClientInfo.class);
         assertEquals(deser, CLIENT_INFO);
+
+        assertEquals(upload.getUserAgent(), TestConstants.UA);
+
+        // Verify that we save the updated upload back to the DAO.
+        verify(mockUploadDao).updateUpload(same(upload));
     }
     
     @Test

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AppConfigControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AppConfigControllerTest.java
@@ -39,7 +39,6 @@ import org.sagebionetworks.bridge.cache.CacheKey;
 import org.sagebionetworks.bridge.cache.CacheProvider;
 import org.sagebionetworks.bridge.cache.ViewCache;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
-import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.GuidVersionHolder;
 import org.sagebionetworks.bridge.models.ResourceList;
@@ -139,7 +138,7 @@ public class AppConfigControllerTest extends Mockito {
     public void getAppConfigByCriteria() throws Exception {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerLanguages(ImmutableList.of("en"))
-                .withCallerClientInfo(ClientInfo.fromUserAgentCache(UA)).build());
+                .withUserAgent(UA).build());
         
         when(mockAppService.getApp(TEST_APP_ID)).thenReturn(app);
         when(mockService.getAppConfigForUser(contextCaptor.capture(), eq(true))).thenReturn(appConfig);
@@ -256,7 +255,7 @@ public class AppConfigControllerTest extends Mockito {
     public void getAppConfigByCriteriaAddsToCache() throws Exception {
         RequestContext.set(new RequestContext.Builder()
                 .withCallerLanguages(ImmutableList.of("en"))
-                .withCallerClientInfo(ClientInfo.fromUserAgentCache(UA)).build());
+                .withUserAgent(UA).build());
         mockRequestBody(mockRequest, appConfig);
         when(mockAppService.getApp(TEST_APP_ID)).thenReturn(app);
         when(mockService.getAppConfigForUser(any(), eq(true))).thenReturn(appConfig);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AuthenticationControllerTest.java
@@ -77,7 +77,6 @@ import org.sagebionetworks.bridge.exceptions.NotAuthenticatedException;
 import org.sagebionetworks.bridge.exceptions.UnauthorizedException;
 import org.sagebionetworks.bridge.exceptions.UnsupportedVersionException;
 import org.sagebionetworks.bridge.json.BridgeObjectMapper;
-import org.sagebionetworks.bridge.models.ClientInfo;
 import org.sagebionetworks.bridge.models.CriteriaContext;
 import org.sagebionetworks.bridge.models.Metrics;
 import org.sagebionetworks.bridge.models.OperatingSystem;
@@ -213,9 +212,7 @@ public class AuthenticationControllerTest extends Mockito {
         doReturn(mockRequest).when(controller).request();
         doReturn(mockResponse).when(controller).response();
         
-        ClientInfo clientInfo = ClientInfo.fromUserAgentCache(USER_AGENT_STRING);
-        RequestContext.set(new RequestContext.Builder()
-                .withCallerClientInfo(clientInfo).build());
+        RequestContext.set(new RequestContext.Builder().withUserAgent(USER_AGENT_STRING).build());
     }
     
     @AfterMethod

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/BaseControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/BaseControllerTest.java
@@ -152,8 +152,8 @@ public class BaseControllerTest extends Mockito {
         app = App.create();
         
         RequestContext.set(new RequestContext.Builder()
-                .withCallerClientInfo(ClientInfo.fromUserAgentCache(UA))
-                .withCallerLanguages(ImmutableList.of("en", "fr")).build());
+                .withCallerLanguages(ImmutableList.of("en", "fr"))
+                .withUserAgent(UA).build());
     }
     
     @AfterMethod
@@ -394,8 +394,8 @@ public class BaseControllerTest extends Mockito {
     @Test
     public void getCriteriaContextWithAppId() {
         RequestContext.set(new RequestContext.Builder()
-                .withCallerClientInfo(ClientInfo.fromUserAgentCache(UA))
                 .withCallerLanguages(ImmutableList.of("en"))
+                .withUserAgent(UA)
                 .build());
         when(mockRequest.getHeader(BridgeConstants.X_FORWARDED_FOR_HEADER)).thenReturn(IP_ADDRESS);
         

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ScheduleControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ScheduleControllerTest.java
@@ -66,7 +66,8 @@ public class ScheduleControllerTest extends Mockito {
         MockitoAnnotations.initMocks(this);
         
         appId = TestUtils.randomName(ScheduleControllerTest.class);
-        ClientInfo clientInfo = ClientInfo.fromUserAgentCache("app name/9");
+        String userAgent = "app name/9";
+        ClientInfo clientInfo = ClientInfo.fromUserAgentCache(userAgent);
         
         List<SchedulePlan> plans = TestUtils.getSchedulePlans(appId);
         
@@ -94,7 +95,7 @@ public class ScheduleControllerTest extends Mockito {
         session.setAppId(appId);
         
         doReturn(session).when(controller).getAuthenticatedAndConsentedSession();
-        RequestContext.set(new RequestContext.Builder().withCallerClientInfo(clientInfo).build());
+        RequestContext.set(new RequestContext.Builder().withUserAgent(userAgent).build());
         
         doReturn(mockRequest).when(controller).request();
         doReturn(mockResponse).when(controller).response();

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/ScheduledActivityControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/ScheduledActivityControllerTest.java
@@ -197,7 +197,7 @@ public class ScheduledActivityControllerTest extends Mockito {
         doReturn(mockRequest).when(controller).request();
         doReturn(mockResponse).when(controller).response();
         
-        RequestContext.set(new RequestContext.Builder().withCallerClientInfo(CLIENT_INFO).build());
+        RequestContext.set(new RequestContext.Builder().withUserAgent(USER_AGENT).build());
     }
     
     @AfterMethod


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-3390

This pull request contains 2 changes:

1. There is a bug where even though the ClientInfo is being captured in the uploadRequest API, we're not actually saving it to DynamoDB, so it is being overridden in the uploadComplete API. This means that if the app is updated between Request and Complete, the ClientInfo will be wrong. This is also more likely to happen in the case of redrives.

2. We only provide the parsed value of ClientInfo. We should also provide the raw user-agent header value. This way, if for whatever reason the user-agent value can’t be parsed, we still provide something rather than nothing.