### PR TITLE
DHP-979 Emergency disable creating participants for mobile-toolbox

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -377,6 +377,12 @@ public class ParticipantService {
     public IdentifierHolder createParticipant(App app, StudyParticipant participant, boolean shouldSendVerification) {
         checkNotNull(app);
         checkNotNull(participant);
+
+        // https://sagebionetworks.jira.com/browse/DHP-979
+        // Temporarily disable creating participants for mobile-toolbox.
+        if (app.getIdentifier().equals("mobile-toolbox")) {
+            throw new LimitExceededException("You are creating accounts too quickly. Please wait a while and try again later.");
+        }
         
         if (app.getAccountLimit() > 0) {
             throwExceptionIfLimitMetOrExceeded(app);


### PR DESCRIPTION
Emergency patch change to disable creating participants in mobile-toolbox. See https://sagebionetworks.jira.com/browse/DHP-979 for more information.

I tested and made sure this doesn't impact normal creation of participants. Obviously I was not able to test this for the actual mobile-toolbox study, since that only exists in Prod.