### PR TITLE
[IT-4976] Add logrotate for catalina.out

### DIFF
--- a/ebextensions/logrotate-tomcat.config
+++ b/ebextensions/logrotate-tomcat.config
@@ -1,0 +1,16 @@
+files:
+  "/etc/logrotate.d/tomcat-catalina":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      /var/log/tomcat/catalina.out {
+        daily
+        rotate 7
+        missingok
+        notifempty
+        compress
+        delaycompress
+        copytruncate
+        size 100M
+      }


### PR DESCRIPTION
catalina.out on EB instances grows without bound — no log rotation was configured at any level (Logback, logrotate, or EB platform hooks). CloudWatch Logs handles cloud-side retention (90 days) but nothing manages on-disk file size.

This adds a logrotate rule via .ebextensions that:
- Rotates daily and on 100M size threshold
- Keeps 7 rotated files (CloudWatch has the full history)
- Uses copytruncate so rsyslog and the CW agent keep their file handles
- Compresses old logs with one-cycle delay for CW agent compatibility

This was discovered by the GRIP team.