### PR TITLE
[IT-3777] Add a WAF to the ALB

### DIFF
--- a/ebextensions/waf.config
+++ b/ebextensions/waf.config
@@ -1,0 +1,58 @@
+Resources:
+  WafAcl:
+    Type: 'AWS::WAFv2::WebACL'
+    Properties:
+      Name: WafAcl
+      Scope: REGIONAL
+      DefaultAction:
+        Allow: {}
+      VisibilityConfig:
+        SampledRequestsEnabled: true
+        CloudWatchMetricsEnabled: true
+        MetricName: WafAclMetric
+      Rules:
+        - Name: AwsCommonRule
+          Priority: 0
+          OverrideAction:
+            None: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: AwsCommonRuleMetric
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesCommonRuleSet
+        - Name: AwsKnownBadRule
+          Priority: 1
+          OverrideAction:
+            None: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: AwsKnownBadRuleMetric
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesKnownBadInputsRuleSet
+        - Name: AwsAdminRule
+          Priority: 2
+          OverrideAction:
+            None: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: AwsAdminRuleMetric
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesAdminProtectionRuleSet
+
+# Attach the Web ACL to the Load Balancer created by Beanstalk
+# https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environment-resources.html
+# https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/customize-containers-format-resources-eb.html
+  WafAclAssociation:
+    Type: 'AWS::WAFv2::WebACLAssociation'
+    Properties:
+      ResourceArn: !Ref AWSEBV2LoadBalancer
+      WebAclArn: !GetAtt WafAcl.Arn


### PR DESCRIPTION
Extend the Application Load Balancer created by Beanstalk with a Web Application Firewall similar to this post [1], modified to use baseline rulesets managed by AWS [2].

[1] https://repost.aws/knowledge-center/elastic-beanstalk-host-attacks
[2] https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html