### PR TITLE
[SYNSD-1762] Remove explicit jjwt dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,11 +122,6 @@
             <version>${aws.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt</artifactId>
-            <version>0.9.1</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <version>${jackson.version}</version><!--$NO-MVN-MAN-VER$-->


### PR DESCRIPTION
Rely on the transitive dependency from synapseJavaClient instead of pinning an explicit version in this pom.xml.