### PR TITLE
BRIDGE-3389 Get Upload Status API - get adherence by upload ID

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/models/upload/UploadViewEx3.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/upload/UploadViewEx3.java
@@ -15,7 +15,8 @@ public class UploadViewEx3 implements BridgeEntity {
     private String id;
     private String healthCode;
     private String userId;
-    private List<AdherenceRecord> adherenceRecords;
+    private List<AdherenceRecord> adherenceRecordsForSchedule;
+    private List<AdherenceRecord> adherenceRecordsForUpload;
     private HealthDataRecordEx3 record;
     private TimelineMetadataView timelineMetadata;
     private Upload upload;
@@ -50,13 +51,22 @@ public class UploadViewEx3 implements BridgeEntity {
         this.userId = userId;
     }
 
-    /** Adherence records associated with this upload/record. */
-    public List<AdherenceRecord> getAdherenceRecords() {
-        return adherenceRecords;
+    /** Adherence records associated with this upload/record via the associated instanceGuid. */
+    public List<AdherenceRecord> getAdherenceRecordsForSchedule() {
+        return adherenceRecordsForSchedule;
     }
 
-    public void setAdherenceRecords(List<AdherenceRecord> adherenceRecords) {
-        this.adherenceRecords = adherenceRecords;
+    public void setAdherenceRecordsForSchedule(List<AdherenceRecord> adherenceRecordsForSchedule) {
+        this.adherenceRecordsForSchedule = adherenceRecordsForSchedule;
+    }
+
+    /** Adherence records associated with this upload/record via the upload ID. */
+    public List<AdherenceRecord> getAdherenceRecordsForUpload() {
+        return adherenceRecordsForUpload;
+    }
+
+    public void setAdherenceRecordsForUpload(List<AdherenceRecord> adherenceRecordsForUpload) {
+        this.adherenceRecordsForUpload = adherenceRecordsForUpload;
     }
 
     /** Health data record corresponding to this upload, if it exists. */

--- a/src/main/java/org/sagebionetworks/bridge/services/UploadService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/UploadService.java
@@ -662,9 +662,24 @@ public class UploadService {
                             .build();
                     List<AdherenceRecord> adherenceRecords = adherenceService.getAdherenceRecords(appId,
                             adherenceSearch).getItems();
-                    view.setAdherenceRecords(adherenceRecords);
+                    view.setAdherenceRecordsForSchedule(adherenceRecords);
                 }
             }
+        }
+
+        // We can also fetch adherence by upload ID. This doesn't require instanceGuid, but it does require study ID.
+        if (fetchAdherence) {
+            // Fetch the adherence record(s). Similar to above, it's unlikely that we have more than 500 records for
+            // a given upload ID.
+            AdherenceRecordsSearch adherenceSearch = new AdherenceRecordsSearch.Builder()
+                    .withPageSize(AdherenceRecordsSearchValidator.MAX_PAGE_SIZE)
+                    .withStudyId(studyId)
+                    .withUploadId(uploadId)
+                    .withUserId(userId)
+                    .build();
+            List<AdherenceRecord> adherenceRecords = adherenceService.getAdherenceRecords(appId, adherenceSearch)
+                    .getItems();
+            view.setAdherenceRecordsForUpload(adherenceRecords);
         }
 
         return view;

--- a/src/test/java/org/sagebionetworks/bridge/models/upload/UploadViewEx3Test.java
+++ b/src/test/java/org/sagebionetworks/bridge/models/upload/UploadViewEx3Test.java
@@ -22,8 +22,11 @@ public class UploadViewEx3Test {
     public void serialize() throws Exception {
         // Make simple AdherenceRecord, HealthDataRecordEx3, TimelineMetadata, and Upload. Just choose a small set of
         // attributes. Full JSON serialization of these classes is tested elsewhere.
-        AdherenceRecord adherenceRecord = new AdherenceRecord();
-        adherenceRecord.setInstanceGuid(INSTANCE_GUID);
+        AdherenceRecord adherenceRecordForSchedule = new AdherenceRecord();
+        adherenceRecordForSchedule.setInstanceGuid(INSTANCE_GUID);
+
+        AdherenceRecord adherenceRecordForUpload = new AdherenceRecord();
+        adherenceRecordForUpload.addUploadId(UPLOAD_ID);
 
         HealthDataRecordEx3 healthDataRecord = HealthDataRecordEx3.create();
         healthDataRecord.setId(UPLOAD_ID);
@@ -40,18 +43,20 @@ public class UploadViewEx3Test {
         uploadView.setId(UPLOAD_ID);
         uploadView.setHealthCode(HEALTH_CODE);
         uploadView.setUserId(TEST_USER_ID);
-        uploadView.setAdherenceRecords(ImmutableList.of(adherenceRecord));
+        uploadView.setAdherenceRecordsForSchedule(ImmutableList.of(adherenceRecordForSchedule));
+        uploadView.setAdherenceRecordsForUpload(ImmutableList.of(adherenceRecordForUpload));
         uploadView.setRecord(healthDataRecord);
         uploadView.setTimelineMetadata(timelineMetadataView);
         uploadView.setUpload(upload);
 
         // Convert to JsonNode.
         JsonNode jsonNode = BridgeObjectMapper.get().convertValue(uploadView, JsonNode.class);
-        assertEquals(jsonNode.size(), 8);
+        assertEquals(jsonNode.size(), 9);
         assertEquals(jsonNode.get("id").textValue(), UPLOAD_ID);
         assertEquals(jsonNode.get("healthCode").textValue(), HEALTH_CODE);
         assertEquals(jsonNode.get("userId").textValue(), TEST_USER_ID);
-        assertEquals(jsonNode.get("adherenceRecords").get(0).get("instanceGuid").textValue(), INSTANCE_GUID);
+        assertEquals(jsonNode.get("adherenceRecordsForSchedule").get(0).get("instanceGuid").textValue(), INSTANCE_GUID);
+        assertEquals(jsonNode.get("adherenceRecordsForUpload").get(0).get("uploadIds").get(0).textValue(), UPLOAD_ID);
         assertEquals(jsonNode.get("record").get("id").textValue(), UPLOAD_ID);
         assertEquals(jsonNode.get("timelineMetadata").get("metadata").get("assessmentInstanceGuid").textValue(),
                 INSTANCE_GUID);


### PR DESCRIPTION
Additional changes to https://sagebionetworks.jira.com/browse/BRIDGE-3389

We added the ability to query adherence records by upload ID, so I added these results to the get upload status API.

Note that this is a breaking change to the UploadViewEx3 object, but right now only the integ tests use this, and we haven't documented it yet, so it's probably safe to change this.