### PR TITLE
patch: don't rate limit for superadmins

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -397,8 +397,9 @@ public class ParticipantService {
         // https://sagebionetworks.jira.com/browse/DHP-968 - Rate limiting.
         // Note that it's possible for the RequestContext to not have a User ID. This is common for sign-up calls.
         // In that case, we don't rate limit.
+        // Note: Don't rate limit for the API app. This is a special case, because the API app is used in integ tests.
         String userId = RequestContext.get().getCallerUserId();
-        if (userId != null) {
+        if (!BridgeConstants.API_APP_ID.equals(app.getIdentifier()) && userId != null) {
             ByteRateLimiter rateLimiter = createParticipantRateLimiters.computeIfAbsent(userId,
                     (u) -> createParticipantRateLimiter());
             if (!rateLimiter.tryConsumeBytes(1)) {

--- a/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
+++ b/src/main/java/org/sagebionetworks/bridge/services/ParticipantService.java
@@ -397,9 +397,10 @@ public class ParticipantService {
         // https://sagebionetworks.jira.com/browse/DHP-968 - Rate limiting.
         // Note that it's possible for the RequestContext to not have a User ID. This is common for sign-up calls.
         // In that case, we don't rate limit.
-        // Note: Don't rate limit for the API app. This is a special case, because the API app is used in integ tests.
-        String userId = RequestContext.get().getCallerUserId();
-        if (!BridgeConstants.API_APP_ID.equals(app.getIdentifier()) && userId != null) {
+        // Note: Don't rate limit for superadmin accounts.
+        RequestContext requestContext = RequestContext.get();
+        String userId = requestContext.getCallerUserId();
+        if (!requestContext.isInRole(Roles.SUPERADMIN) && userId != null) {
             ByteRateLimiter rateLimiter = createParticipantRateLimiters.computeIfAbsent(userId,
                     (u) -> createParticipantRateLimiter());
             if (!rateLimiter.tryConsumeBytes(1)) {

--- a/src/test/java/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/services/ParticipantServiceTest.java
@@ -430,6 +430,15 @@ public class ParticipantServiceTest extends Mockito {
             // expected exception
         }
 
+        // Use a superadmin account with a different User ID. This should not be rate limited.
+        RequestContext.set(new RequestContext.Builder()
+                .withCallerUserId("superadmin-user").withCallerAppId(TEST_APP_ID)
+                .withCallerRoles(ImmutableSet.of(Roles.SUPERADMIN)).build());
+
+        // Can create multiple participants without rate limiting.
+        participantService.createParticipant(APP, participant, false);
+        participantService.createParticipant(APP, participant, false);
+
         // Don't need to test restocking the Rate Limiter. This is tested in ByteRateLimiterTest.
     }
 


### PR DESCRIPTION
Accidentally broke production integ tests with https://github.com/Sage-Bionetworks/BridgeServer2/pull/665 because as it turns out, integ tests create a lot of accounts.

This patch makes it so that superadmins aren't rate limited. Since superadmins are exclusively on the Bridge Server team (or integ tests), this shouldn't be a problem.