### PR TITLE
[IT-3756] Run on Tomcat 9

### DIFF
--- a/ebextensions/tomcatlogs.config
+++ b/ebextensions/tomcatlogs.config
@@ -29,8 +29,8 @@ files:
       log_stream_name={instance_id}
       file=/var/log/eb-activity.log*
 
-      [/var/log/tomcat8/catalina.out]
-      log_group_name=`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/log/tomcat8/catalina.out"]]}`
+      [/var/log/tomcat/catalina.out]
+      log_group_name=`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/log/tomcat/catalina.out"]]}`
       log_stream_name={instance_id}
       file=/var/log/tomcat/catalina.out*
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         
-        <!-- Elastic Beanstalk instances are currently on 8.5.32. -->
-        <tomcat.version>8.5.32</tomcat.version>
+        <!-- Elastic Beanstalk instances are currently on 9.0.87. -->
+        <tomcat.version>9.0.87</tomcat.version>
     </properties>
 
     <parent>

--- a/src/main/resources/newrelic-infra.yml
+++ b/src/main/resources/newrelic-infra.yml
@@ -42,7 +42,7 @@
 #          different than the default (for example, with troubleshooting).
 # Default: Typical default location for standard log files
 #
-log_file: /var/log/tomcat8/newrelic-infra.log
+log_file: /var/log/tomcat/newrelic-infra.log
 
 # Option : log_to_stdout
 # Value  : If you have a log file set through the log_file option, the

--- a/src/main/resources/newrelic.yml
+++ b/src/main/resources/newrelic.yml
@@ -51,7 +51,7 @@ common: &default_settings
 
   # The log file path.
   # Default same directory as newrelic.jar
-  log_file_path: /var/log/tomcat8
+  log_file_path: /var/log/tomcat
 
   # New Relic Real User Monitoring gives you insight into the performance real users are
   # experiencing with your website. This is accomplished by measuring the time it takes for


### PR DESCRIPTION
We need to migrate to a new Beanstalk environment by the end of Sept, with at least an upgrade from Tomcat 8.5 to Tomcat 9 [1]. Update to version 9.0.87 and remote tomcat version from log path.

[1] https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-retiring.html#platforms-retiring.java