### PR TITLE
BRIDGE-3331 Fixing duplicate key error in adherence reporting

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceState.java
+++ b/src/main/java/org/sagebionetworks/bridge/models/schedules2/adherence/AdherenceState.java
@@ -54,8 +54,12 @@ public final class AdherenceState {
         daysSinceEventByEventId = new HashMap<>();
         eventTimestampByEventId = new HashMap<>();
         streamsByStreamKey = new HashMap<>();
-        adherenceByGuid = builder.adherenceRecords.stream()
-                .collect(toMap(AdherenceRecord::getInstanceGuid, (a) -> a));
+        
+        adherenceByGuid = new HashMap<>();
+
+        for (AdherenceRecord adherenceRecord : adherenceRecords) {
+            adherenceByGuid.put(adherenceRecord.getInstanceGuid(), adherenceRecord);
+        }
         
         for (StudyActivityEvent event : builder.events) {
             DateTime eventTimestamp = event.getTimestamp().withZone(zone);


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-3331

Using a collection stream with the map function throws an IllegalStateException when given duplicate keys. Persistent windows can have adherence records with duplicate instance GUIDs, leading to this exception. However we don't use persistent records in adherence reporting. This change allows the map to populate without erroring out due to duplicate keys.