### PR TITLE
Simplify custom bot-scan regex

### DIFF
--- a/ebextensions/waf.config
+++ b/ebextensions/waf.config
@@ -33,13 +33,12 @@ Resources:
             CloudWatchMetricsEnabled: true
             MetricName: CustomBadSuffixMetric
           Statement:
-            # Block requests for paths containing '.env', '.git', 'cgi-bin', or 'phpinfo'
-            # Block requests for paths ending in '.aspx', '.cgi', '.fgci', '.php', or '.rb'
+            # Block requests for paths containing '.env', '.git', '.aspx', '.cgi', '.fgci', '.php', '.rb', 'cgi-bin', or 'phpinfo',
             # https://repost.aws/questions/QUGvcw-5sOQc2Q6RROgLb8DQ/how-do-i-selectively-override-waf-rules-for-only-specific-uris-in-cloudformation
             RegexMatchStatement:
               FieldToMatch:
                 UriPath: {}
-              RegexString: '^.*((\.(env|git)|cgi-bin|phpinfo)\.?.*|(\.(aspx|f?cgi|php|rb)))$'
+              RegexString: '^.*(\.(env|git|aspx|f?cgi|php|rb|log)|(cgi-bin|phpinfo)).*$'
               TextTransformations:
                 - Priority: 0
                   Type: NONE


### PR DESCRIPTION
Bot scans have begun appending additional paths after a .php or .cgi extension. Adjust and simplify the regex to block paths that contain bad suffixes (including the period) anywhere in the path, not just at the end.