### PR TITLE
[IT-5167] Updates for migrating to Amazon Linux 2023

### DIFF
--- a/ebextensions/newrelic-server.config
+++ b/ebextensions/newrelic-server.config
@@ -8,7 +8,7 @@ container_commands:
   "06SetNRAppName":
     command: "echo -e \"\n  app_name: $NEW_RELIC_APP_NAME\" >> /etc/newrelic.yml"
   "07SetNRJVMInstanceId":
-    command: 'export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo -e "\n  process_host:\n    display_name: $INSTANCE_ID" >> /etc/newrelic.yml'
+    command: 'TOKEN=$(curl -sX PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60") && export INSTANCE_ID=$(curl -sH "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id) && echo -e "\n  process_host:\n    display_name: $INSTANCE_ID" >> /etc/newrelic.yml'
 # Setup NR infrastructure agent config
   "10CopyNRInfraConfig":
     command: "cp -rf /var/app/staging/WEB-INF/classes/newrelic-infra.yml /etc/newrelic-infra.yml"

--- a/ebextensions/newrelic-server.config
+++ b/ebextensions/newrelic-server.config
@@ -1,13 +1,4 @@
-packages:
-  yum:
-    newrelic-sysmond: []
-  rpm:
-    newrelic: http://yum.newrelic.com/pub/newrelic/el5/x86_64/newrelic-repo-5-3.noarch.rpm
 container_commands:
-  "01SetLicenseKey":
-    command: "/usr/sbin/nrsysmond-config --set license_key=$NEW_RELIC_LICENSE_KEY"
-  "02SetNRServerInstanceId":
-    command: "export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo hostname=$INSTANCE_ID && echo hostname=$INSTANCE_ID >> /etc/newrelic/nrsysmond.cfg"
   "03CopyNRApmAgent":
     command: "/bin/mkdir -p /usr/local/lib/newrelic && cp -rf /var/app/staging/WEB-INF/lib/newrelic-agent-8.21.0.jar /usr/local/lib/newrelic/newrelic-agent.jar"
   "04CopyNRConfig":
@@ -18,8 +9,6 @@ container_commands:
     command: "echo -e \"\n  app_name: $NEW_RELIC_APP_NAME\" >> /etc/newrelic.yml"
   "07SetNRJVMInstanceId":
     command: 'export INSTANCE_ID=$(curl http://instance-data/latest/meta-data/instance-id) && echo -e "\n  process_host:\n    display_name: $INSTANCE_ID" >> /etc/newrelic.yml'
-  "09StartMonitor":
-    command: "/etc/init.d/newrelic-sysmond start"
 # Setup NR infrastructure agent config
   "10CopyNRInfraConfig":
     command: "cp -rf /var/app/staging/WEB-INF/classes/newrelic-infra.yml /etc/newrelic-infra.yml"
@@ -29,7 +18,7 @@ container_commands:
     command: "echo -e \"\ndisplay_name: $NEW_RELIC_APP_NAME\" >> /etc/newrelic-infra.yml"
 # Install NR infrastructure agent
   "13SetupInfraAgentRepo":
-    command: sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/amazonlinux/2/x86_64/newrelic-infra.repo
+    command: sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/amazonlinux/2023/x86_64/newrelic-infra.repo
   "14UpdateInfraAgentYumCache":
     command: yum -q makecache -y --disablerepo='*' --enablerepo='newrelic-infra'
   "15CreateInitDirectoryBug":

--- a/ebextensions/tomcatlogs.config
+++ b/ebextensions/tomcatlogs.config
@@ -1,38 +1,43 @@
 ###################################################################################################
-#### The configuration below sets the logs to be pushed, the Log Group name to push the logs to and
-#### the Log Stream name as the instance id. The following files are examples of logs that will be
-#### streamed to CloudWatch Logs in near real time:
+#### Streams Tomcat's catalina.out and the EB platform engine log to CloudWatch Logs.
 ####
-#### /var/log/tomcat/catalina.out
+#### On AL2023 the legacy `awslogs`/`awslogsd` agent is no longer available, so this uses the
+#### unified CloudWatch agent (`amazon-cloudwatch-agent`), which is preinstalled on the platform.
+#### Config is dropped into the agent's etc/ dir and merged in with `append-config` so we don't
+#### clobber the platform-provided agent config. Log group names follow EB's convention:
 ####
