### PR TITLE
BRIDGE-3391 Extend Adherence Record Search APIs

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/spring/controllers/AdherenceController.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/controllers/AdherenceController.java
@@ -155,6 +155,7 @@ public class AdherenceController extends BaseController {
         
         AdherenceRecordsSearch payload = parseJson(AdherenceRecordsSearch.class);
         AdherenceRecordsSearch search = payload.toBuilder()
+                .withAppId(session.getAppId())
                 .withUserId(null)
                 .withStudyId(studyId).build();
 

--- a/src/main/java/org/sagebionetworks/bridge/validators/AdherenceRecordsSearchValidator.java
+++ b/src/main/java/org/sagebionetworks/bridge/validators/AdherenceRecordsSearchValidator.java
@@ -1,9 +1,11 @@
 package org.sagebionetworks.bridge.validators;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_BLANK;
 import static org.sagebionetworks.bridge.validators.Validate.CANNOT_BE_NEGATIVE;
 
+import org.joda.time.Days;
 import org.springframework.validation.Errors;
 
 import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecordsSearch;
@@ -11,17 +13,32 @@ import org.sagebionetworks.bridge.models.schedules2.adherence.AdherenceRecordsSe
 public class AdherenceRecordsSearchValidator extends AbstractValidator {
     
     public static final int DEFAULT_PAGE_SIZE = 250;
+    public static final int MAX_DATE_RANGE_IN_DAYS = 60;
     public static final int MAX_PAGE_SIZE = 500;
     public static final int MAX_SET_SIZE = 500;
     public static final int MAX_MAP_SIZE = 50;
+    public static final String APP_OR_USER_REQUIRED_ERROR = "appId or userId is required";
+    public static final String APP_AND_USER_CANT_BOTH_BE_SPECIFIED_ERROR = "appId and userId can't both be specified";
     public static final String MAX_SET_SIZE_ERROR = "exceeds maximum size of " + MAX_SET_SIZE + " entries";
     public static final String MAX_MAP_SIZE_ERROR = "exceeds maximum size of " + MAX_MAP_SIZE + " entries";
     public static final String PAGE_SIZE_ERROR = "must be 1-"+MAX_PAGE_SIZE+" records";
     public static final String START_TIME_MISSING = "must be provided if endTime is provided";
     public static final String END_TIME_MISSING = "must be provided if startTime is provided";
     public static final String END_TIME_BEFORE_START_TIME = "is before the startTime";
-    
+    public static final String EVENT_TIMESTAMP_START_MISSING =
+            "must be provided if eventTimestampEnd, hasMultipleUploadIds, or hasNoUploadIds are provided";
+    public static final String EVENT_TIMESTAMP_END_MISSING =
+            "must be provided if eventTimestampStart, hasMultipleUploadIds, or hasNoUploadIds is provided";
+    public static final String EVENT_TIMESTAMP_END_MUST_BE_AFTER_START =
+            "eventTimestampEnd must be after eventTimestampStart";
+    public static final String EVENT_TIMESTAMP_END_MUST_BE_WITHIN_RANGE =
+            "must be within " + MAX_DATE_RANGE_IN_DAYS + " days of eventTimestampStart";
+    public static final String HAS_NO_HAS_MULTIPLE_UPLOAD_IDS_ERROR =
+            "cannot specify both hasMultipleUploadIds and hasNoUploadIds";
+
     static final String EVENT_TIMESTAMPS_FIELD = "eventTimestamps";
+    static final String EVENT_TIMESTAMP_START_FIELD = "eventTimestampStart";
+    static final String EVENT_TIMESTAMP_END_FIELD = "eventTimestampEnd";
     static final String TIME_WINDOW_GUIDS_FIELD = "timeWindowGuids";
     static final String INSTANCE_GUIDS_FIELD = "instanceGuids";
     static final String SESSION_GUIDS_FIELD = "sessionGuids";
@@ -65,15 +82,53 @@ public class AdherenceRecordsSearchValidator extends AbstractValidator {
                 errors.rejectValue(END_TIME_FIELD, END_TIME_BEFORE_START_TIME);
             }
         }
+
+        // Validate event timestamp start and end.
+        if (search.getEventTimestampStart() != null || search.getEventTimestampEnd() != null) {
+            if (search.getEventTimestampStart() == null) {
+                errors.rejectValue(EVENT_TIMESTAMP_START_FIELD, EVENT_TIMESTAMP_START_MISSING);
+            } else if (search.getEventTimestampEnd() == null) {
+                errors.rejectValue(EVENT_TIMESTAMP_END_FIELD, EVENT_TIMESTAMP_END_MISSING);
+            } else if (!search.getEventTimestampEnd().isAfter(search.getEventTimestampStart())) {
+                errors.rejectValue(EVENT_TIMESTAMP_END_FIELD, EVENT_TIMESTAMP_END_MUST_BE_AFTER_START);
+            } else if (Days.daysBetween(search.getEventTimestampStart(), search.getEventTimestampEnd()).getDays()
+                    > MAX_DATE_RANGE_IN_DAYS) {
+                errors.rejectValue(EVENT_TIMESTAMP_END_FIELD, EVENT_TIMESTAMP_END_MUST_BE_WITHIN_RANGE);
+            }
+        }
+
         // User ID can be blank for study-scoped searches of the data
         if (isBlank(search.getStudyId())) {
             errors.rejectValue(STUDY_ID_FIELD, CANNOT_BE_BLANK);
         }
+
+        // Either user ID or app ID are required.
+        if (isBlank(search.getAppId()) && isBlank(search.getUserId())) {
+            errors.reject(APP_OR_USER_REQUIRED_ERROR);
+        } else if (isNotBlank(search.getAppId()) && isNotBlank(search.getUserId())) {
+            errors.reject(APP_AND_USER_CANT_BOTH_BE_SPECIFIED_ERROR);
+        }
+
         if (search.getOffsetBy() < 0) {
             errors.rejectValue(OFFSET_BY_FIELD, CANNOT_BE_NEGATIVE);
         }
         if (search.getPageSize() < 1 || search.getPageSize() > MAX_PAGE_SIZE) {
             errors.rejectValue(PAGE_SIZE_FIELD, PAGE_SIZE_ERROR);
+        }
+
+        // Validate hasMultiple/hasNoUploadIds.
+        if (search.hasMultipleUploadIds() || search.hasNoUploadIds()) {
+            if (search.hasMultipleUploadIds() && search.hasNoUploadIds()) {
+                errors.reject(HAS_NO_HAS_MULTIPLE_UPLOAD_IDS_ERROR);
+            }
+
+            // We require eventTimestampStart and eventTimestampEnd, so that we don't have to do a full table scan.
+            if (search.getEventTimestampStart() == null) {
+                errors.rejectValue(EVENT_TIMESTAMP_START_FIELD, EVENT_TIMESTAMP_START_MISSING);
+            }
+            if (search.getEventTimestampEnd() == null) {
+                errors.rejectValue(EVENT_TIMESTAMP_END_FIELD, EVENT_TIMESTAMP_END_MISSING);
+            }
         }
     }
 }

