### PR TITLE
DHP-846 Update JodaTime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.8.2</version><!--$NO-MVN-MAN-VER$-->
+            <version>2.12.5</version><!--$NO-MVN-MAN-VER$-->
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/DHP-846

We are using Joda Time 2.8.2, which is from 2015. There have been lots of updates in the last 8 years, such as new timezones and renamed timezones. We should update our Joda Time library.