-#### You can then access the CloudWatch Logs by accessing the AWS CloudWatch Console and clicking
-#### the "Logs" link on the left. The Log Group name will follow this format:
+####     /aws/elasticbeanstalk/<environment name>/<full on-instance log path>
 ####
-#### /aws/elasticbeanstalk/<environment name>/<full log name path>
-####
-#### Please note this configuration can be used additionally to the "Log Streaming" feature:
-#### http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.cloudwatchlogs.html
+#### Retention is managed at the CloudWatch Logs group level (90 days), so it is intentionally
+#### not set here.
 ###################################################################################################
 
-packages:
-  yum:
-    awslogs: []
-
 files:
-  "/etc/awslogs/config/beanstalklogs.conf" :
+  "/opt/aws/amazon-cloudwatch-agent/etc/tomcat-logs.json":
     mode: "000644"
     owner: root
     group: root
     content: |
-      [/var/log/eb-activity.log]
-      log_group_name=`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/log/eb-activity.log"]]}`
-      log_stream_name={instance_id}
-      file=/var/log/eb-activity.log*
-
-      [/var/log/tomcat/catalina.out]
-      log_group_name=`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/log/tomcat/catalina.out"]]}`
-      log_stream_name={instance_id}
-      file=/var/log/tomcat/catalina.out*
+      {
+        "logs": {
+          "logs_collected": {
+            "files": {
+              "collect_list": [
+                {
+                  "file_path": "/var/log/tomcat/catalina.out",
+                  "log_group_name": "`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/log/tomcat/catalina.out"]]}`",
+                  "log_stream_name": "{instance_id}"
+                },
+                {
+                  "file_path": "/var/log/eb-engine.log",
+                  "log_group_name": "`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/log/eb-engine.log"]]}`",
+                  "log_stream_name": "{instance_id}"
+                }
+              ]
+            }
+          }
+        }
+      }
 
   "/etc/rsyslog.d/catalina.conf":
     mode: "0644"
@@ -47,22 +52,11 @@ files:
         *.=info;*.=notice /var/log/tomcat/catalina.out;catalinalog
        }
 
-commands:
-  "01_rm_old_confs":
-    command: "rm beanstalklogs.conf.bak tomcatlogs.conf tomcatlogs.conf.bak"
-    cwd: "/etc/awslogs/config"
+container_commands:
+  "01_append_cloudwatch_agent_config":
+    command: "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/tomcat-logs.json"
+  "02_remove_backup_file":
+    command: "rm -f /opt/aws/amazon-cloudwatch-agent/etc/tomcat-logs.json.bak"
     ignoreErrors: true
-
-  "02a_systemctl_start_awslogsd":
-    command: systemctl start awslogsd
-    ignoreErrors: true
-
-  "02b_systemctl_enable_awslogsd_service":
-    command: systemctl enable awslogsd.service
-    ignoreErrors: true
-
-  "02c_restart_awslogs":
-    command: service awslogsd restart
-
   "03_restart_rsyslog":
-    command: systemctl restart rsyslog
+    command: "systemctl restart rsyslog"


### PR DESCRIPTION
Updates for migrating to Amazon Linux 2023.

Use IMDSv2 for New Relic instance-id lookup
AL2023 platforms default DisableIMDSv1 to true, so the token-less
metadata GET in 07SetNRJVMInstanceId returned empty, leaving the New
Relic JVM process_host.display_name blank. Fetch an IMDSv2 token first
and pass it on the metadata request, and use 169.254.169.254 directly
instead of the instance-data alias.

Stream Tomcat logs via unified CloudWatch agent
The awslogs/awslogsd agent is removed on AL2023, so installing the
awslogs package and starting awslogsd fails the deploy. Replace it with
the preinstalled unified CloudWatch agent (amazon-cloudwatch-agent):

- Write a CloudWatch agent JSON config and merge it with append-config
  so the platform-provided agent config is preserved.
- Keep the EB log-group naming and the rsyslog redirect that populates
  catalina.out.
- Stream eb-engine.log instead of eb-activity.log (the AL2 file does not
  exist on AL2023).
- Omit retention_in_days; retention is managed at the log-group level.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>