--- a/src/main/resources/db/changelog/changelog.sql
+++ b/src/main/resources/db/changelog/changelog.sql
@@ -1085,3 +1085,9 @@ CREATE TABLE IF NOT EXISTS `AdherenceUploads` (
     CONSTRAINT `AdherenceUpload-AdherenceRecord-Constraint` FOREIGN KEY (`userId`, `studyId`, `instanceGuid`, `eventTimestamp`, `instanceTimestamp`) REFERENCES `AdherenceRecords` (`userId`, `studyId`, `instanceGuid`, `eventTimestamp`, `instanceTimestamp`) ON DELETE CASCADE,
     INDEX (`uploadId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+-- changeset bridge:79
+
+ALTER TABLE `AdherenceRecords`
+ADD INDEX `AdherenceRecords-AppId-StudyId-EventTimestamp` (appId, studyId, eventTimestamp),
+ADD INDEX `AdherenceRecords-AppId-StudyId-UserId-EventTimestamp` (appId, studyId, userId, eventTimestamp);

--- a/src/test/java/org/sagebionetworks/bridge/spring/controllers/AdherenceControllerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/controllers/AdherenceControllerTest.java
@@ -152,6 +152,7 @@ public class AdherenceControllerTest extends Mockito {
         verify(mockService).getAdherenceRecords(eq(TEST_APP_ID), searchCaptor.capture());
         
         AdherenceRecordsSearch captured = searchCaptor.getValue();
+        assertEquals(captured.getAppId(), TEST_APP_ID);
         assertNull(captured.getUserId());
         assertEquals(captured.getStudyId(), TEST_STUDY_ID);
         assertEquals(captured.getAssessmentIds(), ImmutableSet.of("A", "B", "C"));


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-3391

Add new fields to the Adherence Record Search to answer the following questions:

* What are the adherence records associated with no uploads?
* What are the adherence records associated with multiple uploads?
* What are the adherence records associated with an upload?

Example SQL queries for these questions are:

```
select * from AdherenceRecords AR
where appId = 'api' and studyId = 'study1' and eventTimestamp >= 1680867770000
  and eventTimestamp < 1680867790000
  and (select count(uploadId) from AdherenceUploads AU
    where AR.userId = AU.userId and AR.studyId = AU.studyID and AR.instanceGuid = AU.instanceGuid
      and AR.eventTimestamp = AU.eventTimestamp and AR.instanceTimestamp = AU.instanceTimestamp) = 0;

select * from AdherenceRecords AR
where appId = 'api' and studyId = 'study1' and eventTimestamp >= 1680867770000
  and eventTimestamp < 1680867790000
  and (select count(distinct uploadId) from AdherenceUploads AU
  where AR.userId = AU.userId and AR.studyId = AU.studyID and AR.instanceGuid = AU.instanceGuid
    and AR.eventTimestamp = AU.eventTimestamp and AR.instanceTimestamp = AU.instanceTimestamp) > 1;

select AR.* from AdherenceRecords AR join AdherenceUploads AU
  on AR.userId = AU.userId and AR.studyId = AU.studyID and AR.instanceGuid = AU.instanceGuid
    and AR.eventTimestamp = AU.eventTimestamp and AR.instanceTimestamp = AU.instanceTimestamp
    LEFT OUTER JOIN TimelineMetadata AS tm ON AR.instanceGuid = tm.guid
	WHERE AR.appId = 'api' and AR.studyId = 'study1' and AU.uploadId = 'dummy-upload-id-1';
```

NOTE: Since study IDs are not globally unique, it is possible for two studies in two different apps to have the same study ID. If you query adherence records by study ID, you will get the adherence records for both studies. This is a bug and also a security hole. (This only applies when you query by study ID. It doesn't apply when you query by user ID, because user IDs are globally unique.)

NOTE: I used eventTimestamp for the query instead of startedOn because startedOn can be null.