### PR TITLE
BRIDGE-3321 move ClientAbortException ("broken pipe") from error to warning

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandler.java
+++ b/src/main/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandler.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableSet;
 
+import org.apache.catalina.connector.ClientAbortException;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,6 +68,13 @@ public class BridgeExceptionHandler {
                 log.warn(msg, throwable);
                 return;
             }
+        }
+
+        // BRIDGE-3321 - ClientAbortException aka "broken pipe" is not a problem, it's just the client. Log a warning
+        // instead of an error.
+        if (throwable instanceof ClientAbortException) {
+            log.warn(msg, throwable);
+            return;
         }
 
         log.error(msg, throwable);

--- a/src/test/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandlerTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/spring/handlers/BridgeExceptionHandlerTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 
 import org.aopalliance.intercept.MethodInvocation;
+import org.apache.catalina.connector.ClientAbortException;
 import org.hibernate.QueryParameterException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
@@ -219,7 +220,15 @@ public class BridgeExceptionHandlerTest extends Mockito {
         // Verify log.
         verify(logger).error(contains(ex.getMessage()), same(ex));
     }
-    
+
+    @Test
+    public void clientAbortException() throws Exception {
+        // Execute. The output is not important. We just want to verify that we log a warning instead of an error.
+        ClientAbortException ex = new ClientAbortException("dummy exception message");
+        handler.handleException(mockRequest, ex);
+        verify(logger).warn(contains(ex.getMessage()), same(ex));
+    }
+
     // If you do not wrap a RuntimeException in BridgeServiceException, it's still reported as a 500 response, 
     // but the JSON will be based on that object, so e.g. the type will be the type of the exception. That and 
     // usually other details are internal to the system and will not make sense to an API caller.


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-3321

After doing some research, it appears that Broken Pipe is a specific case of ClientAbortException, which meant that the client disconnected before we could send them a response.

It seems to disproportionately affect slower calls, such as Reauth (which is slow by design). This makes sense, because the longer a call take, the more likely the app will disconnect before the response arrives. Scrubbing the logs, this appears to affect about 1% of all Reauth calls. None of the affected Reauth calls took longer than ~2.6 seconds.

In any case, it seems like this isn’t indicative of a deeper error, at least not at the volume that would set off Error alarms. Proposed fix is to go into BridgeExceptionHandler, catch ClientAbortException, and log a warning instead of an error. This way, we will still be alarmed if a lot of these show up, but it won’t affect our error logging.