### PR TITLE
Update WAF for new bot scans.

### DIFF
--- a/ebextensions/waf.config
+++ b/ebextensions/waf.config
@@ -34,12 +34,12 @@ Resources:
             MetricName: CustomBadSuffixMetric
           Statement:
             # Block requests for paths storting or ending in '.env'
-            # Block requests for paths ending in '.aspx', '.php', 'phpinfo', or '.rb'
+            # Block requests for paths ending in '.aspx', '.cgi', '.fgci', '.php', 'phpinfo', or '.rb'
             # https://repost.aws/questions/QUGvcw-5sOQc2Q6RROgLb8DQ/how-do-i-selectively-override-waf-rules-for-only-specific-uris-in-cloudformation
             RegexMatchStatement:
               FieldToMatch:
                 UriPath: {}
-              RegexString: '^/*(\.env.*|.*(\.(env|aspx|php|rb)|phpinfo))$'
+              RegexString: '^.*(\.env\.?.*|(\.(aspx|f?cgi|php|rb)|phpinfo))$'
               TextTransformations:
                 - Priority: 0
                   Type: NONE
@@ -52,12 +52,12 @@ Resources:
             CloudWatchMetricsEnabled: true
             MetricName: ErrorFalsePositiveMetric
           Statement:
-            # Block bot scan requests for paths that are incorrectly identified as errors
+            # Block bot scan requests for invalid paths that are incorrectly identified as log errors
             # https://repost.aws/questions/QUGvcw-5sOQc2Q6RROgLb8DQ/how-do-i-selectively-override-waf-rules-for-only-specific-uris-in-cloudformation
             RegexMatchStatement:
               FieldToMatch:
                 UriPath: {}
-              RegexString: '.*(errors?_log|errorCss).*$'
+              RegexString: '^(/?[Ee]rror|.*(errors?_log|errorCss).*)$'
               TextTransformations:
                 - Priority: 0
                   Type: NONE


### PR DESCRIPTION
We've started seeing an increase in invalid bot traffic for nearly a week, notably a large number of 500s for the paths `/error` and `/Error` from a specific IP address, and also an increase in 404s for F/CGI paths (not used anywhere).

Also simplify the `.env*` portion of the regex while adding `.cgi`.