### PR TITLE
Enforce AWS Common Rules in our firewall

### DIFF
--- a/ebextensions/waf.config
+++ b/ebextensions/waf.config
@@ -15,7 +15,7 @@ Resources:
         - Name: AwsCommonRule
           Priority: 2
           OverrideAction:
-            Count: {}  # for testing
+            None: {}
           VisibilityConfig:
             SampledRequestsEnabled: true
             CloudWatchMetricsEnabled: true
@@ -25,14 +25,20 @@ Resources:
               VendorName: AWS
               Name: AWSManagedRulesCommonRuleSet
               RuleActionOverrides:
-                # needs more investigation
-                - Name: GenericRFI_BODY
-                  ActionToUse:
-                    Count: {}
                 # normal for /v3/participants/self
                 - Name: SizeRestrictions_BODY
                   ActionToUse:
                     Allow: {}
+                # needs more investigation
+                - Name: GenericRFI_BODY
+                  ActionToUse:
+                    Count: {}
+                - Name: GenericRFI_QUERYARGUMENTS
+                  ActionToUse:
+                    Count: {}
+                - Name: GenericRFI_URIPATH
+                  ActionToUse:
+                    Count: {}
         - Name: AwsKnownBadRule
           Priority: 1
           OverrideAction:


### PR DESCRIPTION
Start enforcing the rest of the rules from AWSManagedRulesCommonRuleSet except for the RFI rules, they need more investigation.

This will make it easier to search through Bridge error logs by improving the signal to noise ratio.