### PR TITLE
[IT-3986] Remove noise from error logs

### DIFF
--- a/ebextensions/waf.config
+++ b/ebextensions/waf.config
@@ -60,12 +60,31 @@ Resources:
             CloudWatchMetricsEnabled: true
             MetricName: CustomBadSuffixMetric
           Statement:
-            # Block requests for paths ending in '.env' or '.env.local'
+            # Block requests for paths storting or ending in '.env'
+            # Block requests for paths ending in '.aspx', '.php', 'phpinfo', or '.rb'
             # https://repost.aws/questions/QUGvcw-5sOQc2Q6RROgLb8DQ/how-do-i-selectively-override-waf-rules-for-only-specific-uris-in-cloudformation
             RegexMatchStatement:
               FieldToMatch:
                 UriPath: {}
-              RegexString: '.*\.env(\.local)?$'
+              RegexString: '^/*(\.env.*|.*(\.(env|aspx|php|rb)|phpinfo))$'
+              TextTransformations:
+                - Priority: 0
+                  Type: NONE
+        - Name: ErrorFalsePositive
+          Priority: 0
+          Action:
+            Block: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: ErrorFalsePositiveMetric
+          Statement:
+            # Block bot scan requests for paths that are incorrectly identified as errors
+            # https://repost.aws/questions/QUGvcw-5sOQc2Q6RROgLb8DQ/how-do-i-selectively-override-waf-rules-for-only-specific-uris-in-cloudformation
+            RegexMatchStatement:
+              FieldToMatch:
+                UriPath: {}
+              RegexString: '.*(errors?_log|errorCss).*$
               TextTransformations:
                 - Priority: 0
                   Type: NONE


### PR DESCRIPTION
Some of the URLs that bots scan for give 404 errors that are incorrectly logged at ERROR level. Block them at the WAF. Also block more file type suffixes that are invalid for our API.