### PR TITLE
[IT-4430] Increase default timeouts

### DIFF
--- a/src/main/resources/BridgeServer2.conf
+++ b/src/main/resources/BridgeServer2.conf
@@ -13,7 +13,7 @@ prod.aws.account.id = 649232250620
 heartbeat.interval.minutes=30
 
 channel.throttle.max.requests = 1
-channel.throttle.timeout.seconds = 300
+channel.throttle.timeout.seconds = 600
 
 ses.notification.topic.arn = arn:aws:sns:us-east-1:649232250620:SNSBounces
 
@@ -50,7 +50,7 @@ hibernate.connection.useSSL = false
 redis.max.total = 50
 redis.min.idle = 3
 redis.max.idle = 50
-redis.timeout = 2000
+redis.timeout = 10000
 
 elasticache.url = redis://localhost:6379
 


### PR DESCRIPTION
Increase the default internal channel timeout from 5 minutes to 10 minutes, 
and the default redis/jedis connection timeout from 2 seconds to 10 seconds.