### PR TITLE
[IT-5233] Publish catalina.out to S3 and read both Tomcat log paths

### DIFF
--- a/ebextensions/logrotate-tomcat.config
+++ b/ebextensions/logrotate-tomcat.config
@@ -4,6 +4,7 @@ files:
     owner: root
     group: root
     content: |
+      # Rotates the Tomcat catalina.out written by our rsyslog redirect (see tomcatlogs.config).
       /var/log/tomcat/catalina.out {
         daily
         rotate 7

--- a/ebextensions/publishlogs.config
+++ b/ebextensions/publishlogs.config
@@ -1,0 +1,22 @@
+###################################################################################################
+#### Adds Tomcat's catalina.out to Elastic Beanstalk's "publish logs to S3" task.
+####
+#### EB rotates a platform-defined set of logs to the environment's S3 bucket under
+#### resources/environments/logs/publish/<env-id>/<instance-id>/, and the Sumo Logic collectors
+#### ingest from that bucket. The AL2023 Tomcat 9 platform's default publish set does NOT include
+#### the application's catalina.out (only Tomcat's JULI catalina.<date>.log files), so application
+#### logs stopped reaching Sumo Logic after the AL2 -> AL2023 upgrade. This restores them by
+#### explicitly adding catalina.out (and its rotations) to the publish task.
+####
+#### AWS docs, "Extending the default log task configuration":
+####   https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.logging.html
+###################################################################################################
+
+files:
+  "/opt/elasticbeanstalk/tasks/publishlogs.d/catalina-out.conf":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      /var/log/tomcat/catalina.out
+      /var/log/tomcat/catalina.out.*


### PR DESCRIPTION
After the AL2 -> AL2023 upgrade the workers/exporter stopped logging to Sumo Logic. Two things combined: AL2023 runs Tomcat 9 (native log dir /var/log/tomcat9), and the platform's default S3 log-publication set no longer includes catalina.out, so the application log (written by our rsyslog redirect to /var/log/tomcat) stopped reaching the Sumo Logic collectors, which ingest from the EB S3 publish bucket. CloudWatch was unaffected because it read the file directly.

Approach: read catalina.out from both locations, so logs are captured no matter which location holds them, without duplicating entries.

- Add ebextensions/publishlogs.config to explicitly publish catalina.out (and rotations) from both paths to S3, restoring the Sumo Logic feed.
- tomcatlogs.config: rsyslog keeps writing the single canonical /var/log/tomcat/catalina.out; the CloudWatch agent reads both /var/log/tomcat and /var/log/tomcat9, and BOTH stream into the same version-less /var/log/tomcat log group (the reusable group the *-infra stack provisions and attaches its metric-filter alarms to).
- logrotate-tomcat.config: rotate both paths.

The version-less /var/log/tomcat is intentionally the canonical path (*-infra dropped the version "for future reusability"); /var/log/tomcat9 is read as a fallback for the platform's native Tomcat 9 dir.